### PR TITLE
[Core] [Logging] | Integration logs not being ingested

### DIFF
--- a/integrations/gitlab/CHANGELOG.md
+++ b/integrations/gitlab/CHANGELOG.md
@@ -7,6 +7,16 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+0.1.136 (2024-11-05)
+===================
+
+### Bug Fixes
+
+- Await logger writing exception on exit (Integration logs not being ingested)
+- Await logger thread on exit (Integration logs not being ingested)
+- Sirealize exception (Integration logs not being ingested)
+
+
 0.1.135 (2024-10-31)
 ====================
 

--- a/port_ocean/clients/port/mixins/integrations.py
+++ b/port_ocean/clients/port/mixins/integrations.py
@@ -3,7 +3,8 @@ from urllib.parse import quote_plus
 
 import httpx
 from loguru import logger
-
+import copy
+from traceback import format_exception
 from port_ocean.clients.port.authentication import PortAuthentication
 from port_ocean.clients.port.utils import handle_status_code
 from port_ocean.log.sensetive import sensitive_log_filter
@@ -99,15 +100,24 @@ class IntegrationClientMixin:
         handle_status_code(response)
         return response.json()["integration"]
 
+    def sirealize_logs(self,logs: list[dict[str, Any]]):
+        _logs = copy.deepcopy(logs)
+        for log in _logs:
+            if 'extra' in log.keys() and 'exc_info' in log['extra'].keys() and isinstance(log['extra']['exc_info'],Exception):
+                sirealized_exception = ''.join(format_exception(log['extra']['exc_info']))
+                log['extra']['exc_info'] = sirealized_exception
+        return _logs
+
     async def ingest_integration_logs(self, logs: list[dict[str, Any]]) -> None:
         logger.debug("Ingesting logs")
+        sirealized_logs=self.sirealize_logs(logs)
         log_attributes = await self.get_log_attributes()
         headers = await self.auth.headers()
         response = await self.client.post(
             log_attributes["ingestUrl"],
             headers=headers,
             json={
-                "logs": logs,
+                "logs": sirealized_logs,
             },
         )
         handle_status_code(response, should_log=False)

--- a/port_ocean/log/logger_setup.py
+++ b/port_ocean/log/logger_setup.py
@@ -55,6 +55,7 @@ def _http_loguru_handler(level: LogLevelType) -> None:
     logger.configure(patcher=exception_deserializer)
 
     http_memory_handler = HTTPMemoryHandler()
+    signal_handler.register(http_memory_handler.wait_for_lingering_threads)
     signal_handler.register(http_memory_handler.flush)
 
     queue_listener = QueueListener(queue, http_memory_handler)

--- a/port_ocean/ocean.py
+++ b/port_ocean/ocean.py
@@ -123,6 +123,7 @@ class Ocean:
                 yield None
             except Exception:
                 logger.exception("Integration had a fatal error. Shutting down.")
+                logger.complete()
                 sys.exit("Server stopped")
             finally:
                 signal_handler.exit()


### PR DESCRIPTION
# Description

**What:**
- Fix logs not being ingested on integrations fails or exceptions.

**Why:**

- The logger flush method is spawning a new thread that is not awaited when the program exists.
- The logger accepts 'exc_info' that cannot be serialized.
- Upon shutdown of the program the logger writes a message that needs to be awaited in order to be sent to Port API.

**How:**
- Added method - 'wait_for_lingering_threads' to 'HTTPMemoryHandler' that will wait for running threads.
'wait_for_lingering_threads' is invoked via the 'SignalHandler' upon exit.
- Added method - 'serialize_logs' that will look for 'exc_info' in each log and serialize it using 'traceback'.
- Added call - 'logger.complete' so log that is sent on exit of program will be sent to Port API.

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
