### PR TITLE
[Framework] Refer to entity in upsert entity response

### DIFF
--- a/.idea/watcherTasks.xml
+++ b/.idea/watcherTasks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ProjectTasksOptions">
-    <TaskOptions isEnabled="true">
+    <TaskOptions isEnabled="false">
       <option name="arguments" value="$FilePath$" />
       <option name="checkSyntaxErrors" value="true" />
       <option name="description" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
-## 0.9.14 (2024-08-26)
+## 0.10.1 (2024-08-26)
 
 ### Bug Fixes
 
-- Fixed reference to upsert entity api response that causes failure in deleting entities with search identifier/relations
+- Fixed unhashable type: 'dict' error when trying to delete entities with search identifier/relations
 
 
 ## 0.10.0 (2024-08-19)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.9.14 (2024-08-26)
+
+### Bug Fixes
+
+- Fixed reference to upsert entity api response that causes failure in deleting entities with search identifier/relations
+
+
 ## 0.10.0 (2024-08-19)
 
 ### Improvements
@@ -16,7 +23,6 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 
 ## 0.9.14 (2024-08-19)
-
 
 ### Bug Fixes
 
@@ -128,7 +134,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Bug Fixes
 
-- Safely get changelogDestination key instead of accessing it directly 
+- Safely get changelogDestination key instead of accessing it directly
 
 
 ## 0.9.0 (2024-06-19)
@@ -589,7 +595,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Fixed kafka consumer to poll messages asynchronously, to avoid max poll timeout when running long resyncs (PORT-5160)
 - Fixed a bug where the expiration of a Port token is not properly handled (PORT-5161)
-- Fixed a bug where the `retry_every` didn't count failed runs as repetitions (PORT-5161) 
+- Fixed a bug where the `retry_every` didn't count failed runs as repetitions (PORT-5161)
 
 ## 0.4.2 (2023-11-04)
 
@@ -619,7 +625,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Fixed the `initialize-port-resources` option in `ocean sail` to not be a flag.
 - Changed default of `initialize-port-resources` to `true`.
-- Catch all exceptions in the resync of ONCE event listener,to make sure the application will exit gracefully 
+- Catch all exceptions in the resync of ONCE event listener,to make sure the application will exit gracefully
 
 
 ## 0.4.0 (2023-10-31)

--- a/port_ocean/clients/port/mixins/entities.py
+++ b/port_ocean/clients/port/mixins/entities.py
@@ -58,6 +58,7 @@ class EntityClientMixin:
             )
         handle_status_code(response, should_raise)
         result = response.json()
+        # result_entity = Entity.parse_obj(result['entity'])
         result_entity = Entity.parse_obj(result)
         # Set the results of the search relation and identifier to the entity
         entity.identifier = result_entity.identifier or entity.identifier

--- a/port_ocean/clients/port/mixins/entities.py
+++ b/port_ocean/clients/port/mixins/entities.py
@@ -58,8 +58,7 @@ class EntityClientMixin:
             )
         handle_status_code(response, should_raise)
         result = response.json()
-        # result_entity = Entity.parse_obj(result['entity'])
-        result_entity = Entity.parse_obj(result)
+        result_entity = Entity.parse_obj(result["entity"])
         # Set the results of the search relation and identifier to the entity
         entity.identifier = result_entity.identifier or entity.identifier
         entity.relations = result_entity.relations or entity.relations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.10.0"
+version = "0.10.1"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What - Refer to entity in upsert entity response
Why - Response from upsert entity api isn't processed right and causes ocean core to use the raw entity that contains dict typed relation instead of string which is the relation's entity identifier
How - Simply refer to the entity key in a response that looks like {ok: true, entity: {...}}

## Type of change

Please leave one option from the following and delete the rest:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
