### PR TITLE
[integration][Gitlab] - add try-catch in webhook event handling

### DIFF
--- a/integrations/gitlab/CHANGELOG.md
+++ b/integrations/gitlab/CHANGELOG.md
@@ -7,6 +7,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+0.1.67-dev (2024-04-14)
+=======================
+
+### Bug Fixes
+
+- Added try except to some of the event handling logic to have more info about errors (PORT-7657)
+
+
 0.1.66 (2024-04-11)
 ===================
 

--- a/integrations/gitlab/CHANGELOG.md
+++ b/integrations/gitlab/CHANGELOG.md
@@ -7,14 +7,6 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
-0.1.67-dev (2024-04-14)
-=======================
-
-### Bug Fixes
-
-- Added try except to some of the event handling logic to have more info about errors (PORT-7657)
-
-
 0.1.66 (2024-04-11)
 ===================
 

--- a/integrations/gitlab/gitlab_integration/events/event_handler.py
+++ b/integrations/gitlab/gitlab_integration/events/event_handler.py
@@ -18,6 +18,9 @@ class EventHandler:
             self._observers[event].append(observer)
 
     async def notify(self, event: str, body: dict[str, Any]) -> Awaitable[Any]:
+        logger.debug(
+            f"Looking for the matching handlers to notify about event: {event}"
+        )
         try:
             observers = asyncio.gather(
                 *(observer(event, body) for observer in self._observers.get(event, []))

--- a/integrations/gitlab/gitlab_integration/events/event_handler.py
+++ b/integrations/gitlab/gitlab_integration/events/event_handler.py
@@ -18,9 +18,15 @@ class EventHandler:
             self._observers[event].append(observer)
 
     async def notify(self, event: str, body: dict[str, Any]) -> Awaitable[Any]:
-        observers = asyncio.gather(
-            *(observer(event, body) for observer in self._observers.get(event, []))
-        )
+        try:
+            observers = asyncio.gather(
+                *(observer(event, body) for observer in self._observers.get(event, []))
+            )
+        except Exception as error:
+            logger.warning(
+                f"An error occurred while trying to initialize an event handler for {event}. Error was: {error}"
+            )
+            raise error
 
         if not observers:
             logger.debug(

--- a/integrations/gitlab/gitlab_integration/events/hooks/push.py
+++ b/integrations/gitlab/gitlab_integration/events/hooks/push.py
@@ -18,6 +18,7 @@ class PushHook(ProjectHandler):
     system_events = ["push"]
 
     async def _on_hook(self, body: dict[str, Any], gitlab_project: Project) -> None:
+        logger.debug(f"Handling {event} in Push Hook handler")
         before, after, ref = body.get("before"), body.get("after"), body.get("ref")
 
         if before is None or after is None or ref is None:

--- a/integrations/gitlab/gitlab_integration/events/setup.py
+++ b/integrations/gitlab/gitlab_integration/events/setup.py
@@ -125,7 +125,7 @@ def setup_listeners(gitlab_service: GitlabService, webhook_id: str) -> None:
     ]
     for handler in handlers:
         logger.info(
-            f"Setting up listeners for webhook {webhook_id} for group mapping {gitlab_service.group_mapping}"
+            f"Setting up {handler.events} listeners for webhook {webhook_id} for group mapping {gitlab_service.group_mapping}"
         )
         event_ids = [f"{event_name}:{webhook_id}" for event_name in handler.events]
         event_handler.on(event_ids, handler.on_hook)

--- a/integrations/gitlab/gitlab_integration/ocean.py
+++ b/integrations/gitlab/gitlab_integration/ocean.py
@@ -30,6 +30,7 @@ async def handle_webhook(group_id: str, request: Request) -> dict[str, Any]:
         logger.debug(f"Received webhook event {event_id} from Gitlab")
         try:
             body = await request.json()
+            logger.debug(f"Parsed the {event_id} event's request body successfully")
         except Exception as error:
             logger.warning(
                 f"There might be an error when deserializing the request of {event_id}. Error was: {error} "

--- a/integrations/gitlab/gitlab_integration/ocean.py
+++ b/integrations/gitlab/gitlab_integration/ocean.py
@@ -30,7 +30,9 @@ async def handle_webhook(group_id: str, request: Request) -> dict[str, Any]:
         logger.debug(f"Received webhook event {event_id} from Gitlab")
         try:
             body = await request.json()
-            logger.debug(f"Parsed the {event_id} event's request body successfully: {body}")
+            logger.debug(
+                f"Parsed the {event_id} event's request body successfully: {body}"
+            )
         except Exception as error:
             logger.warning(
                 f"There might be an error when deserializing the request of {event_id}. Error was: {error} "

--- a/integrations/gitlab/gitlab_integration/ocean.py
+++ b/integrations/gitlab/gitlab_integration/ocean.py
@@ -30,7 +30,7 @@ async def handle_webhook(group_id: str, request: Request) -> dict[str, Any]:
         logger.debug(f"Received webhook event {event_id} from Gitlab")
         try:
             body = await request.json()
-            logger.debug(f"Parsed the {event_id} event's request body successfully")
+            logger.debug(f"Parsed the {event_id} event's request body successfully: {body}")
         except Exception as error:
             logger.warning(
                 f"There might be an error when deserializing the request of {event_id}. Error was: {error} "

--- a/integrations/gitlab/gitlab_integration/ocean.py
+++ b/integrations/gitlab/gitlab_integration/ocean.py
@@ -28,7 +28,14 @@ async def handle_webhook(group_id: str, request: Request) -> dict[str, Any]:
     event_id = f'{request.headers.get("X-Gitlab-Event")}:{group_id}'
     with logger.contextualize(event_id=event_id):
         logger.debug(f"Received webhook event {event_id} from Gitlab")
-        body = await request.json()
+        try:
+            body = await request.json()
+        except Exception as error:
+            logger.warning(
+                f"There might be an error when deserializing the request of {event_id}. Error was: {error} "
+                f"The request received: {request}"
+            )
+            raise error
         await event_handler.notify(event_id, body)
         return {"ok": True}
 

--- a/integrations/gitlab/pyproject.toml
+++ b/integrations/gitlab/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gitlab"
-version = "0.1.66"
+version = "0.1.67-dev"
 description = "Gitlab integration for Port using Port-Ocean Framework"
 authors = ["Yair Siman-Tov <yair@getport.io>"]
 

--- a/integrations/gitlab/pyproject.toml
+++ b/integrations/gitlab/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gitlab"
-version = "0.1.67-dev"
+version = "0.1.67-dev01"
 description = "Gitlab integration for Port using Port-Ocean Framework"
 authors = ["Yair Siman-Tov <yair@getport.io>"]
 


### PR DESCRIPTION
# Description

What - Surrounded with try-except two logic sites that are not logs supported
Why - To understand better when an event fails over those areas
How - using try-except, and printing the log, then raising the error again

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
