### PR TITLE
[CI] Add `scheduled_resync_interval` option to ECS deployment module

### DIFF
--- a/deployment/terraform/aws/ecs/main.tf
+++ b/deployment/terraform/aws/ecs/main.tf
@@ -37,6 +37,7 @@ module "port_ocean_ecs" {
 
   integration_version       = var.integration_version
   initialize_port_resources = var.initialize_port_resources
+  scheduled_resync_interval = var.scheduled_resync_interval
   event_listener            = var.event_listener
 
   integration = {

--- a/deployment/terraform/aws/ecs/modules/ecs_service/main.tf
+++ b/deployment/terraform/aws/ecs/modules/ecs_service/main.tf
@@ -14,6 +14,10 @@ locals {
       value = var.initialize_port_resources ? "true" : "false"
     },
     {
+      name  = "OCEAN__SCHEDULED_RESYNC_INTERVAL",
+      value = tostring(var.scheduled_resync_interval)
+    },
+    {
       name  = upper("OCEAN__EVENT_LISTENER")
       value = jsonencode({
         for key, value in var.event_listener : key => value if value != null

--- a/deployment/terraform/aws/ecs/modules/ecs_service/variables.tf
+++ b/deployment/terraform/aws/ecs/modules/ecs_service/variables.tf
@@ -94,6 +94,12 @@ variable "initialize_port_resources" {
   default = false
 }
 
+variable "scheduled_resync_interval" {
+  type        = number
+  default     = 1440
+  description = "The interval to resync the integration (in minutes)"
+}
+
 variable "integration" {
   type = object({
     identifier = optional(string)
@@ -106,6 +112,7 @@ variable "lb_targ_group_arn" {
   type    = string
   default = ""
 }
+
 variable "additional_policy_statements" {
   type = list(object({
     actions   = list(string)

--- a/deployment/terraform/aws/ecs/variables.tf
+++ b/deployment/terraform/aws/ecs/variables.tf
@@ -128,6 +128,12 @@ variable "initialize_port_resources" {
   default = false
 }
 
+variable "scheduled_resync_interval" {
+  type        = number
+  default     = 1440
+  description = "The interval to resync the integration (in minutes)"
+}
+
 variable "integration" {
   type = object({
     identifier = optional(string)
@@ -140,6 +146,7 @@ variable "lb_targ_group_arn" {
   type    = string
   default = ""
 }
+
 variable "additional_policy_statements" {
   type = list(object({
     actions   = list(string)


### PR DESCRIPTION
### **User description**
# Description

What: 
  - add scheduled_resync_interval option to ecs deployment module

Why:
  - allows automatic scheduled resync with 3rd party. Resolves [issue 1437](https://github.com/port-labs/ocean/issues/1437) 

How
  - add new variable scheduled_resync_interval with default 1440 which is passed as environment variable OCEAN__SCHEDULED_RESYNC_INTERVAL to ECS service.


___

### **PR Type**
Enhancement


___

### **Description**
- Added `scheduled_resync_interval` variable to ECS deployment module.

- Passed `scheduled_resync_interval` as an environment variable to ECS service.

- Set default value for `scheduled_resync_interval` to 1440 minutes.

- Updated Terraform files to support automatic scheduled resync configuration.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Add `scheduled_resync_interval` to ECS module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

deployment/terraform/aws/ecs/main.tf

<li>Added <code>scheduled_resync_interval</code> variable to the ECS module.<br> <li> Passed the variable to the ECS service configuration.


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1438/files#diff-808002137cf96f5c56eb72bedc4da1cadd9defa73f2c1eb64d4a38ee08505ec8">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Add environment variable for scheduled resync</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

deployment/terraform/aws/ecs/modules/ecs_service/main.tf

<li>Added <code>OCEAN__SCHEDULED_RESYNC_INTERVAL</code> as an environment variable.<br> <li> Used <code>scheduled_resync_interval</code> variable to set its value.


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1438/files#diff-e6ab0bf1afc249ee015617a67cfc6f66ad8a080f806ece2077e4c0236f815786">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Define `scheduled_resync_interval` variable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

deployment/terraform/aws/ecs/modules/ecs_service/variables.tf

<li>Defined new variable <code>scheduled_resync_interval</code>.<br> <li> Set default value and description for the variable.


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1438/files#diff-9876537022bb76076700dc59d3b55b96c2d365da7805bd2e589f338b2d5dd0a6">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Add `scheduled_resync_interval` variable to ECS variables</code></dd></summary>
<hr>

deployment/terraform/aws/ecs/variables.tf

<li>Added <code>scheduled_resync_interval</code> variable definition.<br> <li> Set default value and description for the variable.


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1438/files#diff-ea64917e08309e2cf7598fd9a609df53395a8d39e61e83129de93de1ea9ac5f7">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>