### PR TITLE
[Integration][Wiz] Add configurable limit for wiz issues

### DIFF
--- a/integrations/wiz/.port/resources/port-app-config.yaml
+++ b/integrations/wiz/.port/resources/port-app-config.yaml
@@ -3,7 +3,7 @@ deleteDependentEntities: true
 resources:
   - kind: project
     selector:
-      query: 'true'
+      query: "true"
     port:
       entity:
         mappings:
@@ -16,7 +16,9 @@ resources:
             description: .description
   - kind: issue
     selector:
-      query: 'true'
+      query: "true"
+      maxPages: 20
+      statusList: ["OPEN", "IN_PROGRESS"]
     port:
       entity:
         mappings:
@@ -53,7 +55,7 @@ resources:
             control: .sourceRule.id
   - kind: control
     selector:
-      query: 'true'
+      query: "true"
     port:
       entity:
         mappings:
@@ -65,7 +67,7 @@ resources:
             resolutionRecommendation: .resolutionRecommendation
   - kind: serviceTicket
     selector:
-      query: 'true'
+      query: "true"
     port:
       entity:
         mappings:

--- a/integrations/wiz/CHANGELOG.md
+++ b/integrations/wiz/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+# Port_Ocean 0.1.39 (2024-07-25)
+
+### Improvements
+
+- Add paramter for setting number of issues to fetch
 
 ## 0.1.54 (2024-09-01)
 

--- a/integrations/wiz/integration.py
+++ b/integrations/wiz/integration.py
@@ -1,0 +1,9 @@
+from port_ocean.core.integrations.base import BaseIntegration
+from port_ocean.core.handlers import APIPortAppConfig
+
+from overrides import WizPortAppConfig
+
+
+class WizIntegration(BaseIntegration):
+    class AppConfigHandlerClass(APIPortAppConfig):
+        CONFIG_CLASS = WizPortAppConfig

--- a/integrations/wiz/main.py
+++ b/integrations/wiz/main.py
@@ -1,13 +1,14 @@
 from enum import StrEnum
-from typing import Any
+from typing import Any, cast
 
 from fastapi import Depends, HTTPException
 from fastapi.security import HTTPBearer
 from loguru import logger
 from port_ocean.context.ocean import ocean
 from port_ocean.core.ocean_types import ASYNC_GENERATOR_RESYNC_TYPE
-
+from port_ocean.context.event import event
 from wiz.client import WizClient
+from overrides import IssueResourceConfig
 
 
 class ObjectKind(StrEnum):
@@ -26,31 +27,53 @@ def init_client() -> WizClient:
     )
 
 
