### PR TITLE
[Core] Fixed query to make the search easier on port's side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.18.1 (2025-01-21)
+
+### Improvements
+
+- Updated the search entitites query sent to port with blueprint
+
 ## 0.18.0 (2025-01-15)
 
 ### Improvements

--- a/port_ocean/core/integrations/mixins/sync_raw.py
+++ b/port_ocean/core/integrations/mixins/sync_raw.py
@@ -137,7 +137,7 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
             entities (list[Entity]): List of entities to search for.
 
         Returns:
-            dict: Query structure for searching entities by identifier.
+            dict: Query structure for searching entities by identifier and blueprint.
         """
         return {
             "combinator": "and",
@@ -147,10 +147,14 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                     "rules": [
                         {
                             "property": "$identifier",
+                            "operator": "in",
+                            "value": [entity.identifier for entity in entities],
+                        },
+                        {
+                            "property": "$blueprint",
                             "operator": "=",
-                            "value": entity.identifier,
+                            "value": entities[0].blueprint,
                         }
-                        for entity in entities
                     ]
                 }
             ]
@@ -221,7 +225,7 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
         )
         modified_objects = []
 
-        if ocean.app.is_saas():
+        if not ocean.app.is_saas():
             try:
                 changed_entities = await self._map_entities_compared_with_port(
                     objects_diff[0].entity_selector_diff.passed,

--- a/port_ocean/core/integrations/mixins/sync_raw.py
+++ b/port_ocean/core/integrations/mixins/sync_raw.py
@@ -225,7 +225,7 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
         )
         modified_objects = []
 
-        if not ocean.app.is_saas():
+        if ocean.app.is_saas():
             try:
                 changed_entities = await self._map_entities_compared_with_port(
                     objects_diff[0].entity_selector_diff.passed,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.18.0"
+version = "0.18.1"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What - improvements to reduce port's load

Why - to make the query easier for port

How - added blueprint to the search query

## Type of change

Please leave one option from the following and delete the rest:

- [ ] New feature (non-breaking change which adds functionality)



### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector



