### PR TITLE
[Integration][Azure] Add _target='blank' attribute to spec links

### DIFF
--- a/integrations/azure/.port/spec.yaml
+++ b/integrations/azure/.port/spec.yaml
@@ -18,17 +18,17 @@ configurations:
     required: false
     type: string
     sensitive: true
-    description: Azure Client ID, for more information on how to create and manage the Credentials see here https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal.
+    description: Azure Client ID. For more information on how to create and manage credentials, see the <a href="https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal" target="_blank">Azure documentation</a>.
   - name: azureClientSecret
     required: false
     type: string
     sensitive: true
-    description: Azure Client Secret, for more information on how to create and manage the Credentials see here information https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal.
+    description: Azure Client Secret. For more information on how to create and manage credentials, see the <a href="https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal" target="_blank">Azure documentation</a>.
   - name: azureTenantId
     required: false
     type: string
     sensitive: true
-    description: Azure Tenant ID, for more information on how to create and manage the Credentials see here https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal.
+    description: Azure Tenant ID. For more information on how to create and manage credentials, see the <a href="https://docs.microsoft.com/en-us/azure/active-directory/develop/howto-create-service-principal-portal" target="_blank">Azure documentation</a>
 deploymentMethodRequirements:
   - type: default
     configurations: ['azureClientId', 'azureClientSecret', 'azureTenantId']

--- a/integrations/azure/CHANGELOG.md
+++ b/integrations/azure/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.1.75 (2024-08-01)
+
+### Improvements
+
+- Added _target='blank' attribute to spec links to open a new browser tab instead of the current browser.
+
+
 0.1.74 (2024-07-31)
 
 ### Improvements

--- a/integrations/azure/pyproject.toml
+++ b/integrations/azure/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "azure"
-version = "0.1.74"
+version = "0.1.75"
 description = "Azure integration"
 authors = ["Tom Tankilevitch <tom@getport.io>"]
 


### PR DESCRIPTION
# Description

Update the description content and the attribute target="_blank" to all tags such that the final becomes . Doing this will point the url to open a new browser tab instead of the current browser.

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Documentation (added/updated documentation)

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
