### PR TITLE
[Core] added async to abstract processor functions and fixed handling exceptions while processing events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.20.4 (2025-02-25)
+
+### Bug Fixes
+- Converted should_process_event and get_matching_kinds methods to async.
+- Enhanced error handling to process successful results even if some processors fail.
+- Updated tests to validate async methods and error handling improvements.
+- Added a new integration test for webhook processing with mixed processor outcomes.
+
+
+
 ## 0.20.3 (2025-02-24)
 
 ### Improvements

--- a/port_ocean/core/handlers/webhook/abstract_webhook_processor.py
+++ b/port_ocean/core/handlers/webhook/abstract_webhook_processor.py
@@ -109,9 +109,9 @@ class AbstractWebhookProcessor(ABC):
         pass
 
     @abstractmethod
-    def should_process_event(self, event: WebhookEvent) -> bool:
+    async def should_process_event(self, event: WebhookEvent) -> bool:
         pass
 
     @abstractmethod
-    def get_matching_kinds(self, event: WebhookEvent) -> list[str]:
+    async def get_matching_kinds(self, event: WebhookEvent) -> list[str]:
         pass

--- a/port_ocean/core/handlers/webhook/processor_manager.py
+++ b/port_ocean/core/handlers/webhook/processor_manager.py
@@ -102,13 +102,13 @@ class LiveEventsProcessorManager(LiveEventsMixin, EventsMixin):
                             return_exceptions=True,
                         )
 
