### PR TITLE
[Integration][SonarQube] Bug | 404 response when querying SonarQube issues

### DIFF
--- a/integrations/sonarqube/CHANGELOG.md
+++ b/integrations/sonarqube/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.105 (2024-10-29)
+
+
+### Bug Fixes
+
+- Fixed bug where issues/list API is not available for older SonarQube instance versions
+
+
 ## 0.1.104 (2024-10-23)
 
 

--- a/integrations/sonarqube/client.py
+++ b/integrations/sonarqube/client.py
@@ -46,7 +46,6 @@ class Endpoints:
 
 PAGE_SIZE = 100
 
-
 PORTFOLIO_VIEW_QUALIFIERS = ["VW", "SVW"]
 
 

--- a/integrations/sonarqube/client.py
+++ b/integrations/sonarqube/client.py
@@ -42,7 +42,6 @@ class Endpoints:
     ANALYSIS = "activity_feed/list"
     PORTFOLIO_DETAILS = "views/show"
     PORTFOLIOS = "views/list"
-    VERSION = "server/version"
 
 
 PAGE_SIZE = 100
@@ -337,7 +336,7 @@ class SonarQubeClient:
         """
         component_issues = []
         component_key = component.get("key")
-        query_params = {"componentKeys": component_key}
+        query_params = {"component": component_key}
 
         if api_query_params:
             query_params.update(api_query_params)

--- a/integrations/sonarqube/client.py
+++ b/integrations/sonarqube/client.py
@@ -368,8 +368,6 @@ class SonarQubeClient:
         if api_query_params:
             query_params.update(api_query_params)
 
-        logger.info(f"Endpoint path: {endpoint_path}")
-
         response = await self.send_paginated_api_request(
             endpoint=endpoint_path,
             data_key="issues",

--- a/integrations/sonarqube/client.py
+++ b/integrations/sonarqube/client.py
@@ -335,7 +335,11 @@ class SonarQubeClient:
         """
         component_issues = []
         component_key = component.get("key")
-        query_params = {"component": component_key}
+
+        if self.is_onpremise:
+            query_params = {"components": component_key}
+        else:
+            query_params = {"componentKeys": component_key}
 
         if api_query_params:
             query_params.update(api_query_params)

--- a/integrations/sonarqube/pyproject.toml
+++ b/integrations/sonarqube/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sonarqube"
-version = "0.1.104"
+version = "0.1.105"
 description = "SonarQube projects and code quality analysis integration"
 authors = ["Port Team <support@getport.io>"]
 


### PR DESCRIPTION
# Description

What - Fixed a bug where SonarQube instances lower than 10.2 report a 404 error when retrieving issues

Why - This is because the issues list API on SonarQube was introduced in 10.2 and also as an internal API

How - Checking for the integration version and choosing the right API based on the integration version

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [x] Integration able to create all default resources from scratch
- [x] Resync able to create entities
- [x] Resync able to update entities
- [x] Resync able to detect and delete entities
- [x] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots
![image](https://github.com/user-attachments/assets/9162bb91-71ec-4da1-9dad-b93fb14c75a0)

## API Documentation

[SonarQube issues list API](https://next.sonarqube.com/sonarqube/web_api/api/issues/list?internal=true)
