### PR TITLE
[Sentry] Added catch to ratelimiting header missing error

### DIFF
--- a/integrations/sentry/CHANGELOG.md
+++ b/integrations/sentry/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+# Port_Ocean 0.1.58 (2024-07-10)
+
+### Bugfix
+
+- Added try and catch to missing ratelimiting headers in response to the Sentry API (#1)
+- Added proper logging of missng ratelimiting headers (#1)
+
 # Port_Ocean 0.1.57 (2024-07-10)
 
 ### Improvements

--- a/integrations/sentry/CHANGELOG.md
+++ b/integrations/sentry/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added try and catch to missing ratelimiting headers in response to the Sentry API (#1)
 - Added proper logging of missng ratelimiting headers (#1)
+- Added raise for http status errors from the request (#1)
 
 # Port_Ocean 0.1.57 (2024-07-10)
 

--- a/integrations/sentry/clients/sentry.py
+++ b/integrations/sentry/clients/sentry.py
@@ -71,22 +71,25 @@ class SentryClient:
         while True:
             async with semaphore:
                 response = await self.client.get(url, params=params)
-            rate_limit_remaining = int(
-                response.headers["X-Sentry-Rate-Limit-Remaining"]
-            )
-            if rate_limit_remaining <= MINIMUM_ISSUES_LIMIT_REMAINING:
-                rate_limit_reset = int(response.headers["X-Sentry-Rate-Limit-Reset"])
-                current_time = int(time.time())
-                wait_time = (
-                    rate_limit_reset - current_time
-                    if rate_limit_reset > current_time
-                    else DEFAULT_SLEEP_TIME
+            try:
+                rate_limit_remaining = int(
+                    response.headers["X-Sentry-Rate-Limit-Remaining"]
                 )
-                logger.debug(
-                    f"Approaching rate limit. Waiting for {wait_time} seconds before retrying. "
-                    f"URL: {url}, Remaining: {rate_limit_remaining} "
-                )
-                await asyncio.sleep(wait_time)
+                if rate_limit_remaining <= MINIMUM_ISSUES_LIMIT_REMAINING:
+                    current_time = int(time.time())
+                    rate_limit_reset = int(response.headers["X-Sentry-Rate-Limit-Reset"])
+                    wait_time = (
+                        rate_limit_reset - current_time
+                        if rate_limit_reset > current_time
+                        else DEFAULT_SLEEP_TIME
+                    )
+                    logger.debug(
+                        f"Approaching rate limit. Waiting for {wait_time} seconds before retrying. "
+                        f"URL: {url}, Remaining: {rate_limit_remaining} "
+                    )
+                    await asyncio.sleep(wait_time)
+            except KeyError as e:
+                logger.warning(f"Rate limit headers not found in response: {str(e)} for url {url}")
             return response
 
     def get_next_link(self, link_header: str) -> str:

--- a/integrations/sentry/clients/sentry.py
+++ b/integrations/sentry/clients/sentry.py
@@ -78,7 +78,9 @@ class SentryClient:
                 )
                 if rate_limit_remaining <= MINIMUM_ISSUES_LIMIT_REMAINING:
                     current_time = int(time.time())
-                    rate_limit_reset = int(response.headers["X-Sentry-Rate-Limit-Reset"])
+                    rate_limit_reset = int(
+                        response.headers["X-Sentry-Rate-Limit-Reset"]
+                    )
                     wait_time = (
                         rate_limit_reset - current_time
                         if rate_limit_reset > current_time
@@ -90,7 +92,9 @@ class SentryClient:
                     )
                     await asyncio.sleep(wait_time)
             except KeyError as e:
-                logger.warning(f"Rate limit headers not found in response: {str(e)} for url {url}")
+                logger.warning(
+                    f"Rate limit headers not found in response: {str(e)} for url {url}"
+                )
             except httpx.HTTPStatusError as e:
                 logger.error(
                     f"Got HTTP error to url: {url} with status code: {e.response.status_code} and response text: {e.response.text}"

--- a/integrations/sentry/pyproject.toml
+++ b/integrations/sentry/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sentry"
-version = "0.1.57"
+version = "0.1.58"
 description = "Sentry Integration"
 authors = ["Dvir Segev <dvir@getport.io>","Matan Geva <matang@getport.io>"]
 


### PR DESCRIPTION
# Description

What - Added catching of missing headers in requests to the Sentry API
Why - Some requests seem not to have the header requested to make ratelimiting optimizations
How - Added try and catch in the request method

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
