### PR TITLE
Allow project specific webhook creation for project admins

### DIFF
--- a/integrations/azure-devops/.port/spec.yaml
+++ b/integrations/azure-devops/.port/spec.yaml
@@ -15,6 +15,10 @@ configurations:
     required: true
     type: string
     sensitive: true
+  - name: isProjectAdmin
+    required: false
+    type: boolean
+    description: If the user is a project admin.
   - name: appHost
     required: false
     type: url

--- a/integrations/azure-devops/azure_devops/webhooks/webhook_event.py
+++ b/integrations/azure-devops/azure_devops/webhooks/webhook_event.py
@@ -9,10 +9,13 @@ class WebhookEvent(BaseModel):
     consumerId: str = "webHooks"
     consumerActionId: str = "httpRequest"
     consumerInputs: Optional[dict[str, str]] = None
+    publisherInputs: Optional[dict[str, str]] = None
     status: Optional[str] = None
 
-    def set_consumer_url(self, url: str) -> None:
+    def set_webhook_details(self, url: str, project_id: Optional[str] = None) -> None:
         self.consumerInputs = {"url": url}
+        if project_id:
+            self.publisherInputs = {"projectId": project_id}
 
     def get_event_by_subscription(
         self, subscribed_events: list["WebhookEvent"]
@@ -22,6 +25,7 @@ class WebhookEvent(BaseModel):
                 subscribed_event.publisherId == self.publisherId
                 and subscribed_event.eventType == self.eventType
                 and subscribed_event.consumerInputs == self.consumerInputs
+                and subscribed_event.publisherInputs == self.publisherInputs
             ):
                 return subscribed_event
 

--- a/integrations/azure-devops/bootstrap.py
+++ b/integrations/azure-devops/bootstrap.py
@@ -11,7 +11,7 @@ webhook_event_handler = WebhookEventObserver()
 
 
 async def setup_listeners(
-    app_host: str, azure_devops_client: AzureDevopsClient
+    app_host: str, azure_devops_client: AzureDevopsClient, project_id: str | None = None
 ) -> None:
     listeners: list[HookListener] = [
         PullRequestHookListener(azure_devops_client),
@@ -20,7 +20,7 @@ async def setup_listeners(
     webhook_events: list[WebhookEvent] = list()
     for listener in listeners:
         for event in listener.webhook_events:
-            event.set_consumer_url(f"{app_host}/integration/webhook")
+            event.set_webhook_details(f"{app_host}/integration/webhook", project_id)
         webhook_event_handler.on(listener.webhook_events, listener.on_hook)
         webhook_events.extend(listener.webhook_events)
     await _upsert_webhooks(azure_devops_client, webhook_events)

--- a/integrations/azure-devops/main.py
+++ b/integrations/azure-devops/main.py
@@ -24,7 +24,16 @@ async def setup_webhooks() -> None:
         return
 
     azure_devops_client = AzureDevopsClient.create_from_ocean_config()
-    await setup_listeners(ocean.integration_config["app_host"], azure_devops_client)
+    if ocean.integration_config.get("is_project_admin", False):
+        async for projects in azure_devops_client.generate_projects():
+            for project in projects:
+                await setup_listeners(
+                    ocean.integration_config["app_host"], azure_devops_client, project["id"]
+                )
+    else:
+        await setup_listeners(
+            ocean.integration_config["app_host"], azure_devops_client
+        )
 
 
 @ocean.on_resync(Kind.PROJECT)


### PR DESCRIPTION
# Description

The genesis of this change is documented in this [slack thread](https://port-community.slack.com/archives/C06UR5F2WCX/p1717488013161949)

**What** 
- Users encounter a 400 error when attempting to create subscriptions (webhooks) due to insufficient permissions to edit the subscription. 
- Modify the webhook creation process to include the projectId in the payload.

**Why** 
- The current setup assumes an organisation token when creating webhooks. If a project-scoped token is supplied, the craetion fails


**How**
- When the user holds a project administrator role, and the PAT is scoped only to that specific project, it is necessary to explicitly define the projectId when creating a webhook.
```json
{
  "publisherId": "tfs",
  "eventType": "git.pullrequest.updated",
  "consumerId": "webHooks",
  "consumerActionId": "httpRequest",
  "consumerInputs": {
    "url": "http://20.246.193.102/ado-port/integration/webhook"
  },
  "publisherInputs": {
    "projectId": "4901a905-d07b-4027-b7cc-577d2b6a0e31"
  }
}
```

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
