### PR TITLE
[Integration][ArgoCD] - Add deployment images

### DIFF
--- a/integrations/argocd/.port/resources/blueprints.json
+++ b/integrations/argocd/.port/resources/blueprints.json
@@ -297,7 +297,86 @@
         "target": "argocdApplication",
         "required": false,
         "many": false
+      },
+      "image": {
+        "title": "Image",
+        "target": "image",
+        "required": false,
+        "many": true
       }
     }
+  },
+  {
+    "identifier": "image",
+    "description": "This blueprint represents an image",
+    "title": "Image",
+    "icon": "AWS",
+    "schema": {
+      "properties": {
+        "registryId": {
+          "type": "string",
+          "title": "Registry ID",
+          "description": "The ID of the registry",
+          "icon": "DefaultProperty"
+        },
+        "digest": {
+          "type": "string",
+          "title": "Image Digest",
+          "description": "SHA256 digest of image manifest",
+          "icon": "DefaultProperty"
+        },
+        "tags": {
+          "type": "array",
+          "title": "Image Tags",
+          "description": "List of tags for the image",
+          "icon": "DefaultProperty"
+        },
+        "pushedAt": {
+          "type": "string",
+          "title": "Pushed At",
+          "description": "Date and time the image was pushed to the repository",
+          "format": "date-time",
+          "icon": "DefaultProperty"
+        },
+        "lastRecordedPullTime": {
+          "type": "string",
+          "title": "Last Recorded Pull Time",
+          "description": "Date and time the image was last pulled",
+          "format": "date-time",
+          "icon": "DefaultProperty"
+        },
+        "triggeredBy": {
+          "type": "string",
+          "icon": "TwoUsers",
+          "title": "Triggered By",
+          "description": "The user who triggered the run"
+        },
+        "commitHash": {
+          "type": "string",
+          "title": "Commit Hash",
+          "icon": "DefaultProperty"
+        },
+        "pullRequestId": {
+          "type": "string",
+          "icon": "Git",
+          "title": "Pull Request ID"
+        },
+        "workflowId": {
+          "type": "string",
+          "title": "Workflow ID",
+          "icon": "DefaultProperty"
+        },
+        "image_branch": {
+          "title": "Image branch",
+          "type": "string",
+          "description": "The git branch associated with the repository used to build the Image"
+        }
+      },
+      "required": []
+    },
+    "mirrorProperties": {},
+    "calculationProperties": {},
+    "aggregationProperties": {},
+    "relations": {}
   }
 ]

--- a/integrations/argocd/.port/resources/port-app-config.yaml
+++ b/integrations/argocd/.port/resources/port-app-config.yaml
@@ -90,8 +90,8 @@ resources:
     port:
       entity:
         mappings:
-          identifier: .__application.metadata.uid + "-" + .name
-          title: .__application.metadata.name + "-" + .name
+          identifier: .__application.metadata.uid + "-" + .kind + "-" + .name
+          title: .__application.metadata.name + "-" + .kind + "-" + .name
           blueprint: '"argocdKubernetesResource"'
           properties:
             kind: .kind
@@ -101,3 +101,15 @@ resources:
             labels: .liveState | fromjson | .metadata.labels
           relations:
             application: .__application.metadata.uid
+  - kind: managed-resource
+    selector:
+      query: .kind == "Deployment"
+    port:
+      entity:
+        mappings:
+          identifier: .__application.metadata.uid + "-" + .kind + "-" + .name
+          title: .__application.metadata.name + "-" + .kind + "-" + .name
+          blueprint: '"argocdKubernetesResource"'
+          properties: {}
+          relations:
+            image: '[.liveState | fromjson | .spec.template.spec.containers[] | .image]'

--- a/integrations/argocd/CHANGELOG.md
+++ b/integrations/argocd/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
-- Added a default empty array to the deployment history mapping to stop spanning the logs with JQ NoneType error
+- Added a default empty array to the deployment history mapping to stop spamming the logs with JQ NoneType error
 
 
 # Port_Ocean 0.1.39 (2024-04-24)

--- a/integrations/argocd/CHANGELOG.md
+++ b/integrations/argocd/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+# Port_Ocean 0.1.42 (2024-04-30)
+
+### Improvements
+
+- Updated the default mapping to ingest all images used by deployments and establish a relationship between them
+
+
 # Port_Ocean 0.1.41 (2024-04-30)
 
 ### Improvements

--- a/integrations/argocd/changelog/0.1.42.improvement.md
+++ b/integrations/argocd/changelog/0.1.42.improvement.md
@@ -1,1 +1,0 @@
-Updated the default mapping to ingest all images used by deployments and establish a relationship between them

--- a/integrations/argocd/changelog/0.1.42.improvement.md
+++ b/integrations/argocd/changelog/0.1.42.improvement.md
@@ -1,0 +1,1 @@
+Updated the default mapping to ingest all images used by deployments and establish a relationship between them

--- a/integrations/argocd/pyproject.toml
+++ b/integrations/argocd/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "argocd"
-version = "0.1.41"
+version = "0.1.42"
 description = "Argo CD integration powered by Ocean"
 authors = ["Isaac Coffie <isaac@getport.io>"]
 


### PR DESCRIPTION
# Description

What - We want to update the default blueprints and mapping provided by the Ocean ArgoCD integration, so that it maps the images used by a managed resource (the blueprint is currently called argocdKubernetesResource).

Why -
How -

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.
K8s Resource
<img width="1240" alt="Screenshot 2024-04-30 at 10 17 38 AM" src="https://github.com/port-labs/ocean/assets/15999660/0ed60c4a-9cda-464c-9c9b-ae352d8804a4">

Images
<img width="1240" alt="Screenshot 2024-04-30 at 10 18 08 AM" src="https://github.com/port-labs/ocean/assets/15999660/21a6bad6-1084-4db3-9550-bfb1150006c9">

## API Documentation

Provide links to the API documentation used for this integration.
