### PR TITLE
[integration][KubeCost] - Fix Kubecost 404 error

### DIFF
--- a/integrations/kubecost/.port/resources/port-app-config.yaml
+++ b/integrations/kubecost/.port/resources/port-app-config.yaml
@@ -38,8 +38,8 @@ resources:
       entity:
         mappings:
           blueprint: '"kubecostCloudAllocation"'
-          identifier: .properties.service
-          title: .properties.service
+          identifier: .properties.provider + "/" + .properties.providerID + "/" + .properties.category + "/" + .properties.service | gsub("[^A-Za-z0-9@_.:\\\\/=-]"; "-")
+          title: .properties.provider + "/" + .properties.service
           properties:
             provider: .properties.provider
             accountID: .properties.accountID

--- a/integrations/kubecost/CHANGELOG.md
+++ b/integrations/kubecost/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- Updated the URL of the KubeCost cloud cost endpoint to resolve 404 error
+- Updated the URL of KubeCost cloud cost endpoint from version 1.X (`/model/cloudCost/aggregate`) to 2.2 (`/model/cloudCost`)
 
 
 # Port_Ocean 0.1.38 (2024-05-12)

--- a/integrations/kubecost/CHANGELOG.md
+++ b/integrations/kubecost/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
-# Port_Ocean 0.1.39 (2024-05-14)
+# Port_Ocean 0.1.39 (2024-05-15)
 
 ### Bug Fixes
 

--- a/integrations/kubecost/CHANGELOG.md
+++ b/integrations/kubecost/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+# Port_Ocean 0.1.39 (2024-05-14)
+
+### Bug Fixes
+
+- Updated the URL of the KubeCost cloud cost endpoint to resolve 404 error
+
+
 # Port_Ocean 0.1.38 (2024-05-12)
 
 ### Improvements

--- a/integrations/kubecost/changelog/0.1.39.bugfix.md
+++ b/integrations/kubecost/changelog/0.1.39.bugfix.md
@@ -1,1 +1,0 @@
-Updated the URL of the KubeCost cloud cost endpoint to resolve 404 error

--- a/integrations/kubecost/changelog/0.1.39.bugfix.md
+++ b/integrations/kubecost/changelog/0.1.39.bugfix.md
@@ -1,0 +1,1 @@
+Updated the URL of the KubeCost cloud cost endpoint to resolve 404 error

--- a/integrations/kubecost/client.py
+++ b/integrations/kubecost/client.py
@@ -57,7 +57,7 @@ class KubeCostClient:
 
         try:
             response = await self.http_client.get(
-                url=f"{self.kubecost_host}/model/cloudCost/aggregate",
+                url=f"{self.kubecost_host}/model/cloudCost",
                 params=params,
             )
             response.raise_for_status()

--- a/integrations/kubecost/main.py
+++ b/integrations/kubecost/main.py
@@ -8,7 +8,7 @@ from port_ocean.context.ocean import ocean
 async def on_kubesystem_cost_resync(kind: str) -> list[dict[Any, Any]]:
     client = KubeCostClient(ocean.integration_config["kubecost_host"])
     data = await client.get_kubesystem_cost_allocation()
-    return [value for item in data for value in item.values()]
+    return [value for item in data if item is not None for value in item.values()]
 
 
 @ocean.on_resync("cloud")

--- a/integrations/kubecost/pyproject.toml
+++ b/integrations/kubecost/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "kubecost"
-version = "0.1.38"
+version = "0.1.39"
 description = "Kubecost integration powered by Ocean"
 authors = ["Isaac Coffie <isaac@getport.io>"]
 


### PR DESCRIPTION
# Description

What - The `cloud` kind of the KubeCost exporter was throwing 404 error because KubeCost had change their API route. This led to the exporter hanging up during the resync process. There was also an issue with the mapping of resource so I adjusted the mapping to map all resources as there may be several cost estimates for the same cloud service.

Why -
How - Updated the URL of the cloud cost to use the correct path

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

## Screenshots

<img width="1092" alt="Screenshot 2024-05-14 at 2 06 20 PM" src="https://github.com/port-labs/ocean/assets/15999660/4823197e-453e-42da-9476-64373af05624">


## API Documentation

[Deprecated Cloud Cost API in KubeCost version 1.X](https://docs.kubecost.com/v/1.0x/apis/apis-overview/cloud-cost-api#cloud-cost-aggregate-api)
[Current Cloud Cost API in KubeCost version 2.2](https://docs.kubecost.com/apis/monitoring-apis/cloud-cost-api)
