### PR TITLE
skipping spec publish for dev versions

### DIFF
--- a/.github/workflows/release-integrations.yml
+++ b/.github/workflows/release-integrations.yml
@@ -97,11 +97,13 @@ jobs:
             # If 'version' contains non-numeric and non-dot characters, skip building 'latest' tag
             tags="ghcr.io/port-labs/port-ocean-$type:$version"
             echo "tags=$tags" >> $GITHUB_OUTPUT
+            echo "is_dev_version=true" >> $GITHUB_OUTPUT
             echo "Version contains non-numeric characters. Building without 'latest' tag."
           else
             # If 'version' contains only digits and dots, build with both 'latest' and version tags
             tags="ghcr.io/port-labs/port-ocean-$type:$version,ghcr.io/port-labs/port-ocean-$type:latest"
             echo "tags=$tags" >> $GITHUB_OUTPUT
+            echo "is_dev_version=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Build and push
@@ -122,6 +124,7 @@ jobs:
       packages: write
       contents: read
     needs: release-integration
+    if: needs.release-integration.outputs.is_dev_version == 'false'
     steps:
       - name: Check out code
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description

What - Release integration would update the spec for integration dev version
Why - missing if in the workflow
How - Added a check that should skip the spec publish for integration dev version

## Type of change

- [X] Non-breaking change (fix of existing functionality that will not change current behavior)
