### PR TITLE
PORT-5028 Fixed project fetching bug

### DIFF
--- a/integrations/gitlab/.port/resources/port-app-config.yaml
+++ b/integrations/gitlab/.port/resources/port-app-config.yaml
@@ -1,3 +1,5 @@
+createMissingRelatedEntities: true
+deleteDependentEntities: true
 resources:
   - kind: project
     selector:

--- a/integrations/gitlab/CHANGELOG.md
+++ b/integrations/gitlab/CHANGELOG.md
@@ -7,6 +7,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+0.1.20 (2023-10-24)
+===================
+
+### Bug Fixes
+
+- Fixed wrong useage of project object when checking if it is included in the filter (PORT-5028)
+
+
 0.1.19 (2023-10-11)
 ===================
 

--- a/integrations/gitlab/changelog/PORT-5028.bugfix.md
+++ b/integrations/gitlab/changelog/PORT-5028.bugfix.md
@@ -1,0 +1,1 @@
+Fixed wrong useage of project object when checking if it is included in the filter

--- a/integrations/gitlab/changelog/PORT-5028.bugfix.md
+++ b/integrations/gitlab/changelog/PORT-5028.bugfix.md
@@ -1,1 +1,0 @@
-Fixed wrong useage of project object when checking if it is included in the filter

--- a/integrations/gitlab/gitlab_integration/gitlab_service.py
+++ b/integrations/gitlab/gitlab_integration/gitlab_service.py
@@ -189,7 +189,7 @@ class GitlabService:
             return project
 
         project = self.gitlab_client.projects.get(project_id)
-        if self.should_run_for_project(project.path_with_namespace):
+        if self.should_run_for_project(project):
             event.attributes[PROJECTS_CACHE_KEY][self.gitlab_client.private_token][
                 project_id
             ] = project

--- a/integrations/gitlab/pyproject.toml
+++ b/integrations/gitlab/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gitlab"
-version = "0.1.19"
+version = "0.1.20"
 description = "Gitlab integration for Port using Port-Ocean Framework"
 authors = ["Yair Siman-Tov <yair@getport.io>"]
 


### PR DESCRIPTION
# Description

What - The integration raised an error when fetching a single project
Why - Wrong usage of the function that checks if the project should be included by the filter. `project.path_with_namespace` instead of just `project` was passed to the function
How - removed the `path_with_namespace`

```python
future: <_GatheringFuture finished exception=AttributeError("'str' object has no attribute 'path_with_namespace'")>
Traceback (most recent call last):
  File "/app/gitlab_integration/events/hooks/base.py", line 34, in on_hook
    project = self.gitlab_service.get_project(project_id)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/gitlab_integration/gitlab_service.py", line 192, in get_project
    if self.should_run_for_project(project.path_with_namespace):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/gitlab_integration/gitlab_service.py", line 122, in should_run_for_project
    return self.should_run_for_path(project.path_with_namespace)
```

## Type of change

Please leave one option from the following and delete the rest:

- [X] Bug fix (non-breaking change which fixes an issue)

