### PR TITLE
[Core] Fix memory leak due to repetitive registration of FastAPI routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.13.1 (2024-11-12)
+
+
+### Bug Fixes
+
+- Fix memory leak due to repetitive registration of FastAPI routes
+
+
 ## 0.13.0 (2024-11-10)
 
 

--- a/integrations/fake-integration/main.py
+++ b/integrations/fake-integration/main.py
@@ -28,7 +28,9 @@ async def resync_persons(kind: str) -> List[Dict[Any, Any]]:
     return persons
 
 
+initialize_fake_routes()
+
+
 @ocean.on_start()
 async def on_start() -> None:
     print("Starting fake integration!")
-    initialize_fake_routes()

--- a/integrations/fake-integration/pyproject.toml
+++ b/integrations/fake-integration/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fake-integration"
-version = "0.1.14-dev"
+version = "0.1.15-dev"
 description = "A useless fake integration that helps us test the Ocean Core"
 authors = ["Erik Zaadi <erik@getport.io>"]
 

--- a/port_ocean/ocean.py
+++ b/port_ocean/ocean.py
@@ -114,7 +114,7 @@ class Ocean:
             )
             await repeated_function()
 
-    def initialize_app(self):
+    def initialize_app(self) -> None:
         self.fast_api_app.include_router(self.integration_router, prefix="/integration")
 
         @asynccontextmanager

--- a/port_ocean/ocean.py
+++ b/port_ocean/ocean.py
@@ -70,6 +70,8 @@ class Ocean:
             self.port_client, self.config.scheduled_resync_interval
         )
 
+        self.app_initialized = False
+
     def is_saas(self) -> bool:
         return self.config.runtime == Runtime.Saas
 
@@ -112,7 +114,7 @@ class Ocean:
             )
             await repeated_function()
 
-    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+    def initialize_app(self):
         self.fast_api_app.include_router(self.integration_router, prefix="/integration")
 
         @asynccontextmanager
@@ -129,4 +131,10 @@ class Ocean:
                 signal_handler.exit()
 
         self.fast_api_app.router.lifespan_context = lifecycle
+        self.app_initialized = True
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if not self.app_initialized:
+            self.initialize_app()
+
         await self.fast_api_app(scope, receive, send)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.13.0"
+version = "0.13.1"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What - Fix memory leak due to repetitive registration of FastAPI routes

Why - Constant memory leak when registering FastAPI routes

How - Run app setup just once

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [x] Integration able to create all default resources from scratch
- [x] Resync finishes successfully
- [x] Resync able to create entities
- [x] Resync able to update entities
- [x] Resync able to detect and delete entities
- [x] Scheduled resync able to abort existing resync and start a new one
- [x] Tested with at least 2 integrations from scratch
- [x] Tested with Kafka and Polling event listeners
- [x] Tested deletion of entities that don't pass the selector