-@ocean.on_resync()
-async def on_resync(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
+@ocean.on_resync(kind=ObjectKind.PROJECT)
+async def on_resync_projects(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
+    """Resync projects from Wiz."""
+    wiz_client = init_client()
+    async for projects in wiz_client.get_projects():
+        logger.info(f"Received {len(projects)} projects")
+        yield projects
+
+
+@ocean.on_resync(kind=ObjectKind.ISSUE)
+async def on_resync_issues(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
+    logger.info(f"Resyncing {kind} kind")
     wiz_client = init_client()
 
-    if kind == ObjectKind.PROJECT:
-        async for projects in wiz_client.get_projects():
-            logger.info(f"Received {len(projects)} projects")
-            yield projects
-    else:
-        async for _issues in wiz_client.get_issues():
-            logger.info(f"Received {len(_issues)} issues")
-            if kind == ObjectKind.ISSUE:
-                yield _issues
-            elif kind == ObjectKind.CONTROL:
-                yield [
-                    issue["sourceRule"]
-                    for issue in _issues
-                    if issue.get("sourceRule") is not None
-                ]
-            elif kind == ObjectKind.SERVICE_TICKET:
-                yield [
-                    ticket
-                    for issue in _issues
-                    for ticket in issue.get("serviceTickets", [])
-                ]
+    max_pages = cast(IssueResourceConfig, event.resource_config).selector.max_pages
+    status_list = cast(IssueResourceConfig, event.resource_config).selector.status_list
+
+    async for _issues in wiz_client.get_issues(
+        max_pages=max_pages, status_list=status_list
+    ):
+        logger.info(f"Received {len(_issues)} issues")
+        yield _issues
+
+
+@ocean.on_resync(kind=ObjectKind.CONTROL)
+async def on_resync_controls(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
+    logger.info(f"Resyncing {kind} kind")
+    wiz_client = init_client()
+
+    async for _issues in wiz_client.get_issues():
+        yield [
+            issue["sourceRule"]
+            for issue in _issues
+            if issue.get("sourceRule") is not None
+        ]
+
+
+@ocean.on_resync(kind=ObjectKind.SERVICE_TICKET)
+async def on_resync_tickets(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
+    logger.info(f"Resyncing {kind} kind")
+    wiz_client = init_client()
+
+    async for _issues in wiz_client.get_issues():
+        logger.info(f"Received {len(_issues)} tickets")
+        yield [
+            ticket for issue in _issues for ticket in issue.get("serviceTickets", [])
+        ]
 
 
 @ocean.router.post("/webhook")

--- a/integrations/wiz/main.py
+++ b/integrations/wiz/main.py
@@ -38,14 +38,13 @@ async def on_resync_projects(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
 
 @ocean.on_resync(kind=ObjectKind.ISSUE)
 async def on_resync_issues(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
-    logger.info(f"Resyncing {kind} kind")
     wiz_client = init_client()
 
-    max_pages = cast(IssueResourceConfig, event.resource_config).selector.max_pages
-    status_list = cast(IssueResourceConfig, event.resource_config).selector.status_list
+    selector = cast(IssueResourceConfig, event.resource_config).selector
 
     async for _issues in wiz_client.get_issues(
-        max_pages=max_pages, status_list=status_list
+        max_pages=selector.max_pages, 
+        status_list=selector.status_list
     ):
         logger.info(f"Received {len(_issues)} issues")
         yield _issues
@@ -53,7 +52,6 @@ async def on_resync_issues(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
 
 @ocean.on_resync(kind=ObjectKind.CONTROL)
 async def on_resync_controls(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
-    logger.info(f"Resyncing {kind} kind")
     wiz_client = init_client()
 
     async for _issues in wiz_client.get_issues():
@@ -66,7 +64,6 @@ async def on_resync_controls(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
 
 @ocean.on_resync(kind=ObjectKind.SERVICE_TICKET)
 async def on_resync_tickets(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
-    logger.info(f"Resyncing {kind} kind")
     wiz_client = init_client()
 
     async for _issues in wiz_client.get_issues():

--- a/integrations/wiz/overrides.py
+++ b/integrations/wiz/overrides.py
@@ -1,0 +1,22 @@
+import typing
+
+from port_ocean.core.handlers.port_app_config.models import (
+    ResourceConfig,
+    PortAppConfig,
+    Selector,
+)
+from pydantic import Field
+
+
+class IssueSelector(Selector):
+    max_pages: int = Field(alias="maxPages", default=20)
+    status_list: list[str] = Field(alias="statusList", default_factory=list)
+
+
+class IssueResourceConfig(ResourceConfig):
+    kind: typing.Literal["issue"]
+    selector: IssueSelector
+
+
+class WizPortAppConfig(PortAppConfig):
+    resources: list[IssueResourceConfig | ResourceConfig] = Field(default_factory=list)

--- a/integrations/wiz/wiz/constants.py
+++ b/integrations/wiz/wiz/constants.py
@@ -1,5 +1,5 @@
-PAGE_SIZE = 50
-MAX_PAGES = 5
+PAGE_SIZE = 100
+MAX_PAGES = 20
 AUTH0_URLS = ["https://auth.wiz.io/oauth/token", "https://auth0.gov.wiz.io/oauth/token"]
 COGNITO_URLS = [
     "https://auth.app.wiz.io/oauth/token",


### PR DESCRIPTION
# Description

Currently, the Wiz import feature only displays the top 250 recent issues due to a pre-set limit. Make this limit configurable by using a selector `maxPages`

## Type of change

Please leave one option from the following and delete the rest:

- [ ] New feature (non-breaking change which adds functionality)

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
