### PR TITLE
[PORT-8788] [AWS] [GCP]  add requirements for deployment methods

### DIFF
--- a/integrations/aws/.port/spec.yaml
+++ b/integrations/aws/.port/spec.yaml
@@ -37,7 +37,14 @@ configurations:
     type: string
     sensitive: true
     description: AWS API Key for custom events, used to validate the event source for real-time event updates.
+deploymentMethodRequirements:
+  - type: default
+    configurations: ['awsAccessKeyId', 'awsSecretAccessKey']
 deploymentMethodOverride:
+  - type: helm
+  - type: docker
+  - type: githubWorkflow
+  - type: gitlabCI
   - type: terraform-aws
     module: port-labs/integration-factory/ocean
     example: aws_container_app

--- a/integrations/aws/CHANGELOG.md
+++ b/integrations/aws/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
-- Added new installation methods to the AWS integration (#1)
+- Added support for default installation methods ( Helm, docker, githubworkflow and gitlabCI ) to improve ease of use (#1)
 
 
 # Port_Ocean 0.2.7 (2024-06-23)

--- a/integrations/aws/CHANGELOG.md
+++ b/integrations/aws/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+# Port_Ocean 0.2.8 (2024-06-23)
+
+### Improvements
+
+- Added new installation methods to the AWS integration (#1)
+
+
 # Port_Ocean 0.2.7 (2024-06-23)
 
 ### Improvements

--- a/integrations/aws/pyproject.toml
+++ b/integrations/aws/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws"
-version = "0.2.7"
+version = "0.2.8"
 description = "This integration will map all your resources in all the available accounts to your Port entities"
 authors = ["Shalev Avhar <shalev@getport.io>"]
 

--- a/integrations/gcp/.port/spec.yaml
+++ b/integrations/gcp/.port/spec.yaml
@@ -9,7 +9,7 @@ configurations:
   - name: encodedADCConfiguration
     type: string
     require: false
-    description: Base64 encoding of your Google Cloud's ADC Credentials configuration file. Follow https://cloud.google.com/docs/authentication/provide-credentials-adc to learn more.
+    description: Base64 encoding of your Google Cloud's ADC Credentials configuration file. Go to https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/cloud-providers/gcp/installation for more information
 deploymentMethodRequirements:
   - type: default
     configurations: ['encodedADCConfiguration']

--- a/integrations/gcp/.port/spec.yaml
+++ b/integrations/gcp/.port/spec.yaml
@@ -5,8 +5,18 @@ features:
     section: Cloud Providers
 saas:
   enabled: false
-configurations: []
+configurations:
+  - name: encodedADCConfiguration
+    type: string
+    require: false
+    description: Base64 encoding of your Google Cloud's ADC Credentials configuration file
+deploymentMethodRequirements:
+  - type: default
+    configurations: ['encodedADCConfiguration']
 deploymentMethodOverride:
+  - type: helm
+  - type: docker
+  - type: githubWorkflow
   - type: terraform-gcp
     module: port-labs/integration-factory/ocean
     example: gcp_integration_with_real_time

--- a/integrations/gcp/.port/spec.yaml
+++ b/integrations/gcp/.port/spec.yaml
@@ -17,6 +17,7 @@ deploymentMethodOverride:
   - type: helm
   - type: docker
   - type: githubWorkflow
+  - type: gitlabCI
   - type: terraform-gcp
     module: port-labs/integration-factory/ocean
     example: gcp_integration_with_real_time

--- a/integrations/gcp/.port/spec.yaml
+++ b/integrations/gcp/.port/spec.yaml
@@ -9,7 +9,7 @@ configurations:
   - name: encodedADCConfiguration
     type: string
     require: false
-    description: Base64 encoding of your Google Cloud's ADC Credentials configuration file
+    description: Base64 encoding of your Google Cloud's ADC Credentials configuration file. Follow https://cloud.google.com/docs/authentication/provide-credentials-adc to learn more.
 deploymentMethodRequirements:
   - type: default
     configurations: ['encodedADCConfiguration']

--- a/integrations/gcp/CHANGELOG.md
+++ b/integrations/gcp/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+# Port_Ocean 0.1.26 (2024-06-23)
+
+### Improvements
+
+- Added new installation methods to the GCP integration (#1)
+
+
 # Port_Ocean 0.1.25 (2024-06-23)
 
 ### Improvements

--- a/integrations/gcp/CHANGELOG.md
+++ b/integrations/gcp/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
-- Added new installation methods to the GCP integration (#1)
+- Added support for default installation methods ( Helm, docker, githubworkflow and gitlabCI ) to improve ease of use (#1)
 
 
 # Port_Ocean 0.1.25 (2024-06-23)

--- a/integrations/gcp/main.py
+++ b/integrations/gcp/main.py
@@ -51,7 +51,9 @@ def _resolve_resync_method_for_resource(
 @ocean.on_start()
 async def setup_application_default_credentials() -> None:
     if not ocean.integration_config["encoded_adc_configuration"]:
-        logger.info("Using integration's environment Application Default Credentials configuration")
+        logger.info(
+            "Using integration's environment Application Default Credentials configuration"
+        )
         return
     b64_credentials = ocean.integration_config["encoded_adc_configuration"]
     credentials_json = base64.b64decode(b64_credentials).decode("utf-8")

--- a/integrations/gcp/pyproject.toml
+++ b/integrations/gcp/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gcp"
-version = "0.1.25"
+version = "0.1.26"
 description = "A GCP ocean integration"
 authors = ["Matan Geva <matang@getport.io>"]
 


### PR DESCRIPTION
# Description

What - Added Deployment Requirements for AWS and GCP integrations
Why - To enable different deployment methods for both
How - Using new deployment method requirements feature in the frontend

## Type of change

Please leave one option from the following and delete the rest:

- [ ] New feature (non-breaking change which adds functionality)

