### PR TITLE
PORT-7262-add-a-config-type-for-array-in-ocean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Features
 
-- Added array to config.types in default_config_factory (PORT-7262)
+- Added array to possible integration configuration types (PORT-7262)
 
 
 ## 0.5.5 (2024-03-06)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.5.6 (2024-03-17)
+
+
+### Features
+
+- Added array to config.types in default_config_factory (PORT-7262)
+
+
 ## 0.5.5 (2024-03-06)
 
 

--- a/changelog/PORT-7262.feature.md
+++ b/changelog/PORT-7262.feature.md
@@ -1,0 +1,1 @@
+Added array to config.types in default_config_factory

--- a/changelog/PORT-7262.feature.md
+++ b/changelog/PORT-7262.feature.md
@@ -1,1 +1,0 @@
-Added array to config.types in default_config_factory

--- a/docs/framework-guides/docs/develop-an-integration/integration-spec-and-default-resources.md
+++ b/docs/framework-guides/docs/develop-an-integration/integration-spec-and-default-resources.md
@@ -121,7 +121,7 @@ The integration's `configurations` spec is an array where each item includes:
 - `required` - whether the parameter is required or optional
   - Available values: `true`, `false`
 - `type` - the type of the parameter
-  - Available values: `string`, `number`, `boolean`, `object`, `url`
+  - Available values: `string`, `number`, `boolean`, `object`, `array`, `url`
 - `description` - a description for the parameter and its usage in the integration
   - Please provide a description to make it easier for users who want to use your integration to understand the different required parameters
 - `sensitive` - whether this parameter is secret or sensitive

--- a/port_ocean/config/dynamic.py
+++ b/port_ocean/config/dynamic.py
@@ -46,6 +46,8 @@ def default_config_factory(configurations: Any) -> Type[BaseModel]:
                 field_type = int
             case "boolean":
                 field_type = bool
+            case "array":
+                field_type = list
             case _:
                 raise ValueError(f"Unknown type: {config.type}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.5.5"
+version = "0.5.6"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What - added array to config.types
Why - to support more types for config variables
How - added a new case in the switch case in dynamic.py

## Type of change

Please leave one option from the following and delete the rest:

- [x] New feature (non-breaking change which adds functionality)
