### PR TITLE
Fix gather exception handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.5.25 (2024-06-03)
+
+
+### Bug Fixes
+
+- Fixed faulty error handling caused by gather_and_split_errors_from_results raising errors that are not directly under BaseException (#1)
+
+
 ## 0.5.24 (2024-06-02)
 
 

--- a/changelog/1.bugfix.md
+++ b/changelog/1.bugfix.md
@@ -1,1 +1,0 @@
-Fixed faulty error handling caused by gather_and_split_errors_from_results raising errors that are not directly under BaseException

--- a/changelog/1.bugfix.md
+++ b/changelog/1.bugfix.md
@@ -1,0 +1,1 @@
+Fixed faulty error handling caused by gather_and_split_errors_from_results raising errors that are not directly under BaseException

--- a/port_ocean/core/utils.py
+++ b/port_ocean/core/utils.py
@@ -44,7 +44,7 @@ async def gather_and_split_errors_from_results(
         # https://docs.python.org/3/library/asyncio-task.html#asyncio.gather
         # These exceptions should be raised and not caught for the application to exit properly.
         # https://stackoverflow.com/a/17802352
-        if isinstance(item, BaseException):
+        if isinstance(item, BaseException) and not isinstance(item, Exception):
             raise item
         elif isinstance(item, Exception):
             errors.append(item)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.5.24"
+version = "0.5.25"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What - gather_and_split_errors_from_results would handle baseexception errors incorrectly 
Why - wrong inheritance check
How - Updated the logic

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
