### PR TITLE
[Integration][Jira] Add `totalIssues` field to `project` kind

### DIFF
--- a/integrations/jira/.port/resources/blueprints.json
+++ b/integrations/jira/.port/resources/blueprints.json
@@ -11,6 +11,11 @@
           "type": "string",
           "format": "url",
           "description": "URL to the project in Jira"
+        },
+        "totalIssues": {
+          "title": "Total Issues",
+          "type": "number",
+          "description": "The total number of issues in the project"
         }
       }
     },
@@ -129,11 +134,6 @@
           "type": "string",
           "description": "The datetime the issue changed to a resolved state",
           "format": "date-time"
-        },
-        "totalIssues": {
-          "title": "Total Issues",
-          "type": "number",
-          "description": "The total number of issues in the project"
         }
       }
     },

--- a/integrations/jira/.port/resources/blueprints.json
+++ b/integrations/jira/.port/resources/blueprints.json
@@ -129,6 +129,11 @@
           "type": "string",
           "description": "The datetime the issue changed to a resolved state",
           "format": "date-time"
+        },
+        "totalIssues": {
+          "title": "Total Issues",
+          "type": "number",
+          "description": "The total number of issues in the project"
         }
       }
     },

--- a/integrations/jira/.port/resources/port-app-config.yaml
+++ b/integrations/jira/.port/resources/port-app-config.yaml
@@ -12,6 +12,7 @@ resources:
           blueprint: '"jiraProject"'
           properties:
             url: (.self | split("/") | .[:3] | join("/")) + "/projects/" + .key
+            totalIssues: .insight.totalIssueCount
 
   - kind: user
     selector:
@@ -52,7 +53,6 @@ resources:
             created: .fields.created
             updated: .fields.updated
             resolutionDate: .fields.resolutiondate
-            totalIssues: .insight.totalIssueCount
           relations:
             project: .fields.project.key
             parentIssue: .fields.parent.key

--- a/integrations/jira/.port/resources/port-app-config.yaml
+++ b/integrations/jira/.port/resources/port-app-config.yaml
@@ -52,6 +52,7 @@ resources:
             created: .fields.created
             updated: .fields.updated
             resolutionDate: .fields.resolutiondate
+            totalIssues: .insight.totalIssueCount
           relations:
             project: .fields.project.key
             parentIssue: .fields.parent.key

--- a/integrations/jira/CHANGELOG.md
+++ b/integrations/jira/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
-- Added a field to display total issues in a project (0.2.7)
+- Added a field to display total issues in a project
 
 
 ## 0.2.6 (2024-12-22)

--- a/integrations/jira/CHANGELOG.md
+++ b/integrations/jira/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.2.7 (2024-12-24)
+
+
+### Improvements
+
+- Added a field to display total issues in a project (0.2.7)
+
+
 ## 0.2.6 (2024-12-22)
 
 

--- a/integrations/jira/pyproject.toml
+++ b/integrations/jira/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jira"
-version = "0.2.6"
+version = "0.2.7"
 description = "Integration to bring information from Jira into Port"
 authors = ["Mor Paz <mor@getport.io>"]
 


### PR DESCRIPTION
# Description

What - Add `totalIssues` field to `project` kind

Why - To be able to know how many issues are in a project

How - By accessing the `.insight.totalIssueCount` property from the project response

## Type of change

Please leave one option from the following and delete the rest:

- [ ] New feature (non-breaking change which adds functionality)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
