### PR TITLE
[Ocean] Add helper for integrations to handle failures with Third Party APIs & Fix 401 against Port API when token expired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Bug Fixes
 
 - Fixed kafka consumer to poll messages asynchronously, to avoid max poll timeout when running long resyncs (PORT-5160)
-- Fixed a bug where the port token gets expired (PORT-5161)
+- Fixed a bug where the expiration of a Port token is not properly handled (PORT-5161)
 - Fixed a bug where the `retry_every` didn't count failed runs as repetitions (PORT-5161) 
 
 ## 0.4.2 (2023-11-04)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Features
 
-- Added `RetryTransport` as a helper for retrying requests for integrations to use (PORT-5161)
+- Added `RetryTransport` as a helper for retrying requests that integrations can use (PORT-5161)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,15 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## 0.4.3 (2023-11-09)
 
+### Features
+
+- Added `RetryTransport` as a helper for retrying requests for integrations to use (PORT-5161)
+
 ### Bug Fixes
 
 - Fixed kafka consumer to poll messages asynchronously, to avoid max poll timeout when running long resyncs (PORT-5160)
+- Fixed a bug where the port token gets expired (PORT-5161)
+- Fixed a bug where the `retry_every` didn't count failed runs as repetitions (PORT-5161) 
 
 ## 0.4.2 (2023-11-04)
 

--- a/port_ocean/clients/port/authentication.py
+++ b/port_ocean/clients/port/authentication.py
@@ -81,7 +81,4 @@ class PortAuthentication:
                 self.client_id, self.client_secret
             )
 
-        if random.choices([1, 0]):
-            return "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJvcmdJZCI6Im9yZ19CbmVEdFdvdlBxWGFBMlZaIiwiaXNzIjoiaHR0cHM6Ly9hcGkuc3RnLTAxLmdldHBvcnQuaW8iLCJpc01hY2hpbmUiOnRydWUsInN1YiI6IjYwRXNvb0p0T3FpbWxla3hyTmg3bmZyMmlPZ1RjeUxaIiwianRpIjoiNjJjZDVmMDctZGM0Ni00ZTVhLTgxMzYtMDkwOTQ4MTJkZjA5IiwiaWF0IjoxNjk5NzI2NzEwLCJleHAiOjE2OTk3Mzc1MTB9.3tdkcfrX5zu4L2IBZRiidFWg3jwjyZgcU72dR7Rv5HE1"
-
         return self._last_token_object.full_token

--- a/port_ocean/clients/port/authentication.py
+++ b/port_ocean/clients/port/authentication.py
@@ -1,3 +1,4 @@
+import random
 from typing import Any
 
 import httpx
@@ -72,8 +73,15 @@ class PortAuthentication:
     @property
     async def token(self) -> str:
         if not self._last_token_object or self._last_token_object.expired:
+            msg = "Token expired, fetching new token"
+            if not self._last_token_object:
+                msg = "No token found, fetching new token"
+            logger.info(msg)
             self._last_token_object = await self._get_token(
                 self.client_id, self.client_secret
             )
+
+        if random.choices([1, 0]):
+            return "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJvcmdJZCI6Im9yZ19CbmVEdFdvdlBxWGFBMlZaIiwiaXNzIjoiaHR0cHM6Ly9hcGkuc3RnLTAxLmdldHBvcnQuaW8iLCJpc01hY2hpbmUiOnRydWUsInN1YiI6IjYwRXNvb0p0T3FpbWxla3hyTmg3bmZyMmlPZ1RjeUxaIiwianRpIjoiNjJjZDVmMDctZGM0Ni00ZTVhLTgxMzYtMDkwOTQ4MTJkZjA5IiwiaWF0IjoxNjk5NzI2NzEwLCJleHAiOjE2OTk3Mzc1MTB9.3tdkcfrX5zu4L2IBZRiidFWg3jwjyZgcU72dR7Rv5HE1"
 
         return self._last_token_object.full_token

--- a/port_ocean/clients/port/authentication.py
+++ b/port_ocean/clients/port/authentication.py
@@ -1,4 +1,3 @@
-import random
 from typing import Any
 
 import httpx

