### PR TITLE
[Integration][ADO] Fix integration is not pulling all pull requests

### DIFF
--- a/integrations/azure-devops/.port/spec.yaml
+++ b/integrations/azure-devops/.port/spec.yaml
@@ -10,9 +10,14 @@ features:
 configurations:
   - name: organizationUrl
     description: The URL of your Azure DevOps organization (e.g., "https://dev.azure.com/{your-organization}"). To find your organization URL, refer to the <a target="_blank" href="https://learn.microsoft.com/en-us/azure/devops/extend/develop/work-with-urls?view=azure-devops&tabs=http">Azure DevOps documentation</a>.
-    required: true
+    required: false
     type: url
     sensitive: true
+  - name: organization
+    description: The name of your Azure DevOps organization (e.g., "my-organizations"). To find your organization, refer to the <a target="_blank" href="https://learn.microsoft.com/en-us/azure/devops/extend/develop/work-with-urls?view=azure-devops&tabs=http">Azure DevOps documentation</a>.
+    required: false
+    type: string
+    sensitive: false
   - name: personalAccessToken
     description: A personal access token (PAT) with read permissions for the resources you want to sync. To create a PAT, see the <a target="_blank" href="https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops">Azure DevOps documentation</a>.
     required: true

--- a/integrations/azure-devops/.port/spec.yaml
+++ b/integrations/azure-devops/.port/spec.yaml
@@ -10,14 +10,9 @@ features:
 configurations:
   - name: organizationUrl
     description: The URL of your Azure DevOps organization (e.g., "https://dev.azure.com/{your-organization}"). To find your organization URL, refer to the <a target="_blank" href="https://learn.microsoft.com/en-us/azure/devops/extend/develop/work-with-urls?view=azure-devops&tabs=http">Azure DevOps documentation</a>.
-    required: false
+    required: true
     type: url
     sensitive: true
-  - name: organization
-    description: The name of your Azure DevOps organization (e.g., "my-organizations"). To find your organization, refer to the <a target="_blank" href="https://learn.microsoft.com/en-us/azure/devops/extend/develop/work-with-urls?view=azure-devops&tabs=http">Azure DevOps documentation</a>.
-    required: false
-    type: string
-    sensitive: false
   - name: personalAccessToken
     description: A personal access token (PAT) with read permissions for the resources you want to sync. To create a PAT, see the <a target="_blank" href="https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops">Azure DevOps documentation</a>.
     required: true

--- a/integrations/azure-devops/CHANGELOG.md
+++ b/integrations/azure-devops/CHANGELOG.md
@@ -10,10 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 0.1.132 (2025-02-26)
 
 
-### Improvements
-
-- Added support for specifying organization name instead of organization URL in integration configuration
-
 ### Bug Fixes
 
 - Fixed bug causing repositories of disabled projects to be fetched, causing failure to retrieve child objects of the repositories

--- a/integrations/azure-devops/CHANGELOG.md
+++ b/integrations/azure-devops/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.131 (2025-02-26)
+
+
+### Improvements
+
+- Added support for specifying organization name instead of organization URL in integration configuration
+
+### Bug Fixes
+
+- Fixed bug causing repositories of disabled projects to be fetched, causing failure to retrieve child objects of the repositories
+
+
 ## 0.1.130 (2025-02-25)
 
 

--- a/integrations/azure-devops/azure_devops/client/azure_devops_client.py
+++ b/integrations/azure-devops/azure_devops/client/azure_devops_client.py
@@ -1,17 +1,16 @@
-import json
 import asyncio
-
+import json
 from typing import Any, AsyncGenerator, Optional
+
 from httpx import HTTPStatusError
 from loguru import logger
-
 from port_ocean.context.event import event
 from port_ocean.context.ocean import ocean
 from port_ocean.utils.cache import cache_iterator_result
+
 from azure_devops.webhooks.webhook_event import WebhookEvent
 
 from .base_client import HTTPBaseClient
-
 
 API_URL_PREFIX = "_apis"
 WEBHOOK_API_PARAMS = {"api-version": "7.1-preview.1"}
