### PR TITLE
Flush logs on signal interrupt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Bug Fixes
 
-- Flush logs when receiving SIGTERM
+- Flush all remaining buffered logs when exiting application
 
 
 ## 0.9.5 (2024-07-23)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.9.6 (2024-07-30)
+
+### Bug Fixes
+
+- Flush logs when receiving SIGTERM
+
+
 ## 0.9.5 (2024-07-23)
 
 ### Bug Fixes

--- a/port_ocean/log/logger_setup.py
+++ b/port_ocean/log/logger_setup.py
@@ -9,6 +9,7 @@ from loguru import logger
 from port_ocean.config.settings import LogLevelType
 from port_ocean.log.handlers import HTTPMemoryHandler
 from port_ocean.log.sensetive import sensitive_log_filter
+from port_ocean.utils.signal import signal_handler
 
 
 def setup_logger(level: LogLevelType, enable_http_handler: bool) -> None:
@@ -53,7 +54,10 @@ def _http_loguru_handler(level: LogLevelType) -> None:
     )
     logger.configure(patcher=exception_deserializer)
 
-    queue_listener = QueueListener(queue, HTTPMemoryHandler())
+    http_memory_handler = HTTPMemoryHandler()
+    signal_handler.register(http_memory_handler.flush)
+
+    queue_listener = QueueListener(queue, http_memory_handler)
     queue_listener.start()
 
 

--- a/port_ocean/ocean.py
+++ b/port_ocean/ocean.py
@@ -22,7 +22,7 @@ from port_ocean.core.integrations.base import BaseIntegration
 from port_ocean.log.sensetive import sensitive_log_filter
 from port_ocean.middlewares import request_handler
 from port_ocean.utils.repeat import repeat_every
-from port_ocean.utils.signal import signal_handler, init_signal_handler
+from port_ocean.utils.signal import signal_handler
 from port_ocean.version import __integration_version__
 
 

--- a/port_ocean/ocean.py
+++ b/port_ocean/ocean.py
@@ -97,14 +97,14 @@ class Ocean:
         @asynccontextmanager
         async def lifecycle(_: FastAPI) -> AsyncIterator[None]:
             try:
-                init_signal_handler()
                 await self.integration.start()
                 await self._setup_scheduled_resync()
                 yield None
-                signal_handler.exit()
             except Exception:
                 logger.exception("Integration had a fatal error. Shutting down.")
                 sys.exit("Server stopped")
+            finally:
+                signal_handler.exit()
 
         self.fast_api_app.router.lifespan_context = lifecycle
         await self.fast_api_app(scope, receive, send)

--- a/port_ocean/run.py
+++ b/port_ocean/run.py
@@ -13,6 +13,7 @@ from port_ocean.core.utils import validate_integration_runtime
 from port_ocean.log.logger_setup import setup_logger
 from port_ocean.ocean import Ocean
 from port_ocean.utils.misc import get_spec_file, load_module
+from port_ocean.utils.signal import init_signal_handler
 
 
 def _get_default_config_factory() -> None | Type[BaseModel]:
@@ -33,6 +34,7 @@ def run(
 ) -> None:
     application_settings = ApplicationSettings(log_level=log_level, port=port)
 
+    init_signal_handler()
     setup_logger(
         application_settings.log_level,
         enable_http_handler=application_settings.enable_http_logging,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.9.5"
+version = "0.9.6"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What - Flush logs on signal interrupt
Why - Logs that left in the buffer are not being send when application exits

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
