### PR TITLE
[Framework] Allowing parent event context override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.5.16 (2024-05-01)
+
+### Features
+
+- Allowing override of parent event context in ocean's event context manager
+
+
 ## 0.5.15 (2024-04-30)
 
 ### Bug Fixes

--- a/port_ocean/context/event.py
+++ b/port_ocean/context/event.py
@@ -125,10 +125,13 @@ async def event_context(
     event_type: str,
     trigger_type: TriggerType = "manual",
     attributes: dict[str, Any] | None = None,
+    parent_override: EventContext | None = None,
 ) -> AsyncIterator[EventContext]:
-    attributes = attributes or {}
+    parent = parent_override or _event_context_stack.top
+    parent_attributes = parent.attributes if parent else {}
 
     parent = _event_context_stack.top
+    attributes = {**parent_attributes, **(attributes or {})}
     new_event = EventContext(
         event_type,
         trigger_type=trigger_type,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.5.15"
+version = "0.5.16"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What - Allowing parent event context override
Why - To allow using another event context attributes within task sub threads 

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
