### PR TITLE
PORT-5711-replace-poetry-lock-check-with-the-new-poetry-check-lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,6 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
-## 0.4.10 (2023-12-20)
-
-
-### Improvements
-
-- Changed deprecated `poetry lock --check` in the make files to `poetry check --lock`
-
 
 ## 0.4.9 (2023-12-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.4.10 (2023-12-20)
+
+
+### Improvements
+
+- Changed deprecated `poetry lock --check` in the make files to `poetry check --lock`
+
+
+## 0.4.9 (2023-12-19)
+
+
+### Improvements
+
+- Added a way to create the integration without the Dockerfile and .dockerignore to use the global Docker files when scaffolding a new integration.
+
+
 ## 0.4.8 (2023-12-13)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
-
 ## 0.4.9 (2023-12-19)
 
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ define run_checks
 	exit_code=0; \
 	cd $1; \
 	poetry check || exit_code=$$?;\
-  	poetry check --lock || exit_code=$$?;\
 	mypy . --exclude '/\.venv/' || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ define run_checks
 	exit_code=0; \
 	cd $1; \
 	poetry check || exit_code=$$?;\
-  	poetry lock --check || exit_code=$$?;\
+  	poetry check --lock || exit_code=$$?;\
 	mypy . --exclude '/\.venv/' || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/changelog/PORT-5453.improvement.md
+++ b/changelog/PORT-5453.improvement.md
@@ -1,7 +1,0 @@
-Added a way to create the integration without the Dockerfile and .dockerignore to use the global Docker files when scaffolding a new integration.
-
-
-
-
-
-

--- a/changelog/PORT-5711.improvement.md
+++ b/changelog/PORT-5711.improvement.md
@@ -1,0 +1,1 @@
+Changed deprecated poetry.lock is consistent with pyproject.toml. in the make files to All set!

--- a/changelog/PORT-5711.improvement.md
+++ b/changelog/PORT-5711.improvement.md
@@ -1,1 +1,1 @@
-Changed deprecated poetry.lock is consistent with pyproject.toml. in the make files to All set!
+Changed deprecated `poetry lock --check` in the make files to `poetry check`

