### PR TITLE
[Integration][Servicenow] - Update Connectivity Test

### DIFF
--- a/integrations/servicenow/CHANGELOG.md
+++ b/integrations/servicenow/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+# Port_Ocean 0.1.47 (2024-07-17)
+
+### Improvements
+
+- Updated the connectivity check to use an existing table such as incident instead of the instance table
+
+
 # Port_Ocean 0.1.46 (2024-07-10)
 
 ### Improvements

--- a/integrations/servicenow/changelog/0.1.47.improvement.md
+++ b/integrations/servicenow/changelog/0.1.47.improvement.md
@@ -1,0 +1,1 @@
+Updated the connectivity check to use an existing table such as incident instead of the instance table

--- a/integrations/servicenow/changelog/0.1.47.improvement.md
+++ b/integrations/servicenow/changelog/0.1.47.improvement.md
@@ -1,1 +1,0 @@
-Updated the connectivity check to use an existing table such as incident instead of the instance table

--- a/integrations/servicenow/client.py
+++ b/integrations/servicenow/client.py
@@ -65,12 +65,12 @@ class ServicenowClient:
     async def sanity_check(self) -> None:
         try:
             response = await self.http_client.get(
-                f"{self.servicenow_url}/api/now/table/instance?sysparm_limit=1"
+                f"{self.servicenow_url}/api/now/table/incident?sysparm_limit=1"
             )
             response.raise_for_status()
             logger.info("Servicenow sanity check passed")
             logger.info(
-                f"Servicenow instance name: {response.json().get('result', [])[0].get('instance_name')}"
+                f"Retrieved sample Servicenow incident with number: {response.json().get('result', [])[0].get('number')}"
             )
         except httpx.HTTPStatusError as e:
             logger.error(

--- a/integrations/servicenow/pyproject.toml
+++ b/integrations/servicenow/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "servicenow"
-version = "0.1.46"
+version = "0.1.47"
 description = "Service Now Ocean Integration"
 authors = ["Isaac Coffie <isaac@getport.io>"]
 


### PR DESCRIPTION
# Description

What - Updated the Servicenow connectivity test to use an existing table (incident) rather than the instance table, which may require the user to grant extra permission
Why - As part of the connectivity check, we query the tapi/now/table/instance endpoint to retrieve information about the instance. One customer was particularly worried that they don't want the integration to access this table since it involve granting admin privileges. So, instead of querying another table, we use one of the existing tables which we have access to(incident) to perform the connectivity check. For us to know that the connection was successful, we display a sample incident to the console

How -

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.
<img width="1028" alt="Screenshot 2024-07-17 at 6 26 55 PM" src="https://github.com/user-attachments/assets/f5843575-d13e-4da6-a589-390834b76b64">


## API Documentation

Provide links to the API documentation used for this integration.
