### PR TITLE
Port 4619 cancel resync event before starting a new one

### DIFF
--- a/integrations/gitlab/CHANGELOG.md
+++ b/integrations/gitlab/CHANGELOG.md
@@ -7,6 +7,18 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+0.1.15 (2023-09-04)
+===================
+
+### Improvements
+
+- Added more logs to gitops parsing errors (#1)
+
+### Bug Fixes
+
+- Fixed a bug that caused the gitops parsing to fail (#1)
+
+
 0.1.14 (2023-09-01)
 ===================
 

--- a/integrations/gitlab/changelog/1.bugfix.md
+++ b/integrations/gitlab/changelog/1.bugfix.md
@@ -1,1 +1,0 @@
-Fixed a gitops parsing bug failing the parsing

--- a/integrations/gitlab/changelog/1.improvement.md
+++ b/integrations/gitlab/changelog/1.improvement.md
@@ -1,1 +1,0 @@
-Added more logs to the gitops parsing errors

--- a/port_ocean/context/event.py
+++ b/port_ocean/context/event.py
@@ -148,7 +148,7 @@ async def event_context(
             new_event.abort()
 
     dispatcher.connect(_handle_event, event_type)
-    dispatcher.send(event_type, triggering_event=event.id)
+    dispatcher.send(event_type, triggering_event_id=event.id)
 
     start_time = get_time(seconds_precision=False)
     with logger.contextualize(


### PR DESCRIPTION
# Description

Gitlab changelogs & bug with the event handling in ocean (using the wrong key)

