### PR TITLE
Bump integrations to 0.10.11 and improve fake integration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,3 +89,4 @@ jobs:
           report_paths: '**/junit/test-results-**/*.xml'
           include_passed: true
           require_tests: true
+          fail_on_failure: true

--- a/integrations/_infra/Dockerfile
+++ b/integrations/_infra/Dockerfile
@@ -1,58 +1,28 @@
-FROM python:3.11-alpine AS base
+FROM python:3.11-slim-bookworm
 
 ARG BUILD_CONTEXT
-
-ENV LIBRDKAFKA_VERSION=1.9.2
-
-# Install system dependencies and libraries
-RUN apk add --no-cache \
-    gcc \
-    musl-dev \
-    build-base \
-    bash \
-    oniguruma-dev \
-    make \
-    autoconf \
-    automake \
-    libtool \
-    curl \
-    libffi-dev && \
-        echo "@edge http://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories \
-        && echo "@edgecommunity http://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
-        && apk add --no-cache alpine-sdk "librdkafka@edgecommunity>=${LIBRDKAFKA_VERSION}" "librdkafka-dev@edgecommunity>=${LIBRDKAFKA_VERSION}" && curl -sSL https://install.python-poetry.org | python3 - \
-        && /root/.local/bin/poetry config virtualenvs.in-project true
-
-WORKDIR /app
-
-COPY ./${BUILD_CONTEXT}/pyproject.toml ./${BUILD_CONTEXT}/poetry.lock /app/
-
-RUN /root/.local/bin/poetry install --without dev --no-root --no-interaction --no-ansi --no-cache && pip cache purge
-
-FROM python:3.11-alpine AS prod
-
 ARG INTEGRATION_VERSION
-ARG BUILD_CONTEXT
 
 LABEL INTEGRATION_VERSION=${INTEGRATION_VERSION}
 # Used to ensure that new integrations will be public, see https://docs.github.com/en/packages/learn-github-packages/configuring-a-packages-access-control-and-visibility
-LABEL org.opencontainers.image.source=https://github.com/port-labs/ocean
+LABEL org.opencontainers.image.source https://github.com/port-labs/ocean
 
-# Install only runtime dependencies
-RUN apk add --no-cache \
-    librdkafka-dev \
-    bash \
-    oniguruma-dev
+ENV LIBRDKAFKA_VERSION 1.9.2
 
 WORKDIR /app
 
-# Copy dependencies from the build stage
-COPY --from=base /app /app
+RUN apt update && \
+    apt install -y wget make g++ libssl-dev autoconf automake libtool curl librdkafka-dev && \
+    apt-get clean
 
-# Copy the application code
+COPY ./integrations/_infra/init.sh /app/init.sh
+
+RUN chmod +x /app/init.sh
+
 COPY ./${BUILD_CONTEXT} /app
 
-# Clean up old setuptools + update certificates if needed
-RUN pip uninstall -y setuptools || true && test -e /usr/local/share/ca-certificates/cert.crt && update-ca-certificates || true
+COPY ./integrations/_infra/Makefile /app/Makefile
 
-# Run the application
-CMD ["/app/.venv/bin/python", "/app/.venv/bin/ocean", "sail"]
+RUN export POETRY_VIRTUALENVS_CREATE=false && make install/prod && pip cache purge
+
+ENTRYPOINT ./init.sh

--- a/integrations/_infra/init.sh
+++ b/integrations/_infra/init.sh
@@ -1,0 +1,5 @@
+if test -e /usr/local/share/ca-certificates/cert.crt; then
+  update-ca-certificates
+fi
+
+ocean sail

--- a/integrations/argocd/CHANGELOG.md
+++ b/integrations/argocd/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.87 (2024-09-17)
+
+
+### Improvements
+
+- Bumped ocean version to ^0.10.11
+
+
 ## 0.1.86 (2024-09-12)
 
 

--- a/integrations/argocd/poetry.lock
+++ b/integrations/argocd/poetry.lock
@@ -885,13 +885,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "port-ocean"
-version = "0.10.10"
+version = "0.10.11"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 optional = false
 python-versions = "<4.0,>=3.11"
 files = [
-    {file = "port_ocean-0.10.10-py3-none-any.whl", hash = "sha256:0edfb23a2c7ea48f92819a61315beb333486d97c4088d5e329b93d9993f6d375"},
-    {file = "port_ocean-0.10.10.tar.gz", hash = "sha256:8b2e9104e7ed1b170a2bb286c8dfa44c299b7738df08271c80b3aa70f2105967"},
+    {file = "port_ocean-0.10.11-py3-none-any.whl", hash = "sha256:09881fdf7a836d5946b07b0255b757e96e375df497d724e8d12458c23879ef38"},
+    {file = "port_ocean-0.10.11.tar.gz", hash = "sha256:9f214f1895e2a35dd50c448616cf7d2e32d3c70205d79a546ab612a7be0f62c3"},
 ]
 
 [package.dependencies]
@@ -1790,4 +1790,4 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "18c8d8802ede303b3a09ddbf7cbc76d0b64a3e037d969a1985213dc9014dc183"
+content-hash = "12324544c3e97d143b991fa81cfef87ba7ad1ea424732b037a20feba460faf99"

