### PR TITLE
[Framework] Safely get changelogDestination key instead of accessing it directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.9.1 (2024-06-23)
+
+
+### Bug Fixes
+
+- Safely get changelogDestination key instead of accessing it directly 
+
+
 ## 0.9.0 (2024-06-19)
 
 

--- a/port_ocean/core/defaults/initialize.py
+++ b/port_ocean/core/defaults/initialize.py
@@ -89,8 +89,8 @@ async def _initialize_required_integration_settings(
         "changelog_destination"
     )
     if (
-        integration["changelogDestination"] != changelog_destination
-        or integration["installationAppType"] != integration_config.integration.type
+        integration.get("changelogDestination") != changelog_destination
+        or integration.get("installationAppType") != integration_config.integration.type
         or integration.get("version") != port_client.integration_version
     ):
         await port_client.patch_integration(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.9.0"
+version = "0.9.1"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What - changelogDestination key may not exist
How - solved by safely get changelogDestination key instead of accessing it directly

## Type of change

Please leave one option from the following and delete the rest:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
