### PR TITLE
[Framework] Fix bug search relation error unhashable dict

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,9 @@
 # Description
 
 What -
+
 Why -
+
 How -
 
 ## Type of change
@@ -14,6 +16,39 @@ Please leave one option from the following and delete the rest:
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
 - [ ] Documentation (added/updated documentation)
+
+<h4> All tests should be run against the port production environment(using a testing org). </h4>
+
+### Core testing checklist
+
+- [ ] Integration able to create all default resources from scratch
+- [ ] Resync finishes successfully
+- [ ] Resync able to create entities
+- [ ] Resync able to update entities
+- [ ] Resync able to detect and delete entities
+- [ ] Scheduled resync able to abort existing resync and start a new one
+- [ ] Tested with at least 2 integrations from scratch
+- [ ] Tested with Kafka and Polling event listeners
+
+
+### Integration testing checklist
+
+- [ ] Integration able to create all default resources from scratch
+- [ ] Resync able to create entities
+- [ ] Resync able to update entities
+- [ ] Resync able to detect and delete entities
+- [ ] Resync finishes successfully
+- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory. 
+- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
+- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
+- [ ] Docs PR link [here](#)
+
+### Preflight checklist
+
+- [ ] Handled rate limiting
+- [ ] Handled pagination
+- [ ] Implemented the code in async
+- [ ] Support Multi account
 
 ## Screenshots
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,19 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.10.3 (2024-08-27)
+
+### Bug Fixes
+
+- Handle upsert entity failure when saving modified data for search relations calculations
+
+
 ## 0.10.2 (2024-08-26)
 
 ### Bug Fixes
 
 - Reverted last bugfix
+
 
 ## 0.10.1 (2024-08-26)
 

--- a/port_ocean/clients/port/mixins/entities.py
+++ b/port_ocean/clients/port/mixins/entities.py
@@ -61,16 +61,19 @@ class EntityClientMixin:
         result_entity = (
             Entity.parse_obj(result["entity"]) if result.get("entity") else entity
         )
+        # In order to save memory we'll keep only the identifier and relations of the
+        # upserted entity result for later calculations
+        reduced_entity = Entity(identifier=result_entity.identifier)
 
         # Turning dict typed relations (raw search relations) is required
         # for us to be able to successfully calculate the participation related entities
         # and ignore the ones that don't as they weren't upserted
-        result_entity.relations = {
+        reduced_entity.relations = {
             key: None if isinstance(relation, dict) else relation
             for key, relation in result_entity.relations.items()
         }
 
-        return result_entity
+        return reduced_entity
 
     async def batch_upsert_entities(
         self,

--- a/port_ocean/clients/port/mixins/entities.py
+++ b/port_ocean/clients/port/mixins/entities.py
@@ -62,6 +62,9 @@ class EntityClientMixin:
             Entity.parse_obj(result["entity"]) if result.get("entity") else entity
         )
 
+        # Turning dict typed relations (raw search relations) is required
+        # for us to be able to successfully calculate the participation related entities
+        # and ignore the ones that don't as they weren't upserted
         result_entity.relations = {
             key: None if isinstance(relation, dict) else relation
             for key, relation in result_entity.relations.items()

--- a/port_ocean/clients/port/mixins/entities.py
+++ b/port_ocean/clients/port/mixins/entities.py
@@ -62,8 +62,6 @@ class EntityClientMixin:
             Entity.parse_obj(result["entity"]) if result.get("entity") else entity
         )
 
-        if not result_entity:
-            result_entity.identifier = entity.identifier
         result_entity.relations = {
             key: None if isinstance(relation, dict) else relation
             for key, relation in result_entity.relations.items()

--- a/port_ocean/clients/port/mixins/entities.py
+++ b/port_ocean/clients/port/mixins/entities.py
@@ -58,11 +58,18 @@ class EntityClientMixin:
             )
         handle_status_code(response, should_raise)
         result = response.json()
-        result_entity = Entity.parse_obj(result)
-        # Set the results of the search relation and identifier to the entity
-        entity.identifier = result_entity.identifier or entity.identifier
-        entity.relations = result_entity.relations or entity.relations
-        return entity
+        result_entity = (
+            Entity.parse_obj(result["entity"]) if result.get("entity") else entity
+        )
+
+        if not result_entity:
+            result_entity.identifier = entity.identifier
+        result_entity.relations = {
+            key: None if isinstance(relation, dict) else relation
+            for key, relation in result_entity.relations.items()
+        }
+
+        return result_entity
 
     async def batch_upsert_entities(
         self,

--- a/port_ocean/clients/port/mixins/entities.py
+++ b/port_ocean/clients/port/mixins/entities.py
@@ -61,9 +61,11 @@ class EntityClientMixin:
         result_entity = (
             Entity.parse_obj(result["entity"]) if result.get("entity") else entity
         )
-        # In order to save memory we'll keep only the identifier and relations of the
+        # In order to save memory we'll keep only the identifier, blueprint and relations of the
         # upserted entity result for later calculations
-        reduced_entity = Entity(identifier=result_entity.identifier)
+        reduced_entity = Entity(
+            identifier=result_entity.identifier, blueprint=result_entity.blueprint
+        )
 
         # Turning dict typed relations (raw search relations) is required
         # for us to be able to successfully calculate the participation related entities

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.10.2"
+version = "0.10.3"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.10.3"
+version = "0.10.4"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What - Refer to entity key in upsert entity response, if the response is not 200 then turn raw search relations into None to not harm the deletion proccess

Why - Response from upsert entity api isn't processed right and causes ocean core to use the raw entity that contains dict typed relations instead of string which is the relation's entity identifier

How - refer to the entity key in a response that looks like {ok: true, entity: {...}}, if the response is not 200 turn the dict typed relations into None 

## Type of change

Please leave one option from the following and delete the rest:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [X] Integration able to create all default resources from scratch
- [X] Resync finishes successfully
- [X] Resync able to create entities
- [X] Resync able to update entities
- [X] Resync able to detect and delete entities
- [x] Scheduled resync able to abort existing resync and start a new one
- [x] Tested with at least 2 integrations from scratch
- [x] Tested with Kafka and Polling event listeners


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory. 
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
