### PR TITLE
Port 4965 extend pagerduty query capabilities

### DIFF
--- a/integrations/pagerduty/CHANGELOG.md
+++ b/integrations/pagerduty/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Extended api query abilities for services & incidents exporting (PORT-4965)
 
+### Improvement
+
+- Used async generator syntax to return exported kinds instead of waiting for all the data (PORT-4965)
+
 
 # Port_Ocean 0.1.8 (2023-10-17)
 

--- a/integrations/pagerduty/CHANGELOG.md
+++ b/integrations/pagerduty/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+# Port_Ocean 0.1.9 (2023-10-18)
+
+### Features
+
+- Extended api query abilities for services & incidents exporting (PORT-4965)
+
+
 # Port_Ocean 0.1.8 (2023-10-17)
 
 ### Bug Fixes

--- a/integrations/pagerduty/changelog/PORT-4965.feature.md
+++ b/integrations/pagerduty/changelog/PORT-4965.feature.md
@@ -1,0 +1,1 @@
+Extended api query abilities for services & incidents exporting

--- a/integrations/pagerduty/changelog/PORT-4965.feature.md
+++ b/integrations/pagerduty/changelog/PORT-4965.feature.md
@@ -1,1 +1,0 @@
-Extended api query abilities for services & incidents exporting

--- a/integrations/pagerduty/clients/pagerduty.py
+++ b/integrations/pagerduty/clients/pagerduty.py
@@ -53,7 +53,9 @@ class PagerDutyClient:
     def api_auth_header(self) -> dict[str, Any]:
         return {"Authorization": f"Token token={self.token}"}
 
-    async def paginate_request_to_pager_duty(self, data_key: str) -> list[Any]:
+    async def paginate_request_to_pager_duty(
+        self, data_key: str, params: dict[str, Any] = None
+    ) -> list[Any]:
         url = f"{self.api_url}/{data_key}"
         all_data = []
         offset = 0
@@ -63,7 +65,9 @@ class PagerDutyClient:
             while has_more_data:
                 try:
                     response = await client.get(
-                        url, params={"offset": offset}, headers=self.api_auth_header
+                        url,
+                        params={"offset": offset, **(params or {})},
+                        headers=self.api_auth_header,
                     )
                     response.raise_for_status()
                     data = response.json()

