### PR TITLE
[Core] Added environment variables access restriction option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Improvements
 
 - Added Ocean integration config to remove all environment variables from jq access
-
+- Added log for when receiving invalid port app config mapping
 
 ## 0.9.2 (2024-07-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.9.3 (2024-07-08)
+
+### Improvements
+
+- Added Ocean integration config to remove all environment variables from jq access
+
+
 ## 0.9.2 (2024-07-05)
 
 ### Improvements

--- a/port_ocean/config/settings.py
+++ b/port_ocean/config/settings.py
@@ -62,6 +62,7 @@ class IntegrationSettings(BaseOceanModel, extra=Extra.allow):
 
 
 class IntegrationConfiguration(BaseOceanSettings, extra=Extra.allow):
+    allow_environment_variables_jq_access: bool = True
     initialize_port_resources: bool = True
     scheduled_resync_interval: int | None = None
     client_timeout: int = 30

--- a/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
+++ b/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
@@ -44,6 +44,8 @@ class JQEntityProcessor(BaseEntityProcessor):
 
     @lru_cache
     def _compile(self, pattern: str) -> Any:
+        if not ocean.config.allow_environment_variables_jq_access:
+            pattern = "def env: {}; {} as $ENV | " + pattern
         return jq.compile(pattern)
 
     async def _search(self, data: dict[str, Any], pattern: str) -> Any:

--- a/port_ocean/core/handlers/port_app_config/base.py
+++ b/port_ocean/core/handlers/port_app_config/base.py
@@ -76,6 +76,7 @@ class BasePortAppConfig(BaseHandler):
                 logger.error(
                     "Invalid port app config found. Please check that the integration has been configured correctly."
                 )
+                logger.warning(f"Invalid port app config: {raw_config}")
                 raise
 
         event.port_app_config = self._app_config_cache.port_app_config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.9.2"
+version = "0.9.3"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What - Added a new ocean configuration option- Allow Environment variables jq access, which is true by default
Why - To have an option to hide sensitive information from the integration runner
How - Added Integration configuration

## Type of change

Please leave one option from the following and delete the rest:

- [x] New feature (non-breaking change which adds functionality)