### PR TITLE
[Integrations] [Azure Devops] Fixed remote url error

### DIFF
--- a/integrations/azure-devops/.port/resources/port-app-config.yaml
+++ b/integrations/azure-devops/.port/resources/port-app-config.yaml
@@ -28,7 +28,7 @@ resources:
           blueprint: '"service"'
           title: .name
           properties:
-            url: '.url'
+            url: '.remoteUrl'
             readme: file://README.md
           relations:
             project: .project.id

--- a/integrations/azure-devops/CHANGELOG.md
+++ b/integrations/azure-devops/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+# Port_Ocean 0.1.18 (2024-05-08)
+
+### Improvements
+
+- Changed url to service from api url to remoteUrl (#1)
+
+
 # Port_Ocean 0.1.17 (2024-05-01)
 
 ### Improvements

--- a/integrations/azure-devops/pyproject.toml
+++ b/integrations/azure-devops/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "azure-devops"
-version = "0.1.17"
+version = "0.1.18"
 description = "An Azure Devops Ocean integration"
 authors = ["Matan Geva <matang@getport.io>"]
 


### PR DESCRIPTION
# Description

What - Fixed issue of the azure devops's service routing
Why - It sent the users to the api and not the actual repository
How - Switched from url to remoteurl

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![image](https://github.com/port-labs/ocean/assets/51418643/b71edf96-3bd2-4b4c-95a6-38959c98b50a)

## API Documentation

https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/
