### PR TITLE
Fix `initlialize-port-resources` flag and change default to `True` and catch failures in ONCE resync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## Bug Fixes
 
-- Fixed the `initialize-port-resources` option in `ocean sail` to not be a flag
+- Fixed the `initialize-port-resources` option in `ocean sail` to not be a flag.
+- Changed default of `initialize-port-resources` to `true`.
+- Catch all exceptions in the resync of ONCE event listener,to make sure the application will exit gracefully 
 
 
 ## 0.4.0 (2023-10-31)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.4.1 (2023-11-03)
+
+## Bug Fixes
+
+- Fixed the `initialize-port-resources` option in `ocean sail` to not be a flag
+
+
 ## 0.4.0 (2023-10-31)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 0.4.1 (2023-11-03)
 
-## Bug Fixes
+### Bug Fixes
 
 - Fixed the `initialize-port-resources` option in `ocean sail` to not be a flag.
 - Changed default of `initialize-port-resources` to `true`.

--- a/port_ocean/cli/commands/sail.py
+++ b/port_ocean/cli/commands/sail.py
@@ -33,7 +33,7 @@ from port_ocean.config.settings import LogLevelType
     "--initialize-port-resources",
     "initialize_port_resources",
     type=bool,
-    help="""Set to true to create default resources on installation.
+    help="""Set to False to not create default resources on installation.
             If not specified, will use the environment variable `OCEAN__INITIALIZE_PORT_RESOURCES` to determine whether 
             to initialize resources""",
 )

--- a/port_ocean/cli/commands/sail.py
+++ b/port_ocean/cli/commands/sail.py
@@ -35,7 +35,7 @@ from port_ocean.config.settings import LogLevelType
     type=bool,
     help="""Set to False to not create default resources on installation.
             If not specified, will use the environment variable `OCEAN__INITIALIZE_PORT_RESOURCES` to determine whether 
-            to initialize resources""",
+            to initialize resources, and if not set, will default to True.""",
 )
 @click.option(
     "-O",

--- a/port_ocean/cli/commands/sail.py
+++ b/port_ocean/cli/commands/sail.py
@@ -33,9 +33,9 @@ from port_ocean.config.settings import LogLevelType
     "--initialize-port-resources",
     "initialize_port_resources",
     type=bool,
-    is_flag=True,
     help="""Set to true to create default resources on installation.
-            If not specified, the default value is false.""",
+            If not specified, will use the environment variable `OCEAN__INITIALIZE_PORT_RESOURCES` to determine whether 
+            to initialize resources""",
 )
 @click.option(
     "-O",

--- a/port_ocean/config/settings.py
+++ b/port_ocean/config/settings.py
@@ -35,7 +35,7 @@ class IntegrationSettings(BaseModel, extra=Extra.allow):
 
 
 class IntegrationConfiguration(BaseOceanSettings, extra=Extra.allow):
-    initialize_port_resources: bool = False
+    initialize_port_resources: bool = True
     scheduled_resync_interval: int | None = None
     port: PortSettings
     event_listener: EventListenerSettingsType

--- a/port_ocean/core/event_listener/once.py
+++ b/port_ocean/core/event_listener/once.py
@@ -54,9 +54,9 @@ class OnceEventListener(BaseEventListener):
             logger.info("Once event listener started")
             try:
                 await self.events["on_resync"]({})
-            except Exception as e:
+            except Exception:
                 # we catch all exceptions here to make sure the application will exit gracefully
-                logger.exception(f"Error occurred while resyncing")
+                logger.exception("Error occurred while resyncing")
             logger.info("Once event listener finished")
             logger.info("Exiting application")
             signal.raise_signal(signal.SIGINT)

--- a/port_ocean/core/event_listener/once.py
+++ b/port_ocean/core/event_listener/once.py
@@ -56,7 +56,7 @@ class OnceEventListener(BaseEventListener):
                 await self.events["on_resync"]({})
             except Exception as e:
                 # we catch all exceptions here to make sure the application will exit gracefully
-                logger.error(f"Error occurred while resyncing: {e}")
+                logger.exception(f"Error occurred while resyncing")
             logger.info("Once event listener finished")
             logger.info("Exiting application")
             signal.raise_signal(signal.SIGINT)

--- a/port_ocean/core/event_listener/once.py
+++ b/port_ocean/core/event_listener/once.py
@@ -52,7 +52,11 @@ class OnceEventListener(BaseEventListener):
         @repeat_every(seconds=0, max_repetitions=1)
         async def resync_and_exit() -> None:
             logger.info("Once event listener started")
-            await self.events["on_resync"]({})
+            try:
+                await self.events["on_resync"]({})
+            except Exception as e:
+                # we catch all exceptions here to make sure the application will exit gracefully
+                logger.error(f"Error occurred while resyncing: {e}")
             logger.info("Once event listener finished")
             logger.info("Exiting application")
             signal.raise_signal(signal.SIGINT)

--- a/port_ocean/run.py
+++ b/port_ocean/run.py
@@ -44,6 +44,7 @@ def run(
     # Override config with arguments
     if initialize_port_resources is not None:
         app.config.initialize_port_resources = initialize_port_resources
+
     if app.config.initialize_port_resources:
         initialize_defaults(
             app.integration.AppConfigHandlerClass.CONFIG_CLASS, app.config

--- a/port_ocean/utils.py
+++ b/port_ocean/utils.py
@@ -117,8 +117,6 @@ def repeat_every(
                         logger.error(formatted_exception)
                         if raise_exceptions:
                             raise exc
-                        # # if we don't raise the exception, we still need to increment the repetitions counter
-                        # repetitions += 1
                     await asyncio.sleep(seconds)
 
             ensure_future(loop())

--- a/port_ocean/utils.py
+++ b/port_ocean/utils.py
@@ -117,6 +117,8 @@ def repeat_every(
                         logger.error(formatted_exception)
                         if raise_exceptions:
                             raise exc
+                        # # if we don't raise the exception, we still need to increment the repetitions counter
+                        # repetitions += 1
                     await asyncio.sleep(seconds)
 
             ensure_future(loop())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.4.0"
+version = "0.4.1"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What -
- Fixed the `initialize-port-resources` option in `ocean sail` to not be a flag.
- Changed default of `initialize-port-resources` to `true`.
- Catch all exceptions in the resync of ONCE event listener,to make sure the application will exit gracefully.
Why -
How -

## Type of change

Please leave one option from the following and delete the rest:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

