### PR TITLE
fix: NoneType object is not subscriptable

### DIFF
--- a/integrations/sonarqube/client.py
+++ b/integrations/sonarqube/client.py
@@ -134,7 +134,7 @@ class SonarQubeClient:
                 if len(resource) < PAGE_SIZE:
                     break
 
-                query_params["p"] = paging_info["pageIndex"] + 1
+                query_params["p"] = paging_info["pageIndex"] + 1 if paging_info else 1
 
             return all_resources
 

--- a/integrations/sonarqube/client.py
+++ b/integrations/sonarqube/client.py
@@ -134,7 +134,10 @@ class SonarQubeClient:
                 if len(resource) < PAGE_SIZE:
                     break
 
-                query_params["p"] = paging_info["pageIndex"] + 1 if paging_info else 1
+                if not paging_info:
+                    break
+
+                query_params["p"] = paging_info["pageIndex"] + 1
 
             return all_resources
 


### PR DESCRIPTION
# Description

What - SonarQube API does not return a `paging` object
Why - trying to access `pageIndex` inside `paging` object
How - adding validation before adding index

## Type of change

Please leave one option from the following and delete the rest:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
