### PR TITLE
[CI] Fix release framework workflow to extract the version correctly 

### DIFF
--- a/.github/workflows/release-framework.yml
+++ b/.github/workflows/release-framework.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Remove 'v' from version name
         continue-on-error: true
-        run: echo "VERSION=$(echo ${{ github.ref_name }} | sed 's/^v//')" >> $GITHUB_ENV
+        run: echo "VERSION=$(echo ${{ github.ref_name }} | sed 's/^v//g')" >> $GITHUB_ENV
 
       - name: Send internal release notification
         if: env.VERSION != ''

--- a/.github/workflows/release-framework.yml
+++ b/.github/workflows/release-framework.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Remove 'v' from version name
         continue-on-error: true
-        run: echo "VERSION=${{ github.ref_name:1 }}" >> $GITHUB_ENV
+        run: echo "VERSION=$(echo ${{ github.ref_name }} | sed 's/^v//')" >> $GITHUB_ENV
 
       - name: Send internal release notification
         if: env.VERSION != ''


### PR DESCRIPTION
# Description

What -
Why - CI failed on error 
```
[Invalid workflow file: .github/workflows/release-framework.yml#L35](https://github.com/port-labs/ocean/actions/runs/8455594726/workflow)
The workflow is not valid. .github/workflows/release-framework.yml (Line: 35, Col: 14): Unexpected symbol: 'ref_name:1'. Located at position 8 within expression: github.ref_name:1
```
How -

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
