### PR TITLE
Port 4555 change the name microservice to repository in all the git templates

### DIFF
--- a/integrations/gitlab/.port/resources/blueprints.json
+++ b/integrations/gitlab/.port/resources/blueprints.json
@@ -1,8 +1,8 @@
 [
   {
-    "identifier": "microservice",
-    "title": "Microservice",
-    "icon": "Service",
+    "identifier": "project",
+    "title": "Project",
+    "icon": "GitLab",
     "schema": {
       "properties": {
         "url": {
@@ -74,8 +74,8 @@
       }
     },
     "relations": {
-      "microservice": {
-        "target": "microservice",
+      "project": {
+        "target": "project",
         "required": true,
         "many": false
       }
@@ -138,8 +138,8 @@
       }
     },
     "relations": {
-      "microservice": {
-        "target": "microservice",
+      "project": {
+        "target": "project",
         "required": true,
         "many": false
       }

--- a/integrations/gitlab/.port/resources/port-app-config.yaml
+++ b/integrations/gitlab/.port/resources/port-app-config.yaml
@@ -7,7 +7,7 @@ resources:
         mappings:
           identifier: .path_with_namespace | gsub(" "; "")
           title: .name
-          blueprint: '"microservice"'
+          blueprint: '"project"'
           properties:
             url: .web_link
             description: .description
@@ -30,7 +30,7 @@ resources:
             description: .description
             link: .web_url
           relations:
-            microservice: .references.full
+            project: .references.full
   - kind: issue
     selector:
       query: 'true'
@@ -51,4 +51,4 @@ resources:
             labels: '[.labels[]]'
             object: .
         relations:
-          microservice: .references.full
+          project: .references.full

--- a/integrations/gitlab/CHANGELOG.md
+++ b/integrations/gitlab/CHANGELOG.md
@@ -7,6 +7,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+0.1.12 (2023-08-30)
+===================
+
+### Improvements
+
+- Updated the default microservice blueprint to be project blueprint (PORT-4555)
+
+
 0.1.11 (2023-08-30)
 ===================
 

--- a/integrations/gitlab/changelog/PORT-4555.improvement.md
+++ b/integrations/gitlab/changelog/PORT-4555.improvement.md
@@ -1,1 +1,0 @@
-Updated the default microservice blueprint to be project blueprint

--- a/integrations/gitlab/changelog/PORT-4555.improvement.md
+++ b/integrations/gitlab/changelog/PORT-4555.improvement.md
@@ -1,0 +1,1 @@
+Updated the default microservice blueprint to be project blueprint

--- a/integrations/gitlab/pyproject.toml
+++ b/integrations/gitlab/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gitlab"
-version = "0.1.11"
+version = "0.1.12"
 description = "Gitlab integration for Port using Port-Ocean Framework"
 authors = ["Yair Siman-Tov <yair@getport.io>"]
 


### PR DESCRIPTION
# Description

What - Change the default blueprint terminology 

## Type of change

- [X] Non-breaking change (fix of existing functionality that will not change current behavior)


