### PR TITLE
masked the token to show * instead

### DIFF
--- a/integrations/gitlab/gitlab_integration/gitlab_service.py
+++ b/integrations/gitlab/gitlab_integration/gitlab_service.py
@@ -183,7 +183,7 @@ class GitlabService:
         projects: list[Project] = typing.cast(
             list[Project],
             self.gitlab_client.projects.list(
-                include_subgroups=True, owned=True, all=True
+                include_subgroups=True, owned=False, all=True
             ),
         )
         logger.debug(f"Found {len(projects)} projects")

--- a/integrations/gitlab/gitlab_integration/ocean.py
+++ b/integrations/gitlab/gitlab_integration/ocean.py
@@ -48,8 +48,10 @@ async def on_resync(kind: str) -> RAW_RESULT:
     projects = []
 
     for service in all_tokens_services:
+        token = str(service.gitlab_client.private_token)
+        masked_token = len(token[:-4])*"*"
         logger.info(
-            f"fetching projects for token {service.gitlab_client.private_token}"
+            f"fetching projects for token {masked_token}"
         )
         result = [project.asdict() for project in service.get_all_projects().values()]
         logger.info(f"found {len(result)} projects")


### PR DESCRIPTION
# Description

What - The gitlab token in the gitlab integration shows the private token in plaintext
Why - To masked the token and show "*" instead of the token itself in plaintext
How - Convert the plaintext token to "*" by getting the length and multiply it to the char "*".

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ *] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

