### PR TITLE
[Framework] Fix handling of non existing config key in port app config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.9.4 (2024-07-09)
+
+### Bug Fixes
+
+- Handle non existing config mapping for cases where the integration was created by SAAS and the config mapping was not set
+
+
 ## 0.9.3 (2024-07-08)
 
 ### Improvements

--- a/port_ocean/core/defaults/initialize.py
+++ b/port_ocean/core/defaults/initialize.py
@@ -71,7 +71,7 @@ async def _initialize_required_integration_settings(
                 integration_config.event_listener.to_request(),
                 port_app_config=default_mapping,
             )
-        elif not integration["config"]:
+        elif not integration.get("config"):
             logger.info(
                 "Encountered that the integration's mapping is empty, Initializing to default mapping"
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.9.3"
+version = "0.9.4"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What - Fix handling of non existing config key in port app config
Why - When installing in Saas the config is not set yet and therefor we don't want to fail on that.
How -

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
