### PR TITLE
Port 8213 fix ocean integration publish workflow

### DIFF
--- a/.github/workflows/release-integrations.yml
+++ b/.github/workflows/release-integrations.yml
@@ -94,7 +94,6 @@ jobs:
           echo "dockerfile_path=$dockerfile_path" >> $GITHUB_OUTPUT
 
           # Check if the 'version' variable contains any character other than digits and "."
-          echo "version=$version"
           if [[ ! "$version" =~ ^[0-9.]+$ ]]; then
             # If 'version' contains non-numeric and non-dot characters, skip building 'latest' tag
             tags="ghcr.io/port-labs/port-ocean-$type:$version"
@@ -119,18 +118,6 @@ jobs:
           build-args: |
             BUILD_CONTEXT=${{ steps.prepare_tags.outputs.context_dir }}
             INTEGRATION_VERSION=${{ steps.prepare_tags.outputs.version }}
-
-  test:
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-      contents: read
-    needs: release-integration
-    steps:
-      - name: test
-        run: |
-          echo "is_dev_version: ${{ needs.release-integration.outputs.is_dev_version }}"
-          echo "${{ toJson(needs.release-integration.outputs) }}"
 
   upload-specs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description

What - integration publish workflow would skip the publish spec job
Why - The is_dev_version output was not exported correctly
How - Added output to the job creating the output for other jobs to use

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
