### PR TITLE
PORT-4483 logging for empty configuration

### DIFF
--- a/changelog/PORT-4483.improvement.md
+++ b/changelog/PORT-4483.improvement.md
@@ -1,0 +1,1 @@
+Changed the handle of empty port app config in the PortAppConfig Handler

--- a/changelog/PORT-4483.improvement.md
+++ b/changelog/PORT-4483.improvement.md
@@ -1,1 +1,1 @@
-Changed the handle of empty port app config in the PortAppConfig Handler
+Changed the way an empty port app config is handled in the `PortAppConfig Handler`

--- a/port_ocean/core/handlers/port_app_config/api.py
+++ b/port_ocean/core/handlers/port_app_config/api.py
@@ -20,7 +20,7 @@ class APIPortAppConfig(BasePortAppConfig):
         if not config:
             logger.error(
                 "The integration port app config is empty. "
-                "Please make sure to configure your port app config in the Port API."
+                "Please make sure to configure your port app config using Port's API."
             )
 
         return config

--- a/port_ocean/core/handlers/port_app_config/api.py
+++ b/port_ocean/core/handlers/port_app_config/api.py
@@ -18,7 +18,9 @@ class APIPortAppConfig(BasePortAppConfig):
         config = integration["config"]
 
         if not config:
-            logger.error("The integration port app config is empty. "
-                         "Please make sure to configure your port app config in the Port API.")
+            logger.error(
+                "The integration port app config is empty. "
+                "Please make sure to configure your port app config in the Port API."
+            )
 
         return config

--- a/port_ocean/core/handlers/port_app_config/api.py
+++ b/port_ocean/core/handlers/port_app_config/api.py
@@ -15,4 +15,10 @@ class APIPortAppConfig(BasePortAppConfig):
     async def _get_port_app_config(self) -> dict[str, Any]:
         logger.info("Fetching port app config")
         integration = await self.context.port_client.get_current_integration()
-        return integration["config"]
+        config = integration["config"]
+
+        if not config:
+            logger.error("The integration port app config is empty. "
+                         "Please make sure to configure your port app config in the Port API.")
+
+        return config

--- a/port_ocean/core/handlers/port_app_config/base.py
+++ b/port_ocean/core/handlers/port_app_config/base.py
@@ -34,7 +34,7 @@ class BasePortAppConfig(BaseHandler):
         raw_config = await self._get_port_app_config()
         try:
             config = self.CONFIG_CLASS.parse_obj(raw_config)
-        except ValidationError as e:
+        except ValidationError:
             logger.error(
                 "Invalid port app config found. Please check the integration has been configured correctly."
             )

--- a/port_ocean/core/handlers/port_app_config/base.py
+++ b/port_ocean/core/handlers/port_app_config/base.py
@@ -36,7 +36,7 @@ class BasePortAppConfig(BaseHandler):
             config = self.CONFIG_CLASS.parse_obj(raw_config)
         except ValidationError:
             logger.error(
-                "Invalid port app config found. Please check the integration has been configured correctly."
+                "Invalid port app config found. Please check that the integration has been configured correctly."
             )
             raise
 

--- a/port_ocean/core/handlers/port_app_config/base.py
+++ b/port_ocean/core/handlers/port_app_config/base.py
@@ -35,7 +35,9 @@ class BasePortAppConfig(BaseHandler):
         try:
             config = self.CONFIG_CLASS.parse_obj(raw_config)
         except ValidationError as e:
-            logger.error("Invalid port app config found. Please check the integration has been configured correctly.")
+            logger.error(
+                "Invalid port app config found. Please check the integration has been configured correctly."
+            )
             raise
 
         event.port_app_config = config

--- a/port_ocean/core/handlers/port_app_config/base.py
+++ b/port_ocean/core/handlers/port_app_config/base.py
@@ -1,6 +1,9 @@
 from abc import abstractmethod
 from typing import Type, Any
 
+from loguru import logger
+from pydantic import ValidationError
+
 from port_ocean.context.event import event
 from port_ocean.core.handlers.base import BaseHandler
 from port_ocean.core.handlers.port_app_config.models import PortAppConfig
@@ -29,6 +32,11 @@ class BasePortAppConfig(BaseHandler):
             PortAppConfig: The parsed port application configuration.
         """
         raw_config = await self._get_port_app_config()
-        config = self.CONFIG_CLASS.parse_obj(raw_config)
+        try:
+            config = self.CONFIG_CLASS.parse_obj(raw_config)
+        except ValidationError as e:
+            logger.error("Invalid port app config found. Please check the integration has been configured correctly.")
+            raise
+
         event.port_app_config = config
         return config


### PR DESCRIPTION
# Description

What - Ocean error message for empty port app config is not enough and we want to enrich it with more readable text
Why - When using the integration with no port app config ocean simply raise pydantic error
How - logged before raising the error stating there is an issue with the mapping and  logging when the port app config is empty

## Type of change

- [X] Non-breaking change (fix of existing functionality that will not change current behavior)

