### PR TITLE
changed params body of get_oncall_user

### DIFF
--- a/integrations/pagerduty/clients/pagerduty.py
+++ b/integrations/pagerduty/clients/pagerduty.py
@@ -157,7 +157,7 @@ class PagerDutyClient:
             f"Fetching who is oncall for escalation poilices: {','.join(escalation_policy_ids)}"
         )
         params = {
-            "escalation_policy_ids[]": ",".join(escalation_policy_ids),
+            "escalation_policy_ids[]": escalation_policy_ids,
             "include[]": "users",
         }
         oncalls = []


### PR DESCRIPTION
# Description

What - Changed how the params json is structured in the get_oncall_user function
Why - The parsing was incorrect, and made the API call not work for multiple escalation policy id's
How - by removing the ", + join" from the escalation_policy_id, the url is being structured correctly.

## Type of change

Please leave one option from the following and delete the rest:

- [*] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

