### PR TITLE
[Integration][Argocd] - Add support for managed resources

### DIFF
--- a/integrations/argocd/.port/spec.yaml
+++ b/integrations/argocd/.port/spec.yaml
@@ -10,6 +10,7 @@ features:
       - kind: project
       - kind: application
       - kind: deployment-history
+      - kind: managed-resource
 configurations:
   - name: token
     required: true

--- a/integrations/argocd/CHANGELOG.md
+++ b/integrations/argocd/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+# Port_Ocean 0.1.30 (2024-03-18)
+
+### Improvements
+
+- Added support for Application managed resources kind
+
+
 # Port_Ocean 0.1.29 (2024-03-18)
 
 ### Improvements

--- a/integrations/argocd/client.py
+++ b/integrations/argocd/client.py
@@ -15,6 +15,7 @@ class ObjectKind(StrEnum):
 
 class ResourceKindsWithSpecialHandling(StrEnum):
     DEPLOYMENT_HISTORY = "deployment-history"
+    MANAGED_RESOURCE = "managed-resource"
 
 
 class ArgocdClient:
@@ -71,3 +72,10 @@ class ArgocdClient:
             for history_item in application["status"].get("history", [])
         ]
         return all_history
+
+    async def get_managed_resources(
+        self, application_name: str
+    ) -> list[dict[str, Any]]:
+        url = f"{self.api_url}/{ObjectKind.APPLICATION}s/{application_name}/managed-resources"
+        managed_resources = (await self._send_api_request(url=url))["items"]
+        return managed_resources

--- a/integrations/argocd/client.py
+++ b/integrations/argocd/client.py
@@ -53,6 +53,7 @@ class ArgocdClient:
             raise
 
     async def get_resources(self, resource_kind: ObjectKind) -> list[dict[str, Any]]:
+        logger.info(f"Fetching ArgoCD resource: {resource_kind}")
         url = f"{self.api_url}/{resource_kind}s"
         response_data = (await self._send_api_request(url=url))["items"]
         return response_data
@@ -64,7 +65,7 @@ class ArgocdClient:
 
     async def get_deployment_history(self) -> list[dict[str, Any]]:
         """The ArgoCD application route returns a history of all deployments. This function reuses the output of the application endpoint"""
