### PR TITLE
[Ocean] Fix templates to point to the correct type

### DIFF
--- a/.github/ISSUE_TEMPLATE/integration-enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/integration-enhancement.yml
@@ -1,7 +1,7 @@
 name: Integration Feature Request/Enhancement
 description: Request a new feature or ask for an improvement of existing functionality in an integration powered by the Ocean framework
-title: "[Enhancement/Feature] [Framework]"
-labels: ["enhancement", "framework"]
+title: "[Enhancement/Feature] [Integration] [<Integration Name Here i.e PagerDuty, Jira...>]"
+labels: ["enhancement", "integration"]
 body:
   - type: textarea
     attributes:

--- a/.github/ISSUE_TEMPLATE/ocean-framework-enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/ocean-framework-enhancement.yml
@@ -1,7 +1,7 @@
 name: Ocean Framework Feature Request/Enhancement
 description: Request a new feature or ask for an improvement of existing functionality in the Ocean framework
-title: "[Enhancement/Feature] [Integration] [<Integration Name Here i.e PagerDuty, Jira...>]"
-labels: ["enhancement", "integration"]
+title: "[Enhancement/Feature] [Framework]"
+labels: ["enhancement", "framework"]
 body:
   - type: textarea
     attributes:


### PR DESCRIPTION
# Description

What - Changed the framework issue template to include framework related template, and same for integration issue tempate
Why - It had the opposite templates
How -

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

