### PR TITLE
PORT-8407 Update container base image from slim-buster to slim-bookworm

### DIFF
--- a/integrations/_infra/Dockerfile
+++ b/integrations/_infra/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-buster
+FROM python:3.11-slim-bookworm
 
 ARG BUILD_CONTEXT
 ARG INTEGRATION_VERSION


### PR DESCRIPTION
# Description

What - Update the base image we use to build integration container images
Why - Because we're currently using `slim-buster` which is no longer maintained
How - Update to `slim-bookworm` which is the current stable LTS Debian distro

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
