### PR TITLE
Fix gitlab project key error

### DIFF
--- a/integrations/gitlab/CHANGELOG.md
+++ b/integrations/gitlab/CHANGELOG.md
@@ -7,6 +7,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+0.1.13 (2023-08-31)
+===================
+
+### Bug Fixes
+
+- Fixed an issue causing the push event listener to fail (#1)
+
+
 0.1.12 (2023-08-30)
 ===================
 

--- a/integrations/gitlab/changelog/1.bugfix.md
+++ b/integrations/gitlab/changelog/1.bugfix.md
@@ -1,1 +1,0 @@
-Fixed an issue causing the push event listener to fail

--- a/integrations/gitlab/changelog/1.bugfix.md
+++ b/integrations/gitlab/changelog/1.bugfix.md
@@ -1,0 +1,1 @@
+Fixed an issue causing the push event listener to fail

--- a/integrations/gitlab/gitlab_integration/gitlab_service.py
+++ b/integrations/gitlab/gitlab_integration/gitlab_service.py
@@ -5,13 +5,12 @@ import yaml
 from gitlab import Gitlab, GitlabList
 from gitlab.base import RESTObject
 from gitlab.v4.objects import Project
-from gitlab_integration.core.entities import generate_entity_from_port_yaml
-from gitlab_integration.core.utils import does_pattern_apply
 from loguru import logger
 
+from gitlab_integration.core.entities import generate_entity_from_port_yaml
+from gitlab_integration.core.utils import does_pattern_apply
 from port_ocean.context.event import event
 from port_ocean.core.models import Entity
-
 
 PROJECTS_CACHE_KEY = "__cache_all_projects"
 
@@ -150,8 +149,8 @@ class GitlabService:
         filtered_projects = event.attributes.setdefault(PROJECTS_CACHE_KEY, {}).get(
             self.gitlab_client.private_token, {}
         )
-        project = filtered_projects[project_id]
-        if project:
+
+        if project := filtered_projects.get(project_id):
             return project
 
         project = self.gitlab_client.projects.get(project_id)

--- a/integrations/gitlab/pyproject.toml
+++ b/integrations/gitlab/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gitlab"
-version = "0.1.12"
+version = "0.1.13"
 description = "Gitlab integration for Port using Port-Ocean Framework"
 authors = ["Yair Siman-Tov <yair@getport.io>"]
 


### PR DESCRIPTION
# Description

What - Gitlab integration was failing on push live events
Why - The code tried to fetch from the cache but got key error
How - used .get instead of [] to get none when no cache found and then fill the cache with information

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
