### PR TITLE
[Integration][Sonarqube] - Fix sonarQube client has no attributes metrics

### DIFF
--- a/integrations/sonarqube/CHANGELOG.md
+++ b/integrations/sonarqube/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.86 (2024-08-26)
+
+
+### Bug Fixes
+
+- Fixed SonarQube client instantiation issue by using a singleton pattern to ensure a single shared instance, resolving bug where the client is unable to find the self.metrics
+
+
 ## 0.1.85 (2024-08-26)
 
 

--- a/integrations/sonarqube/client.py
+++ b/integrations/sonarqube/client.py
@@ -43,7 +43,7 @@ class SonarQubeClient:
         self.is_onpremise = is_onpremise
         self.http_client = http_async_client
         self.http_client.headers.update(self.api_auth_params["headers"])
-        self.metrics = []
+        self.metrics: list[str] = []
 
     @property
     def api_auth_params(self) -> dict[str, Any]:

--- a/integrations/sonarqube/client.py
+++ b/integrations/sonarqube/client.py
@@ -43,6 +43,7 @@ class SonarQubeClient:
         self.is_onpremise = is_onpremise
         self.http_client = http_async_client
         self.http_client.headers.update(self.api_auth_params["headers"])
+        self.metrics = []
 
     @property
     def api_auth_params(self) -> dict[str, Any]:

--- a/integrations/sonarqube/main.py
+++ b/integrations/sonarqube/main.py
@@ -18,18 +18,19 @@ def init_sonar_client() -> SonarQubeClient:
     )
 
 
+sonar_client = init_sonar_client()
+
+
 @ocean.on_resync(ObjectKind.PROJECTS)
 async def on_project_resync(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     logger.info(f"Listing Sonarqube resource: {kind}")
 
-    sonar_client = init_sonar_client()
     async for project_list in sonar_client.get_all_projects():
         yield project_list
 
 
 @ocean.on_resync(ObjectKind.ISSUES)
 async def on_issues_resync(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
-    sonar_client = init_sonar_client()
     async for issues_list in sonar_client.get_all_issues():
         yield issues_list
 
@@ -37,7 +38,6 @@ async def on_issues_resync(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
 @ocean.on_resync(ObjectKind.ANALYSIS)
 @ocean.on_resync(ObjectKind.SASS_ANALYSIS)
 async def on_saas_analysis_resync(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
-    sonar_client = init_sonar_client()
     if not ocean.integration_config["sonar_is_on_premise"]:
         async for analyses_list in sonar_client.get_all_sonarcloud_analyses():
             yield analyses_list
@@ -45,7 +45,6 @@ async def on_saas_analysis_resync(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
 
 @ocean.on_resync(ObjectKind.ONPREM_ANALYSIS)
 async def on_onprem_analysis_resync(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
-    sonar_client = init_sonar_client()
     if ocean.integration_config["sonar_is_on_premise"]:
         async for analyses_list in sonar_client.get_all_sonarqube_analyses():
             yield analyses_list
@@ -89,7 +88,6 @@ async def on_start() -> None:
                 "Organization ID is required for SonarCloud. Please specify a valid sonarOrganizationId"
             )
 
-    sonar_client = init_sonar_client()
     sonar_client.sanity_check()
 
     if ocean.event_listener_type == "ONCE":

--- a/integrations/sonarqube/main.py
+++ b/integrations/sonarqube/main.py
@@ -55,7 +55,6 @@ async def handle_sonarqube_webhook(webhook_data: dict[str, Any]) -> None:
     logger.info(
         f"Processing Sonarqube webhook for event type: {webhook_data.get('project', {}).get('key')}"
     )
-    sonar_client = init_sonar_client()
 
     project = await sonar_client.get_single_component(
         webhook_data.get("project", {})

--- a/integrations/sonarqube/pyproject.toml
+++ b/integrations/sonarqube/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sonarqube"
-version = "0.1.85"
+version = "0.1.86"
 description = "SonarQube projects and code quality analysis integration"
 authors = ["Port Team <support@getport.io>"]
 


### PR DESCRIPTION
# Description

What - The integration was throwing an error where the `self.metrics` was not found in the `get_all_sonarqube_analyses`(). This was because each resync handler creates a new instance of the sonarQube client, causing the client to lose the state of it's saved variables. An example is when the self.metrics in the previous handler is lost in subsequent clients. 
Why - Affecting the ingestion of onprem analysis kind as it relies on the metrics
How - Implemented a singleton pattern where we use one global instance of the sonarQube client across the application

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.
<img width="1013" alt="Screenshot 2024-08-26 at 9 07 58 PM" src="https://github.com/user-attachments/assets/71a38fe6-6380-40b2-8460-0b621543c3ef">

## API Documentation

Provide links to the API documentation used for this integration.