--- a/integrations/argocd/pyproject.toml
+++ b/integrations/argocd/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "argocd"
-version = "0.1.86"
+version = "0.1.87"
 description = "Argo CD integration powered by Ocean"
 authors = ["Isaac Coffie <isaac@getport.io>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-port_ocean = {version = "^0.10.10", extras = ["cli"]}
+port_ocean = {version = "^0.10.11", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
 # Uncomment this if you want to debug the ocean core together with your integration

--- a/integrations/aws/CHANGELOG.md
+++ b/integrations/aws/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.2.40 (2024-09-17)
+
+
+### Improvements
+
+- Bumped ocean version to ^0.10.11
+
+
 ## 0.2.39 (2024-09-12)
 
 

--- a/integrations/aws/poetry.lock
+++ b/integrations/aws/poetry.lock
@@ -2179,13 +2179,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "port-ocean"
-version = "0.10.10"
+version = "0.10.11"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 optional = false
 python-versions = "<4.0,>=3.11"
 files = [
-    {file = "port_ocean-0.10.10-py3-none-any.whl", hash = "sha256:0edfb23a2c7ea48f92819a61315beb333486d97c4088d5e329b93d9993f6d375"},
-    {file = "port_ocean-0.10.10.tar.gz", hash = "sha256:8b2e9104e7ed1b170a2bb286c8dfa44c299b7738df08271c80b3aa70f2105967"},
+    {file = "port_ocean-0.10.11-py3-none-any.whl", hash = "sha256:09881fdf7a836d5946b07b0255b757e96e375df497d724e8d12458c23879ef38"},
+    {file = "port_ocean-0.10.11.tar.gz", hash = "sha256:9f214f1895e2a35dd50c448616cf7d2e32d3c70205d79a546ab612a7be0f62c3"},
 ]
 
 [package.dependencies]
@@ -4126,4 +4126,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "5d0ba3e33ce2bc726ef91ef5ea333a27a4a5eec0c9c0b58fb015bb82e8e26e83"
+content-hash = "0c3b5e7c4b1c01552258c7a018ea361bb0f441a4290804b205e1deacafa42b4b"

--- a/integrations/aws/pyproject.toml
+++ b/integrations/aws/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "aws"
-version = "0.2.39"
+version = "0.2.40"
 description = "This integration will map all your resources in all the available accounts to your Port entities"
 authors = ["Shalev Avhar <shalev@getport.io>", "Erik Zaadi <erik@getport.io>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-port_ocean = {version = "^0.10.10", extras = ["cli"]}
+port_ocean = {version = "^0.10.11", extras = ["cli"]}
 python-dotenv = "^1.0.1"
 aioboto3 = "^12.4.0"
 boto3-stubs = {version = "1.34.76", extras = ["acm", "apigateway", "appconfig", "athena", "cloudcontrol", "cloudformation", "cloudwatch", "dynamodb", "ec2", "ec2-instance-connect", "ecr", "ecs", "elasticache", "elb", "elbv2", "events", "iam", "lambda", "logs", "organizations", "rds", "route53", "s3", "sagemaker", "secretsmanager", "sns", "sqs", "ssm", "sts"]}

--- a/integrations/azure-devops/CHANGELOG.md
+++ b/integrations/azure-devops/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.68 (2024-09-17)
+
+
+### Improvements
+
+- Bumped ocean version to ^0.10.11
+
+
 ## 0.1.67 (2024-09-12)
 
 

--- a/integrations/azure-devops/poetry.lock
+++ b/integrations/azure-devops/poetry.lock
@@ -885,13 +885,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "port-ocean"
-version = "0.10.10"
+version = "0.10.11"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 optional = false
 python-versions = "<4.0,>=3.11"
 files = [
-    {file = "port_ocean-0.10.10-py3-none-any.whl", hash = "sha256:0edfb23a2c7ea48f92819a61315beb333486d97c4088d5e329b93d9993f6d375"},
-    {file = "port_ocean-0.10.10.tar.gz", hash = "sha256:8b2e9104e7ed1b170a2bb286c8dfa44c299b7738df08271c80b3aa70f2105967"},
+    {file = "port_ocean-0.10.11-py3-none-any.whl", hash = "sha256:09881fdf7a836d5946b07b0255b757e96e375df497d724e8d12458c23879ef38"},
+    {file = "port_ocean-0.10.11.tar.gz", hash = "sha256:9f214f1895e2a35dd50c448616cf7d2e32d3c70205d79a546ab612a7be0f62c3"},
 ]
 
 [package.dependencies]
@@ -1801,4 +1801,4 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "46cb13c7c3da16d6c683126603f9163cc625ec1fb615109476950ddabb30147f"
+content-hash = "539870d1b8cc6e86ae7bd9435b2d65c821fa4b207e2636c01332f99605a5db52"

--- a/integrations/azure-devops/pyproject.toml
+++ b/integrations/azure-devops/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "azure-devops"
-version = "0.1.67"
+version = "0.1.68"
 description = "An Azure Devops Ocean integration"
 authors = ["Matan Geva <matang@getport.io>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-port_ocean = {version = "^0.10.10", extras = ["cli"]}
+port_ocean = {version = "^0.10.11", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
 # Uncomment this if you want to debug the ocean core together with your integration

--- a/integrations/azure/CHANGELOG.md
+++ b/integrations/azure/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.1.91 (2024-09-17)
+
+### Improvements
+
+- Bumped ocean version to ^0.10.11
+
+
 0.1.90 (2024-09-12)
 
 ### Improvements

--- a/integrations/azure/poetry.lock
+++ b/integrations/azure/poetry.lock
@@ -1560,13 +1560,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "port-ocean"
-version = "0.10.10"
+version = "0.10.11"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 optional = false
 python-versions = "<4.0,>=3.11"
 files = [
-    {file = "port_ocean-0.10.10-py3-none-any.whl", hash = "sha256:0edfb23a2c7ea48f92819a61315beb333486d97c4088d5e329b93d9993f6d375"},
-    {file = "port_ocean-0.10.10.tar.gz", hash = "sha256:8b2e9104e7ed1b170a2bb286c8dfa44c299b7738df08271c80b3aa70f2105967"},
+    {file = "port_ocean-0.10.11-py3-none-any.whl", hash = "sha256:09881fdf7a836d5946b07b0255b757e96e375df497d724e8d12458c23879ef38"},
+    {file = "port_ocean-0.10.11.tar.gz", hash = "sha256:9f214f1895e2a35dd50c448616cf7d2e32d3c70205d79a546ab612a7be0f62c3"},
 ]
 
 [package.dependencies]
@@ -2659,4 +2659,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "2b3a55266ef064a888479c8fc58ca36202a2957614dedcbadafc0f34b40f002c"
+content-hash = "3635163931295200570fae198d8d391e585c14e949bf7d0fe482850d2b173c15"

--- a/integrations/azure/pyproject.toml
+++ b/integrations/azure/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "azure"
-version = "0.1.90"
+version = "0.1.91"
 description = "Azure integration"
 authors = ["Tom Tankilevitch <tom@getport.io>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-port_ocean = {version = "^0.10.10", extras = ["cli"]}
+port_ocean = {version = "^0.10.11", extras = ["cli"]}
 # due to patching the azure-mgmt-resource package, we need to use a specific version
 azure-mgmt-resource = "23.0.1"
 azure-identity = "^1.13.0"

--- a/integrations/datadog/CHANGELOG.md
+++ b/integrations/datadog/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.41 (2024-09-17)
+
+
+### Improvements
+
+- Bumped ocean version to ^0.10.11
+
+
 ## 0.1.40 (2024-09-12)
 
 

--- a/integrations/datadog/poetry.lock
+++ b/integrations/datadog/poetry.lock
@@ -885,13 +885,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "port-ocean"
-version = "0.10.10"
+version = "0.10.11"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 optional = false
 python-versions = "<4.0,>=3.11"
 files = [
-    {file = "port_ocean-0.10.10-py3-none-any.whl", hash = "sha256:0edfb23a2c7ea48f92819a61315beb333486d97c4088d5e329b93d9993f6d375"},
-    {file = "port_ocean-0.10.10.tar.gz", hash = "sha256:8b2e9104e7ed1b170a2bb286c8dfa44c299b7738df08271c80b3aa70f2105967"},
+    {file = "port_ocean-0.10.11-py3-none-any.whl", hash = "sha256:09881fdf7a836d5946b07b0255b757e96e375df497d724e8d12458c23879ef38"},
+    {file = "port_ocean-0.10.11.tar.gz", hash = "sha256:9f214f1895e2a35dd50c448616cf7d2e32d3c70205d79a546ab612a7be0f62c3"},
 ]
 
 [package.dependencies]
@@ -1790,4 +1790,4 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "b30377a1f8d8aa9f7e6cc6f86f1a930bea8c986ee324813ebd99bfdb5610ebb1"
+content-hash = "56d32aea32a3d0c94a3a107bac52e704bc5d70bc5179974dcfc69c4ff7397a92"

--- a/integrations/datadog/pyproject.toml
+++ b/integrations/datadog/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "datadog"
-version = "0.1.40"
+version = "0.1.41"
 description = "Datadog Ocean Integration"
 authors = ["Albert Luganga <albertluganga@getport.io>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-port_ocean = {version = "^0.10.10", extras = ["cli"]}
+port_ocean = {version = "^0.10.11", extras = ["cli"]}
 loguru = "^0.7.2"
 
 [tool.poetry.group.dev.dependencies]

--- a/integrations/dynatrace/CHANGELOG.md
+++ b/integrations/dynatrace/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.53 (2024-09-17)
+
+
+### Improvements
+
+- Bumped ocean version to ^0.10.11
+
+
 ## 0.1.52 (2024-09-12)
 
 

--- a/integrations/dynatrace/poetry.lock
+++ b/integrations/dynatrace/poetry.lock
@@ -885,13 +885,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "port-ocean"
-version = "0.10.10"
+version = "0.10.11"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 optional = false
 python-versions = "<4.0,>=3.11"
 files = [
-    {file = "port_ocean-0.10.10-py3-none-any.whl", hash = "sha256:0edfb23a2c7ea48f92819a61315beb333486d97c4088d5e329b93d9993f6d375"},
-    {file = "port_ocean-0.10.10.tar.gz", hash = "sha256:8b2e9104e7ed1b170a2bb286c8dfa44c299b7738df08271c80b3aa70f2105967"},
+    {file = "port_ocean-0.10.11-py3-none-any.whl", hash = "sha256:09881fdf7a836d5946b07b0255b757e96e375df497d724e8d12458c23879ef38"},
+    {file = "port_ocean-0.10.11.tar.gz", hash = "sha256:9f214f1895e2a35dd50c448616cf7d2e32d3c70205d79a546ab612a7be0f62c3"},
 ]
 
 [package.dependencies]
@@ -1790,4 +1790,4 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "18c8d8802ede303b3a09ddbf7cbc76d0b64a3e037d969a1985213dc9014dc183"
+content-hash = "12324544c3e97d143b991fa81cfef87ba7ad1ea424732b037a20feba460faf99"

--- a/integrations/dynatrace/pyproject.toml
+++ b/integrations/dynatrace/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "dynatrace"
-version = "0.1.52"
+version = "0.1.53"
 description = "An integration used to import Dynatrace resources into Port"
 authors = ["Ayodeji Adeoti <<ayodeji.adeoti@getport.io>>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-port_ocean = {version = "^0.10.10", extras = ["cli"]}
+port_ocean = {version = "^0.10.11", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
 # uncomment this if you want to debug the ocean core together with your integration

--- a/integrations/fake-integration/CHANGELOG.md
+++ b/integrations/fake-integration/CHANGELOG.md
@@ -5,6 +5,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.3-dev (2024-09-17)
+
+
+### Improvements
+
+- Bumped ocean version to ^0.10.11
+
+
 ## 0.1.2 (2024-09-12)
 
 

--- a/integrations/fake-integration/main.py
+++ b/integrations/fake-integration/main.py
@@ -14,7 +14,7 @@ async def resync_department(kind: str) -> List[Dict[Any, Any]]:
 
 
 @ocean.on_resync("fake-person")
-async def resync_puns(kind: str) -> List[Dict[Any, Any]]:
+async def resync_persons(kind: str) -> List[Dict[Any, Any]]:
     tasks = []
     for department in FAKE_DEPARTMENTS:
         tasks.append(get_fake_persons(department))

--- a/integrations/fake-integration/poetry.lock
+++ b/integrations/fake-integration/poetry.lock
@@ -1012,13 +1012,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "port-ocean"
-version = "0.10.10"
+version = "0.10.11"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 optional = false
 python-versions = "<4.0,>=3.11"
 files = [
-    {file = "port_ocean-0.10.10-py3-none-any.whl", hash = "sha256:0edfb23a2c7ea48f92819a61315beb333486d97c4088d5e329b93d9993f6d375"},
-    {file = "port_ocean-0.10.10.tar.gz", hash = "sha256:8b2e9104e7ed1b170a2bb286c8dfa44c299b7738df08271c80b3aa70f2105967"},
+    {file = "port_ocean-0.10.11-py3-none-any.whl", hash = "sha256:09881fdf7a836d5946b07b0255b757e96e375df497d724e8d12458c23879ef38"},
+    {file = "port_ocean-0.10.11.tar.gz", hash = "sha256:9f214f1895e2a35dd50c448616cf7d2e32d3c70205d79a546ab612a7be0f62c3"},
 ]
 
 [package.dependencies]
@@ -2030,4 +2030,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "6d841b378736e98c66fd3709692e6de86494bb8675d118bfa89cfa8739e58b91"
+content-hash = "18c541b2a4e37deca52b99da212867c9436e84be051deb2a42745a0251fd301c"

--- a/integrations/fake-integration/pyproject.toml
+++ b/integrations/fake-integration/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fake-integration"
-version = "0.1.2"
+version = "0.1.2-dev"
 description = "A useless fake integration that helps us test the Ocean Core"
 authors = ["Erik Zaadi <erik@getport.io>"]
 

--- a/integrations/fake-integration/pyproject.toml
+++ b/integrations/fake-integration/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "fake-integration"
-version = "0.1.2-dev"
+version = "0.1.3-dev"
 description = "A useless fake integration that helps us test the Ocean Core"
 authors = ["Erik Zaadi <erik@getport.io>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-port_ocean = {version = "^0.10.10", extras = ["cli"]}
+port_ocean = {version = "^0.10.11", extras = ["cli"]}
 faker = "^28.0.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/integrations/fake-integration/tests/conftest.py
+++ b/integrations/fake-integration/tests/conftest.py
@@ -1,0 +1,5 @@
+# ruff: noqa
+from port_ocean.tests.helpers.fixtures import (
+    get_mocked_ocean_app,
+    get_mock_ocean_resource_configs,
+)

--- a/integrations/firehydrant/CHANGELOG.md
+++ b/integrations/firehydrant/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.76 (2024-09-17)
+
+
+### Improvements
+
+- Bumped ocean version to ^0.10.11
+
+
 ## 0.1.75 (2024-09-12)
 
 

--- a/integrations/firehydrant/poetry.lock
+++ b/integrations/firehydrant/poetry.lock
@@ -885,13 +885,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "port-ocean"
-version = "0.10.10"
+version = "0.10.11"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 optional = false
 python-versions = "<4.0,>=3.11"
 files = [
-    {file = "port_ocean-0.10.10-py3-none-any.whl", hash = "sha256:0edfb23a2c7ea48f92819a61315beb333486d97c4088d5e329b93d9993f6d375"},
-    {file = "port_ocean-0.10.10.tar.gz", hash = "sha256:8b2e9104e7ed1b170a2bb286c8dfa44c299b7738df08271c80b3aa70f2105967"},
+    {file = "port_ocean-0.10.11-py3-none-any.whl", hash = "sha256:09881fdf7a836d5946b07b0255b757e96e375df497d724e8d12458c23879ef38"},
+    {file = "port_ocean-0.10.11.tar.gz", hash = "sha256:9f214f1895e2a35dd50c448616cf7d2e32d3c70205d79a546ab612a7be0f62c3"},
 ]
 
 [package.dependencies]
@@ -1790,4 +1790,4 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "18c8d8802ede303b3a09ddbf7cbc76d0b64a3e037d969a1985213dc9014dc183"
+content-hash = "12324544c3e97d143b991fa81cfef87ba7ad1ea424732b037a20feba460faf99"

--- a/integrations/firehydrant/pyproject.toml
+++ b/integrations/firehydrant/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "firehydrant"
-version = "0.1.75"
+version = "0.1.76"
 description = "FireHydrant Integration Powered by Ocean"
 authors = ["Isaac Coffie <isaac@getport.io>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-port_ocean = {version = "^0.10.10", extras = ["cli"]}
+port_ocean = {version = "^0.10.11", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
 # uncomment this if you want to debug the ocean core together with your integration

--- a/integrations/gcp/CHANGELOG.md
+++ b/integrations/gcp/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.57 (2024-09-17)
+
+
+### Improvements
+
+- Bumped ocean version to ^0.10.11
+
+
 ## 0.1.56 (2024-09-15)
 
 

--- a/integrations/gcp/poetry.lock
+++ b/integrations/gcp/poetry.lock
@@ -1191,13 +1191,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "port-ocean"
-version = "0.10.10"
+version = "0.10.11"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 optional = false
 python-versions = "<4.0,>=3.11"
 files = [
-    {file = "port_ocean-0.10.10-py3-none-any.whl", hash = "sha256:0edfb23a2c7ea48f92819a61315beb333486d97c4088d5e329b93d9993f6d375"},
-    {file = "port_ocean-0.10.10.tar.gz", hash = "sha256:8b2e9104e7ed1b170a2bb286c8dfa44c299b7738df08271c80b3aa70f2105967"},
+    {file = "port_ocean-0.10.11-py3-none-any.whl", hash = "sha256:09881fdf7a836d5946b07b0255b757e96e375df497d724e8d12458c23879ef38"},
+    {file = "port_ocean-0.10.11.tar.gz", hash = "sha256:9f214f1895e2a35dd50c448616cf7d2e32d3c70205d79a546ab612a7be0f62c3"},
 ]
 
 [package.dependencies]
@@ -2186,4 +2186,4 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "ce3e6548ee14be50559ca050aa9b91b4938faa0990b258b4d5e3176c3072df18"
+content-hash = "a8b4e3c8c3e6c76751e537260924f9ac23cdb199c9cd1eac8363ac8f54ba0ba4"

--- a/integrations/gcp/pyproject.toml
+++ b/integrations/gcp/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "gcp"
-version = "0.1.56"
+version = "0.1.57"
 description = "A GCP ocean integration"
 authors = ["Matan Geva <matang@getport.io>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-port_ocean = {version = "^0.10.10", extras = ["cli"]}
+port_ocean = {version = "^0.10.11", extras = ["cli"]}
 google-cloud-asset = "^3.25.1"
 google-cloud-pubsub = "^2.21.1"
 google-cloud-resource-manager = "^1.12.3"

--- a/integrations/gitlab/CHANGELOG.md
+++ b/integrations/gitlab/CHANGELOG.md
@@ -7,6 +7,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+0.1.120 (2024-09-17)
+====================
+
+### Improvements
+
+- Bumped ocean version to ^0.10.11
+
+
 0.1.119 (2024-09-12)
 ====================
 

--- a/integrations/gitlab/poetry.lock
+++ b/integrations/gitlab/poetry.lock
@@ -972,13 +972,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "port-ocean"
-version = "0.10.10"
+version = "0.10.11"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 optional = false
 python-versions = "<4.0,>=3.11"
 files = [
-    {file = "port_ocean-0.10.10-py3-none-any.whl", hash = "sha256:0edfb23a2c7ea48f92819a61315beb333486d97c4088d5e329b93d9993f6d375"},
-    {file = "port_ocean-0.10.10.tar.gz", hash = "sha256:8b2e9104e7ed1b170a2bb286c8dfa44c299b7738df08271c80b3aa70f2105967"},
+    {file = "port_ocean-0.10.11-py3-none-any.whl", hash = "sha256:09881fdf7a836d5946b07b0255b757e96e375df497d724e8d12458c23879ef38"},
+    {file = "port_ocean-0.10.11.tar.gz", hash = "sha256:9f214f1895e2a35dd50c448616cf7d2e32d3c70205d79a546ab612a7be0f62c3"},
 ]
 
 [package.dependencies]
@@ -2048,4 +2048,4 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "fcb4c7dba2767da6f56fa4ce5f28301c1eae78060cdfee80209cd1a3dbde68fb"
+content-hash = "01ced5b4ec812e55cf600a4036496d893931762d703c452603e35353be2d7343"

--- a/integrations/gitlab/pyproject.toml
+++ b/integrations/gitlab/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gitlab"
-version = "0.1.119"
+version = "0.1.120"
 description = "Gitlab integration for Port using Port-Ocean Framework"
 authors = ["Yair Siman-Tov <yair@getport.io>"]
 
@@ -11,7 +11,7 @@ aiolimiter = "^1.1.0"
 python-gitlab = "^3.14.0"
 pathlib = "^1.0.1"
 jsonschema = "^4.17.3"
-port_ocean = {version = "^0.10.10", extras = ["cli"]}
+port_ocean = {version = "^0.10.11", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
 # uncomment this if you want to debug the ocean core together with your integration

--- a/integrations/jenkins/CHANGELOG.md
+++ b/integrations/jenkins/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.58 (2024-09-17)
+
+
+### Improvements
+
+- Bumped ocean version to ^0.10.11
+
+
 ## 0.1.57 (2024-09-12)
 
 

--- a/integrations/jenkins/poetry.lock
+++ b/integrations/jenkins/poetry.lock
@@ -896,13 +896,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "port-ocean"
-version = "0.10.10"
+version = "0.10.11"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 optional = false
 python-versions = "<4.0,>=3.11"
 files = [
-    {file = "port_ocean-0.10.10-py3-none-any.whl", hash = "sha256:0edfb23a2c7ea48f92819a61315beb333486d97c4088d5e329b93d9993f6d375"},
-    {file = "port_ocean-0.10.10.tar.gz", hash = "sha256:8b2e9104e7ed1b170a2bb286c8dfa44c299b7738df08271c80b3aa70f2105967"},
+    {file = "port_ocean-0.10.11-py3-none-any.whl", hash = "sha256:09881fdf7a836d5946b07b0255b757e96e375df497d724e8d12458c23879ef38"},
+    {file = "port_ocean-0.10.11.tar.gz", hash = "sha256:9f214f1895e2a35dd50c448616cf7d2e32d3c70205d79a546ab612a7be0f62c3"},
 ]
 
 [package.dependencies]
@@ -1801,4 +1801,4 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "3c128b5476fac8edf1d9b51037ee598f0acc559532040d4c8c30c887616a55db"
+content-hash = "dae8f401cb6c33a49e1622fb1e0a8596ba595a9601889e8b18f8c6859479806f"

--- a/integrations/jenkins/pyproject.toml
+++ b/integrations/jenkins/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "jenkins"
-version = "0.1.57"
+version = "0.1.58"
 description = "Jenkins Integration to Port Ocean"
 authors = ["Albert Luganga <ahosea15@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-port_ocean = {version = "^0.10.10", extras = ["cli"]}
+port_ocean = {version = "^0.10.11", extras = ["cli"]}
 pip = "^23.3.1"
 python-dotenv = "^1.0.0"
 loguru = "^0.7.2"

--- a/integrations/jira/CHANGELOG.md
+++ b/integrations/jira/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.87 (2024-09-17)
+
+
+### Improvements
+
+- Bumped ocean version to ^0.10.11
+
+
 ## 0.1.86 (2024-09-12)
 
 

--- a/integrations/jira/poetry.lock
+++ b/integrations/jira/poetry.lock
@@ -885,13 +885,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "port-ocean"
-version = "0.10.10"
+version = "0.10.11"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 optional = false
 python-versions = "<4.0,>=3.11"
 files = [
-    {file = "port_ocean-0.10.10-py3-none-any.whl", hash = "sha256:0edfb23a2c7ea48f92819a61315beb333486d97c4088d5e329b93d9993f6d375"},
-    {file = "port_ocean-0.10.10.tar.gz", hash = "sha256:8b2e9104e7ed1b170a2bb286c8dfa44c299b7738df08271c80b3aa70f2105967"},
+    {file = "port_ocean-0.10.11-py3-none-any.whl", hash = "sha256:09881fdf7a836d5946b07b0255b757e96e375df497d724e8d12458c23879ef38"},
+    {file = "port_ocean-0.10.11.tar.gz", hash = "sha256:9f214f1895e2a35dd50c448616cf7d2e32d3c70205d79a546ab612a7be0f62c3"},
 ]
 
 [package.dependencies]
@@ -1790,4 +1790,4 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "e75a8d5d3ad2bb0fa9215edee5f1d498a20d802114c4ef601db28b6d9f2d1b76"
+content-hash = "6fd97423bb47a8540b3a5473b01a734a226f5dcbb468411868de2e08f83c32df"

--- a/integrations/jira/pyproject.toml
+++ b/integrations/jira/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "jira"
-version = "0.1.86"
+version = "0.1.87"
 description = "Integration to bring information from Jira into Port"
 authors = ["Mor Paz <mor@getport.io>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-port_ocean = {version = "^0.10.10", extras = ["cli"]}
+port_ocean = {version = "^0.10.11", extras = ["cli"]}
 httpx = "^0.27.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/integrations/kafka/CHANGELOG.md
+++ b/integrations/kafka/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.75 (2024-09-17)
+
+
+### Improvements
+
+- Bumped ocean version to ^0.10.11
+
+
 ## 0.1.74 (2024-09-12)
 
 

--- a/integrations/kafka/poetry.lock
+++ b/integrations/kafka/poetry.lock
@@ -885,13 +885,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "port-ocean"
-version = "0.10.10"
+version = "0.10.11"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 optional = false
 python-versions = "<4.0,>=3.11"
 files = [
-    {file = "port_ocean-0.10.10-py3-none-any.whl", hash = "sha256:0edfb23a2c7ea48f92819a61315beb333486d97c4088d5e329b93d9993f6d375"},
-    {file = "port_ocean-0.10.10.tar.gz", hash = "sha256:8b2e9104e7ed1b170a2bb286c8dfa44c299b7738df08271c80b3aa70f2105967"},
+    {file = "port_ocean-0.10.11-py3-none-any.whl", hash = "sha256:09881fdf7a836d5946b07b0255b757e96e375df497d724e8d12458c23879ef38"},
+    {file = "port_ocean-0.10.11.tar.gz", hash = "sha256:9f214f1895e2a35dd50c448616cf7d2e32d3c70205d79a546ab612a7be0f62c3"},
 ]
 
 [package.dependencies]
@@ -1790,4 +1790,4 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "3cdeafa20819ac8b72183e96f62517e37f22384a6dcdb88dca03dbce7ba707f6"
+content-hash = "e97f7ae7976aa71c90d7ec5d50920777ab2d12b301866036fcfbf3703a8b982a"

--- a/integrations/kafka/pyproject.toml
+++ b/integrations/kafka/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "kafka"
-version = "0.1.74"
+version = "0.1.75"
 description = "Integration to import information from a Kafka cluster into Port. The integration supports importing metadata regarding the Kafka cluster, brokers and topics."
 authors = ["Tal Sabag <tal@getport.io>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-port_ocean = {version = "^0.10.10", extras = ["cli"]}
+port_ocean = {version = "^0.10.11", extras = ["cli"]}
 confluent-kafka = "^2.2.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/integrations/kubecost/CHANGELOG.md
+++ b/integrations/kubecost/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.80 (2024-09-17)
+
+
+### Improvements
+
+- Bumped ocean version to ^0.10.11
+
+
 ## 0.1.79 (2024-09-12)
 
 

--- a/integrations/kubecost/poetry.lock
+++ b/integrations/kubecost/poetry.lock
@@ -885,13 +885,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "port-ocean"
-version = "0.10.10"
+version = "0.10.11"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 optional = false
 python-versions = "<4.0,>=3.11"
 files = [
-    {file = "port_ocean-0.10.10-py3-none-any.whl", hash = "sha256:0edfb23a2c7ea48f92819a61315beb333486d97c4088d5e329b93d9993f6d375"},
-    {file = "port_ocean-0.10.10.tar.gz", hash = "sha256:8b2e9104e7ed1b170a2bb286c8dfa44c299b7738df08271c80b3aa70f2105967"},
+    {file = "port_ocean-0.10.11-py3-none-any.whl", hash = "sha256:09881fdf7a836d5946b07b0255b757e96e375df497d724e8d12458c23879ef38"},
+    {file = "port_ocean-0.10.11.tar.gz", hash = "sha256:9f214f1895e2a35dd50c448616cf7d2e32d3c70205d79a546ab612a7be0f62c3"},
 ]
 
 [package.dependencies]
@@ -1790,4 +1790,4 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "18c8d8802ede303b3a09ddbf7cbc76d0b64a3e037d969a1985213dc9014dc183"
+content-hash = "12324544c3e97d143b991fa81cfef87ba7ad1ea424732b037a20feba460faf99"

--- a/integrations/kubecost/pyproject.toml
+++ b/integrations/kubecost/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "kubecost"
-version = "0.1.79"
+version = "0.1.80"
 description = "Kubecost integration powered by Ocean"
 authors = ["Isaac Coffie <isaac@getport.io>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-port_ocean = {version = "^0.10.10", extras = ["cli"]}
+port_ocean = {version = "^0.10.11", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
 # uncomment this if you want to debug the ocean core together with your integration

--- a/integrations/launchdarkly/CHANGELOG.md
+++ b/integrations/launchdarkly/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.52 (2024-09-17)
+
+
+### Improvements
+
+- Bumped ocean version to ^0.10.11
+
+
 ## 0.1.51 (2024-09-12)
 
 

--- a/integrations/launchdarkly/poetry.lock
+++ b/integrations/launchdarkly/poetry.lock
@@ -885,13 +885,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "port-ocean"
-version = "0.10.10"
+version = "0.10.11"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 optional = false
 python-versions = "<4.0,>=3.11"
 files = [
-    {file = "port_ocean-0.10.10-py3-none-any.whl", hash = "sha256:0edfb23a2c7ea48f92819a61315beb333486d97c4088d5e329b93d9993f6d375"},
-    {file = "port_ocean-0.10.10.tar.gz", hash = "sha256:8b2e9104e7ed1b170a2bb286c8dfa44c299b7738df08271c80b3aa70f2105967"},
+    {file = "port_ocean-0.10.11-py3-none-any.whl", hash = "sha256:09881fdf7a836d5946b07b0255b757e96e375df497d724e8d12458c23879ef38"},
+    {file = "port_ocean-0.10.11.tar.gz", hash = "sha256:9f214f1895e2a35dd50c448616cf7d2e32d3c70205d79a546ab612a7be0f62c3"},
 ]
 
 [package.dependencies]
@@ -1790,4 +1790,4 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "18c8d8802ede303b3a09ddbf7cbc76d0b64a3e037d969a1985213dc9014dc183"
+content-hash = "12324544c3e97d143b991fa81cfef87ba7ad1ea424732b037a20feba460faf99"

--- a/integrations/launchdarkly/pyproject.toml
+++ b/integrations/launchdarkly/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "launchdarkly"
-version = "0.1.51"
+version = "0.1.52"
 description = "Launchdarkly integration for Port"
 authors = ["Michael Armah <michaelarmah@getport.io>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-port_ocean = {version = "^0.10.10", extras = ["cli"]}
+port_ocean = {version = "^0.10.11", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
 # uncomment this if you want to debug the ocean core together with your integration

--- a/integrations/linear/CHANGELOG.md
+++ b/integrations/linear/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.38 (2024-09-17)
+
+
+### Improvements
+
+- Bumped ocean version to ^0.10.11
+
+
 ## 0.1.37 (2024-09-12)
 
 

--- a/integrations/linear/poetry.lock
+++ b/integrations/linear/poetry.lock
@@ -885,13 +885,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "port-ocean"
-version = "0.10.10"
+version = "0.10.11"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 optional = false
 python-versions = "<4.0,>=3.11"
 files = [
-    {file = "port_ocean-0.10.10-py3-none-any.whl", hash = "sha256:0edfb23a2c7ea48f92819a61315beb333486d97c4088d5e329b93d9993f6d375"},
-    {file = "port_ocean-0.10.10.tar.gz", hash = "sha256:8b2e9104e7ed1b170a2bb286c8dfa44c299b7738df08271c80b3aa70f2105967"},
+    {file = "port_ocean-0.10.11-py3-none-any.whl", hash = "sha256:09881fdf7a836d5946b07b0255b757e96e375df497d724e8d12458c23879ef38"},
+    {file = "port_ocean-0.10.11.tar.gz", hash = "sha256:9f214f1895e2a35dd50c448616cf7d2e32d3c70205d79a546ab612a7be0f62c3"},
 ]
 
 [package.dependencies]
@@ -1790,4 +1790,4 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "18c8d8802ede303b3a09ddbf7cbc76d0b64a3e037d969a1985213dc9014dc183"
+content-hash = "12324544c3e97d143b991fa81cfef87ba7ad1ea424732b037a20feba460faf99"

--- a/integrations/linear/pyproject.toml
+++ b/integrations/linear/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "linear"
-version = "0.1.37"
+version = "0.1.38"
 description = "Integration to bring information from Linear into Port"
 authors = ["Mor Paz <mor@getport.io>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-port_ocean = {version = "^0.10.10", extras = ["cli"]}
+port_ocean = {version = "^0.10.11", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
 # uncomment this if you want to debug the ocean core together with your integration

--- a/integrations/newrelic/CHANGELOG.md
+++ b/integrations/newrelic/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.82 (2024-09-17)
+
+
+### Improvements
+
+- Bumped ocean version to ^0.10.11
+
+
 ## 0.1.81 (2024-09-12)
 
 

--- a/integrations/newrelic/poetry.lock
+++ b/integrations/newrelic/poetry.lock
@@ -885,13 +885,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "port-ocean"
-version = "0.10.10"
+version = "0.10.11"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 optional = false
 python-versions = "<4.0,>=3.11"
 files = [
-    {file = "port_ocean-0.10.10-py3-none-any.whl", hash = "sha256:0edfb23a2c7ea48f92819a61315beb333486d97c4088d5e329b93d9993f6d375"},
-    {file = "port_ocean-0.10.10.tar.gz", hash = "sha256:8b2e9104e7ed1b170a2bb286c8dfa44c299b7738df08271c80b3aa70f2105967"},
+    {file = "port_ocean-0.10.11-py3-none-any.whl", hash = "sha256:09881fdf7a836d5946b07b0255b757e96e375df497d724e8d12458c23879ef38"},
+    {file = "port_ocean-0.10.11.tar.gz", hash = "sha256:9f214f1895e2a35dd50c448616cf7d2e32d3c70205d79a546ab612a7be0f62c3"},
 ]
 
 [package.dependencies]
@@ -1790,4 +1790,4 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "e75a8d5d3ad2bb0fa9215edee5f1d498a20d802114c4ef601db28b6d9f2d1b76"
+content-hash = "6fd97423bb47a8540b3a5473b01a734a226f5dcbb468411868de2e08f83c32df"

--- a/integrations/newrelic/pyproject.toml
+++ b/integrations/newrelic/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "newrelic"
-version = "0.1.81"
+version = "0.1.82"
 description = "New Relic Integration"
 authors = ["Tom Tankilevitch <tomtankilevitch@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-port_ocean = {version = "^0.10.10", extras = ["cli"]}
+port_ocean = {version = "^0.10.11", extras = ["cli"]}
 httpx = "^0.27.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/integrations/octopus/CHANGELOG.md
+++ b/integrations/octopus/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+# Port_Ocean 0.1.10 (2024-09-17)
+
+### Improvements
+
+- Bumped ocean version to ^0.10.11
+
+
 # Port_Ocean 0.1.9 (2024-09-12)
 
 ### Improvements

--- a/integrations/octopus/poetry.lock
+++ b/integrations/octopus/poetry.lock
@@ -885,13 +885,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "port-ocean"
-version = "0.10.10"
+version = "0.10.11"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 optional = false
 python-versions = "<4.0,>=3.11"
 files = [
-    {file = "port_ocean-0.10.10-py3-none-any.whl", hash = "sha256:0edfb23a2c7ea48f92819a61315beb333486d97c4088d5e329b93d9993f6d375"},
-    {file = "port_ocean-0.10.10.tar.gz", hash = "sha256:8b2e9104e7ed1b170a2bb286c8dfa44c299b7738df08271c80b3aa70f2105967"},
+    {file = "port_ocean-0.10.11-py3-none-any.whl", hash = "sha256:09881fdf7a836d5946b07b0255b757e96e375df497d724e8d12458c23879ef38"},
+    {file = "port_ocean-0.10.11.tar.gz", hash = "sha256:9f214f1895e2a35dd50c448616cf7d2e32d3c70205d79a546ab612a7be0f62c3"},
 ]
 
 [package.dependencies]
@@ -1790,4 +1790,4 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "18c8d8802ede303b3a09ddbf7cbc76d0b64a3e037d969a1985213dc9014dc183"
+content-hash = "12324544c3e97d143b991fa81cfef87ba7ad1ea424732b037a20feba460faf99"

--- a/integrations/octopus/pyproject.toml
+++ b/integrations/octopus/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "octopus"
-version = "0.1.9"
+version = "0.1.10"
 description = "This integration ingest data from octopus deploy"
 authors = ["Adebayo Iyanuoluwa <ioluwadunsinadebayo@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-port_ocean = {version = "^0.10.10", extras = ["cli"]}
+port_ocean = {version = "^0.10.11", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
 # Uncomment this if you want to debug the ocean core together with your integration

--- a/integrations/opencost/CHANGELOG.md
+++ b/integrations/opencost/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.78 (2024-09-17)
+
+
+### Improvements
+
+- Bumped ocean version to ^0.10.11
+
+
 ## 0.1.77 (2024-09-12)
 
 

--- a/integrations/opencost/poetry.lock
+++ b/integrations/opencost/poetry.lock
@@ -885,13 +885,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "port-ocean"
-version = "0.10.10"
+version = "0.10.11"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 optional = false
 python-versions = "<4.0,>=3.11"
 files = [
-    {file = "port_ocean-0.10.10-py3-none-any.whl", hash = "sha256:0edfb23a2c7ea48f92819a61315beb333486d97c4088d5e329b93d9993f6d375"},
-    {file = "port_ocean-0.10.10.tar.gz", hash = "sha256:8b2e9104e7ed1b170a2bb286c8dfa44c299b7738df08271c80b3aa70f2105967"},
+    {file = "port_ocean-0.10.11-py3-none-any.whl", hash = "sha256:09881fdf7a836d5946b07b0255b757e96e375df497d724e8d12458c23879ef38"},
+    {file = "port_ocean-0.10.11.tar.gz", hash = "sha256:9f214f1895e2a35dd50c448616cf7d2e32d3c70205d79a546ab612a7be0f62c3"},
 ]
 
 [package.dependencies]
@@ -1790,4 +1790,4 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "18c8d8802ede303b3a09ddbf7cbc76d0b64a3e037d969a1985213dc9014dc183"
+content-hash = "12324544c3e97d143b991fa81cfef87ba7ad1ea424732b037a20feba460faf99"

--- a/integrations/opencost/pyproject.toml
+++ b/integrations/opencost/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "opencost"
-version = "0.1.77"
+version = "0.1.78"
 description = "Ocean integration for OpenCost"
 authors = ["Isaac Coffie <isaac@getport.io>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-port_ocean = {version = "^0.10.10", extras = ["cli"]}
+port_ocean = {version = "^0.10.11", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
 # uncomment this if you want to debug the ocean core together with your integration

--- a/integrations/opsgenie/CHANGELOG.md
+++ b/integrations/opsgenie/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.2.2 (2024-09-17)
+
+
+### Improvements
+
+- Bumped ocean version to ^0.10.11
+
+
 ## 0.2.1 (2024-09-12)
 
 

--- a/integrations/opsgenie/poetry.lock
+++ b/integrations/opsgenie/poetry.lock
@@ -885,13 +885,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "port-ocean"
-version = "0.10.10"
+version = "0.10.11"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 optional = false
 python-versions = "<4.0,>=3.11"
 files = [
-    {file = "port_ocean-0.10.10-py3-none-any.whl", hash = "sha256:0edfb23a2c7ea48f92819a61315beb333486d97c4088d5e329b93d9993f6d375"},
-    {file = "port_ocean-0.10.10.tar.gz", hash = "sha256:8b2e9104e7ed1b170a2bb286c8dfa44c299b7738df08271c80b3aa70f2105967"},
+    {file = "port_ocean-0.10.11-py3-none-any.whl", hash = "sha256:09881fdf7a836d5946b07b0255b757e96e375df497d724e8d12458c23879ef38"},
+    {file = "port_ocean-0.10.11.tar.gz", hash = "sha256:9f214f1895e2a35dd50c448616cf7d2e32d3c70205d79a546ab612a7be0f62c3"},
 ]
 
 [package.dependencies]
@@ -1790,4 +1790,4 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "18c8d8802ede303b3a09ddbf7cbc76d0b64a3e037d969a1985213dc9014dc183"
+content-hash = "12324544c3e97d143b991fa81cfef87ba7ad1ea424732b037a20feba460faf99"

--- a/integrations/opsgenie/pyproject.toml
+++ b/integrations/opsgenie/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "opsgenie"
-version = "0.2.1"
+version = "0.2.2"
 description = "Ocean integration for OpsGenie"
 authors = ["Isaac Coffie <isaac@getport.io>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-port_ocean = {version = "^0.10.10", extras = ["cli"]}
+port_ocean = {version = "^0.10.11", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
 # uncomment this if you want to debug the ocean core together with your integration

--- a/integrations/pagerduty/CHANGELOG.md
+++ b/integrations/pagerduty/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.102 (2024-09-17)
+
+
+### Improvements
+
+- Bumped ocean version to ^0.10.11
+
+
 ## 0.1.101 (2024-09-12)
 
 

--- a/integrations/pagerduty/poetry.lock
+++ b/integrations/pagerduty/poetry.lock
@@ -885,13 +885,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "port-ocean"
-version = "0.10.10"
+version = "0.10.11"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 optional = false
 python-versions = "<4.0,>=3.11"
 files = [
-    {file = "port_ocean-0.10.10-py3-none-any.whl", hash = "sha256:0edfb23a2c7ea48f92819a61315beb333486d97c4088d5e329b93d9993f6d375"},
-    {file = "port_ocean-0.10.10.tar.gz", hash = "sha256:8b2e9104e7ed1b170a2bb286c8dfa44c299b7738df08271c80b3aa70f2105967"},
+    {file = "port_ocean-0.10.11-py3-none-any.whl", hash = "sha256:09881fdf7a836d5946b07b0255b757e96e375df497d724e8d12458c23879ef38"},
+    {file = "port_ocean-0.10.11.tar.gz", hash = "sha256:9f214f1895e2a35dd50c448616cf7d2e32d3c70205d79a546ab612a7be0f62c3"},
 ]
 
 [package.dependencies]
@@ -1790,4 +1790,4 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "e75a8d5d3ad2bb0fa9215edee5f1d498a20d802114c4ef601db28b6d9f2d1b76"
+content-hash = "6fd97423bb47a8540b3a5473b01a734a226f5dcbb468411868de2e08f83c32df"

--- a/integrations/pagerduty/pyproject.toml
+++ b/integrations/pagerduty/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "pagerduty"
-version = "0.1.101"
+version = "0.1.102"
 description = "Pagerduty Integration"
 authors = ["Port Team <support@getport.io>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-port_ocean = {version = "^0.10.10", extras = ["cli"]}
+port_ocean = {version = "^0.10.11", extras = ["cli"]}
 httpx = "^0.27.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/integrations/sentry/CHANGELOG.md
+++ b/integrations/sentry/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.78 (2024-09-17)
+
+
+### Improvements
+
+- Bumped ocean version to ^0.10.11
+
+
 ## 0.1.77 (2024-09-12)
 
 

--- a/integrations/sentry/poetry.lock
+++ b/integrations/sentry/poetry.lock
@@ -885,13 +885,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "port-ocean"
-version = "0.10.10"
+version = "0.10.11"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 optional = false
 python-versions = "<4.0,>=3.11"
 files = [
-    {file = "port_ocean-0.10.10-py3-none-any.whl", hash = "sha256:0edfb23a2c7ea48f92819a61315beb333486d97c4088d5e329b93d9993f6d375"},
-    {file = "port_ocean-0.10.10.tar.gz", hash = "sha256:8b2e9104e7ed1b170a2bb286c8dfa44c299b7738df08271c80b3aa70f2105967"},
+    {file = "port_ocean-0.10.11-py3-none-any.whl", hash = "sha256:09881fdf7a836d5946b07b0255b757e96e375df497d724e8d12458c23879ef38"},
+    {file = "port_ocean-0.10.11.tar.gz", hash = "sha256:9f214f1895e2a35dd50c448616cf7d2e32d3c70205d79a546ab612a7be0f62c3"},
 ]
 
 [package.dependencies]
@@ -1790,4 +1790,4 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "18c8d8802ede303b3a09ddbf7cbc76d0b64a3e037d969a1985213dc9014dc183"
+content-hash = "12324544c3e97d143b991fa81cfef87ba7ad1ea424732b037a20feba460faf99"

--- a/integrations/sentry/pyproject.toml
+++ b/integrations/sentry/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "sentry"
-version = "0.1.77"
+version = "0.1.78"
 description = "Sentry Integration"
 authors = ["Dvir Segev <dvir@getport.io>","Matan Geva <matang@getport.io>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-port_ocean = {version = "^0.10.10", extras = ["cli"]}
+port_ocean = {version = "^0.10.11", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
 # uncomment this if you want to debug the ocean core together with your integration

--- a/integrations/servicenow/CHANGELOG.md
+++ b/integrations/servicenow/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.68 (2024-09-17)
+
+
+### Improvements
+
+- Bumped ocean version to ^0.10.11
+
+
 ## 0.1.67 (2024-09-12)
 
 

--- a/integrations/servicenow/poetry.lock
+++ b/integrations/servicenow/poetry.lock
@@ -885,13 +885,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "port-ocean"
-version = "0.10.10"
+version = "0.10.11"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 optional = false
 python-versions = "<4.0,>=3.11"
 files = [
-    {file = "port_ocean-0.10.10-py3-none-any.whl", hash = "sha256:0edfb23a2c7ea48f92819a61315beb333486d97c4088d5e329b93d9993f6d375"},
-    {file = "port_ocean-0.10.10.tar.gz", hash = "sha256:8b2e9104e7ed1b170a2bb286c8dfa44c299b7738df08271c80b3aa70f2105967"},
+    {file = "port_ocean-0.10.11-py3-none-any.whl", hash = "sha256:09881fdf7a836d5946b07b0255b757e96e375df497d724e8d12458c23879ef38"},
+    {file = "port_ocean-0.10.11.tar.gz", hash = "sha256:9f214f1895e2a35dd50c448616cf7d2e32d3c70205d79a546ab612a7be0f62c3"},
 ]
 
 [package.dependencies]
@@ -1790,4 +1790,4 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "18c8d8802ede303b3a09ddbf7cbc76d0b64a3e037d969a1985213dc9014dc183"
+content-hash = "12324544c3e97d143b991fa81cfef87ba7ad1ea424732b037a20feba460faf99"

--- a/integrations/servicenow/pyproject.toml
+++ b/integrations/servicenow/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "servicenow"
-version = "0.1.67"
+version = "0.1.68"
 description = "Service Now Ocean Integration"
 authors = ["Isaac Coffie <isaac@getport.io>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-port_ocean = {version = "^0.10.10", extras = ["cli"]}
+port_ocean = {version = "^0.10.11", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
 # uncomment this if you want to debug the ocean core together with your integration

--- a/integrations/snyk/CHANGELOG.md
+++ b/integrations/snyk/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.88 (2024-09-17)
+
+
+### Improvements
+
+- Bumped ocean version to ^0.10.11
+
+
 ## 0.1.87 (2024-09-12)
 
 

--- a/integrations/snyk/poetry.lock
+++ b/integrations/snyk/poetry.lock
@@ -885,13 +885,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "port-ocean"
-version = "0.10.10"
+version = "0.10.11"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 optional = false
 python-versions = "<4.0,>=3.11"
 files = [
-    {file = "port_ocean-0.10.10-py3-none-any.whl", hash = "sha256:0edfb23a2c7ea48f92819a61315beb333486d97c4088d5e329b93d9993f6d375"},
-    {file = "port_ocean-0.10.10.tar.gz", hash = "sha256:8b2e9104e7ed1b170a2bb286c8dfa44c299b7738df08271c80b3aa70f2105967"},
+    {file = "port_ocean-0.10.11-py3-none-any.whl", hash = "sha256:09881fdf7a836d5946b07b0255b757e96e375df497d724e8d12458c23879ef38"},
+    {file = "port_ocean-0.10.11.tar.gz", hash = "sha256:9f214f1895e2a35dd50c448616cf7d2e32d3c70205d79a546ab612a7be0f62c3"},
 ]
 
 [package.dependencies]
@@ -1790,4 +1790,4 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "18c8d8802ede303b3a09ddbf7cbc76d0b64a3e037d969a1985213dc9014dc183"
+content-hash = "12324544c3e97d143b991fa81cfef87ba7ad1ea424732b037a20feba460faf99"

--- a/integrations/snyk/pyproject.toml
+++ b/integrations/snyk/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "snyk"
-version = "0.1.87"
+version = "0.1.88"
 description = "Snyk integration powered by Ocean"
 authors = ["Isaac Coffie <isaac@getport.io>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-port_ocean = {version = "^0.10.10", extras = ["cli"]}
+port_ocean = {version = "^0.10.11", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
 # uncomment this if you want to debug the ocean core together with your integration

--- a/integrations/sonarqube/CHANGELOG.md
+++ b/integrations/sonarqube/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.94 (2024-09-17)
+
+
+### Improvements
+
+- Bumped ocean version to ^0.10.11
+
+
 ## 0.1.93 (2024-09-12)
 
 

--- a/integrations/sonarqube/poetry.lock
+++ b/integrations/sonarqube/poetry.lock
@@ -885,13 +885,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "port-ocean"
-version = "0.10.10"
+version = "0.10.11"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 optional = false
 python-versions = "<4.0,>=3.11"
 files = [
-    {file = "port_ocean-0.10.10-py3-none-any.whl", hash = "sha256:0edfb23a2c7ea48f92819a61315beb333486d97c4088d5e329b93d9993f6d375"},
-    {file = "port_ocean-0.10.10.tar.gz", hash = "sha256:8b2e9104e7ed1b170a2bb286c8dfa44c299b7738df08271c80b3aa70f2105967"},
+    {file = "port_ocean-0.10.11-py3-none-any.whl", hash = "sha256:09881fdf7a836d5946b07b0255b757e96e375df497d724e8d12458c23879ef38"},
+    {file = "port_ocean-0.10.11.tar.gz", hash = "sha256:9f214f1895e2a35dd50c448616cf7d2e32d3c70205d79a546ab612a7be0f62c3"},
 ]
 
 [package.dependencies]
@@ -1790,4 +1790,4 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "9a1b05d73363e552e7b981003f9ea28dbd63b9f8e8715f9060d537688eb05d5d"
+content-hash = "d3ccf11a06d6e0c3cdfad160f4d3cdd59b34d440c3ba61e4e5b756d00101c988"

--- a/integrations/sonarqube/pyproject.toml
+++ b/integrations/sonarqube/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "sonarqube"
-version = "0.1.93"
+version = "0.1.94"
 description = "SonarQube projects and code quality analysis integration"
 authors = ["Port Team <support@getport.io>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-port_ocean = {version = "^0.10.10", extras = ["cli"]}
+port_ocean = {version = "^0.10.11", extras = ["cli"]}
 rich = "^13.5.2"
 cookiecutter = "^2.3.0"
 

--- a/integrations/statuspage/CHANGELOG.md
+++ b/integrations/statuspage/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.27 (2024-09-17)
+
+
+### Improvements
+
+- Bumped ocean version to ^0.10.11
+
+
 ## 0.1.26 (2024-09-12)
 
 

--- a/integrations/statuspage/poetry.lock
+++ b/integrations/statuspage/poetry.lock
@@ -885,13 +885,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "port-ocean"
-version = "0.10.10"
+version = "0.10.11"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 optional = false
 python-versions = "<4.0,>=3.11"
 files = [
-    {file = "port_ocean-0.10.10-py3-none-any.whl", hash = "sha256:0edfb23a2c7ea48f92819a61315beb333486d97c4088d5e329b93d9993f6d375"},
-    {file = "port_ocean-0.10.10.tar.gz", hash = "sha256:8b2e9104e7ed1b170a2bb286c8dfa44c299b7738df08271c80b3aa70f2105967"},
+    {file = "port_ocean-0.10.11-py3-none-any.whl", hash = "sha256:09881fdf7a836d5946b07b0255b757e96e375df497d724e8d12458c23879ef38"},
+    {file = "port_ocean-0.10.11.tar.gz", hash = "sha256:9f214f1895e2a35dd50c448616cf7d2e32d3c70205d79a546ab612a7be0f62c3"},
 ]
 
 [package.dependencies]
@@ -1790,4 +1790,4 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "18c8d8802ede303b3a09ddbf7cbc76d0b64a3e037d969a1985213dc9014dc183"
+content-hash = "12324544c3e97d143b991fa81cfef87ba7ad1ea424732b037a20feba460faf99"

--- a/integrations/statuspage/pyproject.toml
+++ b/integrations/statuspage/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "statuspage"
-version = "0.1.26"
+version = "0.1.27"
 description = "Connect Statuspage to Ocean and automatically ingest incidents, updates, and impacted components for comprehensive monitoring"
 authors = ["Albert Luganga <albertluganga@getport.io>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-port_ocean = {version = "^0.10.10", extras = ["cli"]}
+port_ocean = {version = "^0.10.11", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
 # uncomment this if you want to debug the ocean core together with your integration

--- a/integrations/terraform-cloud/CHANGELOG.md
+++ b/integrations/terraform-cloud/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.66 (2024-09-17)
+
+
+### Improvements
+
+- Bumped ocean version to ^0.10.11
+
+
 ## 0.1.65 (2024-09-12)
 
 

--- a/integrations/terraform-cloud/poetry.lock
+++ b/integrations/terraform-cloud/poetry.lock
@@ -885,13 +885,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "port-ocean"
-version = "0.10.10"
+version = "0.10.11"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 optional = false
 python-versions = "<4.0,>=3.11"
 files = [
-    {file = "port_ocean-0.10.10-py3-none-any.whl", hash = "sha256:0edfb23a2c7ea48f92819a61315beb333486d97c4088d5e329b93d9993f6d375"},
-    {file = "port_ocean-0.10.10.tar.gz", hash = "sha256:8b2e9104e7ed1b170a2bb286c8dfa44c299b7738df08271c80b3aa70f2105967"},
+    {file = "port_ocean-0.10.11-py3-none-any.whl", hash = "sha256:09881fdf7a836d5946b07b0255b757e96e375df497d724e8d12458c23879ef38"},
+    {file = "port_ocean-0.10.11.tar.gz", hash = "sha256:9f214f1895e2a35dd50c448616cf7d2e32d3c70205d79a546ab612a7be0f62c3"},
 ]
 
 [package.dependencies]
@@ -1790,4 +1790,4 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "18c8d8802ede303b3a09ddbf7cbc76d0b64a3e037d969a1985213dc9014dc183"
+content-hash = "12324544c3e97d143b991fa81cfef87ba7ad1ea424732b037a20feba460faf99"

--- a/integrations/terraform-cloud/pyproject.toml
+++ b/integrations/terraform-cloud/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "terraform-cloud"
-version = "0.1.65"
+version = "0.1.66"
 description = "Terraform Cloud Integration for Port"
 authors = ["Michael Armah <michaelarmah@getport.io>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-port_ocean = {version = "^0.10.10", extras = ["cli"]}
+port_ocean = {version = "^0.10.11", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
 # uncomment this if you want to debug the ocean core together with your integration

--- a/integrations/wiz/CHANGELOG.md
+++ b/integrations/wiz/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.59 (2024-09-17)
+
+
+### Improvements
+
+- Bumped ocean version to ^0.10.11
+
+
 ## 0.1.58 (2024-09-13)
 
 ### Improvements

--- a/integrations/wiz/poetry.lock
+++ b/integrations/wiz/poetry.lock
@@ -885,13 +885,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "port-ocean"
-version = "0.10.10"
+version = "0.10.11"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 optional = false
 python-versions = "<4.0,>=3.11"
 files = [
-    {file = "port_ocean-0.10.10-py3-none-any.whl", hash = "sha256:0edfb23a2c7ea48f92819a61315beb333486d97c4088d5e329b93d9993f6d375"},
-    {file = "port_ocean-0.10.10.tar.gz", hash = "sha256:8b2e9104e7ed1b170a2bb286c8dfa44c299b7738df08271c80b3aa70f2105967"},
+    {file = "port_ocean-0.10.11-py3-none-any.whl", hash = "sha256:09881fdf7a836d5946b07b0255b757e96e375df497d724e8d12458c23879ef38"},
+    {file = "port_ocean-0.10.11.tar.gz", hash = "sha256:9f214f1895e2a35dd50c448616cf7d2e32d3c70205d79a546ab612a7be0f62c3"},
 ]
 
 [package.dependencies]
@@ -1790,4 +1790,4 @@ dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "18c8d8802ede303b3a09ddbf7cbc76d0b64a3e037d969a1985213dc9014dc183"
+content-hash = "12324544c3e97d143b991fa81cfef87ba7ad1ea424732b037a20feba460faf99"

--- a/integrations/wiz/pyproject.toml
+++ b/integrations/wiz/pyproject.toml
@@ -1,12 +1,12 @@
 [tool.poetry]
 name = "wiz"
-version = "0.1.58"
+version = "0.1.59"
 description = "Wiz Port integration in Ocean"
 authors = ["Albert Luganga <albertluganga@getport.io>"]
 
 [tool.poetry.dependencies]
 python = "^3.11"
-port_ocean = {version = "^0.10.10", extras = ["cli"]}
+port_ocean = {version = "^0.10.11", extras = ["cli"]}
 
 [tool.poetry.group.dev.dependencies]
 # uncomment this if you want to debug the ocean core together with your integration

--- a/scripts/bump-all.sh
+++ b/scripts/bump-all.sh
@@ -1,51 +1,67 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Get the version argument from the command line
-VERSION="$1"
+SCRIPT_BASE="$(cd -P "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd -P "${SCRIPT_BASE}/../" && pwd)"
+CURRENT_DIR=$(pwd)
+VERSION="^$(cd "${ROOT_DIR}" && source ./.venv/bin/activate && poetry version --short)"
 
-if [ -z "$VERSION" ]; then
-    echo "Usage: $0 <version>"
-    exit 1
-fi
+echo "Going to bump ocean core to version ${VERSION} for all integrations"
 
 # Loop through each folder in the 'integrations' directory
-for folder in "$(pwd)"/integrations/*; do
-    if [ -d "$folder" ]; then
-        if [ ! -f "$folder"/pyproject.toml ]; then
-            continue
-        fi
-
-        echo "Bumping integration $folder"
-
-        echo "Run 'make install'"
-        (cd "$folder" && make install)
-
-        echo "Enter the Python virtual environment in the .venv folder"
-        (cd "$folder" && source .venv/bin/activate)
-
-        echo "Bump the version ocean version using Poetry"
-        (cd "$folder" && source .venv/bin/activate && poetry add port-ocean@$VERSION -E cli --no-cache)
-
-        echo "Run towncrier create"
-        (cd "$folder" && source .venv/bin/activate && towncrier create --content "Bumped ocean version to $VERSION" 1.improvement.md)
-        
-        echo "Run towncrier build"
-        current_version=$(cd $folder && source .venv/bin/activate && poetry version --short)
-
-        echo "Current version: $current_version, updating patch version"
-        IFS='.' read -ra version_components <<< "$current_version"
-
-        major_version="${version_components[0]}"
-        minor_version="${version_components[1]}"
-        patch_version="${version_components[2]}"
-
-        ((patch_version++))
-        new_version="$major_version.$minor_version.$patch_version"
-
-        (cd $folder && source .venv/bin/activate && poetry version "$new_version")
-        echo "New version: $new_version"
-        
-        echo "Run towncrier build to increment the patch version"
-        (cd "$folder" && source .venv/bin/activate && towncrier build --yes --version $new_version && rm changelog/1.improvement.md && git add . && echo "committing $(basename "$folder")" && git commit -m "Bumped ocean version to $VERSION for $(basename "$folder")")
+for FOLDER in "${ROOT_DIR}"/integrations/*; do
+    if [[ ! -d "${FOLDER}" || ! -f "${FOLDER}"/pyproject.toml ]]; then
+        continue
     fi
+
+    INTEGRATION=$(basename "${FOLDER}")
+
+    echo "Bumping integration ${INTEGRATION}"
+
+    cd "${FOLDER}" || return
+
+    echo "Run 'make install'"
+    make install
+
+    echo "Enter the Python virtual environment in the .venv folder"
+    source .venv/bin/activate
+
+    echo "Bump the version ocean version using Poetry"
+    poetry add "port-ocean@${VERSION}" -E cli --no-cache
+
+    echo "Run towncrier create"
+    towncrier create --content "Bumped ocean version to ${VERSION}" +random.improvement.md
+
+    echo "Run towncrier build"
+    CURRENT_VERSION=$(poetry version --short)
+
+    echo "Current version: ${CURRENT_VERSION}, updating patch version"
+    IFS='.' read -ra VERSION_COMPONENTS <<< "${CURRENT_VERSION}"
+
+    NON_NUMBER_ONLY='^[0-9]{1,}(.+)$'
+    NUMBER_ONLY='^[0-9]{1,}$'
+
+    MAJOR_VERSION="${VERSION_COMPONENTS[0]}"
+    MINOR_VERSION="${VERSION_COMPONENTS[1]}"
+    PATCH_VERSION="${VERSION_COMPONENTS[2]}"
+
+    if [[ ! ${PATCH_VERSION} =~ ${NUMBER_ONLY} && ${PATCH_VERSION} =~ ${NON_NUMBER_ONLY} ]]; then
+        echo "Found non release version ${CURRENT_VERSION}"
+        NON_NUMERIC=${BASH_REMATCH[1]}
+        ((PATCH_VERSION++))
+        PATCH_VERSION="${PATCH_VERSION}${NON_NUMERIC}"
+    else
+        ((PATCH_VERSION++))
+    fi
+    NEW_VERSION="${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION}"
+
+    poetry version "${NEW_VERSION}"
+    echo "New version: ${NEW_VERSION}"
+
+    echo "Run towncrier build to increment the patch version"
+    towncrier build --keep --version "${NEW_VERSION}" && rm changelog/*
+    git add poetry.lock pyproject.toml CHANGELOG.md
+    echo "Committing ${INTEGRATION}"
+    SKIP="trailing-whitespace,end-of-file-fixer" git commit -m "Bumped ocean version to ${VERSION} for ${INTEGRATION}"
+    deactivate
 done
+cd "${CURRENT_DIR}" || return


### PR DESCRIPTION
# Description

What - Bump ocean core to 0.10.11 for all integrations

In addition

- [x] **Fail on failing tests**
- [x] **Fix bump all versions to not remove beta/dev versions**
- [x] **Return fake to dev version and fix typo** 
- [x] **Update test code in Fake integration to use new fixtures**

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
