### PR TITLE
[Integration][AWS] Fix wrong parameter name in default mapping

### DIFF
--- a/integrations/aws/.port/resources/port-app-config.yml
+++ b/integrations/aws/.port/resources/port-app-config.yml
@@ -18,7 +18,7 @@ resources:
   - kind: AWS::S3::Bucket
     selector:
       query: 'true'
-      useGetResource: 'true'
+      useGetResourceAPI: 'true'
     port:
       entity:
         mappings:
@@ -53,7 +53,7 @@ resources:
   - kind: AWS::ECS::Cluster
     selector:
       query: 'true'
-      useGetResource: 'true'
+      useGetResourceAPI: 'true'
     port:
       entity:
         mappings:

--- a/integrations/aws/.port/resources/port-app-config.yml
+++ b/integrations/aws/.port/resources/port-app-config.yml
@@ -27,7 +27,9 @@ resources:
           blueprint: '"cloudResource"'
           properties:
             kind: .__Kind
-            region: .__Region
+            region: >-
+              .Properties.RegionalDomainName |
+              capture(".*\\.(?<region>[^\\.]+)\\.amazonaws\\.com") | .region
             tags: .Properties.Tags
             arn: .Properties.Arn
             link: '.Properties | select(.Arn != null) | "https://console.aws.amazon.com/go/view?arn=" + .Arn'

--- a/integrations/aws/CHANGELOG.md
+++ b/integrations/aws/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Improvements
 
 - Fix default useGetResourceAPI property name (#1)
+- Use by default the actual S3 Bucket region instead of default region used to fetch it (#2)
 
 # Port_Ocean 0.2.11 (2024-07-09)
 

--- a/integrations/aws/CHANGELOG.md
+++ b/integrations/aws/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+# Port_Ocean 0.2.12 (2024-07-09)
+
+### Improvements
+
+- Fix default useGetResourceAPI property name (#1)
+
 # Port_Ocean 0.2.11 (2024-07-09)
 
 ### Improvements

--- a/integrations/aws/pyproject.toml
+++ b/integrations/aws/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws"
-version = "0.2.11"
+version = "0.2.12"
 description = "This integration will map all your resources in all the available accounts to your Port entities"
 authors = ["Shalev Avhar <shalev@getport.io>", "Erik Zaadi <erik@getport.io>"]
 


### PR DESCRIPTION
# Description

What - change the "get extra data" parameter to the correct name (matches the docs)
Why - the prev parameter is not the correct parameter
How - change the name to `useGetResourceAPI` 

## Type of change

Please leave one option from the following and delete the rest:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
