### PR TITLE
[Core] Added flag to destroy integration config while running clean defaults cli command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.18.9 (2025-02-07)
+
+### Improvements
+
+- Added option to destroy integration config while performing defaults clean cli command: `ocean defaults clean --force --wait --destroy`
+
 ## 0.18.8 (2025-02-04)
 
 ### Bug Fixes

--- a/port_ocean/cli/commands/defaults/clean.py
+++ b/port_ocean/cli/commands/defaults/clean.py
@@ -8,6 +8,7 @@ from port_ocean.cli.commands.main import print_logo, console
 from port_ocean.core.defaults import clean_defaults
 from port_ocean.ocean import Ocean
 from port_ocean.utils.misc import load_module
+from port_ocean.utils.signal import init_signal_handler
 from .group import defaults
 
 
@@ -27,12 +28,20 @@ from .group import defaults
     is_flag=True,
     help="Wait for the migration to finish. when force is set to true.",
 )
-def clean(path: str, force: bool, wait: bool) -> None:
+@click.option(
+    "-d",
+    "--destroy",
+    "destroy",
+    is_flag=True,
+    help="Destroy the integration after cleaning the defaults.",
+)
+def clean(path: str, force: bool, wait: bool, destroy: bool) -> None:
     """
     Clean defaults of the integration from the .port/resources PATH.
 
     PATH: Path to the integration. If not provided, the current directory will be used.
     """
+    init_signal_handler()
     print_logo()
 
     console.print("Cleaning blueprints and configurations! ⚓️")
@@ -52,5 +61,9 @@ def clean(path: str, force: bool, wait: bool) -> None:
     )
 
     clean_defaults(
-        app.integration.AppConfigHandlerClass.CONFIG_CLASS, app.config, force, wait
+        app.integration.AppConfigHandlerClass.CONFIG_CLASS,
+        app.config,
+        force,
+        wait,
+        destroy,
     )

--- a/port_ocean/clients/port/mixins/integrations.py
+++ b/port_ocean/clients/port/mixins/integrations.py
@@ -178,3 +178,18 @@ class IntegrationClientMixin:
         )
         handle_status_code(response, should_log=should_log)
         logger.debug(f"Examples for kind {kind} successfully ingested")
+
+    async def _delete_current_integration(self) -> httpx.Response:
+        logger.info(f"Deleting integration with id: {self.integration_identifier}")
+        response = await self.client.delete(
+            f"{self.auth.api_url}/integration/{self.integration_identifier}",
+            headers=await self.auth.headers(),
+        )
+        return response
+
+    async def delete_current_integration(
+        self, should_raise: bool = True, should_log: bool = True
+    ) -> dict[str, Any]:
+        response = await self._delete_current_integration()
+        handle_status_code(response, should_raise, should_log)
+        return response.json()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.18.8"
+version = "0.18.9"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description  

What  
- Added support for complete removal of an integration in the `ocean defaults clean` command.
- Introduced a new flag `--destroy` to enable full deletion of the integration

Why  
- Previously, the command only cleaned up the default blueprint and associated data but did not allow full removal.
- This enhancement provides users with a way to completely delete an integration during development

How  
- Updated the command logic to handle the `--destroy` flag.
- Ensured `--destroy` removes all integration-related configurations.


## Type of change

Please leave one option from the following and delete the rest:

- [x] New feature (non-breaking change which adds functionality)

<h4> All tests should be run against the port production environment (using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
