### PR TITLE
[Integration][ADO] Set the `isProjectsLimited` paramater to True by default

### DIFF
--- a/integrations/azure-devops/.port/spec.yaml
+++ b/integrations/azure-devops/.port/spec.yaml
@@ -8,12 +8,12 @@ features:
     section: Git Providers
 configurations:
   - name: organizationUrl
-    description: The URL of your Azure DevOps organization. (e.g., "https://dev.azure.com/{your-organization}"). For more information, refer to the Azure Devops [documentation](https://learn.microsoft.com/en-us/azure/devops/extend/develop/work-with-urls?view=azure-devops&tabs=http)
+    description: The URL of your Azure DevOps organization (e.g., "https://dev.azure.com/{your-organization}"). To find your organization URL, refer to the <a href="https://learn.microsoft.com/en-us/azure/devops/extend/develop/work-with-urls?view=azure-devops&tabs=http">Azure DevOps documentation</a>.
     required: true
     type: url
     sensitive: true
   - name: personalAccessToken
-    description: A personal access token (PAT) with read permissions for the resources you want to sync. Visit https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops for more information.
+    description: A personal access token (PAT) with read permissions for the resources you want to sync. To create a PAT, see the <a href="https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops">Azure DevOps documentation</a>.
     required: true
     type: string
     sensitive: true
@@ -21,6 +21,7 @@ configurations:
     description: Set to true if the personal access token's scope is limited to specific projects within your organization.
     required: false
     type: boolean
+    default: true
   - name: appHost
     required: false
     type: url

--- a/integrations/azure-devops/CHANGELOG.md
+++ b/integrations/azure-devops/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+# Port_Ocean 0.1.41 (2024-07-10)
+
+### Improvements
+
+- Set the `isProjectsLimited` paramater to True by default
+- Revise the configuration parameters' descriptions.
+
 # Port_Ocean 0.1.40 (2024-07-09)
 
 ### Improvements

--- a/integrations/azure-devops/main.py
+++ b/integrations/azure-devops/main.py
@@ -24,9 +24,10 @@ async def setup_webhooks() -> None:
         return
 
     azure_devops_client = AzureDevopsClient.create_from_ocean_config()
-    if ocean.integration_config.get("is_projects_limited", True):
+    if ocean.integration_config.get("is_projects_limited"):
         async for projects in azure_devops_client.generate_projects():
             for project in projects:
+                logger.info(f"Setting up webhook listeners for project {project['name']}")
                 await setup_listeners(
                     ocean.integration_config["app_host"],
                     azure_devops_client,

--- a/integrations/azure-devops/main.py
+++ b/integrations/azure-devops/main.py
@@ -27,7 +27,9 @@ async def setup_webhooks() -> None:
     if ocean.integration_config.get("is_projects_limited"):
         async for projects in azure_devops_client.generate_projects():
             for project in projects:
-                logger.info(f"Setting up webhook listeners for project {project['name']}")
+                logger.info(
+                    f"Setting up webhook listeners for project {project['name']}"
+                )
                 await setup_listeners(
                     ocean.integration_config["app_host"],
                     azure_devops_client,

--- a/integrations/azure-devops/poetry.lock
+++ b/integrations/azure-devops/poetry.lock
@@ -806,13 +806,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "port-ocean"
-version = "0.9.3"
+version = "0.9.4"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 optional = false
 python-versions = "<4.0,>=3.11"
 files = [
-    {file = "port_ocean-0.9.3-py3-none-any.whl", hash = "sha256:5028041d33c58a6ecb1d03c1dcc6725ae1f920c3710b6f1e7c5fc9965baf930d"},
-    {file = "port_ocean-0.9.3.tar.gz", hash = "sha256:76621f0c9fc42740b1542a8c769c60b8090109bcf1cae411ff761ab5a114f241"},
+    {file = "port_ocean-0.9.4-py3-none-any.whl", hash = "sha256:afe4771b0044683941269b3a83b82b24ccd0968f3c2ace056e961fd6b0dd37a2"},
+    {file = "port_ocean-0.9.4.tar.gz", hash = "sha256:26018da654867e8c1a49aed2003697595b9b4100892d2f750d79e6b8e166a36a"},
 ]
 
 [package.dependencies]
@@ -1428,4 +1428,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "a38fbefc1ec216b3c6a73266d5be963beb5d41e427a5cfb334d9cd01d24bb376"
+content-hash = "26c0bd2325d262a1df4b76e58f4122004ea7dc8b7d60f6defbf7e656df9cdee9"

--- a/integrations/azure-devops/pyproject.toml
+++ b/integrations/azure-devops/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "azure-devops"
-version = "0.1.40"
+version = "0.1.41"
 description = "An Azure Devops Ocean integration"
 authors = ["Matan Geva <matang@getport.io>"]
 

--- a/integrations/azure-devops/pyproject.toml
+++ b/integrations/azure-devops/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Matan Geva <matang@getport.io>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-port_ocean = {version = "^0.9.3", extras = ["cli"]}
+port_ocean = {version = "^0.9.4", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2"


### PR DESCRIPTION
# Description

Fixed [a bug in the Azure DevOps (ADO) integration](https://port-community.slack.com/archives/C05LZB72NM8/p1718010461875529) where project-scoped webhooks were not being created if the isProjectsLimited parameter was not explicitly set. The default value for this parameter is now set to True, ensuring that webhooks are created with the correct scope.

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [x] Documentation (added/updated documentation)

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
