### PR TITLE
[Integrations][Gitlab] Listen to default branch of repository by default

### DIFF
--- a/integrations/gitlab/CHANGELOG.md
+++ b/integrations/gitlab/CHANGELOG.md
@@ -7,6 +7,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+0.1.60 (2024-03-25)
+===================
+
+### Features
+
+- Changed listening to default branch unless mentioned otherwise in mapping (PORT-7141)
+
+
 0.1.59 (2024-03-24)
 ===================
 

--- a/integrations/gitlab/changelog/PORT-7141.feature.md
+++ b/integrations/gitlab/changelog/PORT-7141.feature.md
@@ -1,1 +1,0 @@
-Changed listening to default branch unless mentioned otherwise in mapping

--- a/integrations/gitlab/changelog/PORT-7141.feature.md
+++ b/integrations/gitlab/changelog/PORT-7141.feature.md
@@ -1,0 +1,1 @@
+Changed listening to default branch unless mentioned otherwise in mapping

--- a/integrations/gitlab/gitlab_integration/events/hooks/push.py
+++ b/integrations/gitlab/gitlab_integration/events/hooks/push.py
@@ -29,7 +29,7 @@ class PushHook(ProjectHandler):
             GitlabPortAppConfig, event.port_app_config
         )
 
-        branch = config.branch if config.branch else gitlab_project.default_branch
+        branch = config.branch or gitlab_project.default_branch
 
         if generate_ref(branch) == ref:
             entities_before, entities_after = self.gitlab_service.get_entities_diff(

--- a/integrations/gitlab/gitlab_integration/events/hooks/push.py
+++ b/integrations/gitlab/gitlab_integration/events/hooks/push.py
@@ -29,13 +29,15 @@ class PushHook(ProjectHandler):
             GitlabPortAppConfig, event.port_app_config
         )
 
-        if generate_ref(config.branch) == ref:
+        branch = config.branch if config.branch else gitlab_project.default_branch
+
+        if generate_ref(branch) == ref:
             entities_before, entities_after = self.gitlab_service.get_entities_diff(
                 gitlab_project,
                 config.spec_path,
                 before,
                 after,
-                config.branch,
+                branch,
             )
             # update the entities diff found in the `config.spec_path` file the user configured
             await ocean.update_diff(

--- a/integrations/gitlab/gitlab_integration/git_integration.py
+++ b/integrations/gitlab/gitlab_integration/git_integration.py
@@ -126,7 +126,7 @@ class GitlabResourceConfig(ResourceConfig):
 
 class GitlabPortAppConfig(PortAppConfig):
     spec_path: str | List[str] = Field(alias="specPath", default="**/port.yml")
-    branch: str = "main"
+    branch: str | None
     filter_owned_projects: bool | None = Field(
         alias="filterOwnedProjects", default=True
     )

--- a/integrations/gitlab/pyproject.toml
+++ b/integrations/gitlab/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gitlab"
-version = "0.1.59"
+version = "0.1.60"
 description = "Gitlab integration for Port using Port-Ocean Framework"
 authors = ["Yair Siman-Tov <yair@getport.io>"]
 


### PR DESCRIPTION
# Description

What - listening to default branch on changes, unless mentioned a specific branch in the mapping
Why - for a more correct way to ingest projects to port
How - added None to branch in config as default, then on push hook checked if None, then used project's default branch.

## Type of change

Please leave one option from the following and delete the rest:

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

