### PR TITLE
[Core] Increase default timeout to the re-usable async client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.4.16 (2024-01-11)
+
+
+### Improvements
+
+- Increased the default timeout for requests to the integrations to 30 seconds, and made it configurable (PORT-6074)
+
+
 ## 0.4.15 (2024-01-07)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Improvements
 
-- Increased the default timeout for requests to the integrations to 30 seconds, and made it configurable (PORT-6074)
+- Increased the default timeout for requests to 3rd party targets to 30 seconds, and made it configurable (PORT-6074)
 
 
 ## 0.4.15 (2024-01-07)

--- a/port_ocean/config/settings.py
+++ b/port_ocean/config/settings.py
@@ -41,6 +41,7 @@ class IntegrationSettings(BaseModel, extra=Extra.allow):
 class IntegrationConfiguration(BaseOceanSettings, extra=Extra.allow):
     initialize_port_resources: bool = True
     scheduled_resync_interval: int | None = None
+    client_timeout: int = 30
     port: PortSettings
     event_listener: EventListenerSettingsType
     integration: IntegrationSettings

--- a/port_ocean/utils.py
+++ b/port_ocean/utils.py
@@ -18,6 +18,7 @@ from starlette.concurrency import run_in_threadpool
 from werkzeug.local import LocalStack, LocalProxy
 
 from port_ocean.helpers.async_client import OceanAsyncClient
+from port_ocean.context.ocean import ocean
 from port_ocean.helpers.retry import RetryTransport
 
 _http_client: LocalStack[httpx.AsyncClient] = LocalStack()
@@ -26,7 +27,7 @@ _http_client: LocalStack[httpx.AsyncClient] = LocalStack()
 def _get_http_client_context() -> httpx.AsyncClient:
     client = _http_client.top
     if client is None:
-        client = OceanAsyncClient(RetryTransport)
+        client = OceanAsyncClient(RetryTransport, timeout=ocean.config.client_timeout)
         _http_client.push(client)
 
     return client

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.4.15"
+version = "0.4.16"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"
 repository = "https://github.com/port-labs/Port-Ocean"
 
-authors = ["Daniel Sinai <daniel@getport.io>", "Yair Siman-Tov <yair@getport.io>"]
+authors = ["Daniel Sinai <daniel@getport.io>", "Yair Siman-Tov <yair@getport.io>", "Tom Tankilevitch <tom@getport.io>"]
 packages = [
     { include = "port_ocean", from = "." }
 ]


### PR DESCRIPTION
# Description

What - Increased default timeout to 30 seconds, and made it configurable
Why - To reduce the amount of failures against third party integrations if it takes them longer than the 5 seconds to return a response.
How - Increased to 30 and added it to the global configuration.

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

