### PR TITLE
[Integration] Added OAuth client to jira + base url instead of app_host

### DIFF
--- a/integrations/jira/.port/spec.yaml
+++ b/integrations/jira/.port/spec.yaml
@@ -14,7 +14,7 @@ configurations:
   - name: appHost
     required: false
     type: url
-    description: "The host of the Port Ocean app. Used to set up the integration endpoint as the target for Webhooks created in Jira"
+    description: "This field is deprecated. Please use the OCEAN__BASE_URL field instead."
   - name: jiraHost
     required: true
     type: string

--- a/integrations/jira/CHANGELOG.md
+++ b/integrations/jira/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.2.39 (2025-02-19)
+
+
+### Improvements
+
+- Added base_url reference instead of app_host
+- Made JiraClient inherit OAuthClient, and implement external access token prior to local jira token
+
+
 ## 0.2.38 (2025-02-19)
 
 

--- a/integrations/jira/jira/client.py
+++ b/integrations/jira/jira/client.py
@@ -4,6 +4,9 @@ from typing import Any, AsyncGenerator, Generator
 import httpx
 from httpx import Auth, BasicAuth, Request, Response, Timeout
 from loguru import logger
+from port_ocean.clients.auth.oauth_client import (
+    OAuthClient,
+)
 from port_ocean.context.ocean import ocean
 from port_ocean.utils import http_async_client
 
@@ -37,10 +40,11 @@ class BearerAuth(Auth):
         yield request
 
 
-class JiraClient:
+class JiraClient(OAuthClient):
     jira_api_auth: Auth
 
     def __init__(self, jira_url: str, jira_email: str, jira_token: str) -> None:
+        super().__init__()
         self.jira_url = jira_url
         self.jira_rest_url = f"{self.jira_url}/rest"
         self.jira_email = jira_email
@@ -48,7 +52,7 @@ class JiraClient:
 
         # If the Jira URL is directing to api.atlassian.com, we use OAuth2 Bearer Auth
         if "api.atlassian.com" in self.jira_url:
-            self.jira_api_auth = BearerAuth(self.jira_token)
+            self.jira_api_auth = self._get_bearer()
         else:
             self.jira_api_auth = BasicAuth(self.jira_email, self.jira_token)
 
@@ -60,6 +64,15 @@ class JiraClient:
         self.client.auth = self.jira_api_auth
         self.client.timeout = Timeout(30)
         self._semaphore = asyncio.Semaphore(MAX_CONCURRENT_REQUESTS)
+
+    def _get_bearer(self)-> BearerAuth:
+        try:
+            return BearerAuth(self.external_access_token)
+        except ValueError:
+            return BearerAuth(self.jira_token)
+
+    def refresh_request_auth_creds(self, request: httpx.Request) -> httpx.Request:
+        return next(self._get_bearer().auth_flow(request))
 
     async def _handle_rate_limit(self, response: Response) -> None:
         if response.status_code == 429:

--- a/integrations/jira/jira/client.py
+++ b/integrations/jira/jira/client.py
@@ -65,7 +65,7 @@ class JiraClient(OAuthClient):
         self.client.timeout = Timeout(30)
         self._semaphore = asyncio.Semaphore(MAX_CONCURRENT_REQUESTS)
 
-    def _get_bearer(self)-> BearerAuth:
+    def _get_bearer(self) -> BearerAuth:
         try:
             return BearerAuth(self.external_access_token)
         except ValueError:

--- a/integrations/jira/main.py
+++ b/integrations/jira/main.py
@@ -34,17 +34,12 @@ def create_jira_client() -> JiraClient:
 
 
 async def setup_application() -> None:
-    logic_settings = ocean.integration_config
-    app_host = logic_settings.get("app_host")
-    if not app_host:
-        logger.warning(
-            "No app host provided, skipping webhook creation. "
-            "Without setting up the webhook, the integration will not export live changes from Jira"
-        )
+    base_url = ocean.app.base_url
+    if not base_url:
         return
 
     client = create_jira_client()
-    await client.create_events_webhook(app_host)
+    await client.create_events_webhook(base_url)
 
 
 @ocean.on_resync(ObjectKind.PROJECT)

--- a/integrations/jira/pyproject.toml
+++ b/integrations/jira/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jira"
-version = "0.2.38"
+version = "0.2.39"
 description = "Integration to bring information from Jira into Port"
 authors = ["Mor Paz <mor@getport.io>"]
 


### PR DESCRIPTION
### **User description**
# Description

What - Added oauth + base url to jira

Why - Enable new oauth refresh flow + deprecating the app_host

How - removing app_host references + JiraClient will now implement the OAuthClient

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Integrated OAuth client into `JiraClient` for token management.

- Replaced `app_host` with `base_url` for webhook setup.

- Deprecated `appHost` configuration in favor of `OCEAN__BASE_URL`.

- Added methods for handling OAuth token refresh in `JiraClient`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>client.py</strong><dd><code>Integrate OAuth client into `JiraClient`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/jira/jira/client.py

<li>Made <code>JiraClient</code> inherit from <code>OAuthClient</code>.<br> <li> Added <code>_get_bearer</code> method for token management.<br> <li> Implemented <code>refresh_request_auth_creds</code> for OAuth token refresh.<br> <li> Replaced direct token usage with OAuth-based authentication.


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1413/files#diff-a98c78f4ca9c522a3bfdb5542ddb9f19e863b787dff0b39169b91f02facb53be">+15/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Replace `app_host` with `base_url` in webhook setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/jira/main.py

<li>Replaced <code>app_host</code> with <code>base_url</code> for webhook creation.<br> <li> Updated webhook setup logic to use <code>base_url</code>.


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1413/files#diff-2b2f2f1d5fe354b3995d362c13d0ef5e3ffe4161ab827726410de8039337e56f">+3/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>spec.yaml</strong><dd><code>Deprecate `appHost` in favor of `OCEAN__BASE_URL`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/jira/.port/spec.yaml

<li>Deprecated <code>appHost</code> configuration field.<br> <li> Updated description to recommend <code>OCEAN__BASE_URL</code> instead.


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1413/files#diff-e6ea9ee47a4a296100981d400a8dd17af3320e1a2f3898a49306f3a2920ed998">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>