### PR TITLE
[Integration][GitLab] Bug | GitOps in GitLab Integration - Failure to map port yml file

### DIFF
--- a/integrations/gitlab/CHANGELOG.md
+++ b/integrations/gitlab/CHANGELOG.md
@@ -7,6 +7,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+0.2.47 (2025-03-06)
+===================
+
+### Bug Fixes
+
+- Fixed bug where glob patterns aren't matched for bare file names such as 'file.yml' against patter '**/file.yml'
+
+
 0.2.46 (2025-03-04)
 ===================
 

--- a/integrations/gitlab/pyproject.toml
+++ b/integrations/gitlab/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gitlab"
-version = "0.2.46"
+version = "0.2.47"
 description = "Gitlab integration for Port using Port-Ocean Framework"
 authors = ["Yair Siman-Tov <yair@getport.io>"]
 

--- a/integrations/gitlab/tests/gitlab_integration/test_core/test_utils.py
+++ b/integrations/gitlab/tests/gitlab_integration/test_core/test_utils.py
@@ -1,0 +1,74 @@
+import pytest
+
+from gitlab_integration.core.utils import (
+    convert_glob_to_gitlab_patterns,
+    does_pattern_apply,
+    generate_ref,
+)
+
+
+@pytest.mark.parametrize(
+    "pattern,string,expected",
+    [
+        # Single string pattern that should match
+        ("foo*", "foobar", True),
+        # Single string pattern that should not match
+        ("bar", "foo", False),
+        # List of patterns, one should match
+        (["foo*", "bar*"], "barbaz", True),
+        # List of patterns, none should match
+        (["foo*", "bar*"], "baz", False),
+        # Exact match
+        ("hello", "hello", True),
+        # Another wildcard test
+        ("hello*", "hello123", True),
+        # Another wildcard not matching
+        ("world*", "hello", False),
+        # Empty pattern should not match anything
+        ("", "anything", False),
+        # List of patterns including an empty pattern
+        (["", "foo*"], "food", True),
+        (["**/port.yml", "**/port.yaml"], "port.yml", True),
+        ("**/port.yml", "port.yml", True),
+        # an important test case we need to pass but doesn't
+        ("**port.yaml", "port.yml", False),
+    ],
+)
+def test_does_pattern_apply(
+    pattern: str | list[str], string: str, expected: bool
+) -> None:
+    assert does_pattern_apply(pattern, string) == expected
+
+
+@pytest.mark.parametrize(
+    "pattern,expected",
+    [
+        # Single pattern with brace expansion
+        ("foo/{bar,baz}", ["foo/bar", "foo/baz"]),
+        # Multiple braces
+        ("a{b,c}d{e,f}", ["abde", "abdf", "acde", "acdf"]),
+        # No braces - should be returned as is
+        ("foo", ["foo"]),
+        # List of patterns, some with braces
+        (["foo/{bar,baz}", "spam/eggs"], ["foo/bar", "foo/baz", "spam/eggs"]),
+        # Empty string in a list
+        (["", "abc"], ["", "abc"]),
+    ],
+)
+def test_convert_glob_to_gitlab_patterns(
+    pattern: str | list[str], expected: list[str]
+) -> None:
+    assert convert_glob_to_gitlab_patterns(pattern) == expected
+
+
+@pytest.mark.parametrize(
+    "branch_name,expected",
+    [
+        ("main", "refs/heads/main"),
+        ("feature/test", "refs/heads/feature/test"),
+        ("", "refs/heads/"),
+        ("some-branch-name", "refs/heads/some-branch-name"),
+    ],
+)
+def test_generate_ref(branch_name: str, expected: str) -> None:
+    assert generate_ref(branch_name) == expected

--- a/integrations/gitlab/tests/gitlab_integration/test_core/test_utils.py
+++ b/integrations/gitlab/tests/gitlab_integration/test_core/test_utils.py
@@ -30,8 +30,7 @@ from gitlab_integration.core.utils import (
         (["", "foo*"], "food", True),
         (["**/port.yml", "**/port.yaml"], "port.yml", True),
         ("**/port.yml", "port.yml", True),
-        # an important test case we need to pass but doesn't
-        ("**port.yaml", "port.yml", False),
+        ("**port.yaml", "port.yaml", True),
     ],
 )
 def test_does_pattern_apply(


### PR DESCRIPTION
# Description

What - Fixed a bug where glob patterns with slashes are not matched against bare file names such as `**/port.yml` pattern not matching `port.yml`.

Why - This is due to the way `fnmatch` handles matching without handling possible leading slashes in file names

How - Reimplemented the `does_pattern_apply` matching logic 

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