@@ -162,13 +161,11 @@ class AzureDevopsClient(HTTPBaseClient):
                     yield repositories
                 else:
                     yield [
-                        repo for repo in repositories
+                        repo
+                        for repo in repositories
                         if (not repo.get("isDisabled"))
-                        and repo.get("project", {}).get("state") in (
-                            "all",
-                            "unchanged",
-                            "wellFormed"
-                        )
+                        and repo.get("project", {}).get("state")
+                        in ("all", "unchanged", "wellFormed")
                     ]
 
     async def generate_pull_requests(

--- a/integrations/azure-devops/azure_devops/client/azure_devops_client.py
+++ b/integrations/azure-devops/azure_devops/client/azure_devops_client.py
@@ -25,35 +25,14 @@ class AzureDevopsClient(HTTPBaseClient):
         super().__init__(personal_access_token)
         self._organization_base_url = organization_url
 
-    @staticmethod
-    def create_organization_url(organization: str) -> str:
-        return f"https://dev.azure.com/{organization}"
-
     @classmethod
     def create_from_ocean_config(cls) -> "AzureDevopsClient":
         if cache := event.attributes.get("azure_devops_client"):
             return cache
-
-        if organization_url := ocean.integration_config.get("organization_url"):
-            logger.warning(
-                "Usage of `organization_url` has "
-                "been deprecated. Use `organization` instead"
-            )
-            azure_devops_client = cls(
-                ocean.integration_config["organization_url"],
-                ocean.integration_config["personal_access_token"],
-            )
-        elif organization := ocean.integration_config.get("organization"):
-            organization_url = cls.create_organization_url(organization)
-            azure_devops_client = cls(
-                organization_url,
-                ocean.integration_config["personal_access_token"],
-            )
-        else:
-            raise ValueError(
-                "Organization or organization_url "
-                "must be provided in the integration config"
-            )
+        azure_devops_client = cls(
+            ocean.integration_config["organization_url"].strip("/"),
+            ocean.integration_config["personal_access_token"],
+        )
         event.attributes["azure_devops_client"] = azure_devops_client
         return azure_devops_client
 

--- a/integrations/azure-devops/azure_devops/client/azure_devops_client.py
+++ b/integrations/azure-devops/azure_devops/client/azure_devops_client.py
@@ -26,14 +26,35 @@ class AzureDevopsClient(HTTPBaseClient):
         super().__init__(personal_access_token)
         self._organization_base_url = organization_url
 
+    @staticmethod
+    def create_organization_url(organization: str) -> str:
+        return f"https://dev.azure.com/{organization}"
+
     @classmethod
     def create_from_ocean_config(cls) -> "AzureDevopsClient":
         if cache := event.attributes.get("azure_devops_client"):
             return cache
-        azure_devops_client = cls(
-            ocean.integration_config["organization_url"],
-            ocean.integration_config["personal_access_token"],
-        )
+
+        if organization_url := ocean.integration_config.get("organization_url"):
+            logger.warning(
+                "Usage of `organization_url` has "
+                "been deprecated. Use `organization` instead"
+            )
+            azure_devops_client = cls(
+                ocean.integration_config["organization_url"],
+                ocean.integration_config["personal_access_token"],
+            )
+        elif organization := ocean.integration_config.get("organization"):
+            organization_url = cls.create_organization_url(organization)
+            azure_devops_client = cls(
+                organization_url,
+                ocean.integration_config["personal_access_token"],
+            )
+        else:
+            raise ValueError(
+                "Organization or organization_url "
+                "must be provided in the integration config"
+            )
         event.attributes["azure_devops_client"] = azure_devops_client
         return azure_devops_client
 
@@ -140,7 +161,15 @@ class AzureDevopsClient(HTTPBaseClient):
                 if include_disabled_repositories:
                     yield repositories
                 else:
-                    yield [repo for repo in repositories if not repo.get("isDisabled")]
+                    yield [
+                        repo for repo in repositories
+                        if (not repo.get("isDisabled"))
+                        and repo.get("project", {}).get("state") in (
+                            "all",
+                            "unchanged",
+                            "wellFormed"
+                        )
+                    ]
 
     async def generate_pull_requests(
         self, search_filters: Optional[dict[str, Any]] = None

--- a/integrations/azure-devops/azure_devops/client/base_client.py
+++ b/integrations/azure-devops/azure_devops/client/base_client.py
@@ -79,14 +79,17 @@ class HTTPBaseClient:
             continuation_token = response.headers.get(CONTINUATION_TOKEN_HEADER)
 
     async def _get_paginated_by_top_and_skip(
-        self, url: str, params: Optional[dict[str, Any]] = None
+        self, url: str, params: Optional[dict[str, Any]] = None, skip_404s: bool = True
     ) -> AsyncGenerator[list[dict[str, Any]], None]:
         default_params = {"$top": PAGE_SIZE, "$skip": 0}
         params = {**default_params, **(params or {})}
         while True:
-            objects_page = (await self.send_request("GET", url, params=params)).json()[
-                "value"
-            ]
+            response = await self.send_request("GET", url, params=params)
+            if skip_404s and response.status_code == 404:
+                logger.error(f"Couldn't access url {url}")
+                break
+
+            objects_page = response.json()["value"]
             if objects_page:
                 logger.info(
                     f"Found {len(objects_page)} objects in url {url} with params: {params}"

--- a/integrations/azure-devops/azure_devops/client/base_client.py
+++ b/integrations/azure-devops/azure_devops/client/base_client.py
@@ -1,8 +1,9 @@
+from typing import Any, AsyncGenerator, Optional
+
 import httpx
 from httpx import BasicAuth, Response
-from typing import Any, AsyncGenerator, Optional
-from port_ocean.utils import http_async_client
 from loguru import logger
+from port_ocean.utils import http_async_client
 
 PAGE_SIZE = 50
 CONTINUATION_TOKEN_HEADER = "x-ms-continuationtoken"

--- a/integrations/azure-devops/pyproject.toml
+++ b/integrations/azure-devops/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "azure-devops"
-version = "0.1.131"
+version = "0.1.132"
 description = "An Azure Devops Ocean integration"
 authors = ["Matan Geva <matang@getport.io>"]
 

--- a/integrations/azure-devops/pyproject.toml
+++ b/integrations/azure-devops/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "azure-devops"
-version = "0.1.130"
+version = "0.1.131"
 description = "An Azure Devops Ocean integration"
 authors = ["Matan Geva <matang@getport.io>"]
 

--- a/integrations/azure-devops/tests/azure_devops/client/test_azure_devops_client.py
+++ b/integrations/azure-devops/tests/azure_devops/client/test_azure_devops_client.py
@@ -68,12 +68,22 @@ EXPECTED_MEMBERS = [
 ]
 
 EXPECTED_REPOSITORIES = [
-    {"id": "repo1", "name": "Repo One", "isDisabled": False, "project": {
-        "state": "wellFormed",
-    }},
-    {"id": "repo2", "name": "Repo Two", "isDisabled": False, "project": {
-        "state": "wellFormed",
-    }},
+    {
+        "id": "repo1",
+        "name": "Repo One",
+        "isDisabled": False,
+        "project": {
+            "state": "wellFormed",
+        },
+    },
+    {
+        "id": "repo2",
+        "name": "Repo Two",
+        "isDisabled": False,
+        "project": {
+            "state": "wellFormed",
+        },
+    },
 ]
 
 EXPECTED_PULL_REQUESTS = [

--- a/integrations/azure-devops/tests/azure_devops/client/test_azure_devops_client.py
+++ b/integrations/azure-devops/tests/azure_devops/client/test_azure_devops_client.py
@@ -68,8 +68,12 @@ EXPECTED_MEMBERS = [
 ]
 
 EXPECTED_REPOSITORIES = [
-    {"id": "repo1", "name": "Repo One", "isDisabled": False},
-    {"id": "repo2", "name": "Repo Two", "isDisabled": False},
+    {"id": "repo1", "name": "Repo One", "isDisabled": False, "project": {
+        "state": "wellFormed",
+    }},
+    {"id": "repo2", "name": "Repo Two", "isDisabled": False, "project": {
+        "state": "wellFormed",
+    }},
 ]
 
 EXPECTED_PULL_REQUESTS = [


### PR DESCRIPTION
### **User description**
# Description

What - The ADO isn't pulling pull requests of repositories under projects that aren't `wellFormed`.

Why - The integration assumes valid repositories to be repositories with only the `isDisabled` parameter set to `true`. Meanwhile, there is need to confirm that the project isn't disabled before pulling repositories.

How - Added a check for the repository project `state`, and ensured that requests related to repositories that return 404 error do not stop the integration

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed bug causing repositories of disabled projects to be fetched.

- Added support for specifying organization name in configuration.

- Updated tests to validate project state filtering for repositories.

- Updated documentation to reflect new configuration options.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>azure_devops_client.py</strong><dd><code>Support organization name and improve repository filtering</code></dd></summary>
<hr>

integrations/azure-devops/azure_devops/client/azure_devops_client.py

<li>Added method to create organization URL from name.<br> <li> Updated client initialization to support organization name.<br> <li> Enhanced repository filtering to check project state.


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1441/files#diff-6d76e1ab85e24b8f643174f9a502ef2dd04e0dc019a5ebd6b1c8e7367624da4f">+35/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base_client.py</strong><dd><code>Minor import adjustments for consistency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/azure-devops/azure_devops/client/base_client.py

- Adjusted imports for consistency and formatting.


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1441/files#diff-ee35b97a38c963706ab969ce36a4221dc674c66967954f5b8153d0984b546617">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_azure_devops_client.py</strong><dd><code>Update tests for repository project state filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/azure-devops/tests/azure_devops/client/test_azure_devops_client.py

<li>Updated repository test data to include project state.<br> <li> Ensured tests validate filtering by project state.


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1441/files#diff-bd6aae4af7c82e93c446c23fc8198110a7e29f73e2fe861ce9940c7a079bacf5">+16/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>spec.yaml</strong><dd><code>Add organization name configuration option</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/azure-devops/.port/spec.yaml

<li>Added new configuration option for organization name.<br> <li> Made organization URL optional in configuration.


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1441/files#diff-ec2671def1fa0360556f9aa2b2ca32d23d60d902aeeb59f40afc085565a92d34">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update changelog with recent changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/azure-devops/CHANGELOG.md

<li>Documented bug fix for repository fetching.<br> <li> Documented support for organization name configuration.


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1441/files#diff-9b4f288c83afcf2c6cdce8a77deca105f812a5b9af7b7b6125bce0786dbfd6a6">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Version bump to 0.1.132</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/azure-devops/pyproject.toml

- Bumped version to 0.1.132.


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1441/files#diff-067c63eae2423648d5f4f587433376d049963f0e9e2a57eb485817e5deb32f5a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>