### PR TITLE
[AzureDevops] Added check only for project id when comparing publisher inputs

### DIFF
--- a/integrations/azure-devops/CHANGELOG.md
+++ b/integrations/azure-devops/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+# Port_Ocean 0.1.44 (2024-07-25)
+
+### Bug Fixes
+
+- Fixed case where comparing events failed because ADO returns unexpected additional keys inside the PublisherInputs.
+
+
 # Port_Ocean 0.1.43 (2024-07-24)
 
 ### Improvements

--- a/integrations/azure-devops/azure_devops/webhooks/webhook_event.py
+++ b/integrations/azure-devops/azure_devops/webhooks/webhook_event.py
@@ -29,7 +29,7 @@ class WebhookEvent(BaseModel):
                 if not self.publisherInputs and not subscribed_event.publisherInputs:
                     return subscribed_event
 
-                # Azure Devops sends more than just the projectId in the publisherInputs, 
+                # Azure Devops sends more than just the projectId in the publisherInputs,
                 # And we only need to verify the projectId
                 if self.publisherInputs and subscribed_event.publisherInputs:
                     if subscribed_event.publisherInputs.get(

--- a/integrations/azure-devops/azure_devops/webhooks/webhook_event.py
+++ b/integrations/azure-devops/azure_devops/webhooks/webhook_event.py
@@ -25,9 +25,15 @@ class WebhookEvent(BaseModel):
                 subscribed_event.publisherId == self.publisherId
                 and subscribed_event.eventType == self.eventType
                 and subscribed_event.consumerInputs == self.consumerInputs
-                and subscribed_event.publisherInputs == self.publisherInputs
             ):
-                return subscribed_event
+                if not self.publisherInputs and not subscribed_event.publisherInputs:
+                    return subscribed_event
+
+                if self.publisherInputs and subscribed_event.publisherInputs:
+                    if subscribed_event.publisherInputs.get(
+                        "projectId", None
+                    ) == self.publisherInputs.get("projectId", None):
+                        return subscribed_event
 
         return None
 

--- a/integrations/azure-devops/azure_devops/webhooks/webhook_event.py
+++ b/integrations/azure-devops/azure_devops/webhooks/webhook_event.py
@@ -29,6 +29,8 @@ class WebhookEvent(BaseModel):
                 if not self.publisherInputs and not subscribed_event.publisherInputs:
                     return subscribed_event
 
+                # Azure Devops sends more than just the projectId in the publisherInputs, 
+                # And we only need to verify the projectId
                 if self.publisherInputs and subscribed_event.publisherInputs:
                     if subscribed_event.publisherInputs.get(
                         "projectId", None

--- a/integrations/azure-devops/pyproject.toml
+++ b/integrations/azure-devops/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "azure-devops"
-version = "0.1.43"
+version = "0.1.44"
 description = "An Azure Devops Ocean integration"
 authors = ["Matan Geva <matang@getport.io>"]
 


### PR DESCRIPTION
# Description

What - Fixed webhook creation bug where each restart would create all webhooks again
Why - Bug
How - Webhook comparing publisherInputs would always fail because ADO pushes additional input

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
