### PR TITLE
Port 5858 allow passing terraform cloud host

### DIFF
--- a/integrations/terraform-cloud/.port/spec.yaml
+++ b/integrations/terraform-cloud/.port/spec.yaml
@@ -9,6 +9,10 @@ features:
       - kind: run
       - kind: state-version
 configurations:
+  - name: terraformCloudHost
+    required: false
+    type: url
+    default: https://app.terraform.io
   - name: terraformCloudToken
     type: string
     required: true

--- a/integrations/terraform-cloud/CHANGELOG.md
+++ b/integrations/terraform-cloud/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+# Port_Ocean 0.1.2 (2023-12-27)
+
+### Features
+
+- Allowing clients to pass the terraformCloudParameter for self hosted terraform cloud (PORT-5858)
+
+
 # Port_Ocean 0.1.1 (2023-12-14)
 
 ### Improvement

--- a/integrations/terraform-cloud/CHANGELOG.md
+++ b/integrations/terraform-cloud/CHANGELOG.md
@@ -14,13 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allowing clients to pass the terraformCloudParameter for self hosted terraform cloud (PORT-5858)
 
 
-# Port_Ocean 0.1.1 (2023-12-14)
+# Port_Ocean 0.1.1 (2023-12-25)
 
 ### Improvement
 
 - Removed the usage of terraform cloud host parameter
 
-# Port_Ocean 0.1.0 (2023-12-14)
+# Port_Ocean 0.1.0 (2023-12-25)
 
 ### Features
 

--- a/integrations/terraform-cloud/CHANGELOG.md
+++ b/integrations/terraform-cloud/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+# Port_Ocean 0.1.1 (2023-12-14)
+
+### Improvement
+
+- Removed the usage of terraform cloud host parameter
+
 # Port_Ocean 0.1.0 (2023-12-14)
 
 ### Features

--- a/integrations/terraform-cloud/changelog/PORT-5858.feature.md
+++ b/integrations/terraform-cloud/changelog/PORT-5858.feature.md
@@ -1,0 +1,1 @@
+Allowing clients to pass the terraformCloudParameter for self hosted terraform cloud

--- a/integrations/terraform-cloud/changelog/PORT-5858.feature.md
+++ b/integrations/terraform-cloud/changelog/PORT-5858.feature.md
@@ -1,1 +1,0 @@
-Allowing clients to pass the terraformCloudParameter for self hosted terraform cloud

--- a/integrations/terraform-cloud/client.py
+++ b/integrations/terraform-cloud/client.py
@@ -18,8 +18,8 @@ PAGE_SIZE = 100
 
 
 class TerraformClient:
-    def __init__(self, auth_token: str) -> None:
-        self.terraform_base_url = "https://app.terraform.io"
+    def __init__(self, terraform_base_url: str, auth_token: str) -> None:
+        self.terraform_base_url = terraform_base_url
         self.base_headers = {
             "Authorization": f"Bearer {auth_token}",
             "Content-Type": "application/vnd.api+json",

--- a/integrations/terraform-cloud/main.py
+++ b/integrations/terraform-cloud/main.py
@@ -23,6 +23,7 @@ def init_terraform_client() -> TerraformClient:
     config = ocean.integration_config
 
     terraform_client = TerraformClient(
+        config["terraform_cloud_host"],
         config["terraform_cloud_token"],
     )
 


### PR DESCRIPTION
# Description

What - Adding the option to pass terraform cloud host
Why - We removed it on the previous version and it is now required
How - Applied the previous code

## Type of change

- [X] New feature (non-breaking change which adds functionality)

