### PR TITLE
checking fork

### DIFF
--- a/.github/workflows/validate-integration-files.yml
+++ b/.github/workflows/validate-integration-files.yml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Setup
       run: |
-        pip install toml-cli yq
+        pip install toml-cli yq packaging
 
     - name: Check Ocean version 🌊
       run: |

--- a/.github/workflows/validate-integration-files.yml
+++ b/.github/workflows/validate-integration-files.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: Check Ocean version 🌊
       run: |
-        git remote add ocean-origin git@github.com:port-labs/ocean.git
+        git remote add ocean-origin https://github.com/port-labs/ocean.git
         git fetch ocean-origin
         changed_dirs=$(git diff --name-only ocean-origin/main HEAD | grep 'integrations/' | cut -d'/' -f 1,2 | sort -u)
         package_version=$(curl -s https://pypi.org/pypi/port-ocean/json | jq -r '.info.version')

--- a/.github/workflows/validate-integration-files.yml
+++ b/.github/workflows/validate-integration-files.yml
@@ -26,7 +26,9 @@ jobs:
 
     - name: Check Ocean version 🌊
       run: |
-        changed_dirs=$(git diff --name-only origin/main origin/${{ github.head_ref }} | grep 'integrations/' | cut -d'/' -f 1,2 | sort -u)
+        git remote add ocean-origin git@github.com:port-labs/ocean.git
+        git fetch ocean-origin
+        changed_dirs=$(git diff --name-only ocean-origin/main HEAD | grep 'integrations/' | cut -d'/' -f 1,2 | sort -u)
         package_version=$(curl -s https://pypi.org/pypi/port-ocean/json | jq -r '.info.version')
         for dir in $changed_dirs; do
           pyproject_file=$(find $dir -name 'pyproject.toml' -not -path "**/.venv/*")

--- a/integrations/argocd/pyproject.toml
+++ b/integrations/argocd/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Isaac Coffie <isaac@getport.io>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-port_ocean = {version = "^0.4.10", extras = ["cli"]}
+port_ocean = {version = "^0.4.9", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2"

--- a/integrations/argocd/pyproject.toml
+++ b/integrations/argocd/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Isaac Coffie <isaac@getport.io>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-port_ocean = {version = "^0.4.9", extras = ["cli"]}
+port_ocean = {version = "^0.4.10", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2"


### PR DESCRIPTION
# Description

What - Ocean version validation wont work for forked projects
Why - there is a diff check between current branch to origin main and the fork branch might be also main
How - adding a remote to the public repo to check against it instead

## Type of change

- [X] Non-breaking change (fix of existing functionality that will not change current behavior)