--- a/integrations/pagerduty/integration.py
+++ b/integrations/pagerduty/integration.py
@@ -1,0 +1,99 @@
+from typing import Literal
+
+from pydantic.fields import Field
+from pydantic.main import BaseModel
+
+from port_ocean.core.handlers.port_app_config.api import APIPortAppConfig
+from port_ocean.core.handlers.port_app_config.models import (
+    PortAppConfig,
+    ResourceConfig,
+    Selector,
+)
+from port_ocean.core.integrations.base import BaseIntegration
+
+
+class ObjectKind:
+    SERVICES = "services"
+    INCIDENTS = "incidents"
+
+
+class PagerdutyServiceAPIQueryParams(BaseModel):
+    include: list[
+        Literal[
+            "escalation_policies",
+            "teams",
+            "integrations",
+            "auto_pause_notifications_parameters",
+        ]
+    ] | None
+    sort_by: Literal["name", "name:asc", "name:desc"] | None
+    team_ids: list[str] | None
+    time_zone: str | None
+
+    def generate_request_params(self) -> dict[str, str]:
+        value = self.dict(exclude_none=True)
+        if include := value.pop("include", None):
+            value["include[]"] = include
+        if team_ids := value.pop("team_ids", None):
+            value["team_ids[]"] = team_ids
+
+        return value
+
+
+class PagerdutyIncidentAPIQueryParams(BaseModel):
+    date_range: str | None
+    incident_key: str | None
+    include: list[str] | None
+    service_ids: list[str] | None
+    since: str | None
+    sort_by: str | None
+    statuses: list[Literal["triggered", "acknowledged", "resolved"]] | None
+    team_ids: list[str] | None
+    time_zone: str | None
+    until: str | None
+    urgencies: list[Literal["high", "low"]] | None
+    user_ids: list[str] | None
+
+    def generate_request_params(self) -> dict[str, str]:
+        value = self.dict(exclude_none=True)
+        if include := value.pop("include", None):
+            value["include[]"] = include
+        if service_ids := value.pop("service_ids", None):
+            value["service_ids[]"] = service_ids
+        if statuses := value.pop("statuses", None):
+            value["statuses[]"] = statuses
+        if team_ids := value.pop("team_ids", None):
+            value["team_ids[]"] = team_ids
+        if urgencies := value.pop("urgencies", None):
+            value["urgencies[]"] = urgencies
+        if user_ids := value.pop("user_ids", None):
+            value["user_ids[]"] = user_ids
+
+        return value
+
+
+class PagerdutyIncidentResourceConfig(ResourceConfig):
+    class PagerdutySelector(Selector):
+        api_query_params: PagerdutyIncidentAPIQueryParams | None
+
+    kind: Literal[ObjectKind.INCIDENTS]
+    selector: PagerdutySelector
+
+
+class PagerdutyServiceResourceConfig(ResourceConfig):
+    class PagerdutySelector(Selector):
+        api_query_params: PagerdutyServiceAPIQueryParams | None
+
+    kind: Literal[ObjectKind.SERVICES]
+    selector: PagerdutySelector
+
+
+class PagerdutyPortAppConfig(PortAppConfig):
+    resources: list[
+        PagerdutyIncidentResourceConfig | PagerdutyServiceResourceConfig
+    ] = Field(default_factory=list)
+
+
+class PagerdutyIntegration(BaseIntegration):
+    class AppConfigHandlerClass(APIPortAppConfig):
+        CONFIG_CLASS = PagerdutyPortAppConfig

--- a/integrations/pagerduty/integration.py
+++ b/integrations/pagerduty/integration.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, Any
 
 from pydantic.fields import Field
 from pydantic.main import BaseModel
@@ -30,7 +30,7 @@ class PagerdutyServiceAPIQueryParams(BaseModel):
     team_ids: list[str] | None
     time_zone: str | None
 
-    def generate_request_params(self) -> dict[str, str]:
+    def generate_request_params(self) -> dict[str, Any]:
         value = self.dict(exclude_none=True)
         if include := value.pop("include", None):
             value["include[]"] = include
@@ -54,7 +54,7 @@ class PagerdutyIncidentAPIQueryParams(BaseModel):
     urgencies: list[Literal["high", "low"]] | None
     user_ids: list[str] | None
 
-    def generate_request_params(self) -> dict[str, str]:
+    def generate_request_params(self) -> dict[str, Any]:
         value = self.dict(exclude_none=True)
         if include := value.pop("include", None):
             value["include[]"] = include
@@ -76,7 +76,7 @@ class PagerdutyIncidentResourceConfig(ResourceConfig):
     class PagerdutySelector(Selector):
         api_query_params: PagerdutyIncidentAPIQueryParams | None
 
-    kind: Literal[ObjectKind.INCIDENTS]
+    kind: Literal["incidents"]
     selector: PagerdutySelector
 
 
@@ -84,14 +84,16 @@ class PagerdutyServiceResourceConfig(ResourceConfig):
     class PagerdutySelector(Selector):
         api_query_params: PagerdutyServiceAPIQueryParams | None
 
-    kind: Literal[ObjectKind.SERVICES]
+    kind: Literal["services"]
     selector: PagerdutySelector
 
 
 class PagerdutyPortAppConfig(PortAppConfig):
     resources: list[
         PagerdutyIncidentResourceConfig | PagerdutyServiceResourceConfig
-    ] = Field(default_factory=list)
+    ] = Field(
+        default_factory=list
+    )  # type: ignore
 
 
 class PagerdutyIntegration(BaseIntegration):

