### PR TITLE
(Bugfix) - Integrations crashing with regex error after 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.5.1 (2024-02-21)
+
+
+### Bug Fixes
+
+- Fixed an issue causing the integration to crash when passing a sensitive configuration with invalid regex characters due to a missing escaping (PORT-6836)
+
+
 ## 0.5.1 (2024-02-20)
 
 

--- a/changelog/PORT-6836.bugfix.md
+++ b/changelog/PORT-6836.bugfix.md
@@ -1,0 +1,1 @@
+Fixed an issue causing the integration to crash when passing a sensitive configuration with invalid regex characters due to a missing escaping

--- a/changelog/PORT-6836.bugfix.md
+++ b/changelog/PORT-6836.bugfix.md
@@ -1,1 +1,0 @@
-Fixed an issue causing the integration to crash when passing a sensitive configuration with invalid regex characters due to a missing escaping

--- a/port_ocean/log/sensetive.py
+++ b/port_ocean/log/sensetive.py
@@ -32,7 +32,7 @@ class SensitiveLogFilter:
 
     def hide_sensitive_strings(self, *tokens: str) -> None:
         self.compiled_patterns.extend(
-            [re.compile(token) for token in tokens if token.strip()]
+            [re.compile(re.escape(token.strip())) for token in tokens if token.strip()]
         )
 
     def create_filter(self, full_hide: bool = False) -> Callable[["Record"], bool]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.5.1"
+version = "0.5.2"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What - Integrations were failing with regex error over the sensitive fields
Why - We are compiling the sensitive values to redact later from the logs and we didnt use escaping over those values
How - Used re.escape()

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
