### PR TITLE
Port 5806 remove terraform cloud host from tf cloud integration

### DIFF
--- a/integrations/terraform-cloud/.port/spec.yaml
+++ b/integrations/terraform-cloud/.port/spec.yaml
@@ -9,10 +9,6 @@ features:
       - kind: run
       - kind: state-version
 configurations:
-  - name: terraformCloudHost
-    required: true
-    type: url
-    default: https://app.terraform.io
   - name: terraformCloudToken
     type: string
     required: true

--- a/integrations/terraform-cloud/changelog/PORT-5806.improvement.md
+++ b/integrations/terraform-cloud/changelog/PORT-5806.improvement.md
@@ -1,1 +1,0 @@
-Removed terraformCloudHost parameter and using the terraform cloud url instaed

--- a/integrations/terraform-cloud/changelog/PORT-5806.improvement.md
+++ b/integrations/terraform-cloud/changelog/PORT-5806.improvement.md
@@ -1,0 +1,1 @@
+Removed terraformCloudHost parameter and using the terraform cloud url instaed

--- a/integrations/terraform-cloud/client.py
+++ b/integrations/terraform-cloud/client.py
@@ -18,8 +18,8 @@ PAGE_SIZE = 100
 
 
 class TerraformClient:
-    def __init__(self, terraform_base_url: str, auth_token: str) -> None:
-        self.terraform_base_url = terraform_base_url
+    def __init__(self, auth_token: str) -> None:
+        self.terraform_base_url = "https://app.terraform.io"
         self.base_headers = {
             "Authorization": f"Bearer {auth_token}",
             "Content-Type": "application/vnd.api+json",

--- a/integrations/terraform-cloud/main.py
+++ b/integrations/terraform-cloud/main.py
@@ -23,7 +23,6 @@ def init_terraform_client() -> TerraformClient:
     config = ocean.integration_config
 
     terraform_client = TerraformClient(
-        config["terraform_cloud_host"],
         config["terraform_cloud_token"],
     )
 

--- a/integrations/terraform-cloud/pyproject.toml
+++ b/integrations/terraform-cloud/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "terraform-cloud"
-version = "0.1.3"
+version = "0.1.1"
 description = "Terraform Cloud Integration for Port"
 authors = ["Michael Armah <michaelarmah@getport.io>"]
 


### PR DESCRIPTION
# Description

Removing redundant configuration from the terraform cloud integration

## Type of change

- [X] Non-breaking change (fix of existing functionality that will not change current behavior)

