### PR TITLE
PORT-7326-gitlab-0-1-58-bugfix-gitlab

### DIFF
--- a/integrations/gitlab/CHANGELOG.md
+++ b/integrations/gitlab/CHANGELOG.md
@@ -7,6 +7,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+0.1.59 (2024-03-24)
+===================
+
+### Bug Fixes
+
+- Fix bug that could not run on startup when not configuring param tokenGroupsHooksOverridMapping (PORT-7326)
+
+
 0.1.58 (2024-03-20)
 ===================
 

--- a/integrations/gitlab/gitlab_integration/ocean.py
+++ b/integrations/gitlab/gitlab_integration/ocean.py
@@ -47,14 +47,10 @@ async def on_start() -> None:
     hook_override_mapping: dict = integration_config[
         "token_group_hooks_override_mapping"
     ]
-    sensitive_log_filter.hide_sensitive_strings(
-        *token_mapping.keys()
-    )
+    sensitive_log_filter.hide_sensitive_strings(*token_mapping.keys())
 
     if hook_override_mapping is not None:
-        sensitive_log_filter.hide_sensitive_strings(
-        *hook_override_mapping.keys()
-    )
+        sensitive_log_filter.hide_sensitive_strings(*hook_override_mapping.keys())
 
     if ocean.event_listener_type == "ONCE":
         logger.info("Skipping webhook creation because the event listener is ONCE")

--- a/integrations/gitlab/gitlab_integration/ocean.py
+++ b/integrations/gitlab/gitlab_integration/ocean.py
@@ -48,7 +48,12 @@ async def on_start() -> None:
         "token_group_hooks_override_mapping"
     ]
     sensitive_log_filter.hide_sensitive_strings(
-        *token_mapping.keys(), *hook_override_mapping.keys()
+        *token_mapping.keys()
+    )
+
+    if hook_override_mapping is not None:
+        sensitive_log_filter.hide_sensitive_strings(
+        *hook_override_mapping.keys()
     )
 
     if ocean.event_listener_type == "ONCE":

--- a/integrations/gitlab/pyproject.toml
+++ b/integrations/gitlab/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gitlab"
-version = "0.1.58"
+version = "0.1.59"
 description = "Gitlab integration for Port using Port-Ocean Framework"
 authors = ["Yair Siman-Tov <yair@getport.io>"]
 


### PR DESCRIPTION
# Description

What - bugfix - could not run on startup when not configuring param tokenGroupsHooksOverridMapping
Why - integration was failing to startup after merge
How - added check for not none on the param before using it

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)

