### PR TITLE
port-8420 Update the default mapping of the integration and bump version files

### DIFF
--- a/integrations/jira/.port/resources/port-app-config.yaml
+++ b/integrations/jira/.port/resources/port-app-config.yaml
@@ -15,7 +15,7 @@ resources:
   - kind: issue
     selector:
       query: "true"
-      jql: "status != Done"
+      jql: "statusCategory != done"
     port:
       entity:
         mappings:

--- a/integrations/jira/CHANGELOG.md
+++ b/integrations/jira/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+0.1.52 (2024-05-30)
+
+### Improvements
+
+- Updated the JQL filter used in the default configuration mapping to not ingest Jira issues of the `done` statusCategory
+- Updated the default mapping for the `issue` kind
+
 0.1.51 (2024-05-30)
 
 ### Improvements

--- a/integrations/jira/pyproject.toml
+++ b/integrations/jira/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jira"
-version = "0.1.51"
+version = "0.1.52"
 description = "Integration to bring information from Jira into Port"
 authors = ["Mor Paz <mor@getport.io>"]
 


### PR DESCRIPTION
# Description

What - Updated the JQL filter used in the default configuration mapping to not ingest Jira issues of the `done` statusCategory
Why - To correctly filter all issues that are categorized as done by Jira
How - Update the `port-app-config.yaml`

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
