### PR TITLE
Changed caching to be with params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.5.5 (2024-03-06)
+
+
+### Bug Fixes
+
+- Changed caching to detect changes in params of function (#1)
+
+
 ## 0.5.4 (2024-03-03)
 
 

--- a/port_ocean/utils/cache.py
+++ b/port_ocean/utils/cache.py
@@ -40,7 +40,7 @@ def cache_iterator_result() -> Callable[[AsyncIteratorCallable], AsyncIteratorCa
         async def wrapper(*args: Any, **kwargs: Any) -> Any:
             # Create Hash key from function name, args and kwargs
             cache_key = hash_func(func.__name__, *args, **kwargs)
-            
+
             # Check if the result is already in the cache
             if cache := event.attributes.get(cache_key):
                 yield cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.5.4"
+version = "0.5.5"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What - Changing ocean to cache functions by name, args and kwargs 
Why - Ocean calls cache for differently parameterized functions
How - Adding caching by hash of args and kwargs, removing param

## Type of change

Please leave one option from the following and delete the rest:

- [ ] New feature (non-breaking change which adds functionality)