### PR TITLE
Port 4964 fix pagerduty default mapping

### DIFF
--- a/integrations/pagerduty/.port/resources/port-app-config.yaml
+++ b/integrations/pagerduty/.port/resources/port-app-config.yaml
@@ -11,7 +11,7 @@ resources:
           properties:
             status: .status
             url: .html_url
-            oncall: .oncall_user[0].user.email
+            oncall: .__oncall_user[0].user.email
   - kind: incidents
     selector:
       query: 'true'

--- a/integrations/pagerduty/CHANGELOG.md
+++ b/integrations/pagerduty/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+# Port_Ocean 0.1.8 (2023-10-17)
+
+### Bug Fixes
+
+- Fixed default mapping for the oncall user (PORT-4964)
+
+
 # Port_Ocean 0.1.7 (2023-09-27)
 
 ### Improvements

--- a/integrations/pagerduty/changelog/PORT-4964.bugfix.md
+++ b/integrations/pagerduty/changelog/PORT-4964.bugfix.md
@@ -1,1 +1,0 @@
-Fixed default mapping for the oncall user

--- a/integrations/pagerduty/changelog/PORT-4964.bugfix.md
+++ b/integrations/pagerduty/changelog/PORT-4964.bugfix.md
@@ -1,0 +1,1 @@
+Fixed default mapping for the oncall user

--- a/integrations/pagerduty/pyproject.toml
+++ b/integrations/pagerduty/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pagerduty"
-version = "0.1.7"
+version = "0.1.8"
 description = "Pagerduty Integration"
 authors = ["Port Team <support@getport.io>"]
 


### PR DESCRIPTION
# Description

What - The pagerduty integration wont return the oncall for the defaullt resourcees
Why - wrong key for the on call (.oncall_user instead of .__oncall_user)
How - Updated default resources

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
