### PR TITLE
[Integration][Gitlab] Fixed issue with webhook not syncing repository languages

### DIFF
--- a/integrations/gitlab/CHANGELOG.md
+++ b/integrations/gitlab/CHANGELOG.md
@@ -7,6 +7,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+0.1.103 (2024-08-14)
+====================
+
+### Improvements
+
+- Fixed issue with webhook not syncing repository languages
+
+
 0.1.102 (2024-08-13)
 ====================
 

--- a/integrations/gitlab/gitlab_integration/events/hooks/push.py
+++ b/integrations/gitlab/gitlab_integration/events/hooks/push.py
@@ -52,7 +52,8 @@ class PushHook(ProjectHandler):
             logger.info(
                 f"Updating project information after push hook for project {gitlab_project.path_with_namespace}"
             )
-            await ocean.register_raw(ObjectKind.PROJECT, [gitlab_project.asdict()])
+            enriched_project = self.gitlab_service.enrich_project_with_extras(project)
+            await ocean.register_raw(ObjectKind.PROJECT, [enriched_project])
         else:
             logger.debug(
                 f"Skipping push hook for project {gitlab_project.path_with_namespace} because the ref {ref} "

--- a/integrations/gitlab/gitlab_integration/events/hooks/push.py
+++ b/integrations/gitlab/gitlab_integration/events/hooks/push.py
@@ -52,7 +52,7 @@ class PushHook(ProjectHandler):
             logger.info(
                 f"Updating project information after push hook for project {gitlab_project.path_with_namespace}"
             )
-            enriched_project = self.gitlab_service.enrich_project_with_extras(project)
+            enriched_project = await self.gitlab_service.enrich_project_with_extras(gitlab_project)
             await ocean.register_raw(ObjectKind.PROJECT, [enriched_project])
         else:
             logger.debug(

--- a/integrations/gitlab/pyproject.toml
+++ b/integrations/gitlab/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gitlab"
-version = "0.1.102"
+version = "0.1.103"
 description = "Gitlab integration for Port using Port-Ocean Framework"
 authors = ["Yair Siman-Tov <yair@getport.io>"]
 


### PR DESCRIPTION
# Description

**What** - After running the integration the enriches the projects language properties, however during webhook events, the project sync with being enriched with language property, thereby resulting in the previously synced languages during the initial setup to be overwritten.
**Why** - On push event, the existing implementation does not enrich projects with languages.
**How** - This was solved by ensuring that during push event an extra function `enrich_project_with_extras` is called to enrich the projects with languages

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
