### PR TITLE
[Integration][PagerDuty] - Map oncall user with highest escalation level

### DIFF
--- a/integrations/pagerduty/.port/resources/blueprints.json
+++ b/integrations/pagerduty/.port/resources/blueprints.json
@@ -31,11 +31,8 @@
         },
         "oncall": {
           "title": "On Call",
-          "type": "array",
-          "items": {
-            "type": "string",
-            "format": "user"
-          }
+          "type": "string",
+          "format": "user"
         },
         "meanSecondsToResolve": {
           "title": "Mean Seconds to Resolve",

--- a/integrations/pagerduty/.port/resources/port-app-config.yaml
+++ b/integrations/pagerduty/.port/resources/port-app-config.yaml
@@ -13,7 +13,7 @@ resources:
           properties:
             status: .status
             url: .html_url
-            oncall: '[.__oncall_user[].user.email]'
+            oncall: .__oncall_user[] | select(.escalation_level == 1) | .user.email
             meanSecondsToResolve: .__analytics.mean_seconds_to_resolve
             meanSecondsToFirstAck: .__analytics.mean_seconds_to_first_ack
             meanSecondsToEngage: .__analytics.mean_seconds_to_engage

--- a/integrations/pagerduty/CHANGELOG.md
+++ b/integrations/pagerduty/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+# Port_Ocean 0.1.52 (2024-04-26)
+
+### Improvements
+
+- Updated the who is oncall for a service to map the first escalation level
+
+
 # Port_Ocean 0.1.51 (2024-04-24)
 
 ### Improvements

--- a/integrations/pagerduty/changelog/0.1.52.improvement.md
+++ b/integrations/pagerduty/changelog/0.1.52.improvement.md
@@ -1,1 +1,0 @@
-Updated the who is oncall for a service to map the first escalation level (1)

--- a/integrations/pagerduty/changelog/0.1.52.improvement.md
+++ b/integrations/pagerduty/changelog/0.1.52.improvement.md
@@ -1,0 +1,1 @@
+Updated the who is oncall for a service to map the first escalation level (1)

--- a/integrations/pagerduty/pyproject.toml
+++ b/integrations/pagerduty/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pagerduty"
-version = "0.1.51"
+version = "0.1.52"
 description = "Pagerduty Integration"
 authors = ["Port Team <support@getport.io>"]
 


### PR DESCRIPTION
# Description

What - Users reported that the oncall property in their PagerDuty service blueprint contains array of users, while in fact, it should just be one user
Why - Their PagerDuty service dashboard also correctly lists only one user as oncall
How - After investigation, it was understood that an escalation policy can have many levels. On the PagerDuty dashboard, the user in the escalation policy with level 1 get's assigned as the primary oncall user. Here is the current service discovery dashboard in our PD account:

<img width="768" alt="Screenshot 2024-04-26 at 12 50 57 PM" src="https://github.com/port-labs/ocean/assets/15999660/0ded105c-a7f6-4b42-866d-7408c3412dae">

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)

## Screenshots
PD Service in Port
![image](https://github.com/port-labs/ocean/assets/15999660/2c1e1b9a-1f03-4f0b-b64a-aafd2741793f)


## API Documentation

[Who is on call](https://developer.pagerduty.com/api-reference/3a6b910f11050-list-all-of-the-on-calls)