### PR TITLE
Support creation of blueprints with aggregation properties & Change entity from optional to required in port app config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Improvements
 
 - Added handling for aggregation properties when initializing the integration, so it will patch the aggregation properties after creating the relations (PORT-5717)
+- Changed entity property in the `portResourceConfig` to be required instead of optional, as we don't support creation of blueprints as part of the app config (PORT-4549) 
 
 
 ## 0.4.10 (2023-12-21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.4.11 (2023-12-21)
+
+### Improvements
+
+- Added handling for aggregation properties when initializing the integration, so it will patch the aggregation properties after creating the relations (PORT-5717)
+
+
 ## 0.4.10 (2023-12-21)
 
 

--- a/port_ocean/clients/port/mixins/entities.py
+++ b/port_ocean/clients/port/mixins/entities.py
@@ -101,7 +101,7 @@ class EntityClientMixin:
             if response.is_error:
                 if response.status_code == 404:
                     logger.info(
-                        f"Weren't able to delete entity: {entity.identifier} of blueprint: {entity.blueprint},"
+                        f"Failed to delete entity: {entity.identifier} of blueprint: {entity.blueprint},"
                         f" as it was already deleted from port"
                     )
                     return

--- a/port_ocean/core/defaults/initialize.py
+++ b/port_ocean/core/defaults/initialize.py
@@ -33,6 +33,7 @@ def deconstruct_blueprints_to_creation_steps(
 
         blueprint.pop("calculationProperties", {})
         blueprint.pop("mirrorProperties", {})
+        blueprint.pop("aggregationProperties", {})
         with_relations.append(blueprint.copy())
 
         blueprint.pop("teamInheritance", {})

--- a/port_ocean/core/handlers/port_app_config/models.py
+++ b/port_ocean/core/handlers/port_app_config/models.py
@@ -17,7 +17,7 @@ class PortResourceConfig(BaseModel):
     class MappingsConfig(BaseModel):
         mappings: EntityMapping
 
-    entity: Optional[MappingsConfig]
+    entity: MappingsConfig
 
 
 class Selector(BaseModel):

--- a/port_ocean/core/handlers/port_app_config/models.py
+++ b/port_ocean/core/handlers/port_app_config/models.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any
+from typing import Any
 
 from pydantic import BaseModel, Field
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.4.10"
+version = "0.4.11"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What - 
- Added handling for aggregation properties when initializing the integration, so it will patch the aggregation properties after creating the relations (PORT-5717)
- Changed entity property in the `portResourceConfig` to be required instead of optional, as we don't support creation of blueprints as part of the app config (PORT-4549) 
- Fixed port merge cr comments in #279  

Why -
- It was failing to create blueprints with aggregation properties due to the order in which we create the blueprints
- There is no need for it any more, and it was causing integration to use `# type ignore` as it was relying on the entity to exist in the port app config

How -
- added the aggregation properties to be patched after relations are being created
- removed optional

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

