### PR TITLE
Add Service Metric and SLO History to DD Integration

### DIFF
--- a/integrations/datadog/.port/resources/blueprints.json
+++ b/integrations/datadog/.port/resources/blueprints.json
@@ -436,5 +436,113 @@
     "mirrorProperties": {},
     "calculationProperties": {},
     "relations": {}
+  },
+  {
+  "identifier": "datadogServiceMetric",
+  "description": "This blueprint represents a Datadog service metric",
+  "title": "Datadog Service Metric",
+  "icon": "Datadog",
+  "schema": {
+    "properties": {
+      "query": {
+        "type": "string",
+        "title": "Query",
+        "description": "The Datadog query used to retrieve this metric"
+      },
+      "series": {
+        "type": "array",
+        "title": "Series",
+        "description": "Array containing detailed information about the metric series"
+      },
+      "res_type": {
+        "type": "string",
+        "title": "Response Type",
+        "description": "The type of response from the Datadog API"
+      },
+      "from_date": {
+        "type": "string",
+        "format": "date-time",
+        "title": "From Date",
+        "description": "Unix timestamp of the start of the queried time period"
+      },
+      "to_date": {
+        "type": "string",
+        "format": "date-time",
+        "title": "To Date",
+        "description": "Unix timestamp of the end of the queried time period"
+      },
+      "env": {
+        "type": "string",
+        "title": "Environment",
+        "description": "The environment of the service"
+      }
+    },
+    "required": []
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {},
+  "relations": {
+    "service": {
+      "title": "Service",
+      "description": "The service associated with this query",
+      "target": "datadogService",
+      "required": false,
+      "many": false
+    }
   }
+}, 
+  {
+  "identifier": "datadogSloHistory",
+  "description": "This blueprint represents a datadog SLO history",
+  "title": "Datadog SLO History",
+  "icon": "Datadog",
+  "schema": {
+    "properties": {
+      "monitor_type": {
+        "icon": "DefaultProperty",
+        "title": "Type",
+        "type": "string"
+      },
+      "sliValue": {
+        "icon": "DefaultProperty",
+        "title": "SLI Value",
+        "type": "number"
+      },
+      "sampling_start_date": {
+        "icon": "DefaultProperty",
+        "type": "string",
+        "title": "Sampling Start Date",
+        "format": "date-time"
+      },
+      "sampling_end_date": {
+        "icon": "DefaultProperty",
+        "type": "string",
+        "title": "Sampling End Date",
+        "format": "date-time"
+      }
+    },
+    "required": []
+  },
+  "mirrorProperties": {
+    "slo_target": {
+      "title": "SLO Target",
+      "path": "slo.targetThreshold"
+    },
+    "slo_warning_threshold": {
+      "title": "SLO Warning Threshold",
+      "path": "slo.warningThreshold"
+    }
+  },
+  "calculationProperties": {},
+  "aggregationProperties": {},
+  "relations": {
+    "slo": {
+      "title": "SLO",
+      "description": "The SLO to which this history belongs to",
+      "target": "datadogSlo",
+      "required": false,
+      "many": false
+    }
+  }
+}
 ]

--- a/integrations/datadog/.port/resources/port-app-config.yaml
+++ b/integrations/datadog/.port/resources/port-app-config.yaml
@@ -1,6 +1,25 @@
 deleteDependentEntities: true
 createMissingRelatedEntities: true
+enableMergeEntity: true
 resources:
+  - kind: sloHistory
+    selector:
+      query: 'true'
+      timeframe: 7
+      periodOfTimeInMonths: 6
+    port:
+      entity:
+        mappings:
+          identifier: .slo.id | tostring
+          title: .slo.name
+          blueprint: '"datadogSloHistory"'
+          properties:
+            monitory_type: .type
+            sampling_start_date: .from_ts | todate
+            sampling_end_date: .to_ts | todate
+            sliValue: .overall.sli_value
+          relations:
+            slo: .slo.id
   - kind: user
     selector:
       query: 'true'
