### PR TITLE
fix(Port 8334): ocean integration wont shut down without forcing it

### DIFF
--- a/changelog/1.bugfix.md
+++ b/changelog/1.bugfix.md
@@ -1,0 +1,1 @@
+Using the fastapi lifespan for shuttind down exiting tasks instead of signal to prevent overriding fastapi signal from shuttind down the server

--- a/changelog/1.bugfix.md
+++ b/changelog/1.bugfix.md
@@ -1,1 +1,1 @@
-Using the fastapi lifespan for shuttind down exiting tasks instead of signal to prevent overriding fastapi signal from shuttind down the server
+Fixed the FastAPI server staying stale after shutdown by using the FastAPI lifespan feature for handling shutdown signals, preventing override of the shutdown process.

--- a/changelog/1.improvement.md
+++ b/changelog/1.improvement.md
@@ -1,1 +1,1 @@
-Switched to use fastapi lifespan feature instead of deprecated old way (on_shutdown and on_start)
+Switched to using the FastAPI lifespan feature instead of the deprecated on_shutdown and on_start methods.

--- a/changelog/1.improvement.md
+++ b/changelog/1.improvement.md
@@ -1,0 +1,1 @@
+Switched to use fastapi lifespan feature instead of deprecated old way (on_shutdown and on_start)

--- a/changelog/2.bugfix.md
+++ b/changelog/2.bugfix.md
@@ -1,1 +1,1 @@
-Fixed integration keep running after shutdown by canceling the task for the resync async generator
+Fixed issue with integration continuing to run after shutdown by canceling the resync async generator task.

--- a/changelog/2.bugfix.md
+++ b/changelog/2.bugfix.md
@@ -1,0 +1,1 @@
+Fixed integration keep running after shutdown by canceling the task for the resync async generator

--- a/port_ocean/core/event_listener/base.py
+++ b/port_ocean/core/event_listener/base.py
@@ -1,5 +1,4 @@
 from abc import abstractmethod
-from asyncio import Task
 from typing import TypedDict, Callable, Any, Awaitable
 
 from pydantic import Extra
@@ -22,7 +21,6 @@ class BaseEventListener:
         events: EventListenerEvents,
     ):
         self.events = events
-        self._tasks_to_close: list[Task[Any]] = []
 
     async def start(self) -> None:
         signal_handler.register(self._stop)
@@ -31,11 +29,6 @@ class BaseEventListener:
     @abstractmethod
     async def _start(self) -> None:
         pass