--- a/port_ocean/clients/port/client.py
+++ b/port_ocean/clients/port/client.py
@@ -8,7 +8,11 @@ from port_ocean.clients.port.mixins.migrations import MigrationClientMixin
 from port_ocean.clients.port.types import (
     KafkaCreds,
 )
-from port_ocean.clients.port.utils import handle_status_code, async_client
+from port_ocean.clients.port.utils import (
+    handle_status_code,
+    async_client,
+    retry_on_http_status,
+)
 from port_ocean.exceptions.clients import KafkaCredentialsNotFound
 
 
@@ -45,6 +49,7 @@ class PortClient(
         BlueprintClientMixin.__init__(self, self.auth, self.client)
         MigrationClientMixin.__init__(self, self.auth, self.client)
 
+    @retry_on_http_status(status_code=401)
     async def get_kafka_creds(self) -> KafkaCreds:
         logger.info("Fetching organization kafka credentials")
         response = await self.client.get(
@@ -61,6 +66,7 @@ class PortClient(
 
         return credentials
 
+    @retry_on_http_status(status_code=401)
     async def get_org_id(self) -> str:
         logger.info("Fetching organization id")
 

--- a/port_ocean/clients/port/mixins/blueprints.py
+++ b/port_ocean/clients/port/mixins/blueprints.py
@@ -5,7 +5,7 @@ from loguru import logger
 
 from port_ocean.clients.port.authentication import PortAuthentication
 from port_ocean.clients.port.types import UserAgentType
-from port_ocean.clients.port.utils import handle_status_code
+from port_ocean.clients.port.utils import handle_status_code, retry_on_http_status
 from port_ocean.core.models import Blueprint
 
 
@@ -14,6 +14,7 @@ class BlueprintClientMixin:
         self.auth = auth
         self.client = client
 
+    @retry_on_http_status(status_code=401)
     async def get_blueprint(self, identifier: str) -> Blueprint:
         logger.info(f"Fetching blueprint with id: {identifier}")
         response = await self.client.get(
@@ -23,6 +24,7 @@ class BlueprintClientMixin:
         handle_status_code(response)
         return Blueprint.parse_obj(response.json()["blueprint"])
 
+    @retry_on_http_status(status_code=401)
     async def create_blueprint(
         self,
         raw_blueprint: dict[str, Any],
@@ -37,6 +39,7 @@ class BlueprintClientMixin:
         if response.is_success:
             return response.json()["blueprint"]
 
+    @retry_on_http_status(status_code=401)
     async def patch_blueprint(
         self,
         identifier: str,
@@ -52,6 +55,7 @@ class BlueprintClientMixin:
         )
         handle_status_code(response)
 
+    @retry_on_http_status(status_code=401)
     async def delete_blueprint(
         self,
         identifier: str,
@@ -81,6 +85,7 @@ class BlueprintClientMixin:
             handle_status_code(response, should_raise)
             return response.json().get("migrationId", "")
 
+    @retry_on_http_status(status_code=401)
     async def create_action(
         self, blueprint_identifier: str, action: dict[str, Any]
     ) -> None:
@@ -93,6 +98,7 @@ class BlueprintClientMixin:
 
         handle_status_code(response)
 
+    @retry_on_http_status(status_code=401)
     async def create_scorecard(
         self,
         blueprint_identifier: str,

--- a/port_ocean/clients/port/mixins/entities.py
+++ b/port_ocean/clients/port/mixins/entities.py
@@ -5,7 +5,7 @@ from loguru import logger
 
 from port_ocean.clients.port.authentication import PortAuthentication
 from port_ocean.clients.port.types import RequestOptions, UserAgentType
-from port_ocean.clients.port.utils import handle_status_code
+from port_ocean.clients.port.utils import handle_status_code, retry_on_http_status
 from port_ocean.core.models import Entity
 
 
@@ -14,6 +14,7 @@ class EntityClientMixin:
         self.auth = auth
         self.client = client
 
+    @retry_on_http_status(status_code=401)
     async def upsert_entity(
         self,
         entity: Entity,
@@ -49,6 +50,7 @@ class EntityClientMixin:
             )
         handle_status_code(response, should_raise)
 
+    @retry_on_http_status(status_code=401)
     async def delete_entity(
         self,
         entity: Entity,
@@ -78,6 +80,7 @@ class EntityClientMixin:
 
         handle_status_code(response, should_raise)
 
+    @retry_on_http_status(status_code=401)
     async def validate_entity_exist(self, identifier: str, blueprint: str) -> None:
         logger.info(f"Validating entity {identifier} of blueprint {blueprint} exists")
 
@@ -93,6 +96,7 @@ class EntityClientMixin:
             )
         handle_status_code(response)
 
+    @retry_on_http_status(status_code=401)
     async def search_entities(self, user_agent_type: UserAgentType) -> list[Entity]:
         query = {
             "combinator": "and",
@@ -118,6 +122,7 @@ class EntityClientMixin:
         handle_status_code(response)
         return [Entity.parse_obj(result) for result in response.json()["entities"]]
 
+    @retry_on_http_status(status_code=401)
     async def search_dependent_entities(self, entity: Entity) -> list[Entity]:
         body = {
             "combinator": "and",
@@ -141,6 +146,7 @@ class EntityClientMixin:
 
         return [Entity.parse_obj(result) for result in response.json()["entities"]]
 
+    @retry_on_http_status(status_code=401)
     async def validate_entity_payload(
         self, entity: Entity, options: RequestOptions
     ) -> None:

--- a/port_ocean/clients/port/mixins/integrations.py
+++ b/port_ocean/clients/port/mixins/integrations.py
@@ -5,7 +5,7 @@ from loguru import logger
 from starlette import status
 
 from port_ocean.clients.port.authentication import PortAuthentication
-from port_ocean.clients.port.utils import handle_status_code
+from port_ocean.clients.port.utils import handle_status_code, retry_on_http_status
 
 if TYPE_CHECKING:
     from port_ocean.core.handlers.port_app_config.models import PortAppConfig
@@ -32,6 +32,7 @@ class IntegrationClientMixin:
         )
         return response
 
+    @retry_on_http_status(status_code=401)
     async def get_current_integration(
         self, should_raise: bool = True, should_log: bool = True
     ) -> dict[str, Any]:
@@ -39,6 +40,7 @@ class IntegrationClientMixin:
         handle_status_code(response, should_raise, should_log)
         return response.json()["integration"]
 
+    @retry_on_http_status(status_code=401)
     async def create_integration(
         self,
         _type: str,
@@ -61,6 +63,7 @@ class IntegrationClientMixin:
         )
         handle_status_code(response)
 
+    @retry_on_http_status(status_code=401)
     async def patch_integration(
         self,
         _type: str | None = None,
@@ -85,6 +88,7 @@ class IntegrationClientMixin:
         )
         handle_status_code(response)
 
+    @retry_on_http_status(status_code=401)
     async def initialize_integration(
         self,
         _type: str,

--- a/port_ocean/clients/port/utils.py
+++ b/port_ocean/clients/port/utils.py
@@ -5,13 +5,20 @@ import httpx
 from loguru import logger
 from werkzeug.local import LocalStack, LocalProxy
 
+from port_ocean.helpers.retry import RetryTransport
+
 _http_client: LocalStack[httpx.AsyncClient] = LocalStack()
 
 
 def _get_http_client_context() -> httpx.AsyncClient:
     client = _http_client.top
     if client is None:
-        client = httpx.AsyncClient()
+        client = httpx.AsyncClient(
+            transport=RetryTransport(
+                httpx.AsyncHTTPTransport(),
+                logger=logger,
+            )
+        )
         _http_client.push(client)
 
     return client

--- a/port_ocean/clients/port/utils.py
+++ b/port_ocean/clients/port/utils.py
@@ -1,3 +1,6 @@
+from functools import wraps
+from typing import Callable, Any
+
 import httpx
 from loguru import logger
 from werkzeug.local import LocalStack, LocalProxy
@@ -26,3 +29,44 @@ def handle_status_code(
         )
     if should_raise:
         response.raise_for_status()
+
+
+def retry_on_http_status(
+    status_code: int,
+    max_retries: int = 2,
+    verbose: bool = True,
+) -> Callable[..., Callable[..., Any]]:
+    """
+    Decorator to retry a function if it raises a httpx.HTTPStatusError with a given status code
+    :param status_code: The status code to retry on
+    :param max_retries: The maximum number of retries
+    :param verbose: Whether to log retries
+    """
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        @wraps(func)
+        async def wrapper(*args, **kwargs) -> Any:  # type: ignore
+            retries = 0
+            while retries < max_retries:
+                try:
+                    result = await func(*args, **kwargs)
+                    return result
+                except httpx.HTTPStatusError as err:
+                    if err.response.status_code == status_code:
+                        retries += 1
+                        if retries < max_retries:
+                            if verbose:
+                                logger.warning(
+                                    f"Retrying {func.__name__} after {status_code} error. Retry {retries}/{max_retries}"
+                                )
+                        else:
+                            logger.error(
+                                f"Reached max retries {max_retries} for {func.__name__} after {status_code} error"
+                            )
+                            raise
+                    else:
+                        raise
+
+        return wrapper
+
+    return decorator

--- a/port_ocean/helpers/retry.py
+++ b/port_ocean/helpers/retry.py
@@ -218,12 +218,13 @@ class RetryTransport(httpx.AsyncBaseTransport, httpx.BaseTransport):
         remaining_attempts = self._max_attempts
         attempts_made = 0
         while True:
+            response: httpx.Response
             if attempts_made > 0:
                 sleep_time = self._calculate_sleep(attempts_made, {})
                 if self._logger:
                     self._logger.warning(
                         f"Request {request.method} {request.url} failed with status code:"
-                        f" {response.status_code}, retrying in {sleep_time} seconds."  # type: ignore
+                        f" {response.status_code}, retrying in {sleep_time} seconds."  # noqa: F821
                     )
                 await asyncio.sleep(sleep_time)
             response = await send_method(request)
@@ -244,12 +245,13 @@ class RetryTransport(httpx.AsyncBaseTransport, httpx.BaseTransport):
         remaining_attempts = self._max_attempts
         attempts_made = 0
         while True:
+            response: httpx.Response
             if attempts_made > 0:
                 sleep_time = self._calculate_sleep(attempts_made, {})
                 if self._logger:
                     self._logger.warning(
                         f"Request {request.method} {request.url} failed with status code:"
-                        f" {response.status_code}, retrying in {sleep_time} seconds."  # type: ignore
+                        f" {response.status_code}, retrying in {sleep_time} seconds."  # noqa: F821
                     )
                 time.sleep(sleep_time)
             response = send_method(request)

--- a/port_ocean/helpers/retry.py
+++ b/port_ocean/helpers/retry.py
@@ -132,7 +132,7 @@ class RetryTransport(httpx.AsyncBaseTransport, httpx.BaseTransport):
             httpx.Response: The response received.
 
         """
-        transport: httpx.BaseTransport = self._wrapped_transport
+        transport: httpx.BaseTransport = self._wrapped_transport  # type: ignore
         if request.method in self._retryable_methods:
             send_method = partial(transport.handle_request)
             response = self._retry_operation(request, send_method)
@@ -150,7 +150,7 @@ class RetryTransport(httpx.AsyncBaseTransport, httpx.BaseTransport):
             The response.
 
         """
-        transport: httpx.AsyncBaseTransport = self._wrapped_transport
+        transport: httpx.AsyncBaseTransport = self._wrapped_transport  # type: ignore
         if request.method in self._retryable_methods:
             send_method = partial(transport.handle_async_request)
             response = await self._retry_operation_async(request, send_method)
@@ -165,7 +165,7 @@ class RetryTransport(httpx.AsyncBaseTransport, httpx.BaseTransport):
 
         This should be called before the object is dereferenced, to ensure that connections are properly cleaned up.
         """
-        transport: httpx.AsyncBaseTransport = self._wrapped_transport
+        transport: httpx.AsyncBaseTransport = self._wrapped_transport  # type: ignore
         await transport.aclose()
 
     def close(self) -> None:
@@ -175,7 +175,7 @@ class RetryTransport(httpx.AsyncBaseTransport, httpx.BaseTransport):
 
         This should be called before the object is dereferenced, to ensure that connections are properly cleaned up.
         """
-        transport: httpx.BaseTransport = self._wrapped_transport
+        transport: httpx.BaseTransport = self._wrapped_transport  # type: ignore
         transport.close()
 
     def _calculate_sleep(

--- a/port_ocean/helpers/retry.py
+++ b/port_ocean/helpers/retry.py
@@ -1,0 +1,248 @@
+import asyncio
+import random
+import time
+from datetime import datetime
+from functools import partial
+from http import HTTPStatus
+from typing import Any, Callable, Coroutine, Iterable, Mapping, Union
+
+import httpx
+from dateutil.parser import isoparse
+
+
+# Adapted from https://github.com/encode/httpx/issues/108#issuecomment-1434439481
+class RetryTransport(httpx.AsyncBaseTransport, httpx.BaseTransport):
+    """
+    A custom HTTP transport that automatically retries requests using an exponential backoff strategy
+    for specific HTTP status codes and request methods.
+
+    Args:
+        wrapped_transport (Union[httpx.BaseTransport, httpx.AsyncBaseTransport]): The underlying HTTP transport
+            to wrap and use for making requests.
+        max_attempts (int, optional): The maximum number of times to retry a request before giving up. Defaults to 10.
+        max_backoff_wait (float, optional): The maximum time to wait between retries in seconds. Defaults to 60.
+        backoff_factor (float, optional): The factor by which the wait time increases with each retry attempt.
+            Defaults to 0.1.
+        jitter_ratio (float, optional): The amount of jitter to add to the backoff time. Jitter is a random
+            value added to the backoff time to avoid a "thundering herd" effect. The value should be between 0 and 0.5.
+            Defaults to 0.1.
+        respect_retry_after_header (bool, optional): Whether to respect the Retry-After header in HTTP responses
+            when deciding how long to wait before retrying. Defaults to True.
+        retryable_methods (Iterable[str], optional): The HTTP methods that can be retried. Defaults to
+            ["HEAD", "GET", "PUT", "DELETE", "OPTIONS", "TRACE"].
+        retry_status_codes (Iterable[int], optional): The HTTP status codes that can be retried. Defaults to
+            [429, 502, 503, 504].
+
+    Attributes:
+        _wrapped_transport (Union[httpx.BaseTransport, httpx.AsyncBaseTransport]): The underlying HTTP transport
+            being wrapped.
+        _max_attempts (int): The maximum number of times to retry a request.
+        _backoff_factor (float): The factor by which the wait time increases with each retry attempt.
+        _respect_retry_after_header (bool): Whether to respect the Retry-After header in HTTP responses.
+        _retryable_methods (frozenset): The HTTP methods that can be retried.
+        _retry_status_codes (frozenset): The HTTP status codes that can be retried.
+        _jitter_ratio (float): The amount of jitter to add to the backoff time.
+        _max_backoff_wait (float): The maximum time to wait between retries in seconds.
+
+    """
+
+    RETRYABLE_METHODS = frozenset(["HEAD", "GET", "PUT", "DELETE", "OPTIONS", "TRACE"])
+    RETRYABLE_STATUS_CODES = frozenset(
+        [
+            HTTPStatus.TOO_MANY_REQUESTS,
+            HTTPStatus.BAD_GATEWAY,
+            HTTPStatus.SERVICE_UNAVAILABLE,
+            HTTPStatus.GATEWAY_TIMEOUT,
+        ]
+    )
+    MAX_BACKOFF_WAIT = 60
+
+    def __init__(
+        self,
+        wrapped_transport: Union[httpx.BaseTransport, httpx.AsyncBaseTransport],
+        max_attempts: int = 10,
+        max_backoff_wait: float = MAX_BACKOFF_WAIT,
+        backoff_factor: float = 0.1,
+        jitter_ratio: float = 0.1,
+        respect_retry_after_header: bool = True,
+        retryable_methods: Iterable[str] | None = None,
+        retry_status_codes: Iterable[int] | None = None,
+    ) -> None:
+        """
+        Initializes the instance of RetryTransport class with the given parameters.
+
+        Args:
+            wrapped_transport (Union[httpx.BaseTransport, httpx.AsyncBaseTransport]):
+                The transport layer that will be wrapped and retried upon failure.
+            max_attempts (int, optional):
+                The maximum number of times the request can be retried in case of failure.
+                Defaults to 10.
+            max_backoff_wait (float, optional):
+                The maximum amount of time (in seconds) to wait before retrying a request.
+                Defaults to 60.
+            backoff_factor (float, optional):
+                The factor by which the waiting time will be multiplied in each retry attempt.
+                Defaults to 0.1.
+            jitter_ratio (float, optional):
+                The ratio of randomness added to the waiting time to prevent simultaneous retries.
+                Should be between 0 and 0.5. Defaults to 0.1.
+            respect_retry_after_header (bool, optional):
+                A flag to indicate if the Retry-After header should be respected.
+                If True, the waiting time specified in Retry-After header is used for the waiting time.
+                Defaults to True.
+            retryable_methods (Iterable[str], optional):
+                The HTTP methods that can be retried. Defaults to ['HEAD', 'GET', 'PUT', 'DELETE', 'OPTIONS', 'TRACE'].
+            retry_status_codes (Iterable[int], optional):
+                The HTTP status codes that can be retried.
+                Defaults to [429, 502, 503, 504].
+        """
+        self._wrapped_transport = wrapped_transport
+        if jitter_ratio < 0 or jitter_ratio > 0.5:
+            raise ValueError(
+                f"Jitter ratio should be between 0 and 0.5, actual {jitter_ratio}"
+            )
+
+        self._max_attempts = max_attempts
+        self._backoff_factor = backoff_factor
+        self._respect_retry_after_header = respect_retry_after_header
+        self._retryable_methods = (
+            frozenset(retryable_methods)
+            if retryable_methods
+            else self.RETRYABLE_METHODS
+        )
+        self._retry_status_codes = (
+            frozenset(retry_status_codes)
+            if retry_status_codes
+            else self.RETRYABLE_STATUS_CODES
+        )
+        self._jitter_ratio = jitter_ratio
+        self._max_backoff_wait = max_backoff_wait
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        """
+        Sends an HTTP request, possibly with retries.
+
+        Args:
+            request (httpx.Request): The request to send.
+
+        Returns:
+            httpx.Response: The response received.
+
+        """
+        transport: httpx.BaseTransport = self._wrapped_transport
+        if request.method in self._retryable_methods:
+            send_method = partial(transport.handle_request)
+            response = self._retry_operation(request, send_method)
+        else:
+            response = transport.handle_request(request)
+        return response
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        """Sends an HTTP request, possibly with retries.
+
+        Args:
+            request: The request to perform.
+
+        Returns:
+            The response.
+
+        """
+        transport: httpx.AsyncBaseTransport = self._wrapped_transport
+        if request.method in self._retryable_methods:
+            send_method = partial(transport.handle_async_request)
+            response = await self._retry_operation_async(request, send_method)
+        else:
+            response = await transport.handle_async_request(request)
+        return response
+
+    async def aclose(self) -> None:
+        """
+        Closes the underlying HTTP transport, terminating all outstanding connections and rejecting any further
+        requests.
+
+        This should be called before the object is dereferenced, to ensure that connections are properly cleaned up.
+        """
+        transport: httpx.AsyncBaseTransport = self._wrapped_transport
+        await transport.aclose()
+
+    def close(self) -> None:
+        """
+        Closes the underlying HTTP transport, terminating all outstanding connections and rejecting any further
+        requests.
+
+        This should be called before the object is dereferenced, to ensure that connections are properly cleaned up.
+        """
+        transport: httpx.BaseTransport = self._wrapped_transport
+        transport.close()
+
+    def _calculate_sleep(
+        self, attempts_made: int, headers: Union[httpx.Headers, Mapping[str, str]]
+    ) -> float:
+        # Retry-After
+        # The Retry-After response HTTP header indicates how long the user agent should wait before
+        # making a follow-up request. There are three main cases this header is used:
+        # - When sent with a 503 (Service Unavailable) response, this indicates how long the service
+        #   is expected to be unavailable.
+        # - When sent with a 429 (Too Many Requests) response, this indicates how long to wait before
+        #   making a new request.
+        # - When sent with a redirect response, such as 301 (Moved Permanently), this indicates the
+        #   minimum time that the user agent is asked to wait before issuing the redirected request.
+        retry_after_header = (headers.get("Retry-After") or "").strip()
+        if self._respect_retry_after_header and retry_after_header:
+            if retry_after_header.isdigit():
+                return float(retry_after_header)
+
+            try:
+                parsed_date = isoparse(
+                    retry_after_header
+                ).astimezone()  # converts to local time
+                diff = (parsed_date - datetime.now().astimezone()).total_seconds()
+                if diff > 0:
+                    return min(diff, self._max_backoff_wait)
+            except ValueError:
+                pass
+
+        backoff = self._backoff_factor * (2 ** (attempts_made - 1))
+        jitter = (backoff * self._jitter_ratio) * random.choice([1, -1])
+        total_backoff = backoff + jitter
+        return min(total_backoff, self._max_backoff_wait)
+
+    async def _retry_operation_async(
+        self,
+        request: httpx.Request,
+        send_method: Callable[..., Coroutine[Any, Any, httpx.Response]],
+    ) -> httpx.Response:
+        remaining_attempts = self._max_attempts
+        attempts_made = 0
+        while True:
+            if attempts_made > 0:
+                await asyncio.sleep(self._calculate_sleep(attempts_made, {}))
+            response = await send_method(request)
+            if (
+                remaining_attempts < 1
+                or response.status_code not in self._retry_status_codes
+            ):
+                return response
+            await response.aclose()
+            attempts_made += 1
+            remaining_attempts -= 1
+
+    def _retry_operation(
+        self,
+        request: httpx.Request,
+        send_method: Callable[..., httpx.Response],
+    ) -> httpx.Response:
+        remaining_attempts = self._max_attempts
+        attempts_made = 0
+        while True:
+            if attempts_made > 0:
+                time.sleep(self._calculate_sleep(attempts_made, {}))
+            response = send_method(request)
+            if (
+                remaining_attempts < 1
+                or response.status_code not in self._retry_status_codes
+            ):
+                return response
+            response.close()
+            attempts_made += 1
+            remaining_attempts -= 1

--- a/port_ocean/helpers/retry.py
+++ b/port_ocean/helpers/retry.py
@@ -7,7 +7,7 @@ from http import HTTPStatus
 from typing import Any, Callable, Coroutine, Iterable, Mapping, Union
 
 import httpx
-from dateutil.parser import isoparse
+from dateutil.parser import isoparse  # type: ignore
 
 
 # Adapted from https://github.com/encode/httpx/issues/108#issuecomment-1434439481

--- a/port_ocean/utils.py
+++ b/port_ocean/utils.py
@@ -114,12 +114,13 @@ def repeat_every(
                 if wait_first:
                     await asyncio.sleep(seconds)
                 while max_repetitions is None or repetitions < max_repetitions:
+                    # count the repetition even if an exception is raised
+                    repetitions += 1
                     try:
                         if is_coroutine:
                             await func()  # type: ignore
                         else:
                             await run_in_threadpool(func)
-                        repetitions += 1
                     except Exception as exc:
                         formatted_exception = "".join(
                             format_exception(type(exc), exc, exc.__traceback__)


### PR DESCRIPTION
# Description

- Add retry decorator on 401 for requests against Port ( reason we don't use the HTTPX Retry Class in this case is because we need to re-run the `token` property that re-initializes the token )
- Add HTTPX retry client, both for port client as well as for integrations to use to handle different http errors, for better durability  - #224  uses implementation from - https://github.com/encode/httpx/issues/108#issuecomment-1434439481
- Fix `repeat_every` to calculate failed as repetition runs as well ( For Once Event Listener )


## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

