### PR TITLE
[Core] Fix `ocean new` on Unix-like systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.19.1 (2025-02-24)
+
+
+### Bug Fixes
+
+- Fixed `ocean new` on Unix-like systems failing with `FileNotFoundError` (#1402)
+
+
 ## 0.19.0 (2025-02-16)
 
 ### Features

--- a/changelog/1402.bugfix
+++ b/changelog/1402.bugfix
@@ -1,1 +1,0 @@
-Fixed `ocean new` on Unix-like systems failing with `FileNotFoundError`

--- a/changelog/1402.bugfix
+++ b/changelog/1402.bugfix
@@ -1,0 +1,1 @@
+Fixed `ocean new` on Unix-like systems failing with `FileNotFoundError`

--- a/port_ocean/cli/cookiecutter/hooks/post_gen_project.py
+++ b/port_ocean/cli/cookiecutter/hooks/post_gen_project.py
@@ -8,7 +8,7 @@ def handle_private_integration_flags():
     )
     root_dir = os.path.join("{{ cookiecutter._repo_dir }}", "../../../")
     infra_make_file = os.path.join(root_dir, "integrations/_infra/Makefile")
-    infra_dockerfile = os.path.join(root_dir, "integrations/_infra/Dockerfile.deb")
+    infra_dockerfile = os.path.join(root_dir, "integrations/_infra/Dockerfile.Deb")
     infra_dockerignore = os.path.join(
         root_dir, "integrations/_infra/Dockerfile.dockerignore"
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.19.0"
+version = "0.19.1"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
### **User description**
# Description

The `ocean new` command was failing with a `FileNotFoundError` when trying to copy the `Dockerfile.Deb` file, due to a typo in this filename. This was probably masked on Windows systems where filenames are generally case-insensitive.

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

Testing checklists etc. are N/A (change only affects cookiecutter)


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed a typo in the filename `Dockerfile.Deb`.

- Resolved `FileNotFoundError` in `ocean new` command.

- Ensured compatibility on Unix-like systems with case-sensitive filesystems.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>post_gen_project.py</strong><dd><code>Corrected filename typo in `post_gen_project.py`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

port_ocean/cli/cookiecutter/hooks/post_gen_project.py

<li>Corrected the filename from <code>Dockerfile.deb</code> to <code>Dockerfile.Deb</code>.<br> <li> Fixed a case-sensitivity issue causing errors on Unix-like systems.


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1402/files#diff-61501843cdb62d9c060571deef883835c29a01e9500c082980918dfee344d543">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>