-
-    def stop(self) -> None:
-        self._stop()
-        for task in self._tasks_to_close:
-            task.cancel()
 
     def _stop(self) -> None:
         """

--- a/port_ocean/core/event_listener/polling.py
+++ b/port_ocean/core/event_listener/polling.py
@@ -10,6 +10,7 @@ from port_ocean.core.event_listener.base import (
     EventListenerSettings,
 )
 from port_ocean.utils.repeat import repeat_every
+from port_ocean.utils.signal import signal_handler
 
 
 class PollingEventListenerSettings(EventListenerSettings):
@@ -79,7 +80,7 @@ class PollingEventListener(BaseEventListener):
                 running_task: Task[Any] = get_event_loop().create_task(
                     self.events["on_resync"]({})  # type: ignore
                 )
-                self._tasks_to_close.append(running_task)
+                signal_handler.register(running_task.cancel)
 
                 await running_task
 

--- a/port_ocean/ocean.py
+++ b/port_ocean/ocean.py
@@ -2,7 +2,7 @@ import asyncio
 import sys
 import threading
 from contextlib import asynccontextmanager
-from typing import Callable, Any, Dict, AsyncIterator, Never
+from typing import Callable, Any, Dict, AsyncIterator
 
 from fastapi import FastAPI, APIRouter
 from loguru import logger
@@ -95,12 +95,12 @@ class Ocean:
         self.fast_api_app.include_router(self.integration_router, prefix="/integration")
 
         @asynccontextmanager
-        async def lifecycle(_: FastAPI) -> AsyncIterator[Never]:
+        async def lifecycle(_: FastAPI) -> AsyncIterator[None]:
             try:
                 init_signal_handler()
                 await self.integration.start()
                 await self._setup_scheduled_resync()
-                yield
+                yield None
                 signal_handler.exit()
             except Exception:
                 logger.exception("Integration had a fatal error. Shutting down.")

--- a/port_ocean/ocean.py
+++ b/port_ocean/ocean.py
@@ -2,7 +2,7 @@ import asyncio
 import sys
 import threading
 from contextlib import asynccontextmanager
-from typing import Callable, Any, Dict
+from typing import Callable, Any, Dict, AsyncIterator, Never
 
 from fastapi import FastAPI, APIRouter
 from loguru import logger
@@ -95,7 +95,7 @@ class Ocean:
         self.fast_api_app.include_router(self.integration_router, prefix="/integration")
 
         @asynccontextmanager
-        async def lifecycle(_: FastAPI) -> None:
+        async def lifecycle(_: FastAPI) -> AsyncIterator[Never]:
             try:
                 init_signal_handler()
                 await self.integration.start()

--- a/port_ocean/ocean.py
+++ b/port_ocean/ocean.py
@@ -95,7 +95,7 @@ class Ocean:
         self.fast_api_app.include_router(self.integration_router, prefix="/integration")
 
         @asynccontextmanager
-        async def lifecycle(_: FastAPI):
+        async def lifecycle(_: FastAPI) -> None:
             try:
                 init_signal_handler()
                 await self.integration.start()

--- a/port_ocean/ocean.py
+++ b/port_ocean/ocean.py
@@ -1,6 +1,7 @@
 import asyncio
 import sys
 import threading
+from contextlib import asynccontextmanager
 from typing import Callable, Any, Dict
 
 from fastapi import FastAPI, APIRouter
@@ -21,7 +22,7 @@ from port_ocean.core.integrations.base import BaseIntegration
 from port_ocean.log.sensetive import sensitive_log_filter
 from port_ocean.middlewares import request_handler
 from port_ocean.utils.repeat import repeat_every
-from port_ocean.utils.signal import init_signal_handler
+from port_ocean.utils.signal import signal_handler, init_signal_handler
 from port_ocean.version import __integration_version__
 
 
@@ -93,14 +94,17 @@ class Ocean:
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         self.fast_api_app.include_router(self.integration_router, prefix="/integration")
 
-        @self.fast_api_app.on_event("startup")
-        async def startup() -> None:
-            init_signal_handler()
+        @asynccontextmanager
+        async def lifecycle(_: FastAPI):
             try:
+                init_signal_handler()
                 await self.integration.start()
                 await self._setup_scheduled_resync()
+                yield
+                signal_handler.exit()
             except Exception:
-                logger.exception("Failed to start integration")
+                logger.exception("Integration had a fatal error. Shutting down.")
                 sys.exit("Server stopped")
 
+        self.fast_api_app.router.lifespan_context = lifecycle
         await self.fast_api_app(scope, receive, send)

--- a/port_ocean/utils/signal.py
+++ b/port_ocean/utils/signal.py
@@ -1,4 +1,3 @@
-import signal
 from typing import Callable, Any
 
 from werkzeug.local import LocalProxy, LocalStack
@@ -13,10 +12,8 @@ from port_ocean.utils.misc import generate_uuid
 class SignalHandler:
     def __init__(self) -> None:
         self._handlers: dict[str, Callable[[], Any]] = {}
-        signal.signal(signal.SIGINT, lambda _, __: self._exit())
-        signal.signal(signal.SIGTERM, lambda _, __: self._exit())
 
-    def _exit(self) -> None:
+    def exit(self) -> None:
         """
         Handles the exit signal.
         """


### PR DESCRIPTION
# Description

What - After shutting down an integration it will keep running
Why - Incorrect handling of async tasks
How - Better handling and moved from listenning to signal to the fastapi lifespan feature

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