--- a/docs/framework-guides/docs/develop-an-integration/publish-an-integration.md
+++ b/docs/framework-guides/docs/develop-an-integration/publish-an-integration.md
@@ -18,7 +18,6 @@ This guide assumes that you already went through the [quickstart](../getting-sta
   - `mypy` for type checking.
   - `ruff` for code quality analysis.
   - `poetry check` for dependency checks.
-  - `poetry lock` to update the `pyproject.toml` file.
 
 :::note
 

--- a/integrations/argocd/Makefile
+++ b/integrations/argocd/Makefile
@@ -4,7 +4,6 @@ define run_checks
 	exit_code=0; \
 	cd $1; \
 	poetry check || exit_code=$$?;\
-  	poetry check --lock || exit_code=$$?;\
 	mypy . || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/integrations/argocd/Makefile
+++ b/integrations/argocd/Makefile
@@ -4,7 +4,7 @@ define run_checks
 	exit_code=0; \
 	cd $1; \
 	poetry check || exit_code=$$?;\
-  	poetry lock --check || exit_code=$$?;\
+  	poetry check --lock || exit_code=$$?;\
 	mypy . || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/integrations/azure/Makefile
+++ b/integrations/azure/Makefile
@@ -4,7 +4,6 @@ define run_checks
 	exit_code=0; \
 	cd $1; \
 	poetry check || exit_code=$$?;\
-  	poetry check --lock || exit_code=$$?;\
 	mypy . || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/integrations/azure/Makefile
+++ b/integrations/azure/Makefile
@@ -4,7 +4,7 @@ define run_checks
 	exit_code=0; \
 	cd $1; \
 	poetry check || exit_code=$$?;\
-  	poetry lock --check || exit_code=$$?;\
+  	poetry check --lock || exit_code=$$?;\
 	mypy . || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/integrations/firehydrant/Makefile
+++ b/integrations/firehydrant/Makefile
@@ -4,7 +4,6 @@ define run_checks
 	exit_code=0; \
 	cd $1; \
 	poetry check || exit_code=$$?;\
-  	poetry check --lock || exit_code=$$?;\
 	mypy . || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/integrations/firehydrant/Makefile
+++ b/integrations/firehydrant/Makefile
@@ -4,7 +4,7 @@ define run_checks
 	exit_code=0; \
 	cd $1; \
 	poetry check || exit_code=$$?;\
-  	poetry lock --check || exit_code=$$?;\
+  	poetry check --lock || exit_code=$$?;\
 	mypy . || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/integrations/gitlab/Makefile
+++ b/integrations/gitlab/Makefile
@@ -4,7 +4,6 @@ define run_checks
 	exit_code=0; \
 	cd $1; \
 	poetry check || exit_code=$$?;\
-  	poetry check --lock || exit_code=$$?;\
 	mypy . || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/integrations/gitlab/Makefile
+++ b/integrations/gitlab/Makefile
@@ -4,7 +4,7 @@ define run_checks
 	exit_code=0; \
 	cd $1; \
 	poetry check || exit_code=$$?;\
-  	poetry lock --check || exit_code=$$?;\
+  	poetry check --lock || exit_code=$$?;\
 	mypy . || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/integrations/jira/Makefile
+++ b/integrations/jira/Makefile
@@ -4,7 +4,7 @@ define run_checks
 	exit_code=0; \
 	cd $1; \
 	poetry check || exit_code=$$?;\
-  	poetry lock --check || exit_code=$$?;\
+  	poetry check --lock || exit_code=$$?;\
 	mypy . --exclude .venv || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/integrations/jira/Makefile
+++ b/integrations/jira/Makefile
@@ -4,7 +4,6 @@ define run_checks
 	exit_code=0; \
 	cd $1; \
 	poetry check || exit_code=$$?;\
-  	poetry check --lock || exit_code=$$?;\
 	mypy . --exclude .venv || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/integrations/kafka/Makefile
+++ b/integrations/kafka/Makefile
@@ -4,7 +4,6 @@ define run_checks
 	exit_code=0; \
 	cd $1; \
 	poetry check || exit_code=$$?;\
-  	poetry check --lock || exit_code=$$?;\
 	mypy . || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/integrations/kafka/Makefile
+++ b/integrations/kafka/Makefile
@@ -4,7 +4,7 @@ define run_checks
 	exit_code=0; \
 	cd $1; \
 	poetry check || exit_code=$$?;\
-  	poetry lock --check || exit_code=$$?;\
+  	poetry check --lock || exit_code=$$?;\
 	mypy . || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/integrations/kubecost/Makefile
+++ b/integrations/kubecost/Makefile
@@ -4,7 +4,6 @@ define run_checks
 	exit_code=0; \
 	cd $1; \
 	poetry check || exit_code=$$?;\
-  	poetry check --lock || exit_code=$$?;\
 	mypy . || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/integrations/kubecost/Makefile
+++ b/integrations/kubecost/Makefile
@@ -4,7 +4,7 @@ define run_checks
 	exit_code=0; \
 	cd $1; \
 	poetry check || exit_code=$$?;\
-  	poetry lock --check || exit_code=$$?;\
+  	poetry check --lock || exit_code=$$?;\
 	mypy . || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/integrations/newrelic/Makefile
+++ b/integrations/newrelic/Makefile
@@ -4,7 +4,6 @@ define run_checks
 	exit_code=0; \
 	cd $1; \
 	poetry check || exit_code=$$?;\
-  	poetry check --lock || exit_code=$$?;\
 	mypy . || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/integrations/newrelic/Makefile
+++ b/integrations/newrelic/Makefile
@@ -4,7 +4,7 @@ define run_checks
 	exit_code=0; \
 	cd $1; \
 	poetry check || exit_code=$$?;\
-  	poetry lock --check || exit_code=$$?;\
+  	poetry check --lock || exit_code=$$?;\
 	mypy . || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/integrations/opencost/Makefile
+++ b/integrations/opencost/Makefile
@@ -3,8 +3,7 @@ ACTIVATE := . .venv/bin/activate
 define run_checks
 	exit_code=0; \
 	cd $1; \
-	poetry check || exit_code=$$?;\
-  	poetry check --lock || exit_code=$$?;\
+  	poetry check || exit_code=$$?;\
 	mypy . || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/integrations/opencost/Makefile
+++ b/integrations/opencost/Makefile
@@ -4,7 +4,7 @@ define run_checks
 	exit_code=0; \
 	cd $1; \
 	poetry check || exit_code=$$?;\
-  	poetry lock --check || exit_code=$$?;\
+  	poetry check --lock || exit_code=$$?;\
 	mypy . || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/integrations/opsgenie/Makefile
+++ b/integrations/opsgenie/Makefile
@@ -4,7 +4,6 @@ define run_checks
 	exit_code=0; \
 	cd $1; \
 	poetry check || exit_code=$$?;\
-  	poetry check --lock || exit_code=$$?;\
 	mypy . || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/integrations/opsgenie/Makefile
+++ b/integrations/opsgenie/Makefile
@@ -4,7 +4,7 @@ define run_checks
 	exit_code=0; \
 	cd $1; \
 	poetry check || exit_code=$$?;\
-  	poetry lock --check || exit_code=$$?;\
+  	poetry check --lock || exit_code=$$?;\
 	mypy . || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/integrations/pagerduty/Makefile
+++ b/integrations/pagerduty/Makefile
@@ -4,7 +4,6 @@ define run_checks
 	exit_code=0; \
 	cd $1; \
 	poetry check || exit_code=$$?;\
-  	poetry check --lock || exit_code=$$?;\
 	mypy . || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/integrations/pagerduty/Makefile
+++ b/integrations/pagerduty/Makefile
@@ -4,7 +4,7 @@ define run_checks
 	exit_code=0; \
 	cd $1; \
 	poetry check || exit_code=$$?;\
-  	poetry lock --check || exit_code=$$?;\
+  	poetry check --lock || exit_code=$$?;\
 	mypy . || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/integrations/sentry/Makefile
+++ b/integrations/sentry/Makefile
@@ -4,7 +4,6 @@ define run_checks
 	exit_code=0; \
 	cd $1; \
 	poetry check || exit_code=$$?;\
-  	poetry check --lock || exit_code=$$?;\
 	mypy . || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/integrations/sentry/Makefile
+++ b/integrations/sentry/Makefile
@@ -4,7 +4,7 @@ define run_checks
 	exit_code=0; \
 	cd $1; \
 	poetry check || exit_code=$$?;\
-  	poetry lock --check || exit_code=$$?;\
+  	poetry check --lock || exit_code=$$?;\
 	mypy . || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/integrations/servicenow/Makefile
+++ b/integrations/servicenow/Makefile
@@ -4,7 +4,6 @@ define run_checks
 	exit_code=0; \
 	cd $1; \
 	poetry check || exit_code=$$?;\
-  	poetry check --lock || exit_code=$$?;\
 	mypy . || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/integrations/servicenow/Makefile
+++ b/integrations/servicenow/Makefile
@@ -4,7 +4,7 @@ define run_checks
 	exit_code=0; \
 	cd $1; \
 	poetry check || exit_code=$$?;\
-  	poetry lock --check || exit_code=$$?;\
+  	poetry check --lock || exit_code=$$?;\
 	mypy . || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/integrations/snyk/Makefile
+++ b/integrations/snyk/Makefile
@@ -4,7 +4,6 @@ define run_checks
 	exit_code=0; \
 	cd $1; \
 	poetry check || exit_code=$$?;\
-  	poetry check --lock || exit_code=$$?;\
 	mypy . || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/integrations/snyk/Makefile
+++ b/integrations/snyk/Makefile
@@ -4,7 +4,7 @@ define run_checks
 	exit_code=0; \
 	cd $1; \
 	poetry check || exit_code=$$?;\
-  	poetry lock --check || exit_code=$$?;\
+  	poetry check --lock || exit_code=$$?;\
 	mypy . || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/integrations/sonarqube/Makefile
+++ b/integrations/sonarqube/Makefile
@@ -4,7 +4,6 @@ define run_checks
 	exit_code=0; \
 	cd $1; \
 	poetry check || exit_code=$$?;\
-  	poetry check --lock || exit_code=$$?;\
 	mypy . || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/integrations/sonarqube/Makefile
+++ b/integrations/sonarqube/Makefile
@@ -4,7 +4,7 @@ define run_checks
 	exit_code=0; \
 	cd $1; \
 	poetry check || exit_code=$$?;\
-  	poetry lock --check || exit_code=$$?;\
+  	poetry check --lock || exit_code=$$?;\
 	mypy . || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/port_ocean/cli/cookiecutter/{{cookiecutter.integration_slug}}/Makefile
+++ b/port_ocean/cli/cookiecutter/{{cookiecutter.integration_slug}}/Makefile
@@ -4,7 +4,6 @@ define run_checks
 	exit_code=0; \
 	cd $1; \
 	poetry check || exit_code=$$?;\
-  	poetry check --lock || exit_code=$$?;\
 	mypy . || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/port_ocean/cli/cookiecutter/{{cookiecutter.integration_slug}}/Makefile
+++ b/port_ocean/cli/cookiecutter/{{cookiecutter.integration_slug}}/Makefile
@@ -4,7 +4,7 @@ define run_checks
 	exit_code=0; \
 	cd $1; \
 	poetry check || exit_code=$$?;\
-  	poetry lock --check || exit_code=$$?;\
+  	poetry check --lock || exit_code=$$?;\
 	mypy . || exit_code=$$?; \
 	ruff . || exit_code=$$?; \
 	black --check . || exit_code=$$?; \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.4.9"
+version = "0.4.10"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.4.10"
+version = "0.4.9"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What - Swapped `poetry lock --check` with `poetry check --lock`
Why - `poetry lock --check` is deprecated

## Type of change

- [X] Non-breaking change (fix of existing functionality that will not change current behavior)

