### PR TITLE
[Integration][PagerDuty] - Add Oncall to Escalation policy

### DIFF
--- a/integrations/pagerduty/.port/resources/blueprints.json
+++ b/integrations/pagerduty/.port/resources/blueprints.json
@@ -266,6 +266,11 @@
           "title": "Summary",
           "type": "string"
         },
+        "primaryOncall": {
+          "title": "Primary Oncall",
+          "type": "string",
+          "format": "user"
+        },
         "escalationRules": {
           "title": "Escalation Rules",
           "type": "array",

--- a/integrations/pagerduty/.port/resources/port-app-config.yaml
+++ b/integrations/pagerduty/.port/resources/port-app-config.yaml
@@ -77,7 +77,7 @@ resources:
   - kind: escalation_policies
     selector:
       query: 'true'
-      attachOncallUser: 'true'
+      attachOncallUsers: 'true'
     port:
       entity:
         mappings:

--- a/integrations/pagerduty/.port/resources/port-app-config.yaml
+++ b/integrations/pagerduty/.port/resources/port-app-config.yaml
@@ -77,7 +77,7 @@ resources:
   - kind: escalation_policies
     selector:
       query: 'true'
-      attachOncallUsers: 'true'
+      attachOncallUser: 'true'
     port:
       entity:
         mappings:

--- a/integrations/pagerduty/.port/resources/port-app-config.yaml
+++ b/integrations/pagerduty/.port/resources/port-app-config.yaml
@@ -87,5 +87,5 @@ resources:
           properties:
             url: .html_url
             description: .summary
-            primaryOncall: .__oncall_user | sort_by(.escalation_level) | .[0].user.email
+            primaryOncall: .__oncall_users | sort_by(.escalation_level) | .[0].user.email
             escalationRules: .escalation_rules

--- a/integrations/pagerduty/.port/resources/port-app-config.yaml
+++ b/integrations/pagerduty/.port/resources/port-app-config.yaml
@@ -77,6 +77,7 @@ resources:
   - kind: escalation_policies
     selector:
       query: 'true'
+      attachOncallUsers: 'true'
     port:
       entity:
         mappings:
@@ -84,6 +85,7 @@ resources:
           title: .name
           blueprint: '"pagerdutyEscalationPolicy"'
           properties:
-            description: .summary
-            escalationRules: .escalation_rules
             url: .html_url
+            description: .summary
+            primaryOncall: .__oncall_user | sort_by(.escalation_level) | .[0].user.email
+            escalationRules: .escalation_rules

--- a/integrations/pagerduty/.port/spec.yaml
+++ b/integrations/pagerduty/.port/spec.yaml
@@ -15,13 +15,14 @@ configurations:
     required: true
     type: string
     sensitive: true
-    description: PagerDuty API token
+    description: The PagerDuty API token. To create a token, see the <a href="https://support.pagerduty.com/docs/api-access-keys">PagerDuty documentation</a>
   - name: apiUrl
-    description: Pagerduty api url. If not specified, the default will be https://api.pagerduty.com
     required: true
     type: string
     default: https://api.pagerduty.com
+    description: Pagerduty Api URL. If not specified, the default will be https://api.pagerduty.com. Customers on the EU data centers should set this to https://api.eu.pagerduty.com
   - name: appHost
-    description: "The host of the Port Ocean app. Used to set up the integration endpoint as the target for Webhooks created in PagerDuty"
     required: false
     type: string
+    description: The host of the Port Ocean app. Used to set up the integration endpoint as the target for Webhooks created in PagerDuty
+

--- a/integrations/pagerduty/.port/spec.yaml
+++ b/integrations/pagerduty/.port/spec.yaml
@@ -25,4 +25,3 @@ configurations:
     required: false
     type: string
     description: The host of the Port Ocean app. Used to set up the integration endpoint as the target for Webhooks created in PagerDuty
-

--- a/integrations/pagerduty/CHANGELOG.md
+++ b/integrations/pagerduty/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+# Port_Ocean 0.1.79 (2024-07-10)
+
+### Improvements
+
+- Added the primary oncall user to the escalation policy blueprint
+
+
 # Port_Ocean 0.1.78 (2024-07-10)
 
 ### Improvements

--- a/integrations/pagerduty/changelog/0.1.79.improvement.md
+++ b/integrations/pagerduty/changelog/0.1.79.improvement.md
@@ -1,1 +1,0 @@
-Added the primary oncall user to the escalation policy blueprint

--- a/integrations/pagerduty/changelog/0.1.79.improvement.md
+++ b/integrations/pagerduty/changelog/0.1.79.improvement.md
@@ -1,0 +1,1 @@
+Added the primary oncall user to the escalation policy blueprint

--- a/integrations/pagerduty/clients/pagerduty.py
+++ b/integrations/pagerduty/clients/pagerduty.py
@@ -170,7 +170,6 @@ class PagerDutyClient:
             data_key="oncalls", params=params
         ):
             logger.info(f"Received oncalls with batch size {len(oncall_batch)}")
