### PR TITLE
[Integration][Datadog] Add _target='blank' attribute to spec links

### DIFF
--- a/integrations/datadog/.port/spec.yaml
+++ b/integrations/datadog/.port/spec.yaml
@@ -12,7 +12,7 @@ features:
       - kind: datadogSloHistory
 configurations:
   - name: datadogBaseUrl
-    description: Datadog Base URL (e.g., "https://api.datadoghq.com" or "https://api.datadoghq.eu"). To identify your base URL, see the <a target=”_blank” href="https://docs.datadoghq.com/getting_started/site/#:~:text=within%20their%20environments.-,Access%20the%20Datadog%20site,-You%20can%20identify">Datadog documentation</a>.
+    description: Datadog Base URL (e.g., "https://api.datadoghq.com" or "https://api.datadoghq.eu"). To identify your base URL, see the <a target="_blank" href="https://docs.datadoghq.com/getting_started/site/#:~:text=within%20their%20environments.-,Access%20the%20Datadog%20site,-You%20can%20identify">Datadog documentation</a>.
     type: url
     required: true
     default: "https://api.datadoghq.com"

--- a/integrations/datadog/.port/spec.yaml
+++ b/integrations/datadog/.port/spec.yaml
@@ -12,17 +12,17 @@ features:
       - kind: datadogSloHistory
 configurations:
   - name: datadogBaseUrl
-    description: Datadog Base URL (e.g., "https://api.datadoghq.com" or "https://api.datadoghq.eu"). To identify your base URL, see the <a href="https://docs.datadoghq.com/getting_started/site/#:~:text=within%20their%20environments.-,Access%20the%20Datadog%20site,-You%20can%20identify">Datadog documentation</a>.
+    description: Datadog Base URL (e.g., "https://api.datadoghq.com" or "https://api.datadoghq.eu"). To identify your base URL, see the <a target=”_blank” href="https://docs.datadoghq.com/getting_started/site/#:~:text=within%20their%20environments.-,Access%20the%20Datadog%20site,-You%20can%20identify">Datadog documentation</a>.
     type: url
     required: true
     default: "https://api.datadoghq.com"
   - name: datadogApiKey
-    description: Datadog API key. To create an API key, see the <a href="https://docs.datadoghq.com/account_management/api-app-keys/#add-an-api-key-or-client-token">Datadog documentation</a>.
+    description: Datadog API key. To create an API key, see the <a target=”_blank” href="https://docs.datadoghq.com/account_management/api-app-keys/#add-an-api-key-or-client-token">Datadog documentation</a>.
     required: true
     type: string
     sensitive: true
   - name: datadogApplicationKey
-    description: Datadog application key. To create an application key, see the <a href="https://docs.datadoghq.com/account_management/api-app-keys/#add-application-keys">Datadog documentation</a>.
+    description: Datadog application key. To create an application key, see the <a target=”_blank” href="https://docs.datadoghq.com/account_management/api-app-keys/#add-application-keys">Datadog documentation</a>.
     required: true
     type: string
     sensitive: true
@@ -31,7 +31,7 @@ configurations:
     required: false
     description: "The host of the Port Ocean app. Used to set up the integration endpoint as the target for Webhooks created in the 3rd party service"
   - name: datadogWebhookToken
-    description: Datadog webhook token (optional). This is used to secure webhook communication between Datadog and Port. To learn more, see the <a href="https://docs.datadoghq.com/integrations/webhooks/#setup">Datadog documentation</a>.
+    description: Datadog webhook token (optional). This is used to secure webhook communication between Datadog and Port. To learn more, see the <a target=”_blank” href="https://docs.datadoghq.com/integrations/webhooks/#setup">Datadog documentation</a>.
     type: string
     required: false
     sensitive: true

--- a/integrations/datadog/.port/spec.yaml
+++ b/integrations/datadog/.port/spec.yaml
@@ -17,7 +17,7 @@ configurations:
     required: true
     default: "https://api.datadoghq.com"
   - name: datadogApiKey
-    description: Datadog API key. To create an API key, see the <a target=”_blank” href="https://docs.datadoghq.com/account_management/api-app-keys/#add-an-api-key-or-client-token">Datadog documentation</a>.
+    description: Datadog API key. To create an API key, see the <a target="_blank" href="https://docs.datadoghq.com/account_management/api-app-keys/#add-an-api-key-or-client-token">Datadog documentation</a>.
     required: true
     type: string
     sensitive: true

