### PR TITLE
PORT 9167 bug aws integration stops resync after access denied

### DIFF
--- a/integrations/aws/CHANGELOG.md
+++ b/integrations/aws/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+# Port_Ocean 0.2.14 (2024-07-11)
+
+### Improvements
+
+- Add access denied exception support (#1)
+
 # Port_Ocean 0.2.13 (2024-07-10)
 
 ### Improvements

--- a/integrations/aws/pyproject.toml
+++ b/integrations/aws/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws"
-version = "0.2.13"
+version = "0.2.14"
 description = "This integration will map all your resources in all the available accounts to your Port entities"
 authors = ["Shalev Avhar <shalev@getport.io>", "Erik Zaadi <erik@getport.io>"]
 


### PR DESCRIPTION
- **feat: add access denied exception support**
- **feat: bump version**

# Description

What - handle access denied errors from AWS
Why - in case there is no permission to read resources in certain regions we need to keep reading from other regions
How - add try-catch boundaries

## Type of change

Please leave one option from the following and delete the rest:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