-                        successful_raw_results = [
+                        successful_raw_results: list[WebhookEventRawResults] = [
                             result
                             for result in webhook_event_raw_results_for_all_resources
-                            if not isinstance(result, Exception)
+                            if isinstance(result, WebhookEventRawResults)
                         ]
 
-                        if successful_raw_results and all(successful_raw_results):
+                        if successful_raw_results:
                             logger.info(
                                 "Exporting raw event results to entities",
                                 webhook_event_raw_results_for_all_resources_length=len(

--- a/port_ocean/core/handlers/webhook/processor_manager.py
+++ b/port_ocean/core/handlers/webhook/processor_manager.py
@@ -47,7 +47,7 @@ class LiveEventsProcessorManager(LiveEventsMixin, EventsMixin):
             except Exception as e:
                 logger.exception(f"Error starting queue processor for {path}: {str(e)}")
 
-    def _extract_matching_processors(
+    async def _extract_matching_processors(
         self, webhook_event: WebhookEvent, path: str
     ) -> list[tuple[ResourceConfig, AbstractWebhookProcessor]]:
         """Find and extract the matching processor for an event"""
@@ -56,8 +56,8 @@ class LiveEventsProcessorManager(LiveEventsMixin, EventsMixin):
 
         for processor_class in self._processors_classes[path]:
             processor = processor_class(webhook_event.clone())
-            if processor.should_process_event(webhook_event):
-                kinds = processor.get_matching_kinds(webhook_event)
+            if await processor.should_process_event(webhook_event):
+                kinds = await processor.get_matching_kinds(webhook_event)
                 for kind in kinds:
                     for resource in event.port_app_config.resources:
                         if resource.kind == kind:
@@ -92,26 +92,30 @@ class LiveEventsProcessorManager(LiveEventsMixin, EventsMixin):
                         parent_override=webhook_event.event_context,
                     ):
                         matching_processors_with_resource = (
-                            self._extract_matching_processors(webhook_event, path)
+                            await self._extract_matching_processors(webhook_event, path)
                         )
                         webhook_event_raw_results_for_all_resources = await asyncio.gather(
                             *(
                                 self._process_single_event(processor, path, resource)
                                 for resource, processor in matching_processors_with_resource
-                            )
+                            ),
+                            return_exceptions=True,
                         )
-                        if webhook_event_raw_results_for_all_resources and all(
-                            webhook_event_raw_results_for_all_resources
-                        ):
+
+                        successful_raw_results = [
+                            result
+                            for result in webhook_event_raw_results_for_all_resources
+                            if not isinstance(result, Exception)
+                        ]
+
+                        if successful_raw_results and all(successful_raw_results):
                             logger.info(
                                 "Exporting raw event results to entities",
                                 webhook_event_raw_results_for_all_resources_length=len(
-                                    webhook_event_raw_results_for_all_resources
+                                    successful_raw_results
                                 ),
                             )
-                            await self.sync_raw_results(
-                                webhook_event_raw_results_for_all_resources
-                            )
+                            await self.sync_raw_results(successful_raw_results)
             except asyncio.CancelledError:
                 logger.info(f"Queue processor for {path} is shutting down")
                 for _, processor in matching_processors_with_resource:

--- a/port_ocean/tests/core/handlers/webhook/test_abstract_webhook_processor.py
+++ b/port_ocean/tests/core/handlers/webhook/test_abstract_webhook_processor.py
@@ -32,7 +32,7 @@ class ConcreteWebhookProcessor(AbstractWebhookProcessor):
     ) -> WebhookEventRawResults:
         return WebhookEventRawResults(updated_raw_results=[{}], deleted_raw_results=[])
 
-    def should_process_event(self, webhook_event: WebhookEvent) -> bool:
+    async def should_process_event(self, webhook_event: WebhookEvent) -> bool:
         return True
 
     async def before_processing(self) -> None:
@@ -47,7 +47,7 @@ class ConcreteWebhookProcessor(AbstractWebhookProcessor):
         await super().cancel()
         self.cancel_called = True
 
-    def get_matching_kinds(self, event: WebhookEvent) -> list[str]:
+    async def get_matching_kinds(self, event: WebhookEvent) -> list[str]:
         return ["test"]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.20.3"
+version = "0.20.4"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
### **User description**
# Description

What - fix error handling for processors - if one processor fails, don’t fail the other ones + add async to should_process_event and get matching kinds

Why - this methods should be async because some integrations need to perfirm async tasks to get matching kind and should process events. also, we don't want to fail all processors if one fails.

How - added async, fix gather function parameters and added tests

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


___

### **PR Type**
Enhancement, Bug fix, Tests


___

### **Description**
- Converted `should_process_event` and `get_matching_kinds` methods to async.

- Enhanced error handling to process successful results even if some processors fail.

- Updated tests to validate async methods and error handling improvements.

- Added a new integration test for webhook processing with mixed processor outcomes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>abstract_webhook_processor.py</strong><dd><code>Refactored abstract processor methods to async</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

port_ocean/core/handlers/webhook/abstract_webhook_processor.py

<li>Converted <code>should_process_event</code> to async.<br> <li> Converted <code>get_matching_kinds</code> to async.


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1434/files#diff-f60f5ff3f95635c8925f0287711e29616cbeb177fa431e60bdb3cdad9f13e5b4">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>processor_manager.py</strong><dd><code>Improved processor manager with async and error handling</code>&nbsp; </dd></summary>
<hr>

port_ocean/core/handlers/webhook/processor_manager.py

<li>Made <code>_extract_matching_processors</code> async.<br> <li> Updated <code>process_queue</code> to handle exceptions in <code>asyncio.gather</code>.<br> <li> Processed only successful results from processors.


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1434/files#diff-58a2a8bcf5e453cdb2b298a8edcb716c3c3454bb37eed3d6fb3c0c88b50e8b6d">+16/-12</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_processor_manager.py</strong><dd><code>Enhanced tests for async methods and error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

port_ocean/tests/core/handlers/webhook/test_processor_manager.py

<li>Updated tests to use async <code>should_process_event</code> and <br><code>get_matching_kinds</code>.<br> <li> Added integration test for mixed processor outcomes.<br> <li> Validated successful results processing despite exceptions.


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1434/files#diff-c4d9fe8ab65a6567657055450e2b5c30bcbe7750aef09f7e209a65c926a10a2d">+174/-36</a></td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>