@@ -20,7 +39,7 @@ resources:
   - kind: team
     selector:
       query: 'true'
-      includeMembers: 'true'
+      includeMembers: true
     port:
       entity:
         mappings:
@@ -35,16 +54,15 @@ resources:
             createdAt: .attributes.created_at | todate
           relations:
             members: if .__members then .__members[].id else [] end
-
   - kind: host
     selector:
-      query: "true"
+      query: 'true'
     port:
       entity:
         mappings:
-          blueprint: '"datadogHost"'
           identifier: .id | tostring
           title: .aws_name // .host_name
+          blueprint: '"datadogHost"'
           properties:
             up: .up
             host_name: .host_name
@@ -58,7 +76,7 @@ resources:
             tags: .tags_by_source
   - kind: monitor
     selector:
-      query: "true"
+      query: 'true'
     port:
       entity:
         mappings:
@@ -76,7 +94,7 @@ resources:
             updatedAt: .modified
   - kind: service
     selector:
-      query: "true"
+      query: 'true'
     port:
       entity:
         mappings:
@@ -102,7 +120,7 @@ resources:
                   value: .attributes.schema.team
   - kind: slo
     selector:
-      query: "true"
+      query: 'true'
     port:
       entity:
         mappings:
@@ -131,9 +149,9 @@ resources:
     port:
       entity:
         mappings:
-          blueprint: '"datadogCloudResource"'
           identifier: .id | tostring
           title: .aws_name // .host_name
+          blueprint: '"datadogCloudResource"'
           properties:
             up: .up
             host_name: .host_name
@@ -145,3 +163,57 @@ resources:
             cpu_cores: .meta.cpuCores
             agent_version: .meta.agent_version
             tags: .tags_by_source
+  - kind: serviceMetric
+    selector:
+      query: 'true'
+      datadogSelector:
+        metric: avg:system.mem.used
+        env:
+          tag: env
+          value: '*'
+        service:
+          tag: servicename
+          value: '*'
+        timeframe: 10
+    port:
+      entity:
+        mappings:
+          blueprint: '"datadogServiceMetric"'
+          identifier: .__query_id
+          title: .query
+          properties:
+            query: .__query
+            series: .series
+            res_type: .res_type
+            from_date: .from_date / 1000 | todate
+            to_date: .to_date / 1000 | todate
+            env: .__env
+          relations:
+            service: .__service
+  - kind: serviceMetric
+    selector:
+      query: 'true'
+      datadogSelector:
+        metric: avg:system.disk.used
+        env:
+          tag: env
+          value: prod
+        service:
+          tag: servicename
+          value: '*'
+        timeframe: 5
+    port:
+      entity:
+        mappings:
+          blueprint: '"datadogServiceMetric"'
+          identifier: .__query_id
+          title: .query
+          properties:
+            query: .__query
+            series: .series
+            res_type: .res_type
+            from_date: .from_date / 1000 | todate
+            to_date: .to_date / 1000 | todate
+            env: .__env
+          relations:
+            service: .__service


### PR DESCRIPTION
# Description


What -
This PR adds out of the box resource blueprints and mappings for SLO History and Service Metric entities. Note this will only work for Ocean, not for the Port hosted integration. I recommend the engineering team consider making this default for that integration setup as well.

Why -
Currently, the documentation lists both Service Metric and SLO History as [supported resources](https://docs.port.io/build-your-software-catalog/sync-data-to-catalog/apm-alerting/datadog/#supported-resources). There isn't, however, any indication that these require additional configuration via a blueprint and resource mapping. 

How -
blueprints.json and port-app-config.yaml are updated for the Datadog integration for Ocean. 

## Type of change

Please leave one option from the following and delete the rest:

- [ X] Bug fix (non-breaking change which fixes an issue)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
