### PR TITLE
[Ocean] Fix Kafka poll max timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.4.3 (2023-11-09)
+
+### Bug Fixes
+
+- Fixed kafka consumer to poll messages asynchronously, to avoid max poll timeout when running long resyncs (PORT-5160)
+
 ## 0.4.2 (2023-11-04)
 
 ### Features

--- a/port_ocean/consumers/kafka_consumer.py
+++ b/port_ocean/consumers/kafka_consumer.py
@@ -122,7 +122,6 @@ class KafkaConsumer(BaseConsumer):
                                 ).start()
                                 logger.info(f"thread {thread_name} started")
 
-                            # self._handle_message(msg)
                         except Exception as process_error:
                             logger.exception(
                                 "Failed process message"

--- a/port_ocean/consumers/kafka_consumer.py
+++ b/port_ocean/consumers/kafka_consumer.py
@@ -1,16 +1,11 @@
-import asyncio
-import json
 import signal
-import sys
-import threading
-from typing import Any, Callable, Awaitable
+from typing import Any, Callable
 
 from confluent_kafka import Consumer, KafkaException, Message  # type: ignore
 from loguru import logger
 from pydantic import BaseModel
 
 from port_ocean.consumers.base_consumer import BaseConsumer
-from port_ocean.context.utils import wrap_method_with_context
 
 
 class KafkaConsumerConfig(BaseModel):

--- a/port_ocean/context/utils.py
+++ b/port_ocean/context/utils.py
@@ -9,18 +9,14 @@ from port_ocean.context.ocean import (
 
 def wrap_method_with_context(
     func: Callable[..., None],
-    context: PortOceanContext | None = None,
 ) -> Callable[..., None]:
     """
     A method that wraps a method and initializing the PortOceanContext and invoking the given function.
 
     :param func: The function to be wrapped.
-    :param context: The PortOceanContext to be used, if None, the current PortOceanContext will be used.
     """
-    if context is None:
-        ocean_app = ocean.app
-    else:
-        ocean_app = context.app
+    # assign the current ocean app to a variable
+    ocean_app = ocean.app
 
     def wrapper(*args, **kwargs) -> None:  # type: ignore
         initialize_port_ocean_context(ocean_app=ocean_app)

--- a/port_ocean/context/utils.py
+++ b/port_ocean/context/utils.py
@@ -1,0 +1,29 @@
+from typing import Callable, Any
+
+from port_ocean.context.ocean import (
+    PortOceanContext,
+    initialize_port_ocean_context,
+    ocean,
+)
+
+
+def wrap_method_with_context(
+    func: Callable[[], None] | Callable[[Any], None],
+    context: PortOceanContext | None = None,
+) -> Callable[[], None]:
+    """
+    A method that wraps a method and initializing the PortOceanContext and invoking the given function.
+
+    :param func: The function to be wrapped.
+    :param context: The PortOceanContext to be used, if None, the current PortOceanContext will be used.
+    """
+    if context is None:
+        ocean_app = ocean.app
+    else:
+        ocean_app = context.app
+
+    def wrapper(*args, **kwargs) -> None:  # type: ignore
+        initialize_port_ocean_context(ocean_app=ocean_app)
+        func(*args, **kwargs)
+
+    return wrapper

--- a/port_ocean/context/utils.py
+++ b/port_ocean/context/utils.py
@@ -1,4 +1,4 @@
-from typing import Callable, Any
+from typing import Callable, Any, Awaitable, TypeVar
 
 from port_ocean.context.ocean import (
     PortOceanContext,
@@ -8,9 +8,9 @@ from port_ocean.context.ocean import (
 
 
 def wrap_method_with_context(
-    func: Callable[[], None] | Callable[[Any], None],
+    func: Callable[..., None],
     context: PortOceanContext | None = None,
-) -> Callable[[], None]:
+) -> Callable[..., None]:
     """
     A method that wraps a method and initializing the PortOceanContext and invoking the given function.
 

--- a/port_ocean/context/utils.py
+++ b/port_ocean/context/utils.py
@@ -1,7 +1,6 @@
-from typing import Callable, Any, Awaitable, TypeVar
+from typing import Callable
 
 from port_ocean.context.ocean import (
-    PortOceanContext,
     initialize_port_ocean_context,
     ocean,
 )

--- a/port_ocean/core/event_listener/kafka.py
+++ b/port_ocean/core/event_listener/kafka.py
@@ -4,7 +4,7 @@ import sys
 import threading
 from typing import Any, Literal
 
-from confluent_kafka import Message
+from confluent_kafka import Message  # type: ignore
 from loguru import logger
 
 from port_ocean.consumers.kafka_consumer import KafkaConsumer, KafkaConsumerConfig

--- a/port_ocean/core/event_listener/kafka.py
+++ b/port_ocean/core/event_listener/kafka.py
@@ -103,7 +103,7 @@ class KafkaEventListener(BaseEventListener):
 
         return False
 
-    def _handle_thread(self, message: dict[Any, Any]) -> None:
+    def _resync_in_new_event_loop(self, message: dict[Any, Any]) -> None:
         """
         A private method that handles incoming Kafka messages in a separate thread.
         It triggers the `on_resync` event handler.
@@ -141,7 +141,7 @@ class KafkaEventListener(BaseEventListener):
             logger.info(f"spawning thread {thread_name} to start resync")
             threading.Thread(
                 name=thread_name,
-                target=wrap_method_with_context(self._handle_thread),
+                target=wrap_method_with_context(self._resync_in_new_event_loop),
                 args=(message,),
             ).start()
             logger.info(f"thread {thread_name} started")

--- a/port_ocean/core/event_listener/kafka.py
+++ b/port_ocean/core/event_listener/kafka.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import sys
 import threading
-from typing import Any, Callable, Literal, Awaitable
+from typing import Any, Literal
 
 from confluent_kafka import Message
 from loguru import logger

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.4.2"
+version = "0.4.3"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What -  Fixed the following error, which was caused as a result of the code running the resync in a synchronous way which caused the integration to no poll message from kafka in the max timeout period.
```
ERROR    | KafkaError{code=_ASSIGNMENT_LOST,val=-142,str="Commit failed: Local: Group partition assignment lost"}
ERROR    | KafkaError{code=_MAX_POLL_EXCEEDED,val=-147,str="Application maximum poll interval (300000ms) exceeded by 193ms"}
```
Why -
How - Fixed by spawning the resync in a separate thread, which allowed the code to keep polling messages from kafka. This also takes advantage of the `ABORT` mechanism that we previously implemented that once new resync arrives it closes the current running resync. 

```
2023-11-09 16:52:52.860 | WARNING  | ABORTING RESYNC EVENT DUE TO NEWER RESYNC REQUEST
2023-11-09 16:52:55.093 | WARNING  | Resync aborted successfully
2023-11-09 16:52:52.861 | INFO     | Event started
2023-11-09 16:52:52.861 | INFO     | Fetching port app config
2023-11-09 16:52:52.861 | INFO     | Fetching integration with id: my_gitlab_integration
2023-11-09 16:52:53.224 | INFO     | Searching entities with query {'combinator': 'and', 'rules': [{'property': '$datasource', 'operator': '=', 'value': 'port-ocean/gitlab/0.1.27/my_gitlab_integration/exporter'}]}
2023-11-09 16:52:53.370 | INFO     | Fetching project resync results
2023-11-09 16:52:53.370 | INFO     | Found 1 resync tasks for project
2023-11-09 16:52:53.371 | INFO     | Triggered 0 tasks for project, failed: 0
2023-11-09 16:52:53.371 | INFO     | Calculating diff in entities between states
2023-11-09 16:52:53.372 | INFO     | Upserting 0 entities
2023-11-09 16:52:53.373 | INFO     | Gitlab clients are not cached, creating them
2023-11-09 16:52:53.373 | INFO     | Creating gitlab clients for 1 tokens
2023-11-09 16:52:53.374 | INFO     | fetching projects for token **********************
2023-11-09 16:52:53.374 | INFO     | fetching all projects for the token
2023-11-09 16:52:53.374 | INFO     | Fetching page 1. Batch size: 100
```

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

