### PR TITLE
PORT-6853 Update broken links in READMEs

### DIFF
--- a/integrations/jenkins/README.md
+++ b/integrations/jenkins/README.md
@@ -219,7 +219,7 @@ The following resources can be used to map data from Jenkins, it is possible to 
 :::
 
 :::note
-You will be able to see realtime `build` data after you have successfully configured the web hook on your Jenkins instance according to this [documentation](https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/ci-cd/jenkins-deployment/)
+You will be able to see realtime `build` data after you have successfully configured the web hook on your Jenkins instance according to this [documentation](https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/ci-cd/jenkins)
 :::
 
 - The root key of the integration configuration is the `resources` key:

--- a/integrations/jira/README.md
+++ b/integrations/jira/README.md
@@ -2,6 +2,6 @@
 
 An integration used to import Jira resources into Port.
 
-#### Install & use the integration - [Integration documentation](https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/project-management/jira)
+#### Install & use the integration - [Integration documentation](https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/jira)
 
 #### Develop & improve the integration - [Ocean integration development documentation](https://ocean.getport.io/develop-an-integration/)


### PR DESCRIPTION
# Description

What - fix broken links to Port's documentation for some of the integrations
Why - because the docs tree in Port's docs changed
How - update to the correct links

## Type of change

Please leave one option from the following and delete the rest:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

