### PR TITLE
[Core] Added base_url to core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Features
 
-- Added new `webhook_base_url` to Ocean Core.
+- Added new `base_url` to Ocean Core. This will be used to deprecate the `OCEAN__INTEGRATION__CONFIG__APP_HOST` usage.
 
 ## 0.19.2 (2025-02-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.19.3 (2025-02-19)
+
+### Features
+
+- Added new `webhook_base_url` to ocean core.
+
 ## 0.19.2 (2025-02-19)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Features
 
-- Added new `webhook_base_url` to ocean core.
+- Added new `webhook_base_url` to Ocean Core.
 
 ## 0.19.2 (2025-02-19)
 

--- a/port_ocean/config/settings.py
+++ b/port_ocean/config/settings.py
@@ -72,7 +72,7 @@ class IntegrationConfiguration(BaseOceanSettings, extra=Extra.allow):
     create_port_resources_origin: CreatePortResourcesOrigin | None = None
     send_raw_data_examples: bool = True
     oauth_access_token_file_path: str | None = None
-    webhook_base_url: str | None = None
+    base_url: str | None = None
     port: PortSettings
     event_listener: EventListenerSettingsType = Field(
         default=cast(EventListenerSettingsType, {"type": "POLLING"})

--- a/port_ocean/config/settings.py
+++ b/port_ocean/config/settings.py
@@ -72,6 +72,7 @@ class IntegrationConfiguration(BaseOceanSettings, extra=Extra.allow):
     create_port_resources_origin: CreatePortResourcesOrigin | None = None
     send_raw_data_examples: bool = True
     oauth_access_token_file_path: str | None = None
+    webhook_base_url: str | None = None
     port: PortSettings
     event_listener: EventListenerSettingsType = Field(
         default=cast(EventListenerSettingsType, {"type": "POLLING"})

--- a/port_ocean/ocean.py
+++ b/port_ocean/ocean.py
@@ -119,15 +119,15 @@ class Ocean:
             await repeated_function()
 
     @property
-    def webhook_base_url(self) -> str:
+    def base_url(self) -> str:
         integration_config = self.config.integration.config
         if isinstance(integration_config, BaseModel):
             integration_config = integration_config.dict()
         if integration_config.get("app_host"):
             logger.warning(
-                "The OCEAN__INTEGRATION__CONFIG__APP_HOST field is deprecated. Please use the OCEAN__WEBHOOK_BASE_URL field instead."
+                "The OCEAN__INTEGRATION__CONFIG__APP_HOST field is deprecated. Please use the OCEAN__BASE_URL field instead."
             )
-        return self.config.webhook_base_url or integration_config.get("app_host")
+        return self.config.base_url or integration_config.get("app_host")
 
     def load_external_oauth_access_token(self) -> str | None:
         if self.config.oauth_access_token_file_path is not None:
@@ -148,7 +148,7 @@ class Ocean:
         async def lifecycle(_: FastAPI) -> AsyncIterator[None]:
             try:
                 await self.integration.start()
-                if self.webhook_base_url:
+                if self.base_url:
                     await self.webhook_manager.start_processing_event_messages()
                 await self._setup_scheduled_resync()
                 yield None

--- a/port_ocean/ocean.py
+++ b/port_ocean/ocean.py
@@ -150,6 +150,8 @@ class Ocean:
                 await self.integration.start()
                 if self.base_url:
                     await self.webhook_manager.start_processing_event_messages()
+                else:
+                    logger.warning("No base URL provided, skipping webhook processing")
                 await self._setup_scheduled_resync()
                 yield None
             except Exception:

--- a/port_ocean/ocean.py
+++ b/port_ocean/ocean.py
@@ -118,6 +118,17 @@ class Ocean:
             )
             await repeated_function()
 
+    @property
+    def webhook_base_url(self) -> str:
+        integration_config = self.config.integration.config
+        if isinstance(integration_config, BaseModel):
+            integration_config = integration_config.dict()
+        if integration_config.get("app_host"):
+            logger.warning(
+                "The OCEAN__INTEGRATION__CONFIG__APP_HOST field is deprecated. Please use the OCEAN__WEBHOOK_BASE_URL field instead."
+            )
+        return self.config.webhook_base_url or integration_config.get("app_host")
+
     def load_external_oauth_access_token(self) -> str | None:
         if self.config.oauth_access_token_file_path is not None:
             try:
@@ -137,7 +148,8 @@ class Ocean:
         async def lifecycle(_: FastAPI) -> AsyncIterator[None]:
             try:
                 await self.integration.start()
-                await self.webhook_manager.start_processing_event_messages()
+                if self.webhook_base_url:
+                    await self.webhook_manager.start_processing_event_messages()
                 await self._setup_scheduled_resync()
                 yield None
             except Exception:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.19.2"
+version = "0.19.3"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
### **User description**
# Description

What - Added a new base_url variable to core

Why - allow us to deprecate the app_host usage and to standardize naming to core

How - added new variable to ocean config

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.


___

### **PR Type**
Enhancement


___

### **Description**
- Introduced `webhook_base_url` to replace `app_host`.

- Added deprecation warning for `app_host` usage.

- Updated lifecycle logic to conditionally start webhook processing.

- Updated version and changelog to reflect changes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>settings.py</strong><dd><code>Added `webhook_base_url` configuration field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

port_ocean/config/settings.py

- Added `webhook_base_url` as a new configuration field.


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1411/files#diff-c4ab144128bdbbe50dd95b726ae9c2f4cbc7306025e07a9e1db3dff7c5d4b3bb">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ocean.py</strong><dd><code>Added `webhook_base_url` property and lifecycle updates</code>&nbsp; &nbsp; </dd></summary>
<hr>

port_ocean/ocean.py

<li>Implemented <code>webhook_base_url</code> property with fallback to <code>app_host</code>.<br> <li> Added deprecation warning for <code>app_host</code> usage.<br> <li> Modified lifecycle to conditionally start webhook processing.


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1411/files#diff-c8b6a91b406bdc777f220ab2fcead0b5027c8817c7c2e2e7adb06c192cc95ad6">+13/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Updated changelog for version 0.19.3</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

- Documented addition of `webhook_base_url` in version 0.19.3.


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1411/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Updated project version to 0.19.3</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

- Bumped version to 0.19.3.


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1411/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>