### PR TITLE
[PORT-8828] [AWS] Ensure default region for global resources

### DIFF
--- a/integrations/aws/CHANGELOG.md
+++ b/integrations/aws/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+# Port_Ocean 0.2.9 (2024-07-02)
+
+### Bugfix
+
+- Ensure default region for global resources (#1)
+
+
 # Port_Ocean 0.2.8 (2024-06-23)
 
 ### Improvements

--- a/integrations/aws/aws/aws_credentials.py
+++ b/integrations/aws/aws/aws_credentials.py
@@ -15,6 +15,7 @@ class AwsCredentials:
         self.secret_access_key = secret_access_key
         self.session_token = session_token
         self.enabled_regions: list[str] = []
+        self.default_regions: list[str] = []
 
     async def update_enabled_regions(self) -> None:
         session = aioboto3.Session(
@@ -26,6 +27,11 @@ class AwsCredentials:
             )
             regions = response.get("Regions", [])
             self.enabled_regions = [region["RegionName"] for region in regions]
+            self.default_regions = [
+                region["RegionName"]
+                for region in regions
+                if region["RegionOptStatus"] == "ENABLED_BY_DEFAULT"
+            ]
 
     def is_role(self) -> bool:
         return self.session_token is not None

--- a/integrations/aws/pyproject.toml
+++ b/integrations/aws/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.poetry]
 name = "aws"
-version = "0.2.8"
+version = "0.2.9"
 description = "This integration will map all your resources in all the available accounts to your Port entities"
-authors = ["Shalev Avhar <shalev@getport.io>"]
+authors = ["Shalev Avhar <shalev@getport.io>", "Erik Zaadi <erik@getport.io>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"


### PR DESCRIPTION
# Description

What - Ensure that there's a default region for global AWS resources
Why - Creating an instance of the cloudcontrol client would fail if no AWS default region was known
How - Lookup default regions from the credentials

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
