### PR TITLE
[Core][Deployment][ECS] - Fix resource name limit by 64

### DIFF
--- a/deployment/terraform/aws/ecs/modules/ecs_service/main.tf
+++ b/deployment/terraform/aws/ecs/modules/ecs_service/main.tf
@@ -117,17 +117,17 @@ data "aws_iam_policy_document" "task_execution_role_policy" {
 }
 
 resource "aws_iam_role" "task_role" {
-  name               = "ecs-task-role-${local.service_name}"
+  name               = local.service_name
   assume_role_policy = data.aws_iam_policy_document.ecs_assume_role_policy.json
 }
 
 resource "aws_iam_policy" "execution-policy" {
-  name   = "ecs-task-execution-policy-${local.service_name}"
+  name   = local.service_name
   policy = data.aws_iam_policy_document.task_execution_role_policy.json
 }
 
 resource "aws_iam_role" "task_execution_role" {
-  name               = "ecs-task-execution-role-${local.service_name}"
+  name               = local.service_name
   assume_role_policy = data.aws_iam_policy_document.ecs_assume_role_policy.json
 }
 


### PR DESCRIPTION
# Description

What - #830 
Why - we were concatenating the type of the resource to the resource name causing it to exceed the allowed length of the resource 
How - remove the prefix for those resources

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