-        logger.info("fetching Argocd deployment history from applications endpoint")
+        logger.info("Fetching Argocd deployment history from applications endpoint")
         applications = await self.get_resources(resource_kind=ObjectKind.APPLICATION)
         all_history = [
             {**history_item, "__applicationId": application["metadata"]["uid"]}
@@ -76,6 +77,7 @@ class ArgocdClient:
     async def get_managed_resources(
         self, application_name: str
     ) -> list[dict[str, Any]]:
+        logger.info(f"Fetching managed resources for application: {application_name}")
         url = f"{self.api_url}/{ObjectKind.APPLICATION}s/{application_name}/managed-resources"
         managed_resources = (await self._send_api_request(url=url))["items"]
         return managed_resources

--- a/integrations/argocd/client.py
+++ b/integrations/argocd/client.py
@@ -65,7 +65,6 @@ class ArgocdClient:
 
     async def get_deployment_history(self) -> list[dict[str, Any]]:
         """The ArgoCD application route returns a history of all deployments. This function reuses the output of the application endpoint"""
-        logger.info("Fetching Argocd deployment history from applications endpoint")
         applications = await self.get_resources(resource_kind=ObjectKind.APPLICATION)
         all_history = [
             {**history_item, "__applicationId": application["metadata"]["uid"]}

--- a/integrations/argocd/main.py
+++ b/integrations/argocd/main.py
@@ -1,6 +1,6 @@
 from loguru import logger
 from port_ocean.context.ocean import ocean
-from port_ocean.core.ocean_types import RAW_RESULT
+from port_ocean.core.ocean_types import RAW_RESULT, ASYNC_GENERATOR_RESYNC_TYPE
 from client import ArgocdClient, ObjectKind, ResourceKindsWithSpecialHandling
 from fastapi import Request
 
@@ -30,6 +30,28 @@ async def on_history_resync(kind: str) -> RAW_RESULT:
     argocd_client = init_client()
 
     return await argocd_client.get_deployment_history()
+
+
+@ocean.on_resync(kind=ResourceKindsWithSpecialHandling.MANAGED_RESOURCE)
+async def on_managed_resources_resync(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
+    logger.info("Listing ArgoCD managed resources")
+    argocd_client = init_client()
+
+    applications = await argocd_client.get_resources(
+        resource_kind=ObjectKind.APPLICATION
+    )
+    for application in applications:
+        logger.info(
+            f"Listing managed resources for application: {application['metadata']['name']}"
+        )
+        managed_resources = await argocd_client.get_managed_resources(
+            application_name=application["metadata"]["name"]
+        )
+        application_resource = [
+            {**managed_resource, "__applicationId": application["metadata"]["uid"]}
+            for managed_resource in managed_resources
+        ]
+        yield application_resource
 
 
 @ocean.router.post("/webhook")

--- a/integrations/argocd/main.py
+++ b/integrations/argocd/main.py
@@ -14,8 +14,6 @@ def init_client() -> ArgocdClient:
 
 @ocean.on_resync()
 async def on_resources_resync(kind: str) -> RAW_RESULT:
-    logger.info(f"Listing ArgoCD resource: {kind}")
-
     if kind in iter(ResourceKindsWithSpecialHandling):
         logger.info(f"Kind {kind} has a special handling. Skipping...")
         return []
@@ -26,7 +24,6 @@ async def on_resources_resync(kind: str) -> RAW_RESULT:
 
 @ocean.on_resync(kind=ResourceKindsWithSpecialHandling.DEPLOYMENT_HISTORY)
 async def on_history_resync(kind: str) -> RAW_RESULT:
-    logger.info("Listing ArgoCD deployment history")
     argocd_client = init_client()
 
     return await argocd_client.get_deployment_history()
@@ -34,16 +31,12 @@ async def on_history_resync(kind: str) -> RAW_RESULT:
 
 @ocean.on_resync(kind=ResourceKindsWithSpecialHandling.MANAGED_RESOURCE)
 async def on_managed_resources_resync(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
-    logger.info("Listing ArgoCD managed resources")
     argocd_client = init_client()
 
     applications = await argocd_client.get_resources(
         resource_kind=ObjectKind.APPLICATION
     )
     for application in applications:
-        logger.info(
-            f"Listing managed resources for application: {application['metadata']['name']}"
-        )
         managed_resources = await argocd_client.get_managed_resources(
             application_name=application["metadata"]["name"]
         )

--- a/integrations/argocd/pyproject.toml
+++ b/integrations/argocd/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "argocd"
-version = "0.1.29"
+version = "0.1.30"
 description = "Argo CD integration powered by Ocean"
 authors = ["Isaac Coffie <isaac@getport.io>"]
 


### PR DESCRIPTION
# Description

What - Added support for `managed-resource `by ArgoCD application
Why - We are working on a new mini guide that helps users to connect Argocd to it's deployed image. To be able to achieve this, we needed a way to get all deployments created by an Argo application since each deployment contains the running image. 
How - Used the ArgoCD managed resource API https://host/applications/{app_name}/managed-resources


## Type of change

Please leave one option from the following and delete the rest:

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.
<img width="1269" alt="Screenshot 2024-03-18 at 3 31 05 PM" src="https://github.com/port-labs/ocean/assets/15999660/71e62b44-a432-497b-8b3a-da6c380ad823">

## API Documentation

Provide links to the API documentation used for this integration.
https://cd.apps.argoproj.io/swagger-ui#operation/ApplicationService_ManagedResources