### PR TITLE
[Integration][Launchdarkly] - Fixed Issue Causing Feature Flags sync to fail

### DIFF
--- a/integrations/launchdarkly/.port/resources/port-app-config.yaml
+++ b/integrations/launchdarkly/.port/resources/port-app-config.yaml
@@ -25,7 +25,6 @@ resources:
             kind: .kind
             description: .description
             creationDate: .creationDate / 1000 | strftime("%Y-%m-%dT%H:%M:%SZ")
-            includeInSnippet: .includeInSnippet
             clientSideAvailability: .clientSideAvailability
             temporary: .temporary
             tags: .tags
@@ -35,7 +34,7 @@ resources:
             customProperties: .customProperties
             archived: .archived
           relations:
-            environments: .environments
+            environments: .environments | keys
   - kind: environment
     selector:
       query: "true"

--- a/integrations/launchdarkly/.port/spec.yaml
+++ b/integrations/launchdarkly/.port/spec.yaml
@@ -1,6 +1,6 @@
 type: launchdarkly
 description: launchdarkly integration for Port Ocean
-docs: https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/launchdarkly
+docs: https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/feature-management/launchdarkly
 icon: Launchdarkly
 features:
   - type: exporter

--- a/integrations/launchdarkly/CHANGELOG.md
+++ b/integrations/launchdarkly/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+# Port_Ocean 0.1.5 (2024-04-11)
+
+### Bug Fixes
+
+- Updated documentation path (0.1.5)
+- Resolved an issue where the relationship between feature flags and environments was causing synchronization of feature flags to fail (0.1.5)
+
+
 # Port_Ocean 0.1.4 (2024-04-11)
 
 ### Improvements

--- a/integrations/launchdarkly/CHANGELOG.md
+++ b/integrations/launchdarkly/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- Updated documentation path (0.1.5)
+- Updated documentation path in `spec.yml`
 - Resolved an issue where the relationship between feature flags and environments was causing synchronization of feature flags to fail (0.1.5)
 
 

--- a/integrations/launchdarkly/CHANGELOG.md
+++ b/integrations/launchdarkly/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Bug Fixes
 
 - Updated documentation path in `spec.yml`
-- Resolved an issue where the relationship between feature flags and environments was causing synchronization of feature flags to fail (0.1.5)
+- Resolved an issue where the relationship between feature flags and environments was causing synchronization of feature flags to fail
 
 
 # Port_Ocean 0.1.4 (2024-04-11)

--- a/integrations/launchdarkly/config.yaml
+++ b/integrations/launchdarkly/config.yaml
@@ -10,4 +10,4 @@ integration:
   config:
     launchdarklyToken: '{{ from env LAUNCHDARKLY_TOKEN }}'
     launchdarklyHost: '{{ from env LAUNCHDARKLY_HOST }}'
-    appHost: '{{ from env LAUNCHDARKLY_APP_HOST }}'
+    appHost: '{{ from env APP_HOST }}'

--- a/integrations/launchdarkly/pyproject.toml
+++ b/integrations/launchdarkly/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "launchdarkly"
-version = "0.1.4"
+version = "0.1.5"
 description = "Launchdarkly integration for Port"
 authors = ["Michael Armah <michaelarmah@getport.io>"]
 


### PR DESCRIPTION
# Description

What 
- Updated Launchdarkly Documentation Path in spec.yaml
- Resolved an [issue](https://github.com/port-labs/ocean/issues/487) where the relationship between feature flags and environments was causing synchronization of feature flags to fail. ()

Why - Feature Flags were failing to sync as a result.

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)