### PR TITLE
[Integration][AWS] throw error if no permissions on region

### DIFF
--- a/integrations/aws/CHANGELOG.md
+++ b/integrations/aws/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+# Port_Ocean 0.2.25 (2024-08-05)
+
+### Improvements
+
+- Add live events error handling
+
 # Port_Ocean 0.2.24 (2024-08-05)
 
 ### Improvements

--- a/integrations/aws/main.py
+++ b/integrations/aws/main.py
@@ -228,6 +228,10 @@ async def webhook(update: ResourceUpdate, response: Response) -> fastapi.Respons
                 if is_access_denied_exception(e):
                     raise e
                 resource = None
+                
+            # some aws resources return not found as an empty response
+            if not resource:
+                resource = None
 
             for kind in matching_resource_configs:
                 blueprints = matching_resource_configs[kind]

--- a/integrations/aws/main.py
+++ b/integrations/aws/main.py
@@ -226,9 +226,16 @@ async def webhook(update: ResourceUpdate, response: Response) -> fastapi.Respons
                     resource_type, identifier, account_id, region
                 )
             except Exception as e:
-                if is_access_denied_exception(e) or is_server_error(e):
+                if is_access_denied_exception(e):
                     logger.error(
-                        f"Skipping resyncing {resource_type} in region {region} due to missing access permissions"
+                        f"Cannot sync {resource_type} in region {region} in account {account_id} due to missing access permissions {e}"
+                    )
+                    return fastapi.Response(
+                        status_code=status.HTTP_200_OK,
+                    )
+                if is_server_error(e):
+                    logger.error(
+                        f"Cannot sync {resource_type} in region {region} in account {account_id} due to server error {e}"
                     )
                     return fastapi.Response(
                         status_code=status.HTTP_200_OK,

--- a/integrations/aws/main.py
+++ b/integrations/aws/main.py
@@ -232,7 +232,6 @@ async def webhook(update: ResourceUpdate, response: Response) -> fastapi.Respons
                     )
                     return fastapi.Response(
                         status_code=status.HTTP_200_OK,
-                        content=json.dumps({"ok": True}),
                     )
                 resource = None
 

--- a/integrations/aws/main.py
+++ b/integrations/aws/main.py
@@ -224,7 +224,9 @@ async def webhook(update: ResourceUpdate, response: Response) -> fastapi.Respons
                 resource = await describe_single_resource(
                     resource_type, identifier, account_id, region
                 )
-            except Exception:
+            except Exception as e:
+                if is_access_denied_exception(e):
+                    raise e
                 resource = None
 
             for kind in matching_resource_configs:

--- a/integrations/aws/main.py
+++ b/integrations/aws/main.py
@@ -33,6 +33,7 @@ from utils.misc import (
     CustomProperties,
     ResourceKindsWithSpecialHandling,
     is_access_denied_exception,
+    is_server_error,
 )
 
 
@@ -225,7 +226,7 @@ async def webhook(update: ResourceUpdate, response: Response) -> fastapi.Respons
                     resource_type, identifier, account_id, region
                 )
             except Exception as e:
-                if is_access_denied_exception(e):
+                if is_access_denied_exception(e) or is_server_error(e):
                     logger.error(
                         f"Skipping resyncing {resource_type} in region {region} due to missing access permissions"
                     )

--- a/integrations/aws/main.py
+++ b/integrations/aws/main.py
@@ -226,9 +226,15 @@ async def webhook(update: ResourceUpdate, response: Response) -> fastapi.Respons
                 )
             except Exception as e:
                 if is_access_denied_exception(e):
-                    raise e
+                    logger.error(
+                        f"Skipping resyncing {resource_type} in region {region} due to missing access permissions"
+                    )
+                    return fastapi.Response(
+                        status_code=status.HTTP_200_OK,
+                        content=json.dumps({"ok": True}),
+                    )
                 resource = None
-                
+
             # some aws resources return not found as an empty response
             if not resource:
                 resource = None

--- a/integrations/aws/main.py
+++ b/integrations/aws/main.py
@@ -236,10 +236,6 @@ async def webhook(update: ResourceUpdate, response: Response) -> fastapi.Respons
                     )
                 resource = None
 
-            # some aws resources return not found as an empty response
-            if not resource:
-                resource = None
-
             for kind in matching_resource_configs:
                 blueprints = matching_resource_configs[kind]
                 if not resource:  # Resource probably deleted

--- a/integrations/aws/pyproject.toml
+++ b/integrations/aws/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws"
-version = "0.2.24"
+version = "0.2.25"
 description = "This integration will map all your resources in all the available accounts to your Port entities"
 authors = ["Shalev Avhar <shalev@getport.io>", "Erik Zaadi <erik@getport.io>"]
 

--- a/integrations/aws/utils/misc.py
+++ b/integrations/aws/utils/misc.py
@@ -32,6 +32,14 @@ def is_access_denied_exception(e: Exception) -> bool:
     return False
 
 
+def is_server_error(e: Exception) -> bool:
+    if hasattr(e, "response"):
+        status = e.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+        return status >= 500
+
+    return False
+
+
 def get_matching_kinds_and_blueprints_from_config(
     kind: str,
 ) -> dict[str, list[str]]:


### PR DESCRIPTION
# Description

What - We have implemented blacklist error handling for AWS errors in our system. This ensures that certain AWS error types are specifically caught and handled differently from other errors.

Why - Each AWS resource handles "not found" errors differently, making it challenging to distinguish between a resource not being found and an actual error in the system. This inconsistency can lead to misinterpretation of errors and inappropriate error handling. By adding blacklist error handling, we can provide more accurate and consistent error handling across different AWS resources.

How - We have introduced a blacklist mechanism that explicitly catches specific AWS error codes related to "not found" scenarios. These error codes are then handled separately from other types of errors, allowing us to treat them as non-critical issues and proceed accordingly. This ensures that our system can gracefully handle situations where AWS resources are legitimately not found without mistaking them for system errors. This approach improves our system's robustness and reliability in interacting with AWS services.


## Type of change

Please leave one option from the following and delete the rest:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
