### PR TITLE
PORT-7394 Added docs URL to Dynatrace integration spec.yaml

### DIFF
--- a/integrations/dynatrace/.port/spec.yaml
+++ b/integrations/dynatrace/.port/spec.yaml
@@ -1,6 +1,7 @@
 type: dynatrace
 description: Dynatrace integration for Port Ocean
 icon: Dynatrace
+docs: https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/apm-alerting/dynatrace
 features:
   - type: exporter
     section: Incident Management


### PR DESCRIPTION
# Description

What - Add URL to the docs page of the Dynatrace integration to the spec.yaml file of the integration
Why - To support link from Port's data sources menu
How - Add the URL to the spec.yaml

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [X] Documentation (added/updated documentation)

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
