### PR TITLE
PORT-5799 fix stale blueprint identifiers in ocean gitlab

### DIFF
--- a/integrations/azure/.port/resources/blueprints.json
+++ b/integrations/azure/.port/resources/blueprints.json
@@ -70,7 +70,7 @@
     "calculationProperties": {},
     "relations": {
       "resourceGroup": {
-        "target": "resourceGroup",
+        "target": "azureResourceGroup",
         "title": "Resource Group",
         "required": false,
         "many": false
@@ -168,7 +168,7 @@
     "calculationProperties": {},
     "relations": {
       "resourceGroup": {
-        "target": "resourceGroup",
+        "target": "azureResourceGroup",
         "title": "Resource Group",
         "required": false,
         "many": false
@@ -231,7 +231,7 @@
     "calculationProperties": {},
     "relations": {
       "resourceGroup": {
-        "target": "resourceGroup",
+        "target": "azureResourceGroup",
         "title": "Resource Group",
         "required": false,
         "many": false
@@ -323,7 +323,7 @@
     "calculationProperties": {},
     "relations": {
       "resourceGroup": {
-        "target": "resourceGroup",
+        "target": "azureResourceGroup",
         "title": "Resource Group",
         "required": false,
         "many": false
@@ -384,7 +384,7 @@
     "calculationProperties": {},
     "relations": {
       "storageAccount": {
-        "target": "storageAccount",
+        "target": "azureStorageAccount",
         "title": "Storage Account",
         "required": false,
         "many": false
@@ -461,7 +461,7 @@
     "calculationProperties": {},
     "relations": {
       "resourceGroup": {
-        "target": "resourceGroup",
+        "target": "azureResourceGroup",
         "title": "Resource Group",
         "required": false,
         "many": false

--- a/integrations/azure/CHANGELOG.md
+++ b/integrations/azure/CHANGELOG.md
@@ -1,3 +1,10 @@
+v0.1.22 (2023-12-25)
+
+### Improvements
+
+- Fix stale relation identifiers in default blueprints (port-5799)
+
+
 v0.1.21 (2023-12-24)
 
 ### Improvements

--- a/integrations/azure/pyproject.toml
+++ b/integrations/azure/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "azure"
-version = "0.1.21"
+version = "0.1.22"
 description = "Azure integration"
 authors = ["Tom Tankilevitch <tom@getport.io>"]
 

--- a/integrations/gitlab/.port/resources/blueprints.json
+++ b/integrations/gitlab/.port/resources/blueprints.json
@@ -87,7 +87,7 @@
     },
     "relations": {
       "repository": {
-        "target": "repository",
+        "target": "gitlabRepository",
         "required": false,
         "many": false
       }
@@ -148,7 +148,7 @@
     },
     "relations": {
       "repository": {
-        "target": "repository",
+        "target": "gitlabRepository",
         "title": "Repository",
         "required": true,
         "many": false

--- a/integrations/gitlab/CHANGELOG.md
+++ b/integrations/gitlab/CHANGELOG.md
@@ -7,6 +7,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+v0.1.39 (2023-12-25)
+====================
+
+### Improvements
+
+- Fix stale relation identifiers in default blueprints (port-5799)
+
+
 v0.1.38 (2023-12-24)
 ====================
 

--- a/integrations/gitlab/pyproject.toml
+++ b/integrations/gitlab/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gitlab"
-version = "0.1.38"
+version = "0.1.39"
 description = "Gitlab integration for Port using Port-Ocean Framework"
 authors = ["Yair Siman-Tov <yair@getport.io>"]
 

--- a/integrations/jira/.port/resources/blueprints.json
+++ b/integrations/jira/.port/resources/blueprints.json
@@ -83,20 +83,20 @@
     "calculationProperties": {},
     "relations": {
       "project": {
-        "target": "project",
+        "target": "jiraProject",
         "title": "Project",
         "description": "The Jira project that contains this issue",
         "required": false,
         "many": false
       },
       "parentIssue": {
-        "target": "issue",
+        "target": "jiraIssue",
         "title": "Parent Issue",
         "required": false,
         "many": false
       },
       "subtasks": {
-        "target": "issue",
+        "target": "jiraIssue",
         "title": "Subtasks",
         "required": false,
         "many": true

--- a/integrations/jira/CHANGELOG.md
+++ b/integrations/jira/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+v0.1.22 (2023-12-25)
+
+### Improvements
+
+- Fix stale relation identifiers in default blueprints (port-5799)
+
+
 v0.1.21 (2023-12-24)
 
 ### Improvements

--- a/integrations/jira/pyproject.toml
+++ b/integrations/jira/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "Jira"
-version = "0.1.21"
+version = "0.1.22"
 description = "Integration to bring information from Jira into Port"
 authors = ["Mor Paz <mor@getport.io>"]
 

--- a/integrations/kafka/.port/resources/blueprints.json
+++ b/integrations/kafka/.port/resources/blueprints.json
@@ -38,7 +38,7 @@
     },
     "relations": {
       "cluster": {
-        "target": "cluster",
+        "target": "kafkaCluster",
         "required": true,
         "many": false
       }
@@ -82,12 +82,12 @@
     },
     "relations": {
       "cluster": {
-        "target": "cluster",
+        "target": "kafkaCluster",
         "required": true,
         "many": false
       },
       "brokers": {
-        "target": "broker",
+        "target": "kafkaBroker",
         "required": false,
         "many": true
       }

--- a/integrations/kafka/CHANGELOG.md
+++ b/integrations/kafka/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+# Port_Ocean v0.1.14 (2023-12-25)
+
+### Improvements
+
+- Fix stale relation identifiers in default blueprints (port-5799)
+
+
 # Port_Ocean v0.1.13 (2023-12-24)
 
 ### Improvements

--- a/integrations/kafka/pyproject.toml
+++ b/integrations/kafka/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kafka"
-version = "0.1.13"
+version = "0.1.14"
 description = "Integration to import information from a Kafka cluster into Port. The integration supports importing metadata regarding the Kafka cluster, brokers and topics."
 authors = ["Tal Sabag <tal@getport.io>"]
 

--- a/integrations/sentry/.port/resources/blueprints.json
+++ b/integrations/sentry/.port/resources/blueprints.json
@@ -64,7 +64,7 @@
     "relations": {
       "project": {
         "title": "project",
-        "target": "project",
+        "target": "sentryProject",
         "required": false,
         "many": false
       }

--- a/integrations/sentry/CHANGELOG.md
+++ b/integrations/sentry/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+# Port_Ocean v0.1.14 (2023-12-25)
+
+### Improvements
+
+- Fix stale relation identifiers in default blueprints (port-5799)
+
+
 # Port_Ocean v0.1.13 (2023-12-24)
 
 ### Improvements

--- a/integrations/sentry/pyproject.toml
+++ b/integrations/sentry/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sentry"
-version = "0.1.13"
+version = "0.1.14"
 description = "Sentry Integration"
 authors = ["Dvir Segev <dvir@getport.io>"]
 


### PR DESCRIPTION
# Description

What - update some stale blueprint identifiers in relations
Why - they weren't updated last time
How - update

## Type of change

Please leave one option from the following and delete the rest:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

