### PR TITLE
[PORT-8788] [OceanCore] Removed validation if integration has deployment requirements

### DIFF
--- a/port_ocean/config/dynamic.py
+++ b/port_ocean/config/dynamic.py
@@ -28,7 +28,7 @@ def dynamic_parse(value: Any, field: ModelField) -> Any:
     return value
 
 
-def default_config_factory(configurations: Any) -> Type[BaseModel]:
+def default_config_factory(configurations: Any, deployment_method_requirements: Any) -> Type[BaseModel]:
     configurations = parse_obj_as(list[Configuration], configurations)
     fields: dict[str, tuple[Any, Any]] = {}
 
@@ -51,7 +51,7 @@ def default_config_factory(configurations: Any) -> Type[BaseModel]:
             case _:
                 raise ValueError(f"Unknown type: {config.type}")
 
-        default = ... if config.required else None
+        default = ... if config.required and not deployment_method_requirements else None
         if config.default is not None:
             default = parse_obj_as(field_type, config.default)
         fields[decamelize(config.name)] = (

--- a/port_ocean/run.py
+++ b/port_ocean/run.py
@@ -19,7 +19,7 @@ def _get_default_config_factory() -> None | Type[BaseModel]:
     spec = get_spec_file()
     config_factory = None
     if spec is not None:
-        config_factory = default_config_factory(spec.get("configurations", []))
+        config_factory = default_config_factory(spec.get("configurations", []), spec.get("deploymentMethodRequirements", []))
 
     return config_factory
 


### PR DESCRIPTION
# Description

What - Removed configurations 'required' validation if "deploymentMethodRequirements" key exists in spec.yaml
Why - Enable Integrations to specify requirements based on different deployment methods
How - Added a case to where the required configurations are marked

## Type of change

Please leave one option from the following and delete the rest:

- [ ] New feature (non-breaking change which adds functionality)
