### PR TITLE
[Core] JQ Mapping log enrichment - empty values support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.17.3 (2024-12-31)
+
+
+### Bug Fixes
+
+- Added support for empty values for JQ mapping logs
+- Added tests to assert for proper response when JQ is missmapped or values are empty
+
 ## 0.17.2 (2024-12-31)
 
 

--- a/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
+++ b/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
@@ -2,7 +2,7 @@ import asyncio
 from asyncio import Task
 from dataclasses import dataclass, field
 from functools import lru_cache
-from typing import Any, Optional, TypedDict
+from typing import Any, Optional
 import jq  # type: ignore
 from loguru import logger
 
@@ -34,14 +34,6 @@ class MappedEntity:
     did_entity_pass_selector: bool = False
     raw_data: Optional[dict[str, Any]] = None
     misconfigurations: dict[str, str] = field(default_factory=dict)
-
-
-@dataclass
-class EntityMappingFaultCounters(TypedDict):
-    """Helper class to collect entity mapping batch fault values like empty and none"""
-
-    empty_identifiers: int
-    empty_blueprints: int
 
 
 class JQEntityProcessor(BaseEntityProcessor):

--- a/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
+++ b/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
@@ -66,7 +66,7 @@ class JQEntityProcessor(BaseEntityProcessor):
         return inner
 
     @staticmethod
-    def _log_mapping_issues_identified(
+    def _notify_mapping_issues(
         entity_misconfigurations: dict[str, str],
         missing_required_fields: bool,
         entity_mapping_fault_counter: int,
@@ -292,11 +292,11 @@ class JQEntityProcessor(BaseEntityProcessor):
                     entity_mapping_fault_counter += 1
                 else:
                     logger.debug(
-                        f"Transformation failed, values verification for identifier: {result.entity.get("identifier")}, \
+                        f"Mapping failed, values verification for identifier: {result.entity.get("identifier")}, \
                                  for blueprint: {result.entity.get("blueprint")}"
                     )
 
-        self._log_mapping_issues_identified(
+        self._notify_mapping_issues(
             entity_misconfigurations,
             missing_required_fields,
             entity_mapping_fault_counter,

--- a/port_ocean/tests/core/handlers/entity_processor/test_jq_entity_processor.py
+++ b/port_ocean/tests/core/handlers/entity_processor/test_jq_entity_processor.py
@@ -340,9 +340,9 @@ class TestJQEntityProcessor:
         logger.remove(sink_id)
         logs_captured = stream.getvalue()
 
-        assert "identifier: 1, blueprint: 1" in logs_captured
+        assert "2 transformations of batch failed due to empty values" in logs_captured
         assert (
             "{'blueprint': '.bar', 'identifier': '.foo'} (null, missing, or misconfigured)"
             in logs_captured
         )
-        assert "identifier: 0, blueprint: 1" in logs_captured
+        assert "1 transformations of batch failed due to empty values" in logs_captured

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.17.2"
+version = "0.17.3"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What -
added test and support for use-case of empty string of identifier/blueprint values, 
added debug log to validate the identifier and blueprint values
Why -
I've identified that there are 2 main use-cases for us to log the details about, for null, missing and / or mis configured values
AND for empty strings. 
the empty string is not a "wrong / misconfigured" value for JQ, but it is a non valid identifier. 
current logs were missing this details and were not clear enough
also added example on how to assert on logs
How -
added tests and validations following logs investigations

```
raw_results: list[dict[Any, Any]] = [
            {"foo": "", "bar": "bluePrintMapped"},
            {"foo": "identifierMapped", "bar": ""},
        ]
        result = await mocked_processor._parse_items(mapping, raw_results)
        assert "identifier" not in result.misonfigured_entity_keys
        assert "blueprint" not in result.misonfigured_entity_keys

        raw_results = [
            {"foo": "identifierMapped", "bar": None},
            {"foo": None, "bar": ""},
        ]
        result = await mocked_processor._parse_items(mapping, raw_results)
        assert result.misonfigured_entity_keys == {
            "identifier": ".foo",
            "blueprint": ".bar",
        }
```

tests now pass values with empty strings and None, tests validate proper logs and make sure to output the relevant details with an additional counter for the empty values. 
expected to see a batch of 100 with 65 empty values and only 35 upserted. 


new logs text example (picture below): 
```
port_ocean/tests/core/handlers/entity_processor/test_jq_entity_processor.py::TestJQEntityProcessor::test_parse_items_empty_required 2025-01-01 15:54:09.083 | INFO     | port_ocean.core.handlers.entity_processor.jq_entity_processor:_parse_items:256 - Parsing 2 raw results into entities
2025-01-01 15:54:09.083 | DEBUG    | port_ocean.utils.queue_utils:_start_processor_worker:21 - Processing async task
2025-01-01 15:54:09.084 | DEBUG    | port_ocean.utils.queue_utils:_start_processor_worker:21 - Processing async task
2025-01-01 15:54:09.088 | DEBUG    | port_ocean.core.handlers.entity_processor.jq_entity_processor:_parse_items:267 - Finished parsing raw results into entities with 0 errors. errors: []
2025-01-01 15:54:09.089 | INFO     | port_ocean.core.handlers.entity_processor.jq_entity_processor:_log_mapping_issues_identified:88 - 2 transformations of batch failed due to empty values
2025-01-01 15:54:09.089 | INFO     | port_ocean.core.handlers.entity_processor.jq_entity_processor:_parse_items:256 - Parsing 2 raw results into entities
2025-01-01 15:54:09.089 | DEBUG    | port_ocean.utils.queue_utils:_start_processor_worker:21 - Processing async task
2025-01-01 15:54:09.089 | DEBUG    | port_ocean.utils.queue_utils:_start_processor_worker:21 - Processing async task
2025-01-01 15:54:09.090 | DEBUG    | port_ocean.core.handlers.entity_processor.jq_entity_processor:_parse_items:267 - Finished parsing raw results into entities with 0 errors. errors: []
2025-01-01 15:54:09.090 | DEBUG    | port_ocean.core.handlers.entity_processor.jq_entity_processor:_parse_items:298 - Transformation failed, values verification for identifier: identifierMapped,                                  for blueprint: None
2025-01-01 15:54:09.090 | INFO     | port_ocean.core.handlers.entity_processor.jq_entity_processor:_log_mapping_issues_identified:84 - Unable to find valid data for: {'blueprint': '.bar', 'identifier': '.foo'} (null, missing, or misconfigured)
2025-01-01 15:54:09.090 | INFO     | port_ocean.core.handlers.entity_processor.jq_entity_processor:_log_mapping_issues_identified:88 - 1 transformations of batch failed due to empty values
```
![Screenshot 2025-01-01 at 15 54 16](https://github.com/user-attachments/assets/d3f886a2-5d81-416c-81bd-3ed772c35b50)


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)