### PR TITLE
[Integration][AWS] use the same event loop for all threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.10.3 (2024-08-28)
+
+### Bug Fixes
+
+- Bugfix Semaphores get fail when moving to the next scheduled resync when syncing a large number of entities, using a single event loop for all threads
+
+
 ## 0.10.2 (2024-08-26)
 
 ### Bug Fixes

--- a/port_ocean/ocean.py
+++ b/port_ocean/ocean.py
@@ -89,6 +89,7 @@ class Ocean:
                 raise e
 
         interval = self.config.scheduled_resync_interval
+        loop = asyncio.get_event_loop()
         if interval is not None:
             logger.info(
                 f"Setting up scheduled resync, the integration will automatically perform a full resync every {interval} minutes)"
@@ -99,7 +100,9 @@ class Ocean:
                 wait_first=True,
             )(
                 lambda: threading.Thread(
-                    target=lambda: asyncio.run(execute_resync_all())
+                    target=lambda: asyncio.run_coroutine_threadsafe(
+                        execute_resync_all(), loop
+                    )
                 ).start()
             )
             await repeated_function()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.10.2"
+version = "0.10.3"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
Since running on new event loops got us Semaphore is bound to a different event loop error

# Description

What - fix `Semaphore is bound to a different event loop`
Why - all Semaphore were used in different event loops and once the thread ended the Semaphore could not run in a different event loop
How - use the same event loop across all threads

## Type of change

Please leave one option from the following and delete the rest:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

### Core testing checklist
- [x] Integration able to create all default resources from scratch
- [x] Resync finishes successfully
- [x] Resync able to create entities
- [x] Resync able to update entities
- [x] Resync able to detect and delete entities
- [x] Scheduled resync able to abort existing resync and start a new one
- [x] Tested with at least 2 integrations from scratch
- [x] Tested with Kafka and Polling event listeners