--- a/integrations/pagerduty/main.py
+++ b/integrations/pagerduty/main.py
@@ -4,7 +4,7 @@ from typing import Any
 from loguru import logger
 
 from clients.pagerduty import PagerDutyClient
-from integration import ObjectKind
+from integration import ObjectKind, PagerdutyServiceResourceConfig
 from integration import PagerdutyIncidentResourceConfig
 from port_ocean.context.event import event
 from port_ocean.context.ocean import ocean
@@ -36,9 +36,13 @@ async def on_services_resync(kind: str) -> list[dict[str, Any]]:
         ocean.integration_config["api_url"],
         ocean.integration_config.get("app_host"),
     )
+    query_params = typing.cast(
+        PagerdutyServiceResourceConfig, event.resource_config
+    ).selector.api_query_params
 
     services = await pager_duty_client.paginate_request_to_pager_duty(
-        data_key=ObjectKind.SERVICES
+        data_key=ObjectKind.SERVICES,
+        params=query_params.generate_request_params() if query_params else None,
     )
     return await pager_duty_client.update_oncall_users(services)
 

--- a/integrations/pagerduty/main.py
+++ b/integrations/pagerduty/main.py
@@ -8,10 +8,11 @@ from integration import ObjectKind, PagerdutyServiceResourceConfig
 from integration import PagerdutyIncidentResourceConfig
 from port_ocean.context.event import event
 from port_ocean.context.ocean import ocean
+from port_ocean.core.ocean_types import ASYNC_GENERATOR_RESYNC_TYPE
 
 
 @ocean.on_resync(ObjectKind.INCIDENTS)
-async def on_incidents_resync(kind: str) -> list[dict[str, Any]]:
+async def on_incidents_resync(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     logger.info(f"Listing Pagerduty resource: {kind}")
     pager_duty_client = PagerDutyClient(
         ocean.integration_config["token"],
@@ -22,14 +23,15 @@ async def on_incidents_resync(kind: str) -> list[dict[str, Any]]:
         PagerdutyIncidentResourceConfig, event.resource_config
     ).selector.api_query_params
 
-    return await pager_duty_client.paginate_request_to_pager_duty(
+    async for incidents in pager_duty_client.paginate_request_to_pager_duty(
         data_key=ObjectKind.INCIDENTS,
         params=query_params.generate_request_params() if query_params else None,
-    )
+    ):
+        yield incidents
 
 
 @ocean.on_resync(ObjectKind.SERVICES)
-async def on_services_resync(kind: str) -> list[dict[str, Any]]:
+async def on_services_resync(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     logger.info(f"Listing Pagerduty resource: {kind}")
     pager_duty_client = PagerDutyClient(
         ocean.integration_config["token"],
@@ -40,11 +42,11 @@ async def on_services_resync(kind: str) -> list[dict[str, Any]]:
         PagerdutyServiceResourceConfig, event.resource_config
     ).selector.api_query_params
 
-    services = await pager_duty_client.paginate_request_to_pager_duty(
+    async for services in pager_duty_client.paginate_request_to_pager_duty(
         data_key=ObjectKind.SERVICES,
         params=query_params.generate_request_params() if query_params else None,
-    )
-    return await pager_duty_client.update_oncall_users(services)
+    ):
+        yield await pager_duty_client.update_oncall_users(services)
 
 
 @ocean.router.post("/webhook")

--- a/integrations/pagerduty/pyproject.toml
+++ b/integrations/pagerduty/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pagerduty"
-version = "0.1.8"
+version = "0.1.9"
 description = "Pagerduty Integration"
 authors = ["Port Team <support@getport.io>"]
 


### PR DESCRIPTION
# Description

What - Clients are having errors because we query alot of objects
Why - API limitations
How - Allowed the user to pass query params for the api calls using the port app config

## Type of change

- [X] New feature (non-breaking change which adds functionality)

