### PR TITLE
PORT-4325-Listen-to-all-webhook-events-in-the-gitlab

### DIFF
--- a/integrations/gitlab/.port/spec.yaml
+++ b/integrations/gitlab/.port/spec.yaml
@@ -1,4 +1,4 @@
-version: v0.1.0
+version: v0.1.1
 type: gitlab
 description: Gitlab integration for Port Ocean
 icon: GitLab

--- a/integrations/gitlab/CHANGELOG.md
+++ b/integrations/gitlab/CHANGELOG.md
@@ -7,6 +7,17 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+0.1.1 (2023-07-23)
+
+### Breaking Changes
+
+- Changed the mergeRequest kind to merge-request (PORT-4327)
+
+### Bug Fixes
+
+- Creating the gitlab webhook with more event triggers (job_events, pipeline_events, etc...) (PORT-4325)
+
+
 1.0.1 (2023-07-20)
 
 ### Features

--- a/integrations/gitlab/changelog/PORT-4325.bugfix.md
+++ b/integrations/gitlab/changelog/PORT-4325.bugfix.md
@@ -1,1 +1,0 @@
-Creating the gitlab webhook with more event triggers (job_events, pipeline_events, etc...)

--- a/integrations/gitlab/changelog/PORT-4327.breaking.md
+++ b/integrations/gitlab/changelog/PORT-4327.breaking.md
@@ -1,1 +1,0 @@
-Changed the mergeRequest kind to merge-request

--- a/integrations/gitlab/pyproject.toml
+++ b/integrations/gitlab/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gitlab"
-version = "0.1.0"
+version = "0.1.1"
 description = "Gitlab integration for Port using Port-Ocean Framework"
 authors = ["Yair Siman-Tov <yair@getport.io>"]
 


### PR DESCRIPTION
# Description

What - The gitlab integration is not listening to events for some of the kinds
Why - The webhook is created only with push events
How - Added more events when creating the webhook

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

