### PR TITLE
[Integration][GCP] | Improved rate limit handling

### DIFF
--- a/.github/workflows/release-integrations.yml
+++ b/.github/workflows/release-integrations.yml
@@ -124,7 +124,6 @@ jobs:
       packages: write
       contents: read
     needs: release-integration
-    if: needs.release-integration.outputs.is_dev_version == 'false'
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -137,42 +136,69 @@ jobs:
           aws-region: ${{ secrets.AWS_REGION }}
       - name: Upload specifications to s3
         run: |
-          # Temporary file to store the concatenated YAML content
-          all_integrations_temp_file="all_integrations_temp_file.yaml"
-
-          # Temporary file to store each integration YAML content
-          specific_integration_temp_file="specific_integration_temp_file.yaml"
+          # Temporary file
+          temp_file="temp.yaml"
 
           # Output file name
-          output_file="index.json"
+          index_file="index.json"
 
           # AWS S3 bucket details
           aws_s3_bucket="ocean-registry"
+
+          # Fetch existing index file or create empty one of not exists
+          if aws s3 ls "s3://$aws_s3_bucket/$index_file" > /dev/null 2>&1; then
+            aws s3 cp "s3://$aws_s3_bucket/$index_file" $index_file
+            echo "Successfully fetched global index file from s3 bucket."
+          else
+            echo "Index file does not exist in the S3 bucket, Creating new one..."
+            echo "[]" > "$index_file"
+          fi
 
           # Find all ocean-spec.yaml files under the specified directory
           find integrations/*/.port -type f -name "spec.yaml" > file_list.txt
 
           while IFS= read -r file; do
           integration_dir=$(dirname "$file")
+          integration_name=$(echo "$integration_dir" | awk -F'/' '{print $2}')
+
           # Extract the type for pyproject.toml
           type=$(grep -E '^name = ".*"' "$integration_dir/../pyproject.toml" | cut -d'"' -f2)
 
           # Extract the version from pyproject.toml
           version=$(grep -E '^version = ".*"' "$integration_dir/../pyproject.toml" | cut -d'"' -f2)
 
-          # Store the integration's yaml file content into a temporary file
-          integration_dest="$(echo $integration_dir | awk -F'/' '{print $2}').json"
-          sed 's/^/  /' "$file" > "$specific_integration_temp_file"
-          echo "  type: $type" >> "$specific_integration_temp_file"
-          echo "  version: $version" >> "$specific_integration_temp_file"
+          integration_spec="$integration_name-$version.json"
+          integration_dest="$integration_name/$integration_spec"
+          integration_legacy_dest="$integration_name.json" # TODO: legacy support, remove once not in use
 
-          yq -o=json . < "$specific_integration_temp_file" > "$integration_dest"
-          aws s3 cp "$integration_dest" "s3://$aws_s3_bucket/$integration_dest"
+          # Convert YAML to JSON
+          yq -o json "$file" > "$temp_file"
 
-          # Concatenate the YAML files into a temporary file
-          echo "- " >> "$all_integrations_temp_file"
-          cat "$specific_integration_temp_file" >> "$all_integrations_temp_file"
+          # Add version attribute
+          jq --arg type "$type" --arg version "$version" '. + {type: $type, version: $version}' "$temp_file" > "$integration_spec"
+
+          # Upload integration's version manifest to s3
+          aws s3 cp "$integration_spec" "s3://$aws_s3_bucket/$integration_dest"
+          aws s3 cp "$integration_spec" "s3://$aws_s3_bucket/$integration_legacy_dest" # TODO: legacy support, remove once not in use
+          echo "Successfully uploaded $integration_spec to s3 bucket."
+
+          # Get the latest version of the current integration
+          latest_version=$(jq --arg type "$type" -r '.[] | select(.type == $type) | .version' "$index_file")
+
+          # Add integration's spec to global index file
+          regexp="^[0-9.]+$"
+          if [[ ! "$latest_version" ]]; then
+            # Add new integration spec if latest tag doesn't exist
+            jq --argjson new_spec "[$(cat "$integration_spec")]" '. += $new_spec' "$index_file" > "$temp_file"
+            mv "$temp_file" "$index_file"
+          elif [[ ! "$latest_version" =~ $regexp ]] || [[ "$version" =~ $regexp ]]; then
+            # Override global index file if released non-dev version or integration doesn't have non-dev latest tag
+            jq --argjson updated_spec "$(cat "$integration_spec")" --arg type "$type" \
+              'map(if .type == $type then $updated_spec else . end)' "$index_file" > "$temp_file"
+            mv "$temp_file" "$index_file"
+          fi
           done < file_list.txt
 
-          yq -o=json . < "$all_integrations_temp_file" > "$output_file"
-          aws s3 cp "$output_file" "s3://$aws_s3_bucket/$output_file"
+          # Upload global index file to s3
+          aws s3 cp "$index_file" "s3://$aws_s3_bucket/$index_file"
+          echo "Successfully uploaded $index_file to s3 bucket."

--- a/integrations/gcp/CHANGELOG.md
+++ b/integrations/gcp/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.39 (2024-08-12)
+
+
+### Improvements
+
+- Added rate limit strategy to SearchAllResources calls
+
+
 ## 0.1.38 (2024-08-11)
 
 

--- a/integrations/gcp/gcp_core/search/iterators.py
+++ b/integrations/gcp/gcp_core/search/iterators.py
@@ -5,6 +5,7 @@ from port_ocean.utils.async_iterators import stream_async_iterators_tasks
 
 from gcp_core.errors import NoProjectsFoundError
 from gcp_core.search.resource_searches import search_all_projects
+from gcp_core.search.utils import execute_with_concurrency_control
 
 
 async def iterate_per_available_project(
@@ -15,7 +16,9 @@ async def iterate_per_available_project(
     try:
         async for projects in search_all_projects():
             tasks = [
-                project_dependent_callable(project, *args, **kwargs)
+                execute_with_concurrency_control(
+                    project_dependent_callable, project, *args, **kwargs
+                )
                 for project in projects
             ]
             async for batch in stream_async_iterators_tasks(*tasks):

--- a/integrations/gcp/gcp_core/search/resource_searches.py
+++ b/integrations/gcp/gcp_core/search/resource_searches.py
@@ -41,12 +41,12 @@ _TOTAL_TIME_ALLOWED_FOR_RETRIES = 300.0
 
 
 def _is_retryable(error: Exception) -> bool:
-    return isinstance(exc, _RETRIABLE_ERROR_TYPES)
+    return isinstance(error, _RETRIABLE_ERROR_TYPES)
 
 
-def _log_retry_attempt(exc: Exception) -> None:
+def _log_retry_attempt(error: Exception) -> None:
     logger.warning(
-        f"Retrying due to {exc.__class__.__name__} error: {exc}",
+        f"Retrying due to {error.__class__.__name__} error: {exc}",
     )
 
 

--- a/integrations/gcp/gcp_core/search/resource_searches.py
+++ b/integrations/gcp/gcp_core/search/resource_searches.py
@@ -1,16 +1,10 @@
 from typing import Any
 import typing
 
-from google.api_core.exceptions import (
-    NotFound,
-    PermissionDenied,
-    TooManyRequests,
-    ServiceUnavailable,
-)
+from google.api_core.exceptions import NotFound, PermissionDenied
 from google.cloud.asset_v1 import (
     AssetServiceAsyncClient,
 )
-from google.api_core.retry_async import AsyncRetry
 from google.cloud.asset_v1.services.asset_service import pagers
 from google.cloud.resourcemanager_v3 import (
     FoldersAsyncClient,
@@ -31,33 +25,7 @@ from gcp_core.utils import (
     parse_protobuf_messages,
     parse_latest_resource_from_asset,
 )
-
-# Retry policy constants
-_RETRIABLE_ERROR_TYPES = (TooManyRequests, ServiceUnavailable)
-_INITIAL_DELAY_BEFORE_FIRST_RETRY_ATTEMPT = 1.0
-_MAXIMUM_DELAY_BETWEEN_RETRY_ATTEMPTS = 60.0
-_MULTIPLIER_FOR_EXPONENTIAL_BACKOFF = 2.0
-_TOTAL_TIME_ALLOWED_FOR_RETRIES = 300.0
-
-
-def _is_retryable(error: Exception) -> bool:
-    return isinstance(error, _RETRIABLE_ERROR_TYPES)
-
-
-def _log_retry_attempt(error: Exception) -> None:
-    logger.warning(
-        f"Retrying due to {error.__class__.__name__} error: {error}",
-    )
-
-
-retry_policy = AsyncRetry(
-    predicate=_is_retryable,
-    on_error=_log_retry_attempt,
-    initial=_INITIAL_DELAY_BEFORE_FIRST_RETRY_ATTEMPT,
-    maximum=_MAXIMUM_DELAY_BETWEEN_RETRY_ATTEMPTS,
-    multiplier=_MULTIPLIER_FOR_EXPONENTIAL_BACKOFF,
-    deadline=_TOTAL_TIME_ALLOWED_FOR_RETRIES,
-)
+from gcp_core.search.utils import retry_policy
 
 
 async def search_all_resources(

--- a/integrations/gcp/gcp_core/search/resource_searches.py
+++ b/integrations/gcp/gcp_core/search/resource_searches.py
@@ -32,15 +32,31 @@ from gcp_core.utils import (
     parse_latest_resource_from_asset,
 )
 
+# Retry policy constants
 _RETRIABLE_ERROR_TYPES = (TooManyRequests, ServiceUnavailable)
+_INITIAL_DELAY_BEFORE_FIRST_RETRY_ATTEMPT = 1.0
+_MAXIMUM_DELAY_BETWEEN_RETRY_ATTEMPTS = 60.0
+_MULTIPLIER_FOR_EXPONENTIAL_BACKOFF = 2.0
+_TOTAL_TIME_ALLOWED_FOR_RETRIES = 300.0
 
 
 def _is_retryable(exc: Exception) -> bool:
     return isinstance(exc, _RETRIABLE_ERROR_TYPES)
 
 
+def _log_retry_attempt(exc: Exception) -> None:
+    logger.warning(
+        f"Retrying due to {exc.__class__.__name__} error: {exc}",
+    )
+
+
 retry_policy = AsyncRetry(
-    predicate=_is_retryable, initial=1.0, maximum=60.0, multiplier=2.0, deadline=300.0
+    predicate=_is_retryable,
+    on_error=_log_retry_attempt,
+    initial=_INITIAL_DELAY_BEFORE_FIRST_RETRY_ATTEMPT,
+    maximum=_MAXIMUM_DELAY_BETWEEN_RETRY_ATTEMPTS,
+    multiplier=_MULTIPLIER_FOR_EXPONENTIAL_BACKOFF,
+    deadline=_TOTAL_TIME_ALLOWED_FOR_RETRIES,
 )
 
 
@@ -107,7 +123,7 @@ async def list_all_topics_per_project(
     async with PublisherAsyncClient() as async_publisher_client:
         try:
             list_topics_pagers = await async_publisher_client.list_topics(
-                project=project_name
+                project=project_name, retry=retry_policy
             )
             async for paginated_response in list_topics_pagers.pages:
                 topics = parse_protobuf_messages(paginated_response.topics)
@@ -136,7 +152,9 @@ async def search_all_projects() -> ASYNC_GENERATOR_RESYNC_TYPE:
     """
     logger.info("Searching projects")
     async with ProjectsAsyncClient() as projects_client:
-        search_projects_pager = await projects_client.search_projects()
+        search_projects_pager = await projects_client.search_projects(
+            retry=retry_policy
+        )
         async for projects_page in search_projects_pager.pages:
             raw_projects = projects_page.projects
             logger.info(f"Found {len(raw_projects)} Projects")
@@ -149,7 +167,7 @@ async def search_all_folders() -> ASYNC_GENERATOR_RESYNC_TYPE:
     """
     logger.info("Searching folders")
     async with FoldersAsyncClient() as folders_client:
-        search_folders_pager = await folders_client.search_folders()
+        search_folders_pager = await folders_client.search_folders(retry=retry_policy)
         async for folders_page in search_folders_pager.pages:
             raw_folders = folders_page.folders
             logger.info(f"Found {len(raw_folders)} Folders")
@@ -162,7 +180,9 @@ async def search_all_organizations() -> ASYNC_GENERATOR_RESYNC_TYPE:
     """
     logger.info("Searching organizations")
     async with OrganizationsAsyncClient() as organizations_client:
-        search_organizations_pager = await organizations_client.search_organizations()
+        search_organizations_pager = await organizations_client.search_organizations(
+            retry=retry_policy
+        )
         async for organizations_page in search_organizations_pager.pages:
             raw_orgs = organizations_page.organizations
             logger.info(f"Found {len(raw_orgs)} organizations")
@@ -172,19 +192,23 @@ async def search_all_organizations() -> ASYNC_GENERATOR_RESYNC_TYPE:
 async def get_single_project(project_name: str) -> RAW_ITEM:
     async with ProjectsAsyncClient() as projects_client:
         return parse_protobuf_message(
-            await projects_client.get_project(name=project_name)
+            await projects_client.get_project(name=project_name, retry=retry_policy)
         )
 
 
 async def get_single_folder(folder_name: str) -> RAW_ITEM:
     async with FoldersAsyncClient() as folders_client:
-        return parse_protobuf_message(await folders_client.get_folder(name=folder_name))
+        return parse_protobuf_message(
+            await folders_client.get_folder(name=folder_name, retry=retry_policy)
+        )
 
 
 async def get_single_organization(organization_name: str) -> RAW_ITEM:
     async with OrganizationsAsyncClient() as organizations_client:
         return parse_protobuf_message(
-            await organizations_client.get_organization(name=organization_name)
+            await organizations_client.get_organization(
+                name=organization_name, retry=retry_policy
+            )
         )
 
 
@@ -195,7 +219,7 @@ async def get_single_topic(topic_id: str) -> RAW_ITEM:
     """
     async with PublisherAsyncClient() as async_publisher_client:
         return parse_protobuf_message(
-            await async_publisher_client.get_topic(topic=topic_id)
+            await async_publisher_client.get_topic(topic=topic_id, retry=retry_policy)
         )
 
 

--- a/integrations/gcp/gcp_core/search/resource_searches.py
+++ b/integrations/gcp/gcp_core/search/resource_searches.py
@@ -46,7 +46,7 @@ def _is_retryable(error: Exception) -> bool:
 
 def _log_retry_attempt(error: Exception) -> None:
     logger.warning(
-        f"Retrying due to {error.__class__.__name__} error: {exc}",
+        f"Retrying due to {error.__class__.__name__} error: {error}",
     )
 
 

--- a/integrations/gcp/gcp_core/search/resource_searches.py
+++ b/integrations/gcp/gcp_core/search/resource_searches.py
@@ -35,7 +35,7 @@ from gcp_core.utils import (
 _RETRIABLE_ERROR_TYPES = (TooManyRequests, ServiceUnavailable)
 
 
-def _is_retryable(exc):
+def _is_retryable(exc: Exception) -> bool:
     return isinstance(exc, _RETRIABLE_ERROR_TYPES)
 
 

--- a/integrations/gcp/gcp_core/search/utils.py
+++ b/integrations/gcp/gcp_core/search/utils.py
@@ -1,0 +1,50 @@
+import asyncio
+from typing import Any, Callable, AsyncGenerator
+from loguru import logger
+from port_ocean.core.ocean_types import ASYNC_GENERATOR_RESYNC_TYPE
+
+from google.api_core.retry_async import AsyncRetry
+from google.api_core.exceptions import (
+    TooManyRequests,
+    ServiceUnavailable,
+)
+
+
+RETRIABLE_ERROR_TYPES = (TooManyRequests, ServiceUnavailable)
+INITIAL_DELAY_BEFORE_FIRST_RETRY_ATTEMPT = 1.0
+MAXIMUM_DELAY_BETWEEN_RETRY_ATTEMPTS = 60.0
+MULTIPLIER_FOR_EXPONENTIAL_BACKOFF = 2.0
+TOTAL_TIME_ALLOWED_FOR_RETRIES = 300.0
+
+MAX_CONCURRENT_CALLS = 10
+semaphore = asyncio.BoundedSemaphore(MAX_CONCURRENT_CALLS)
+
+
+def is_retryable(error: Exception) -> bool:
+    """Check if the error is retryable based on defined error types."""
+    return isinstance(error, RETRIABLE_ERROR_TYPES)
+
+
+def log_retry_attempt(error: Exception) -> None:
+    """Log a warning when a retryable error occurs."""
+    logger.warning(f"Retrying due to {error.__class__.__name__} error: {error}")
+
+
+retry_policy = AsyncRetry(
+    predicate=is_retryable,
+    on_error=log_retry_attempt,
+    initial=INITIAL_DELAY_BEFORE_FIRST_RETRY_ATTEMPT,
+    maximum=MAXIMUM_DELAY_BETWEEN_RETRY_ATTEMPTS,
+    multiplier=MULTIPLIER_FOR_EXPONENTIAL_BACKOFF,
+    deadline=TOTAL_TIME_ALLOWED_FOR_RETRIES,
+    timeout=TOTAL_TIME_ALLOWED_FOR_RETRIES,
+)
+
+
+async def execute_with_concurrency_control(
+    callable_func: Callable[..., AsyncGenerator[Any, None]], *args: Any, **kwargs: Any
+) -> ASYNC_GENERATOR_RESYNC_TYPE:
+    """Execute a callable with concurrency control using a bounded semaphore."""
+    async with semaphore:
+        async for item in callable_func(*args, **kwargs):
+            yield item

--- a/integrations/gcp/pyproject.toml
+++ b/integrations/gcp/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gcp"
-version = "0.1.38"
+version = "0.1.39"
 description = "A GCP ocean integration"
 authors = ["Matan Geva <matang@getport.io>"]
 

--- a/integrations/gcp/pyproject.toml
+++ b/integrations/gcp/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gcp"
-version = "0.1.39"
+version = "0.1.40"
 description = "A GCP ocean integration"
 authors = ["Matan Geva <matang@getport.io>"]
 


### PR DESCRIPTION
# Description

**What** - Added rate limit retry and backoff strategy to when searching for resources that the caller has `cloudasset.assets.searchAllResources`
**Why** -  GCP throws a 419 rate limit error which prevents resources from getting synced to port. Maximum Quota that can be set on GCP for cloud asset API calls is 400, to exceed that users are required to apply for higher quota.  
**How** - By leveraging the inbuilt support for Retry, we are able to implement an exponential backoff strategy for rate limit handling. 

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)