### PR TITLE
[Integration][ADO] Fix default relation mapping from service to project

### DIFF
--- a/integrations/azure-devops/.port/resources/port-app-config.yaml
+++ b/integrations/azure-devops/.port/resources/port-app-config.yaml
@@ -31,7 +31,7 @@ resources:
             url: '.remoteUrl'
             readme: file://README.md
           relations:
-            project: .project.id
+            project: '.project.id | gsub(" "; "")'
 
   - kind: repository-policy
     selector:

--- a/integrations/azure-devops/CHANGELOG.md
+++ b/integrations/azure-devops/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+# Port_Ocean 0.1.23 (2024-05-15)
+
+### Bug Fixes
+
+- Fixed default relation mapping between service and project (#1)
+
 # Port_Ocean 0.1.21 (2024-05-12)
 
 ### Improvements

--- a/integrations/azure-devops/CHANGELOG.md
+++ b/integrations/azure-devops/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
-# Port_Ocean 0.1.23 (2024-05-15)
+# Port_Ocean 0.1.22 (2024-05-15)
 
 ### Bug Fixes
 

--- a/integrations/azure-devops/pyproject.toml
+++ b/integrations/azure-devops/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "azure-devops"
-version = "0.1.21"
+version = "0.1.22"
 description = "An Azure Devops Ocean integration"
 authors = ["Matan Geva <matang@getport.io>"]
 


### PR DESCRIPTION
# Description

What - Fix default relation mapping from service to project
Why - due to using `gsub(" ", "")` to remove empty spaces
How -

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
