### PR TITLE
Port 5610 fix ci failing for non existing image

### DIFF
--- a/.github/workflows/release-integrations.yml
+++ b/.github/workflows/release-integrations.yml
@@ -34,6 +34,7 @@ jobs:
             version=$(grep -E '^version = ".*"' "$folder/../pyproject.toml" | cut -d'"' -f2)
 
             # Check if the version exists in the ghcr.io registry
+            rc=0
             docker manifest inspect ghcr.io/port-labs/port-ocean-$type:$version > /dev/null 2>&1 || rc=$?
 
             if [ $rc -eq 0 ]; then

--- a/.github/workflows/release-integrations.yml
+++ b/.github/workflows/release-integrations.yml
@@ -34,8 +34,7 @@ jobs:
             version=$(grep -E '^version = ".*"' "$folder/../pyproject.toml" | cut -d'"' -f2)
 
             # Check if the version exists in the ghcr.io registry
-            docker manifest inspect ghcr.io/port-labs/port-ocean-$type:$version > /dev/null 2>&1
-            rc=$?
+            docker manifest inspect ghcr.io/port-labs/port-ocean-$type:$version > /dev/null 2>&1 || rc=$?
 
             if [ $rc -eq 0 ]; then
               echo "Image already exists in $repository: port-ocean-$type:$version"


### PR DESCRIPTION
# Description

What - The CD for integration fails after changing the flow
Why - Failure when handling exit code for docker inspect command
How - better handling

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
