### PR TITLE
Pre-Commit checks and debuggable ocean core in integrations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+exclude: 'cookiecutter.*'
+repos:
+  - repo: 'https://github.com/pre-commit/pre-commit-hooks'
+    rev: v3.2.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: check-executables-have-shebangs
+      - id: check-symlinks
+      - id: detect-aws-credentials
+  - repo: local
+    hooks:
+      - id: lint
+        name: Run linter
+        description: This hooks runs our linters
+        entry: make lint
+        language: system
+        types:
+          - python

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,10 @@ define install_poetry
 	fi
 endef
 
+define install_precommit
+	command pre-commit install
+endef
+
 define deactivate_virtualenv
     if [ -n "$$VIRTUAL_ENV" ]; then \
         unset VIRTUAL_ENV; \
@@ -46,7 +50,9 @@ endef
 install:
 	$(call deactivate_virtualenv) && \
 	$(call install_poetry) && \
-	poetry install --with dev --all-extras
+	poetry install --with dev --all-extras &&  \
+	$(ACTIVATE) && \
+	$(call install_precommit)
 
 test/all: test
 	pytest --import-mode=importlib -n auto ./port_ocean/tests ./integrations/*/tests
@@ -102,3 +108,7 @@ clean:
 # make bump/integrations VERSION=0.3.2
 bump/integrations:
 	./scripts/bump-all.sh $(VERSION)
+
+# make bump/single-integration INTEGRATION=aws
+bump/single-integration:
+	./scripts/bump-single-integration.sh -i $(INTEGRATION)

--- a/integrations/argocd/changelog/.gitignore
+++ b/integrations/argocd/changelog/.gitignore
@@ -1,1 +1,2 @@
+*
 !.gitignore

--- a/integrations/argocd/pyproject.toml
+++ b/integrations/argocd/pyproject.toml
@@ -9,6 +9,8 @@ python = "^3.11"
 port_ocean = {version = "^0.9.14", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
+# Uncomment this if you want to debug the ocean core together with your integration
+# port_ocean = { path = '../../', develop = true, extras = ['all'] }
 pytest = "^7.2"
 black = "^24.4.2"
 mypy = "^1.3.0"
@@ -54,8 +56,8 @@ underlines = [""]
   showcontent = true
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
 exclude = [

--- a/integrations/aws/changelog/.gitignore
+++ b/integrations/aws/changelog/.gitignore
@@ -1,1 +1,2 @@
+*
 !.gitignore

--- a/integrations/aws/pyproject.toml
+++ b/integrations/aws/pyproject.toml
@@ -14,6 +14,8 @@ types-aioboto3 = "^12.4.0"
 types-aiobotocore = {extras = ["sts"], version = "^2.12.3"}
 
 [tool.poetry.group.dev.dependencies]
+# Uncomment this if you want to debug the ocean core together with your integration
+# port_ocean = { path = '../../', develop = true, extras = ['all'] }
 pytest = "^7.2"
 black = "^24.3.0"
 mypy = "^1.3.0"
@@ -59,8 +61,8 @@ underlines = [""]
   showcontent = true
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
 exclude = [

--- a/integrations/azure-devops/changelog/.gitignore
+++ b/integrations/azure-devops/changelog/.gitignore
@@ -1,1 +1,2 @@
+*
 !.gitignore

--- a/integrations/azure-devops/pyproject.toml
+++ b/integrations/azure-devops/pyproject.toml
@@ -9,6 +9,8 @@ python = "^3.11"
 port_ocean = {version = "^0.9.14", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
+# Uncomment this if you want to debug the ocean core together with your integration
+# port_ocean = { path = '../../', develop = true, extras = ['all'] }
 pytest = "^7.2"
 black = "^24.4.2"
 mypy = "^1.3.0"
@@ -55,8 +57,8 @@ underlines = [""]
   showcontent = true
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
 exclude = [

--- a/integrations/azure/changelog/.gitignore
+++ b/integrations/azure/changelog/.gitignore
@@ -1,1 +1,2 @@
+*
 !.gitignore

--- a/integrations/azure/pyproject.toml
+++ b/integrations/azure/pyproject.toml
@@ -16,6 +16,8 @@ azure-mgmt-subscription = "^3.1.1"
 aiostream = "^0.5.2"
 
 [tool.poetry.group.dev.dependencies]
+# Uncomment this if you want to debug the ocean core together with your integration
+# port_ocean = { path = '../../', develop = true, extras = ['all'] }
 pytest = "^7.2"
 black = "^24.4.2"
 mypy = "^1.3.0"
@@ -59,8 +61,8 @@ filename = "CHANGELOG.md"
   showcontent = true
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
 exclude = [

--- a/integrations/datadog/changelog/.gitignore
+++ b/integrations/datadog/changelog/.gitignore
@@ -1,1 +1,2 @@
+*
 !.gitignore

--- a/integrations/datadog/pyproject.toml
+++ b/integrations/datadog/pyproject.toml
@@ -10,6 +10,8 @@ port_ocean = {version = "^0.9.14", extras = ["cli"]}
 loguru = "^0.7.2"
 
 [tool.poetry.group.dev.dependencies]
+# Uncomment this if you want to debug the ocean core together with your integration
+# port_ocean = { path = '../../', develop = true, extras = ['all'] }
 pytest = "^7.2"
 black = "^24.3.0"
 mypy = "^1.3.0"
@@ -55,8 +57,8 @@ underlines = [""]
   showcontent = true
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
 exclude = [

--- a/integrations/dynatrace/changelog/.gitignore
+++ b/integrations/dynatrace/changelog/.gitignore
@@ -1,1 +1,2 @@
+*
 !.gitignore

--- a/integrations/dynatrace/pyproject.toml
+++ b/integrations/dynatrace/pyproject.toml
@@ -9,6 +9,8 @@ python = "^3.11"
 port_ocean = {version = "^0.9.14", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
+# uncomment this if you want to debug the ocean core together with your integration
+# port_ocean = { path = '../../', develop = true, extras = ['all'] }
 pytest = "^7.2"
 black = "^24.4.2"
 mypy = "^1.3.0"
@@ -54,8 +56,8 @@ underlines = [""]
   showcontent = true
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
 exclude = [

--- a/integrations/firehydrant/changelog/.gitignore
+++ b/integrations/firehydrant/changelog/.gitignore
@@ -1,1 +1,2 @@
+*
 !.gitignore

--- a/integrations/firehydrant/pyproject.toml
+++ b/integrations/firehydrant/pyproject.toml
@@ -9,6 +9,8 @@ python = "^3.11"
 port_ocean = {version = "^0.9.14", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
+# uncomment this if you want to debug the ocean core together with your integration
+# port_ocean = { path = '../../', develop = true, extras = ['all'] }
 pytest = "^7.2"
 black = "^24.4.2"
 mypy = "^1.3.0"
@@ -54,8 +56,8 @@ underlines = [""]
   showcontent = true
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
 exclude = [

--- a/integrations/gcp/changelog/.gitignore
+++ b/integrations/gcp/changelog/.gitignore
@@ -1,1 +1,2 @@
+*
 !.gitignore

--- a/integrations/gcp/pyproject.toml
+++ b/integrations/gcp/pyproject.toml
@@ -12,6 +12,8 @@ google-cloud-pubsub = "^2.21.1"
 google-cloud-resource-manager = "^1.12.3"
 
 [tool.poetry.group.dev.dependencies]
+# uncomment this if you want to debug the ocean core together with your integration
+# port_ocean = { path = '../../', develop = true, extras = ['all'] }
 pytest = "^7.2"
 black = "^24.4.2"
 mypy = "^1.3.0"
@@ -57,8 +59,8 @@ underlines = [""]
   showcontent = true
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
 exclude = [

--- a/integrations/gitlab/changelog/.gitignore
+++ b/integrations/gitlab/changelog/.gitignore
@@ -1,1 +1,2 @@
-\]!.gitignore
+*
+!.gitignore

--- a/integrations/gitlab/pyproject.toml
+++ b/integrations/gitlab/pyproject.toml
@@ -13,6 +13,8 @@ jsonschema = "^4.17.3"
 port_ocean = {version = "^0.9.14", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
+# uncomment this if you want to debug the ocean core together with your integration
+# port_ocean = { path = '../../', develop = true, extras = ['all'] }
 pytest = "^7.2"
 black = "^24.4.2"
 mypy = "^1.3.0"
@@ -62,8 +64,8 @@ title_format = "{version} ({project_date})"
   showcontent = true
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
 exclude = [

--- a/integrations/jenkins/changelog/.gitignore
+++ b/integrations/jenkins/changelog/.gitignore
@@ -1,1 +1,2 @@
+*
 !.gitignore

--- a/integrations/jenkins/pyproject.toml
+++ b/integrations/jenkins/pyproject.toml
@@ -12,6 +12,8 @@ python-dotenv = "^1.0.0"
 loguru = "^0.7.2"
 
 [tool.poetry.group.dev.dependencies]
+# uncomment this if you want to debug the ocean core together with your integration
+# port_ocean = { path = '../../', develop = true, extras = ['all'] }
 pytest = "^7.2"
 black = "^24.4.2"
 mypy = "^1.3.0"
@@ -57,8 +59,8 @@ underlines = [""]
   showcontent = true
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
 exclude = [

--- a/integrations/jira/changelog/.gitignore
+++ b/integrations/jira/changelog/.gitignore
@@ -1,1 +1,2 @@
+*
 !.gitignore

--- a/integrations/jira/pyproject.toml
+++ b/integrations/jira/pyproject.toml
@@ -10,6 +10,8 @@ port_ocean = {version = "^0.9.14", extras = ["cli"]}
 httpx = "^0.24.1"
 
 [tool.poetry.group.dev.dependencies]
+# uncomment this if you want to debug the ocean core together with your integration
+# port_ocean = { path = '../../', develop = true, extras = ['all'] }
 pytest = "^7.2"
 black = "^24.4.2"
 mypy = "^1.3.0"
@@ -55,8 +57,8 @@ underlines = [""]
   showcontent = true
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
 exclude = [

--- a/integrations/kafka/changelog/.gitignore
+++ b/integrations/kafka/changelog/.gitignore
@@ -1,1 +1,2 @@
+*
 !.gitignore

--- a/integrations/kafka/pyproject.toml
+++ b/integrations/kafka/pyproject.toml
@@ -10,6 +10,8 @@ port_ocean = {version = "^0.9.14", extras = ["cli"]}
 confluent-kafka = "^2.2.0"
 
 [tool.poetry.group.dev.dependencies]
+# uncomment this if you want to debug the ocean core together with your integration
+# port_ocean = { path = '../../', develop = true, extras = ['all'] }
 pytest = "^7.2"
 black = "^24.4.2"
 mypy = "^1.3.0"
@@ -55,8 +57,8 @@ underlines = [""]
   showcontent = true
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
 exclude = [

--- a/integrations/kubecost/changelog/.gitignore
+++ b/integrations/kubecost/changelog/.gitignore
@@ -1,1 +1,2 @@
+*
 !.gitignore

--- a/integrations/kubecost/pyproject.toml
+++ b/integrations/kubecost/pyproject.toml
@@ -9,6 +9,8 @@ python = "^3.11"
 port_ocean = {version = "^0.9.14", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
+# uncomment this if you want to debug the ocean core together with your integration
+# port_ocean = { path = '../../', develop = true, extras = ['all'] }
 pytest = "^7.2"
 black = "^24.4.2"
 mypy = "^1.3.0"
@@ -54,8 +56,8 @@ underlines = [""]
   showcontent = true
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
 exclude = [

--- a/integrations/launchdarkly/changelog/.gitignore
+++ b/integrations/launchdarkly/changelog/.gitignore
@@ -1,1 +1,2 @@
+*
 !.gitignore

--- a/integrations/launchdarkly/pyproject.toml
+++ b/integrations/launchdarkly/pyproject.toml
@@ -9,6 +9,8 @@ python = "^3.11"
 port_ocean = {version = "^0.9.14", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
+# uncomment this if you want to debug the ocean core together with your integration
+# port_ocean = { path = '../../', develop = true, extras = ['all'] }
 pytest = "^7.2"
 black = "^24.4.2"
 mypy = "^1.3.0"
@@ -54,8 +56,8 @@ underlines = [""]
   showcontent = true
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
 exclude = [

--- a/integrations/linear/changelog/.gitignore
+++ b/integrations/linear/changelog/.gitignore
@@ -1,1 +1,2 @@
+*
 !.gitignore

--- a/integrations/linear/pyproject.toml
+++ b/integrations/linear/pyproject.toml
@@ -9,6 +9,8 @@ python = "^3.11"
 port_ocean = {version = "^0.9.14", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
+# uncomment this if you want to debug the ocean core together with your integration
+# port_ocean = { path = '../../', develop = true, extras = ['all'] }
 pytest = "^7.2"
 black = "^24.3.0"
 mypy = "^1.3.0"
@@ -54,8 +56,8 @@ underlines = [""]
   showcontent = true
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
 exclude = [

--- a/integrations/newrelic/changelog/.gitignore
+++ b/integrations/newrelic/changelog/.gitignore
@@ -1,1 +1,2 @@
+*
 !.gitignore

--- a/integrations/newrelic/pyproject.toml
+++ b/integrations/newrelic/pyproject.toml
@@ -10,6 +10,8 @@ port_ocean = {version = "^0.9.14", extras = ["cli"]}
 httpx = "^0.24.1"
 
 [tool.poetry.group.dev.dependencies]
+# uncomment this if you want to debug the ocean core together with your integration
+# port_ocean = { path = '../../', develop = true, extras = ['all'] }
 pytest = "^7.2"
 black = "^24.4.2"
 mypy = "^1.3.0"
@@ -55,8 +57,8 @@ underlines = [""]
   showcontent = true
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
 exclude = [

--- a/integrations/opencost/changelog/.gitignore
+++ b/integrations/opencost/changelog/.gitignore
@@ -1,1 +1,2 @@
+*
 !.gitignore

--- a/integrations/opencost/pyproject.toml
+++ b/integrations/opencost/pyproject.toml
@@ -9,6 +9,8 @@ python = "^3.11"
 port_ocean = {version = "^0.9.14", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
+# uncomment this if you want to debug the ocean core together with your integration
+# port_ocean = { path = '../../', develop = true, extras = ['all'] }
 pytest = "^7.2"
 black = "^24.4.2"
 mypy = "^1.3.0"
@@ -54,8 +56,8 @@ underlines = [""]
   showcontent = true
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
 exclude = [

--- a/integrations/opsgenie/changelog/.gitignore
+++ b/integrations/opsgenie/changelog/.gitignore
@@ -1,1 +1,2 @@
+*
 !.gitignore

--- a/integrations/opsgenie/pyproject.toml
+++ b/integrations/opsgenie/pyproject.toml
@@ -9,6 +9,8 @@ python = "^3.11"
 port_ocean = {version = "^0.9.14", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
+# uncomment this if you want to debug the ocean core together with your integration
+# port_ocean = { path = '../../', develop = true, extras = ['all'] }
 pytest = "^7.2"
 black = "^24.4.2"
 mypy = "^1.3.0"
@@ -54,8 +56,8 @@ underlines = [""]
   showcontent = true
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
 exclude = [

--- a/integrations/pagerduty/changelog/.gitignore
+++ b/integrations/pagerduty/changelog/.gitignore
@@ -1,1 +1,2 @@
+*
 !.gitignore

--- a/integrations/pagerduty/pyproject.toml
+++ b/integrations/pagerduty/pyproject.toml
@@ -10,6 +10,8 @@ port_ocean = {version = "^0.9.14", extras = ["cli"]}
 httpx = "^0.24.1"
 
 [tool.poetry.group.dev.dependencies]
+# uncomment this if you want to debug the ocean core together with your integration
+# port_ocean = { path = '../../', develop = true, extras = ['all'] }
 pytest = "^7.2"
 black = "^24.4.2"
 mypy = "^1.3.0"
@@ -55,8 +57,8 @@ underlines = [""]
   showcontent = true
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
 exclude = [

--- a/integrations/sentry/changelog/.gitignore
+++ b/integrations/sentry/changelog/.gitignore
@@ -1,1 +1,2 @@
+*
 !.gitignore

--- a/integrations/sentry/pyproject.toml
+++ b/integrations/sentry/pyproject.toml
@@ -9,6 +9,8 @@ python = "^3.11"
 port_ocean = {version = "^0.9.14", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
+# uncomment this if you want to debug the ocean core together with your integration
+# port_ocean = { path = '../../', develop = true, extras = ['all'] }
 pytest = "^7.2"
 black = "^24.4.2"
 mypy = "^1.3.0"
@@ -54,8 +56,8 @@ underlines = [""]
   showcontent = true
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
 exclude = [

--- a/integrations/servicenow/changelog/.gitignore
+++ b/integrations/servicenow/changelog/.gitignore
@@ -1,1 +1,2 @@
+*
 !.gitignore

--- a/integrations/servicenow/pyproject.toml
+++ b/integrations/servicenow/pyproject.toml
@@ -9,6 +9,8 @@ python = "^3.11"
 port_ocean = {version = "^0.9.14", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
+# uncomment this if you want to debug the ocean core together with your integration
+# port_ocean = { path = '../../', develop = true, extras = ['all'] }
 pytest = "^7.2"
 black = "^24.4.2"
 mypy = "^1.3.0"
@@ -54,8 +56,8 @@ underlines = [""]
   showcontent = true
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
 exclude = [

--- a/integrations/snyk/changelog/.gitignore
+++ b/integrations/snyk/changelog/.gitignore
@@ -1,1 +1,2 @@
+*
 !.gitignore

--- a/integrations/snyk/pyproject.toml
+++ b/integrations/snyk/pyproject.toml
@@ -9,6 +9,8 @@ python = "^3.11"
 port_ocean = {version = "^0.9.14", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
+# uncomment this if you want to debug the ocean core together with your integration
+# port_ocean = { path = '../../', develop = true, extras = ['all'] }
 pytest = "^7.2"
 black = "^24.4.2"
 mypy = "^1.3.0"
@@ -54,8 +56,8 @@ underlines = [""]
   showcontent = true
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
 exclude = [

--- a/integrations/sonarqube/changelog/.gitignore
+++ b/integrations/sonarqube/changelog/.gitignore
@@ -1,1 +1,2 @@
+*
 !.gitignore

--- a/integrations/sonarqube/pyproject.toml
+++ b/integrations/sonarqube/pyproject.toml
@@ -11,6 +11,8 @@ rich = "^13.5.2"
 cookiecutter = "^2.3.0"
 
 [tool.poetry.group.dev.dependencies]
+# uncomment this if you want to debug the ocean core together with your integration
+# port_ocean = { path = '../../', develop = true, extras = ['all'] }
 pytest = "^7.2"
 black = "^24.4.2"
 mypy = "^1.3.0"
@@ -56,8 +58,8 @@ underlines = [""]
   showcontent = true
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
 exclude = [

--- a/integrations/statuspage/changelog/.gitignore
+++ b/integrations/statuspage/changelog/.gitignore
@@ -1,1 +1,2 @@
+*
 !.gitignore

--- a/integrations/statuspage/pyproject.toml
+++ b/integrations/statuspage/pyproject.toml
@@ -9,6 +9,8 @@ python = "^3.11"
 port_ocean = {version = "^0.9.14", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
+# uncomment this if you want to debug the ocean core together with your integration
+# port_ocean = { path = '../../', develop = true, extras = ['all'] }
 pytest = "^7.2"
 black = "^24.3.0"
 mypy = "^1.3.0"
@@ -54,8 +56,8 @@ underlines = [""]
   showcontent = true
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
 exclude = [

--- a/integrations/terraform-cloud/changelog/.gitignore
+++ b/integrations/terraform-cloud/changelog/.gitignore
@@ -1,1 +1,2 @@
+*
 !.gitignore

--- a/integrations/terraform-cloud/pyproject.toml
+++ b/integrations/terraform-cloud/pyproject.toml
@@ -9,6 +9,8 @@ python = "^3.11"
 port_ocean = {version = "^0.9.14", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
+# uncomment this if you want to debug the ocean core together with your integration
+# port_ocean = { path = '../../', develop = true, extras = ['all'] }
 pytest = "^7.2"
 black = "^24.4.2"
 mypy = "^1.3.0"
@@ -54,8 +56,8 @@ underlines = [""]
   showcontent = true
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
 exclude = [

--- a/integrations/wiz/changelog/.gitignore
+++ b/integrations/wiz/changelog/.gitignore
@@ -1,1 +1,2 @@
+*
 !.gitignore

--- a/integrations/wiz/pyproject.toml
+++ b/integrations/wiz/pyproject.toml
@@ -9,6 +9,8 @@ python = "^3.11"
 port_ocean = {version = "^0.9.14", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
+# uncomment this if you want to debug the ocean core together with your integration
+# port_ocean = { path = '../../', develop = true, extras = ['all'] }
 pytest = "^7.2"
 black = "^24.4.2"
 mypy = "^1.3.0"
@@ -54,8 +56,8 @@ underlines = [""]
   showcontent = true
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
 exclude = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -137,6 +137,17 @@ files = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.4.0"
+description = "Validate configuration and produce human readable error messages."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9"},
+    {file = "cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560"},
+]
+
+[[package]]
 name = "chardet"
 version = "5.2.0"
 description = "Universal encoding detector for Python 3"
@@ -359,6 +370,17 @@ graph = ["objgraph (>=1.7.2)"]
 profile = ["gprof2dot (>=2022.7.29)"]
 
 [[package]]
+name = "distlib"
+version = "0.3.8"
+description = "Distribution utilities"
+optional = false
+python-versions = "*"
+files = [
+    {file = "distlib-0.3.8-py2.py3-none-any.whl", hash = "sha256:034db59a0b96f8ca18035f36290806a9a6e6bd9d1ff91e45a7f172eb17e51784"},
+    {file = "distlib-0.3.8.tar.gz", hash = "sha256:1530ea13e350031b6312d8580ddb6b27a104275a31106523b8f123787f494f64"},
+]
+
+[[package]]
 name = "dnspython"
 version = "2.6.1"
 description = "DNS toolkit"
@@ -449,6 +471,22 @@ uvicorn = {version = ">=0.15.0", extras = ["standard"]}
 
 [package.extras]
 standard = ["uvicorn[standard] (>=0.15.0)"]
+
+[[package]]
+name = "filelock"
+version = "3.15.4"
+description = "A platform independent file lock."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "filelock-3.15.4-py3-none-any.whl", hash = "sha256:6ca1fffae96225dab4c6eaf1c4f4f28cd2568d3ec2a44e15a08520504de468e7"},
+    {file = "filelock-3.15.4.tar.gz", hash = "sha256:2207938cbc1844345cb01a5a95524dae30f0ce089eba5b00378295a17e3e90cb"},
+]
+
+[package.extras]
+docs = ["furo (>=2023.9.10)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.25.2)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8.0.1)", "pytest (>=7.4.3)", "pytest-asyncio (>=0.21)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)", "pytest-timeout (>=2.2)", "virtualenv (>=20.26.2)"]
+typing = ["typing-extensions (>=4.8)"]
 
 [[package]]
 name = "h11"
@@ -553,6 +591,20 @@ brotli = ["brotli", "brotlicffi"]
 cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
+
+[[package]]
+name = "identify"
+version = "2.6.0"
+description = "File identification library for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "identify-2.6.0-py2.py3-none-any.whl", hash = "sha256:e79ae4406387a9d300332b5fd366d8994f1525e8414984e1a59e058b2eda2dd0"},
+    {file = "identify-2.6.0.tar.gz", hash = "sha256:cb171c685bdc31bcc4c1734698736a7d5b6c8bf2e0c15117f4d469c8640ae5cf"},
+]
+
+[package.extras]
+license = ["ukkonen"]
 
 [[package]]
 name = "idna"
@@ -830,6 +882,17 @@ files = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.9.1"
+description = "Node.js virtual environment builder"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+files = [
+    {file = "nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9"},
+    {file = "nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f"},
+]
+
+[[package]]
 name = "packaging"
 version = "24.1"
 description = "Core utilities for Python packages"
@@ -881,6 +944,24 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "pre-commit"
+version = "3.8.0"
+description = "A framework for managing and maintaining multi-language pre-commit hooks."
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pre_commit-3.8.0-py2.py3-none-any.whl", hash = "sha256:9a90a53bf82fdd8778d58085faf8d83df56e40dfe18f45b19446e26bf1b3a63f"},
+    {file = "pre_commit-3.8.0.tar.gz", hash = "sha256:8bb6494d4a20423842e198980c9ecf9f96607a07ea29549e180eef9ae80fe7af"},
+]
+
+[package.dependencies]
+cfgv = ">=2.0.0"
+identify = ">=1.0.0"
+nodeenv = ">=0.11.1"
+pyyaml = ">=5.1"
+virtualenv = ">=20.10.0"
 
 [[package]]
 name = "pydantic"
@@ -1511,6 +1592,26 @@ docs = ["Sphinx (>=4.1.2,<4.2.0)", "sphinx-rtd-theme (>=0.5.2,<0.6.0)", "sphinxc
 test = ["Cython (>=0.29.36,<0.30.0)", "aiohttp (==3.9.0b0)", "aiohttp (>=3.8.1)", "flake8 (>=5.0,<6.0)", "mypy (>=0.800)", "psutil", "pyOpenSSL (>=23.0.0,<23.1.0)", "pycodestyle (>=2.9.0,<2.10.0)"]
 
 [[package]]
+name = "virtualenv"
+version = "20.26.3"
+description = "Virtual Python Environment builder"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "virtualenv-20.26.3-py3-none-any.whl", hash = "sha256:8cc4a31139e796e9a7de2cd5cf2489de1217193116a8fd42328f1bd65f434589"},
+    {file = "virtualenv-20.26.3.tar.gz", hash = "sha256:4c43a2a236279d9ea36a0d76f98d84bd6ca94ac4e0f4a3b9d46d05e10fea542a"},
+]
+
+[package.dependencies]
+distlib = ">=0.3.7,<1"
+filelock = ">=3.12.2,<4"
+platformdirs = ">=3.9.1,<5"
+
+[package.extras]
+docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2,!=7.3)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.6)"]
+test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8)", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10)"]
+
+[[package]]
 name = "watchfiles"
 version = "0.23.0"
 description = "Simple, modern and high performance file watching and code reload in python."
@@ -1745,4 +1846,4 @@ cli = ["click", "cookiecutter", "jinja2-time", "rich"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "030f0ad69c977eea740cb286d7d85c754b5f4704643d638432b55f9c0b723ce7"
+content-hash = "b8dece6b37f159ee650e587fbef8420ee3f8071806fc6a946b9b52bf235df1b8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ towncrier = "^23.6.0"
 yamllint = "^1.32.0"
 types-python-dateutil = "^2.9.0.20240316"
 pytest-xdist = "^3.6.1"
+pre-commit = "^3.7.1"
 
 [tool.towncrier]
 directory = "changelog"

--- a/scripts/bump-single-integration.sh
+++ b/scripts/bump-single-integration.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+SCRIPT_BASE="$(cd -P "$(dirname "$0")" && pwd)"
+SCRIPT_NAME="$(basename "$0")"
+INTEGRATION_DIR="${SCRIPT_BASE}/../integrations"
+INTEGRATION_TO_BUMP=""
+TOWNCRIER_TYPES=( feature breaking deprecation improvement bugfix doc )
+
+_usage() {
+  echo -e "Usage :  ${SCRIPT_NAME} INTEGRATION_NAME
+  Options:
+    -h       Display this message
+    -i       Integration
+    -v       Optional explicit version (default to bumping minor)
+"
+
+}
+
+_err() {
+    echo -e "$1\n"
+    _usage
+    exit 1
+}
+
+
+_select_fragment_type_fzf(){
+    printf "%s\n" "${TOWNCRIER_TYPES[@]}" | fzf -i --header="$@"
+}
+
+_select_fragment_type(){
+    if [[ $(which fzf) ]]; then
+        _select_fragment_type_fzf "$@"
+        return
+    fi
+    PS3="Please enter change type: for $@:  "
+    select opt in "${TOWNCRIER_TYPES[@]}"
+    do
+        case $opt in
+            *)
+                if [[ ${TOWNCRIER_TYPES[@]} =~ ${REPLY} ]]; then
+                    echo "${REPLY}";
+                    break;
+                fi
+                ;;
+        esac
+    done
+}
+
+
+while getopts "hi:v:" opt; do
+  case ${opt} in
+  h )
+    _usage;
+    exit 0
+    ;;
+
+  i )
+    INTEGRATION_TO_BUMP="${OPTARG}"
+    ;;
+
+  v )
+    EXPLICIT_VERSION_TO_BUMP="${OPTARG}"
+    ;;
+
+  * )
+    _err "Option does not exist : ${OPTARG}";
+    ;;
+  esac
+done
+shift $((OPTIND -1))
+
+
+if [[ -z ${INTEGRATION_TO_BUMP} ]]; then
+    _err "Missing Integration to bump"
+fi
+
+CURRENT_INTEGRATION_DIR="${INTEGRATION_DIR}/${INTEGRATION_TO_BUMP}"
+
+if [[ ! -d "${CURRENT_INTEGRATION_DIR}"  ]]; then
+    _err "Invalid integration (${INTEGRATION_TO_BUMP}), it should be in the integrations directory"
+fi
+
+if [[ ! -f "${CURRENT_INTEGRATION_DIR}/pyproject.toml" ]]; then
+    _err "${INTEGRATION_TO_BUMP} is missing a 'pyproject.toml' file"
+fi
+
+
+pushd ${CURRENT_INTEGRATION_DIR}
+source .venv/bin/activate
+CURRENT_VERSION=$(poetry version --short)
+
+echo "Current version: ${CURRENT_VERSION}"
+IFS='.' read -ra VERSION_COMPONENTS <<< "${CURRENT_VERSION}"
+
+MAJOR_VERSION="${VERSION_COMPONENTS[0]}"
+MINOR_VERSION="${VERSION_COMPONENTS[1]}"
+PATCH_VERSION="${VERSION_COMPONENTS[2]}"
+
+((PATCH_VERSION++))
+NEW_VERSION="${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION}"
+if [[ ! -z ${EXPLICIT_VERSION_TO_BUMP} ]]; then
+    NEW_VERSION=${EXPLICIT_VERSION_TO_BUMP}
+fi
+
+poetry version "${NEW_VERSION}"
+echo "New version: ${NEW_VERSION}"
+
+echo "Gathering changelog for towncrier"
+for COMMIT_SHA in $(git rev-list main...); do
+    CURRENT_COMMIT=$(git log -1 --pretty="format:[%as] @%an - %B" ${COMMIT_SHA})
+    CURRENT_TYPE=$(_select_fragment_type "${CURRENT_COMMIT}")
+    towncrier create -c "${CURRENT_COMMIT}" --edit +random.${CURRENT_TYPE}
+done
+
+echo "Creating towncrier fragment"
+echo "Run towncrier build to increment the patch version"
+towncrier build --yes --version ${NEW_VERSION}
+rm -rf ${CURRENT_INTEGRATION_DIR}/changelog/*
+git add ${CURRENT_INTEGRATION_DIR}/pyproject.toml ${CURRENT_INTEGRATION_DIR}/CHANGELOG.md
+
+echo "committing ${INTEGRATION_TO_BUMP} bump"
+git commit -m "Bumped ${INTEGRATION_TO_BUMP} integration version from ${CURRENT_VERSION} to ${NEW_VERSION}"
+
+popd


### PR DESCRIPTION

- **Single integration version bump**
- **pre-commit hooks**
- **Update all integrations with debug link information**

# Description

Add a script to bump a single integration version (instead of doing it manually)

Add `pre-commit` hooks to ensure linting standards upon committing

Ensure that it's possible to debug Ocean Core (`port_ocean`) when debugging an integration

## Type of change

- [x] Non-breaking change (fix of existing functionality that will not change current behavior)
