### PR TITLE
Fixed incorrect pydantic validation over the integration settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.5.27 (2024-06-05)
+
+
+### Bug Fixes
+
+- Fixed incorrect pydantic validation over the integration settings
+
+
 ## 0.5.26 (2024-06-04)
 
 

--- a/port_ocean/config/settings.py
+++ b/port_ocean/config/settings.py
@@ -1,14 +1,13 @@
 from typing import Any, Literal
 
+from port_ocean.config.base import BaseOceanSettings, BaseOceanModel
+from port_ocean.core.event_listener import EventListenerSettingsType
+from port_ocean.utils.misc import get_integration_name
 from pydantic import Extra, AnyHttpUrl, parse_obj_as
 from pydantic.class_validators import root_validator
 from pydantic.env_settings import InitSettingsSource, EnvSettingsSource, BaseSettings
 from pydantic.fields import Field
 from pydantic.main import BaseModel
-
-from port_ocean.config.base import BaseOceanSettings, BaseOceanModel
-from port_ocean.core.event_listener import EventListenerSettingsType
-from port_ocean.utils.misc import get_integration_name
 
 LogLevelType = Literal["ERROR", "WARNING", "INFO", "DEBUG", "CRITICAL"]
 
@@ -42,8 +41,8 @@ class PortSettings(BaseOceanModel, extra=Extra.allow):
 
 
 class IntegrationSettings(BaseOceanModel, extra=Extra.allow):
-    identifier: str = Field(..., min_length=1)
-    type: str = Field(..., min_length=1)
+    identifier: str
+    type: str
     config: dict[str, Any] | BaseModel = Field(default_factory=dict)
 
     @root_validator(pre=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.5.26"
+version = "0.5.27"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What - Without setting an identifier the integration failed
Why - incorrect pydantic validation over the integration settings

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
