### PR TITLE
[Core] Fix event handling when using `register_raw` and `unregister_raw`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.17.6 (2025-01-08)
+
+### Bug Fixes
+
+- Fixed a bug where the `unregister_raw` and `register_raw` were not handling right the errors and misconfigured entity keys
+
+
 ## 0.17.5 (2025-01-07)
 
 

--- a/port_ocean/core/integrations/mixins/sync_raw.py
+++ b/port_ocean/core/integrations/mixins/sync_raw.py
@@ -245,7 +245,7 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
         if not resource_mappings:
             return []
 
-        diffs, errors = zip(
+        diffs, errors, misconfigured_entity_keys = zip(
             *await asyncio.gather(
                 *(
                     self._register_resource_raw(
@@ -258,6 +258,7 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
 
         diffs = list(diffs)
         errors = sum(errors, [])
+        misconfigured_entity_keys = sum(misconfigured_entity_keys, [])
 
         if errors:
             message = f"Failed to register {len(errors)} entities. Skipping delete phase due to incomplete state"
@@ -321,7 +322,7 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
             resource for resource in config.resources if resource.kind == kind
         ]
 
-        entities, errors = zip_and_sum(
+        entities, errors, misconfigured_entity_keys = zip_and_sum(
             await asyncio.gather(
                 *(
                     self._unregister_resource_raw(resource, results, user_agent_type)

--- a/port_ocean/core/integrations/mixins/sync_raw.py
+++ b/port_ocean/core/integrations/mixins/sync_raw.py
@@ -121,7 +121,6 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
         parse_all: bool = False,
         send_raw_data_examples_amount: int = 0,
     ) -> list[CalculationResult]:
-        print(f"!!!!!!! raw diff {raw_diff}")
         return await asyncio.gather(
             *(
                 self.entity_processor.parse_items(
@@ -259,11 +258,9 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
         )
 
         diffs = list(diffs)
-        print(f"!!!!!!! {diffs}")
         errors = sum(errors, [])
-        print(f"!!!!!!! {errors}")
         misconfigured_entity_keys = list(misconfigured_entity_keys)
-        print(f"!!!!!!! {misconfigured_entity_keys}")
+
 
         if errors:
             message = f"Failed to register {len(errors)} entities. Skipping delete phase due to incomplete state"

--- a/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
+++ b/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
@@ -164,6 +164,14 @@ def mock_sync_raw_mixin(
     return sync_raw_mixin
 
 
+@pytest.fixture
+def mock_sync_raw_mixin_with_jq_processor(
+    mock_sync_raw_mixin: SyncRawMixin,
+) -> SyncRawMixin:
+    mock_sync_raw_mixin._entity_processor = JQEntityProcessor(mock_context)  # type: ignore
+    return mock_sync_raw_mixin
+
+
 @asynccontextmanager
 async def no_op_event_context(
     existing_event: EventContext,
@@ -398,3 +406,147 @@ async def test_sync_raw_mixin_dependency(
                     "entity_3-entity_1-entity_4-entity_2-entity_5",
                     "entity_3-entity_1-entity_4-entity_5-entity_2",
                 )
+
+
+@pytest.mark.asyncio
+async def test_register_raw(
+    mock_sync_raw_mixin_with_jq_processor: SyncRawMixin, mock_ocean: Ocean
+) -> None:
+    kind = "service"
+    user_agent_type = UserAgentType.exporter
+    raw_entity = [
+        {"id": "entity_1", "name": "entity_1", "web_url": "https://example.com"},
+    ]
+    expected_result = [
+        {
+            "identifier": "entity_1",
+            "blueprint": "service",
+            "name": "entity_1",
+            "properties": {"url": "https://example.com"},
+        },
+    ]
+
+    async with event_context(EventType.RESYNC, trigger_type="machine") as event:
+        # Use patch to mock the method instead of direct assignment
+        with patch.object(
+            mock_sync_raw_mixin_with_jq_processor.port_app_config_handler,
+            "get_port_app_config",
+            return_value=PortAppConfig(
+                enable_merge_entity=True,
+                delete_dependent_entities=True,
+                create_missing_related_entities=False,
+                resources=[
+                    ResourceConfig(
+                        kind=kind,
+                        selector=Selector(query="true"),
+                        port=PortResourceConfig(
+                            entity=MappingsConfig(
+                                mappings=EntityMapping(
+                                    identifier=".id | tostring",
+                                    title=".name",
+                                    blueprint='"service"',
+                                    properties={"url": ".web_url"},
+                                    relations={},
+                                )
+                            )
+                        ),
+                    )
+                ],
+            ),
+        ):
+            # Ensure the event.port_app_config is set correctly
+            event.port_app_config = await mock_sync_raw_mixin_with_jq_processor.port_app_config_handler.get_port_app_config(
+                use_cache=False
+            )
+
+            def upsert_side_effect(
+                entities: list[Entity], user_agent_type: UserAgentType
+            ) -> list[Entity]:
+                # Simulate returning the passed entities
+                return entities
+
+            # Patch the upsert method with the side effect
+            with patch.object(
+                mock_sync_raw_mixin_with_jq_processor.entities_state_applier,
+                "upsert",
+                side_effect=upsert_side_effect,
+            ):
+                # Call the register_raw method
+                registered_entities = (
+                    await mock_sync_raw_mixin_with_jq_processor.register_raw(
+                        kind, raw_entity, user_agent_type
+                    )
+                )
+
+                # Assert that the registered entities match the expected results
+                assert len(registered_entities) == len(expected_result)
+                for entity, result in zip(registered_entities, expected_result):
+                    assert entity.identifier == result["identifier"]
+                    assert entity.blueprint == result["blueprint"]
+                    assert entity.properties == result["properties"]
+
+
+@pytest.mark.asyncio
+async def test_unregister_raw(
+    mock_sync_raw_mixin_with_jq_processor: SyncRawMixin, mock_ocean: Ocean
+) -> None:
+    kind = "service"
+    user_agent_type = UserAgentType.exporter
+    raw_entity = [
+        {"id": "entity_1", "name": "entity_1", "web_url": "https://example.com"},
+    ]
+    expected_result = [
+        {
+            "identifier": "entity_1",
+            "blueprint": "service",
+            "name": "entity_1",
+            "properties": {"url": "https://example.com"},
+        },
+    ]
+
+    async with event_context(EventType.RESYNC, trigger_type="machine") as event:
+        # Use patch to mock the method instead of direct assignment
+        with patch.object(
+            mock_sync_raw_mixin_with_jq_processor.port_app_config_handler,
+            "get_port_app_config",
+            return_value=PortAppConfig(
+                enable_merge_entity=True,
+                delete_dependent_entities=True,
+                create_missing_related_entities=False,
+                resources=[
+                    ResourceConfig(
+                        kind=kind,
+                        selector=Selector(query="true"),
+                        port=PortResourceConfig(
+                            entity=MappingsConfig(
+                                mappings=EntityMapping(
+                                    identifier=".id | tostring",
+                                    title=".name",
+                                    blueprint='"service"',
+                                    properties={"url": ".web_url"},
+                                    relations={},
+                                )
+                            )
+                        ),
+                    )
+                ],
+            ),
+        ):
+            # Ensure the event.port_app_config is set correctly
+            event.port_app_config = await mock_sync_raw_mixin_with_jq_processor.port_app_config_handler.get_port_app_config(
+                use_cache=False
+            )
+
+            # Call the unregister_raw method
+            unregistered_entities = (
+                await mock_sync_raw_mixin_with_jq_processor.unregister_raw(
+                    kind, raw_entity, user_agent_type
+                )
+            )
+
+            # Assert that the unregistered entities match the expected results
+            assert len(unregistered_entities) == len(expected_result)
+            for entity, result in zip(unregistered_entities, expected_result):
+                assert entity.identifier == result["identifier"]
+                assert entity.blueprint == result["blueprint"]
+                assert entity.properties == result["properties"]

--- a/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
+++ b/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
@@ -426,7 +426,7 @@ async def test_register_raw(
         },
     ]
 
-    async with event_context(EventType.RESYNC, trigger_type="machine") as event:
+    async with event_context(EventType.HTTP_REQUEST, trigger_type="machine") as event:
         # Use patch to mock the method instead of direct assignment
         with patch.object(
             mock_sync_raw_mixin_with_jq_processor.port_app_config_handler,
@@ -504,7 +504,7 @@ async def test_unregister_raw(
         },
     ]
 
-    async with event_context(EventType.RESYNC, trigger_type="machine") as event:
+    async with event_context(EventType.HTTP_REQUEST, trigger_type="machine") as event:
         # Use patch to mock the method instead of direct assignment
         with patch.object(
             mock_sync_raw_mixin_with_jq_processor.port_app_config_handler,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.17.5"
+version = "0.17.6"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What - Fixed a bug effecting live events handling

Why - There was a bug in the `register_raw` and `unregister_raw` that didn't handle correctly the response type from the `_register_resource_raw` and `_unregister_resource_raw` response which was changed in #1265 

How - Added handling for that new response type and added tests

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