--- a/integrations/datadog/.port/spec.yaml
+++ b/integrations/datadog/.port/spec.yaml
@@ -31,7 +31,7 @@ configurations:
     required: false
     description: "The host of the Port Ocean app. Used to set up the integration endpoint as the target for Webhooks created in the 3rd party service"
   - name: datadogWebhookToken
-    description: Datadog webhook token (optional). This is used to secure webhook communication between Datadog and Port. To learn more, see the <a target=”_blank” href="https://docs.datadoghq.com/integrations/webhooks/#setup">Datadog documentation</a>.
+    description: Datadog webhook token (optional). This is used to secure webhook communication between Datadog and Port. To learn more, see the <a target="_blank" href="https://docs.datadoghq.com/integrations/webhooks/#setup">Datadog documentation</a>.
     type: string
     required: false
     sensitive: true

--- a/integrations/datadog/.port/spec.yaml
+++ b/integrations/datadog/.port/spec.yaml
@@ -12,7 +12,7 @@ features:
       - kind: datadogSloHistory
 configurations:
   - name: datadogBaseUrl
-    description: Datadog Base URL (e.g., "https://api.datadoghq.com" or "https://api.datadoghq.eu"). To identify your base URL, see the <a target="_blank" href="https://docs.datadoghq.com/getting_started/site/#:~:text=within%20their%20environments.-,Access%20the%20Datadog%20site,-You%20can%20identify">Datadog documentation</a>.
+    description: Datadog Base URL (e.g., <a target="_blank" href="https://api.datadoghq.com">https://api.datadoghq.com</a> or <a target="_blank" href= "https://api.datadoghq.eu")>https://api.datadoghq.eu</a>. To identify your base URL, see the <a target="_blank" href="https://docs.datadoghq.com/getting_started/site/#:~:text=within%20their%20environments.-,Access%20the%20Datadog%20site,-You%20can%20identify">Datadog documentation</a>.
     type: url
     required: true
     default: "https://api.datadoghq.com"

--- a/integrations/datadog/.port/spec.yaml
+++ b/integrations/datadog/.port/spec.yaml
@@ -22,7 +22,7 @@ configurations:
     type: string
     sensitive: true
   - name: datadogApplicationKey
-    description: Datadog application key. To create an application key, see the <a target=”_blank” href="https://docs.datadoghq.com/account_management/api-app-keys/#add-application-keys">Datadog documentation</a>.
+    description: Datadog application key. To create an application key, see the <a target="_blank" href="https://docs.datadoghq.com/account_management/api-app-keys/#add-application-keys">Datadog documentation</a>.
     required: true
     type: string
     sensitive: true

--- a/integrations/datadog/CHANGELOG.md
+++ b/integrations/datadog/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
-# Port_Ocean 0.1.21 (2024-07-31)
+# Port_Ocean 0.1.23 (2024-08-01)
 
 ### Improvements
 

--- a/integrations/datadog/CHANGELOG.md
+++ b/integrations/datadog/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
-- Add _target='blank' attribute to spec links to open a new browser tab instead of the current browser.
+- Added _target='blank' attribute to spec links to open a new browser tab instead of the current browser.
 
 # Port_Ocean 0.1.22 (2024-07-31)
 

--- a/integrations/datadog/CHANGELOG.md
+++ b/integrations/datadog/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+# Port_Ocean 0.1.21 (2024-07-31)
+
+### Improvements
+
+- Add _target='blank' attribute to spec links to open a new browser tab instead of the current browser.
 
 # Port_Ocean 0.1.22 (2024-07-31)
 

--- a/integrations/datadog/pyproject.toml
+++ b/integrations/datadog/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "datadog"
-version = "0.1.22"
+version = "0.1.23"
 description = "Datadog Ocean Integration"
 authors = ["Albert Luganga <albertluganga@getport.io>"]
 


### PR DESCRIPTION
# Description

Update the description content and the attribute target="_blank" to all <a> tags such that the final becomes <a href=”some_link” target=”_blank”></a>. Doing this will point the url to open a new browser tab instead of the current browser.

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Documentation (added/updated documentation)

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