-            logger.info(f"Listing received oncalls data: {oncall_batch}")
             oncalls.extend(oncall_batch)
 
         return oncalls

--- a/integrations/pagerduty/integration.py
+++ b/integrations/pagerduty/integration.py
@@ -188,7 +188,7 @@ class PagerdutyEscalationPolicyResourceConfig(ResourceConfig):
             alias="apiQueryParams"
         )
         attach_oncall_users: bool = Field(
-            alias="attachOncallUser",
+            alias="attachOncallUsers",
             description=" When set to true, it fetches the oncall data per escalation policy",
             default=True,
         )

--- a/integrations/pagerduty/integration.py
+++ b/integrations/pagerduty/integration.py
@@ -187,8 +187,8 @@ class PagerdutyEscalationPolicyResourceConfig(ResourceConfig):
         api_query_params: PagerdutyEscalationPolicyAPIQueryParams | None = Field(
             alias="apiQueryParams"
         )
-        attach_oncall_users: bool = Field(
-            alias="attachOncallUsers",
+        attach_oncall_user: bool = Field(
+            alias="attachOncallUser",
             description=" When set to true, fetches oncall data per escalation policy",
             default=True,
         )

--- a/integrations/pagerduty/integration.py
+++ b/integrations/pagerduty/integration.py
@@ -187,6 +187,11 @@ class PagerdutyEscalationPolicyResourceConfig(ResourceConfig):
         api_query_params: PagerdutyEscalationPolicyAPIQueryParams | None = Field(
             alias="apiQueryParams"
         )
+        attach_oncall_users: bool = Field(
+            alias="attachOncallUsers",
+            description=" When set to true, fetches oncall data per escalation policy",
+            default=True,
+        )
 
     kind: Literal["escalation_policies"]
     selector: PagerdutySelector

--- a/integrations/pagerduty/integration.py
+++ b/integrations/pagerduty/integration.py
@@ -187,9 +187,9 @@ class PagerdutyEscalationPolicyResourceConfig(ResourceConfig):
         api_query_params: PagerdutyEscalationPolicyAPIQueryParams | None = Field(
             alias="apiQueryParams"
         )
-        attach_oncall_user: bool = Field(
+        attach_oncall_users: bool = Field(
             alias="attachOncallUser",
-            description=" When set to true, fetches oncall data per escalation policy",
+            description=" When set to true, it fetches the oncall data per escalation policy",
             default=True,
         )
 

--- a/integrations/pagerduty/main.py
+++ b/integrations/pagerduty/main.py
@@ -166,7 +166,7 @@ async def on_escalation_policies_resync(kind: str) -> ASYNC_GENERATOR_RESYNC_TYP
             )
 
             for policy in escalation_policies:
-                policy["__oncall_user"] = [
+                policy["__oncall_users"] = [
                     user
                     for user in oncall_users
                     if user["escalation_policy"]["id"] == policy["id"]

--- a/integrations/pagerduty/main.py
+++ b/integrations/pagerduty/main.py
@@ -159,7 +159,7 @@ async def on_escalation_policies_resync(kind: str) -> ASYNC_GENERATOR_RESYNC_TYP
             else None
         ),
     ):
-        if selector.attach_oncall_user:
+        if selector.attach_oncall_users:
             logger.info("Fetching oncall users for escalation policies")
             oncall_users = await pager_duty_client.get_oncall_user(
                 *[policy["id"] for policy in escalation_policies]

--- a/integrations/pagerduty/main.py
+++ b/integrations/pagerduty/main.py
@@ -159,7 +159,7 @@ async def on_escalation_policies_resync(kind: str) -> ASYNC_GENERATOR_RESYNC_TYP
             else None
         ),
     ):
-        if selector.attach_oncall_users:
+        if selector.attach_oncall_user:
             logger.info("Fetching oncall users for escalation policies")
             oncall_users = await pager_duty_client.get_oncall_user(
                 *[policy["id"] for policy in escalation_policies]

--- a/integrations/pagerduty/pyproject.toml
+++ b/integrations/pagerduty/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pagerduty"
-version = "0.1.78"
+version = "0.1.79"
 description = "Pagerduty Integration"
 authors = ["Port Team <support@getport.io>"]
 


### PR DESCRIPTION
# Description

What - Added the primary oncall user to the escalation policy blueprint
Why - Customers needed to know who is the current oncall for a given escalation policy
How - Used integration filters to allow users to bring oncall data as part of the resync event for the escalation_policy kind

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

## Screenshots

<img width="1220" alt="Screenshot 2024-07-10 at 6 31 18 PM" src="https://github.com/port-labs/ocean/assets/15999660/8dce3997-b4d2-45f2-9665-78c6c57f5f69">

## API Documentation

Provide links to the API documentation used for this integration.
