### PR TITLE
Port 5938 ocean integration mapping to team property is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
-## 0.4.13 (2024-01-07)
+## 0.4.14 (2024-01-07)
 
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.4.13 (2024-01-07)
+
+
+### Bug Fixes
+
+- Fixed missing team parameter in the port app config model (PORT-5938)
+
+
 ## 0.4.13 (2023-12-31)
 
 ### Features

--- a/changelog/PORT-5938.bugfix.md
+++ b/changelog/PORT-5938.bugfix.md
@@ -1,0 +1,1 @@
+Fixed missing team parameter in the port app config model

--- a/changelog/PORT-5938.bugfix.md
+++ b/changelog/PORT-5938.bugfix.md
@@ -1,1 +1,0 @@
-Fixed missing team parameter in the port app config model

--- a/port_ocean/core/handlers/port_app_config/models.py
+++ b/port_ocean/core/handlers/port_app_config/models.py
@@ -9,6 +9,7 @@ class EntityMapping(BaseModel):
     identifier: str
     title: str | None
     blueprint: str
+    team: str | None
     properties: dict[str, str] = Field(default_factory=dict)
     relations: dict[str, str] = Field(default_factory=dict)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.4.13"
+version = "0.4.14"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What - Integrations failed to map team property
Why - the team property was missing in the port app config model

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

