### PR TITLE
fixed sanity check with non json response

### DIFF
--- a/integrations/sonarqube/CHANGELOG.md
+++ b/integrations/sonarqube/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+# Port_Ocean 0.1.47 (2024-05-02)
+
+### Bug Fixes
+
+- Fixed an issue with the integration startup when the sanity-check return a non json response
+
+
 # Port_Ocean 0.1.46 (2024-05-01)
 
 ### Improvements

--- a/integrations/sonarqube/client.py
+++ b/integrations/sonarqube/client.py
@@ -1,6 +1,7 @@
 import asyncio
-from typing import Any, Optional, AsyncGenerator, cast
 import base64
+from typing import Any, Optional, AsyncGenerator, cast
+
 import httpx
 from loguru import logger
 
@@ -417,8 +418,11 @@ class SonarQubeClient:
             response = httpx.get(f"{self.base_url}/api/system/status", timeout=5)
             response.raise_for_status()
             logger.info("Sonarqube sanity check passed")
-            logger.info(f"Sonarqube status: {response.json().get('status')}")
-            logger.info(f"Sonarqube version: {response.json().get('version')}")
+            if response.headers.get("content-type") == "application/json":
+                logger.info(f"Sonarqube status: {response.json().get('status')}")
+                logger.info(f"Sonarqube version: {response.json().get('version')}")
+            else:
+                logger.info(f"Sonarqube sanity check response: {response.text}")
         except httpx.HTTPStatusError as e:
             logger.error(
                 f"Sonarqube failed connectivity check to the sonarqube instance because of HTTP error: {e.response.status_code} and response text: {e.response.text}"

--- a/integrations/sonarqube/pyproject.toml
+++ b/integrations/sonarqube/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sonarqube"
-version = "0.1.46"
+version = "0.1.47"
 description = "SonarQube projects and code quality analysis integration"
 authors = ["Port Team <support@getport.io>"]
 


### PR DESCRIPTION
# Description

What - The sanity check failed

```
By: Port.io
Setting sail... ⛵️⚓️⛵️⚓️ All hands on deck! ⚓️
🌊 Ocean version: 0.5.17
🚢 Integration version: 0.1.46
2024-05-01 12:51:20.168 | INFO     | Registering resync event listener for kind projects
2024-05-01 12:51:20.169 | INFO     | Registering resync event listener for kind issues
2024-05-01 12:51:20.169 | INFO     | Registering resync event listener for kind saas_analysis
2024-05-01 12:51:20.170 | INFO     | Registering resync event listener for kind analysis
2024-05-01 12:51:20.171 | INFO     | Registering resync event listener for kind onprem_analysis
2024-05-01 12:51:20.180 | INFO     | Found default resources, starting creation process
2024-05-01 12:51:20.180 | INFO     | Fetching integration with id: my-sonarqube-integration
2024-05-01 12:51:20.188 | INFO     | No token found, fetching new token
2024-05-01 12:51:20.188 | INFO     | Fetching access token for clientId: 
2024-05-01 12:51:21.031 | INFO     | Integration already exists, skipping integration creation...
2024-05-01 12:51:21.032 | INFO     | Fetching integration with id: my-sonarqube-integration
INFO:     Started server process [8]
INFO:     Waiting for application startup.
2024-05-01 12:51:21.051 | INFO     | Starting integration
2024-05-01 12:51:21.052 | INFO     | Initializing integration components
2024-05-01 12:51:21.053 | INFO     | Initializing integration at port
2024-05-01 12:51:21.053 | INFO     | Initiating integration with id: my-sonarqube-integration
2024-05-01 12:51:21.054 | INFO     | Fetching integration with id: my-sonarqube-integration
2024-05-01 12:51:21.716 | INFO     | Checking for diff in integration configuration
2024-05-01 12:51:21.716 | INFO     | Integration with id: my-sonarqube-integration successfully registered
2024-05-01 12:51:21.717 | INFO     | Event started
2024-05-01 12:51:21.718 | WARNING  | Organization key is missing for an on-premise Sonarqube setup
2024-05-01 12:51:22.311 | INFO     | Sonarqube sanity check passed
2024-05-01 12:51:22.312 | INFO     | Event finished
2024-05-01 12:51:22.313 | ERROR    | Failed to start integration
Traceback (most recent call last):
  File "/usr/local/bin/ocean", line 8, in <module>
    sys.exit(cli_start())
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/usr/local/lib/python3.11/site-packages/port_ocean/cli/commands/sail.py", line 74, in sail
    run(path, log_level, port, initialize_port_resources, override)
  File "/usr/local/lib/python3.11/site-packages/port_ocean/run.py", line 57, in run
    uvicorn.run(app, host="0.0.0.0", port=application_settings.port)
  File "/usr/local/lib/python3.11/site-packages/uvicorn/main.py", line 578, in run
    server.run()
  File "/usr/local/lib/python3.11/site-packages/uvicorn/server.py", line 61, in run
    return asyncio.run(self.serve(sockets=sockets))
  File "/usr/local/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
  File "/usr/local/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
  File "/usr/local/lib/python3.11/asyncio/base_events.py", line 640, in run_until_complete
    self.run_forever()
  File "/usr/local/lib/python3.11/asyncio/base_events.py", line 607, in run_forever
    self._run_once()
  File "/usr/local/lib/python3.11/asyncio/base_events.py", line 1922, in _run_once
    handle._run()
  File "/usr/local/lib/python3.11/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
  File "/usr/local/lib/python3.11/site-packages/uvicorn/lifespan/on.py", line 88, in main
    await app(scope, self.receive, self.send)
  File "/usr/local/lib/python3.11/site-packages/uvicorn/middleware/proxy_headers.py", line 78, in __call__
    return await self.app(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/port_ocean/ocean.py", line 106, in __call__
    await self.fast_api_app(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/fastapi/applications.py", line 1054, in __call__
    await super().__call__(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/applications.py", line 123, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/errors.py", line 151, in __call__
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/base.py", line 103, in __call__
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 48, in __call__
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 762, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 771, in app
    await self.lifespan(scope, receive, send)
  File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 738, in lifespan
    async with self.lifespan_context(app) as maybe_state:
  File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 610, in __aenter__
    await self._router.startup()
  File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 715, in startup
    await handler()
> File "/usr/local/lib/python3.11/site-packages/port_ocean/ocean.py", line 100, in startup
    await self.integration.start()
  File "/usr/local/lib/python3.11/site-packages/port_ocean/core/integrations/base.py", line 81, in start
    await asyncio.gather(
  File "/app/./main.py", line 105, in on_start
    sonar_client.sanity_check()
  File "/app/client.py", line 420, in sanity_check
    logger.info(f"Sonarqube status: {response.json().get('status')}")
  File "/usr/local/lib/python3.11/site-packages/httpx/_models.py", line 756, in json
    return jsonlib.loads(self.text, **kwargs)
  File "/usr/local/lib/python3.11/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/local/lib/python3.11/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/local/lib/python3.11/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
Exception: Expecting value: line 2 column 1 (char 1)
ERROR:    Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/port_ocean/ocean.py", line 100, in startup
    await self.integration.start()
  File "/usr/local/lib/python3.11/site-packages/port_ocean/core/integrations/base.py", line 81, in start
    await asyncio.gather(
  File "/app/./main.py", line 105, in on_start
    sonar_client.sanity_check()
  File "/app/client.py", line 420, in sanity_check
    logger.info(f"Sonarqube status: {response.json().get('status')}")
                                     ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/httpx/_models.py", line 756, in json
    return jsonlib.loads(self.text, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 2 column 1 (char 1)
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 738, in lifespan
    async with self.lifespan_context(app) as maybe_state:
  File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 610, in __aenter__
    await self._router.startup()
  File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 715, in startup
    await handler()
  File "/usr/local/lib/python3.11/site-packages/port_ocean/ocean.py", line 104, in startup
    sys.exit("Server stopped")
SystemExit: Server stopped
ERROR:    Application startup failed. Exiting.
Error: Process completed with exit code 3.
```

Why - The response returned a non json response
How - logging the response differently in that case

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
