### PR TITLE
[Integration][Wiz] Added _target='blank' attribute to spec links

### DIFF
--- a/integrations/wiz/.port/spec.yaml
+++ b/integrations/wiz/.port/spec.yaml
@@ -12,20 +12,20 @@ features:
 configurations:
   - name: wizClientId
     required: true
-    description: Wiz Client ID. For more information, see the <a href="https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/code-quality-security/wiz#wiz-credentials">documentation</a>.
+    description: Wiz Client ID. For more information, see the  <a target="_blank" href="https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/code-quality-security/wiz#wiz-credentials">documentation</a>.
     type: string
     sensitive: true
   - name: wizClientSecret
-    description: Wiz Client Secret. For more information, see the <a href="https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/code-quality-security/wiz#wiz-credentials">documentation</a>.
+    description: Wiz Client Secret. For more information, see the  <a target="_blank" href="https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/code-quality-security/wiz#wiz-credentials">documentation</a>.
     required: true
     type: string
     sensitive: true
   - name: wizApiUrl
-    description: The base URL for accessing the Wiz API (e.g., "https://api.us.wiz.io"). This is specific to your Wiz region. To get the API URL, refer to the <a href="https://docs.wiz.io/wiz-docs/docs/using-the-wiz-api#the-graphql-endpoint">Wiz documentation</a>.
+    description: The base URL for accessing the Wiz API (e.g., "https://api.us.wiz.io"). This is specific to your Wiz region. To get the API URL, refer to the  <a target="_blank" href="https://docs.wiz.io/wiz-docs/docs/using-the-wiz-api#the-graphql-endpoint">Wiz documentation</a>.
     type: string
     required: true
   - name: wizTokenUrl
-    description: The URL used to obtain an access token for the Wiz API e.g https://auth.app.wiz.io/oauth/token. For more information, see the <a href="https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/code-quality-security/wiz#wiz-credentials">documentation</a>.
+    description: The URL used to obtain an access token for the Wiz API e.g https://auth.app.wiz.io/oauth/token. For more information, see the  <a target="_blank" href="https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/code-quality-security/wiz#wiz-credentials">documentation</a>.
     type: string
     required: true
   - name: wizWebhookVerificationToken

--- a/integrations/wiz/.port/spec.yaml
+++ b/integrations/wiz/.port/spec.yaml
@@ -12,20 +12,20 @@ features:
 configurations:
   - name: wizClientId
     required: true
-    description: Wiz Client ID. For more information, see the  <a target="_blank" href="https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/code-quality-security/wiz#wiz-credentials">documentation</a>.
+    description: Wiz Client ID. For more information, see the <a target="_blank" href="https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/code-quality-security/wiz#wiz-credentials">documentation</a>.
     type: string
     sensitive: true
   - name: wizClientSecret
-    description: Wiz Client Secret. For more information, see the  <a target="_blank" href="https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/code-quality-security/wiz#wiz-credentials">documentation</a>.
+    description: Wiz Client Secret. For more information, see the <a target="_blank" href="https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/code-quality-security/wiz#wiz-credentials">documentation</a>.
     required: true
     type: string
     sensitive: true
   - name: wizApiUrl
-    description: The base URL for accessing the Wiz API (e.g., "https://api.us.wiz.io"). This is specific to your Wiz region. To get the API URL, refer to the  <a target="_blank" href="https://docs.wiz.io/wiz-docs/docs/using-the-wiz-api#the-graphql-endpoint">Wiz documentation</a>.
+    description: The base URL for accessing the Wiz API (e.g., "https://api.us.wiz.io"). This is specific to your Wiz region. To get the API URL, refer to the <a target="_blank" href="https://docs.wiz.io/wiz-docs/docs/using-the-wiz-api#the-graphql-endpoint">Wiz documentation</a>.
     type: string
     required: true
   - name: wizTokenUrl
-    description: The URL used to obtain an access token for the Wiz API e.g https://auth.app.wiz.io/oauth/token. For more information, see the  <a target="_blank" href="https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/code-quality-security/wiz#wiz-credentials">documentation</a>.
+    description: The URL used to obtain an access token for the Wiz API e.g https://auth.app.wiz.io/oauth/token. For more information, see the <a target="_blank" href="https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/code-quality-security/wiz#wiz-credentials">documentation</a>.
     type: string
     required: true
   - name: wizWebhookVerificationToken

--- a/integrations/wiz/CHANGELOG.md
+++ b/integrations/wiz/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+# Port_Ocean 0.1.42 (2024-08-01)
+
+### Improvements
+
+- Added _target='blank' attribute to spec links to open a new browser tab instead of the current browser.
+
+
 # Port_Ocean 0.1.41 (2024-07-31)
 
 ### Improvements

--- a/integrations/wiz/pyproject.toml
+++ b/integrations/wiz/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "wiz"
-version = "0.1.41"
+version = "0.1.42"
 description = "Wiz Port integration in Ocean"
 authors = ["Albert Luganga <albertluganga@getport.io>"]
 


### PR DESCRIPTION
# Description

Update the description content and the attribute target="_blank" to all tags such that the final becomes . Doing this will point the url to open a new browser tab instead of the current browser.

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Documentation (added/updated documentation)

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
