### PR TITLE
Changed print in the http error handling to log info

### DIFF
--- a/integrations/sonarqube/CHANGELOG.md
+++ b/integrations/sonarqube/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+# Sonarqube 0.1.4 (2023-10-15)
+
+### Improvements
+
+- Changed print in the http error handling to log info
+
+
 # Sonarqube 0.1.3 (2023-10-04)
 
 ### Improvements

--- a/integrations/sonarqube/client.py
+++ b/integrations/sonarqube/client.py
@@ -1,4 +1,5 @@
 from typing import Any, Optional, AsyncGenerator, cast
+
 import httpx
 from loguru import logger
 
@@ -97,7 +98,7 @@ class SonarQubeClient:
             return all_resources
 
         except httpx.HTTPStatusError as e:
-            print(
+            logger.info(
                 f"HTTP error with status code: {e.response.status_code} and response text: {e.response.text}"
             )
             raise

--- a/integrations/sonarqube/client.py
+++ b/integrations/sonarqube/client.py
@@ -98,7 +98,7 @@ class SonarQubeClient:
             return all_resources
 
         except httpx.HTTPStatusError as e:
-            logger.info(
+            logger.error(
                 f"HTTP error with status code: {e.response.status_code} and response text: {e.response.text}"
             )
             raise

--- a/integrations/sonarqube/pyproject.toml
+++ b/integrations/sonarqube/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sonarqube"
-version = "0.1.3"
+version = "0.1.4"
 description = "SonarQube projects and code quality analysis integration"
 authors = ["Port Team <support@getport.io>"]
 


### PR DESCRIPTION
# Description

What - Sonarqube didnt log for http error when paginating requests
Why - used print instead of the logger
How - changed to print

## Type of change

- [X] Non-breaking change (fix of existing functionality that will not change current behavior)


