### PR TITLE
[Integration][ArgoCD] - Fix managed resources KeyError

### DIFF
--- a/integrations/argocd/.port/resources/port-app-config.yaml
+++ b/integrations/argocd/.port/resources/port-app-config.yaml
@@ -69,7 +69,7 @@ resources:
     selector:
       query: "true"
     port:
-      itemsToParse: .status.history
+      itemsToParse: .status.history // []
       entity:
         mappings:
           identifier: .metadata.uid + "-" + (.item.id | tostring)

--- a/integrations/argocd/CHANGELOG.md
+++ b/integrations/argocd/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+# Port_Ocean 0.1.40 (2024-04-25)
+
+### Bug Fixes
+
+- Fixed a bug in the managed-resources kind that caused the integration to throw a KeyError
+
+### Improvements
+
+- Added a default empty array to the deployment history mapping to stop spanning the logs with JQ NoneType error
+
+
 # Port_Ocean 0.1.39 (2024-04-24)
 
 ### Improvements

--- a/integrations/argocd/changelog/0.1.40.bugfix.md
+++ b/integrations/argocd/changelog/0.1.40.bugfix.md
@@ -1,0 +1,1 @@
+Fixed a bug in the managed-resources kind that caused the integration to throw a error

--- a/integrations/argocd/changelog/0.1.40.bugfix.md
+++ b/integrations/argocd/changelog/0.1.40.bugfix.md
@@ -1,1 +1,0 @@
-Fixed a bug in the managed-resources kind that caused the integration to throw a error

--- a/integrations/argocd/client.py
+++ b/integrations/argocd/client.py
@@ -104,5 +104,5 @@ class ArgocdClient:
     ) -> list[dict[str, Any]]:
         logger.info(f"Fetching managed resources for application: {application_name}")
         url = f"{self.api_url}/{ObjectKind.APPLICATION}s/{application_name}/managed-resources"
-        managed_resources = (await self._send_api_request(url=url))["items"]
+        managed_resources = (await self._send_api_request(url=url)).get("items", [])
         return managed_resources

--- a/integrations/argocd/pyproject.toml
+++ b/integrations/argocd/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "argocd"
-version = "0.1.39"
+version = "0.1.40"
 description = "Argo CD integration powered by Ocean"
 authors = ["Isaac Coffie <isaac@getport.io>"]
 


### PR DESCRIPTION
# Description

What - A PR to fix the issue reported [here](https://github.com/port-labs/ocean/issues/577) when trying to get item manage resources items 
Why -
How - it is understood that some apps may not be managing any k8s resources. This causes the ArgoCD to return null, or without the items keyword. So instead of using a square bracket to fetch the response, we now use .get("items", [])

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
