### PR TITLE
feat: Add useGetResource property to AWS default mapping

### DIFF
--- a/integrations/aws/.port/resources/port-app-config.yml
+++ b/integrations/aws/.port/resources/port-app-config.yml
@@ -18,6 +18,7 @@ resources:
   - kind: AWS::S3::Bucket
     selector:
       query: 'true'
+      useGetResource: 'true'
     port:
       entity:
         mappings:
@@ -52,10 +53,11 @@ resources:
   - kind: AWS::ECS::Cluster
     selector:
       query: 'true'
+      useGetResource: 'true'
     port:
       entity:
         mappings:
-          identifier: .Identifier
+          identifier: .Properties.Arn
           title: .Identifier
           blueprint: '"cloudResource"'
           properties:


### PR DESCRIPTION
# Description

What - use unique identifier in AWS default mapping
Why - some of the resources can be overriden if they are created in the same name in a different region/account
How - use `ARN` property or globally unique identifier

## Type of change

Please leave one option from the following and delete the rest:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
