### PR TITLE
[Integration][AWS] fix: Cannot read global resources without regional permissions

### DIFF
--- a/integrations/aws/CHANGELOG.md
+++ b/integrations/aws/CHANGELOG.md
@@ -9,9 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # Port_Ocean 0.2.16 (2024-07-16)
 
-### Improvements
+### Bug Fixes
 
-- Add auto-discover for available regions in case global resources do not have permissions in default region  (#1)
+- Add auto-discover for available regions in case global resources do not have permissions in default region
 - Add access denied handler to STS:AssumeRole 
 - Add access denied handler to custom kind resync
 

--- a/integrations/aws/CHANGELOG.md
+++ b/integrations/aws/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+# Port_Ocean 0.2.16 (2024-07-16)
+
+### Improvements
+
+- Brute force global resource if does not have permissions in default region (#1)
+
+
 # Port_Ocean 0.2.15 (2024-07-12)
 
 ### Improvements

--- a/integrations/aws/CHANGELOG.md
+++ b/integrations/aws/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
-- Brute force global resource if does not have permissions in default region (#1)
+- Add auto-discover for available regions in case global resources do not have permissions in default region  (#1)
+- Add access denied handler to STS:AssumeRole 
+- Add access denied handler to custom kind resync
 
 
 # Port_Ocean 0.2.15 (2024-07-12)

--- a/integrations/aws/aws/session_manager.py
+++ b/integrations/aws/aws/session_manager.py
@@ -103,9 +103,7 @@ class SessionManager:
                 )
             except sts_client.exceptions.ClientError as e:
                 if e.response.get("Error", {}).get("Code") == "AccessDenied":
-                    logger.warning(
-                        "Caller does not have permission to assume the organization role. Assuming application role has access to organization accounts."
-                    )
+                    logger.warning("Cannot assume role to the organization account.")
                     return self._application_session
                 else:
                     raise

--- a/integrations/aws/aws/session_manager.py
+++ b/integrations/aws/aws/session_manager.py
@@ -104,7 +104,9 @@ class SessionManager:
                 )
             except sts_client.exceptions.ClientError as e:
                 if is_access_denied_exception(e):
-                    logger.warning("Cannot assume role to the organization account.")
+                    logger.warning(
+                        "Cannot assume role to the organization account, using the application role."
+                    )
                     return self._application_session
                 else:
                     raise

--- a/integrations/aws/aws/session_manager.py
+++ b/integrations/aws/aws/session_manager.py
@@ -2,6 +2,7 @@ from typing import Any
 import typing
 import aioboto3
 from aws.aws_credentials import AwsCredentials
+from utils.misc import is_access_denied_exception
 from port_ocean.context.ocean import ocean
 from loguru import logger
 
@@ -102,7 +103,7 @@ class SessionManager:
                     aws_session_token=credentials["SessionToken"],
                 )
             except sts_client.exceptions.ClientError as e:
-                if e.response.get("Error", {}).get("Code") == "AccessDenied":
+                if is_access_denied_exception(e):
                     logger.warning("Cannot assume role to the organization account.")
                     return self._application_session
                 else:
@@ -160,7 +161,7 @@ class SessionManager:
             self._aws_credentials.append(credentials)
             self._aws_accessible_accounts.append(account)
         except sts_client.exceptions.ClientError as e:
-            if e.response["Error"]["Code"] == "AccessDenied":
+            if is_access_denied_exception(e):
                 logger.info(f"Cannot assume role in account {account['Id']}. Skipping.")
                 pass  # Skip the account if assume_role fails due to permission issues or non-existent role
             else:

--- a/integrations/aws/main.py
+++ b/integrations/aws/main.py
@@ -45,7 +45,7 @@ async def resync_all(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     except Exception as e:
         if is_access_denied_exception(e):
             async for batch in resync_cloudcontrol(
-                kind, is_global=False, stop_on_first_data=True
+                kind, is_global=False, stop_on_first_region=True
             ):
                 yield batch
 

--- a/integrations/aws/main.py
+++ b/integrations/aws/main.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 from port_ocean.core.models import Entity
 
 from utils.resources import (
+    is_global_resource,
     resync_custom_kind,
     describe_single_resource,
     fix_unserializable_date_properties,
@@ -36,7 +37,8 @@ async def resync_all(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     if kind in iter(ResourceKindsWithSpecialHandling):
         return
     await update_available_access_credentials()
-    async for batch in resync_cloudcontrol(kind):
+    is_global = is_global_resource(kind)
+    async for batch in resync_cloudcontrol(kind, is_global):
         yield batch
 
 

--- a/integrations/aws/pyproject.toml
+++ b/integrations/aws/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws"
-version = "0.2.15"
+version = "0.2.16"
 description = "This integration will map all your resources in all the available accounts to your Port entities"
 authors = ["Shalev Avhar <shalev@getport.io>", "Erik Zaadi <erik@getport.io>"]
 

--- a/integrations/aws/utils/misc.py
+++ b/integrations/aws/utils/misc.py
@@ -1,6 +1,5 @@
 import enum
 
-import aioboto3
 from port_ocean.context.event import event
 
 

--- a/integrations/aws/utils/misc.py
+++ b/integrations/aws/utils/misc.py
@@ -1,4 +1,6 @@
 import enum
+
+import aioboto3
 from port_ocean.context.event import event
 
 
@@ -15,6 +17,20 @@ class ResourceKindsWithSpecialHandling(enum.StrEnum):
     CLOUDFORMATION_STACK = "AWS::CloudFormation::Stack"
     ELASTICACHE_CLUSTER = "AWS::ElastiCache::Cluster"
     ELBV2_LOAD_BALANCER = "AWS::ELBV2::LoadBalancer"
+
+
+def is_access_denied_exception(e: Exception) -> bool:
+    access_denied_error_codes = [
+        "AccessDenied",
+        "AccessDeniedException",
+        "UnauthorizedOperation",
+    ]
+
+    if hasattr(e, "response"):
+        error_code = e.response.get("Error", {}).get("Code")
+        return error_code in access_denied_error_codes
+
+    return False
 
 
 def get_matching_kinds_and_blueprints_from_config(

--- a/integrations/aws/utils/resources.py
+++ b/integrations/aws/utils/resources.py
@@ -163,7 +163,7 @@ async def resync_custom_kind(
 
 
 async def resync_cloudcontrol(
-    kind: str, is_global: bool = False, stop_on_first_data: bool = False
+    kind: str, is_global: bool = False, stop_on_first_region: bool = False
 ) -> ASYNC_GENERATOR_RESYNC_TYPE:
     use_get_resource_api = typing.cast(
         AWSResourceConfig, event.resource_config
@@ -238,5 +238,5 @@ async def resync_cloudcontrol(
                             )
                             break  # no need to continue querying on the same region since we don't have access
                     raise e
-        if found_data and stop_on_first_data:
+        if found_data and stop_on_first_region:
             return

--- a/integrations/aws/utils/resources.py
+++ b/integrations/aws/utils/resources.py
@@ -240,10 +240,10 @@ async def resync_cloudcontrol(
                                 kind, is_global=False
                             ):
                                 yield batch
-                                return  # stop once we have some resources
+                                return  # no need to continue querying once we got some data since it's global
                         logger.warning(
                             f"Skipping resyncing {kind} in region {region} due to missing access permissions"
                         )
-                        break  # stop pagination if access is denied in this region
+                        break  # no need to continue querying on the same region since we don't have access
                     else:
                         raise e


### PR DESCRIPTION
- **feat: add access denied handler to STS:AssumeRole**
- **feat: add access denied handler to custom kind resync**
- **feat: brute force global resource if does not have permissions in default region**

# Description

What - Read all regions in global resource
Why - Whenever there are no permissions in a region global resources (such as AWS::S3::Bucket) that only use the first default region cannot read any resources.
How - Read all regions until there's resources in any region

## Type of change

Please leave one option from the following and delete the rest:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
