### PR TITLE
chore: fix workflow dependency on release integrations and always syn…

### DIFF
--- a/.github/workflows/release-integrations.yml
+++ b/.github/workflows/release-integrations.yml
@@ -97,7 +97,6 @@ jobs:
     permissions:
       packages: write
       contents: read
-    needs: release-integration
     steps:
       - name: Check out code
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description

What - Alwasys syncing S3
Why - Sometimes, you might want to update the spec.yaml but not to actually require a new integration release
How - Change the depends_on key in the gh workflow

## Type of change

- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)

