### PR TITLE
[Core] Wrong integration version showing in UI and API fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.21.1 (2025-03-09)
+
+### Bug Fixes
+
+- fixed wrong integration version showing in UI and API by moving the check of OCEAN__INITIALIZE_PORT_RESOURCES=false to after the patch
+
 ## 0.21.0 (2025-03-01)
 
 ### Features

--- a/port_ocean/core/defaults/initialize.py
+++ b/port_ocean/core/defaults/initialize.py
@@ -208,9 +208,6 @@ async def _create_resources(
 async def _initialize_defaults(
     config_class: Type[PortAppConfig], integration_config: IntegrationConfiguration
 ) -> None:
-    if not integration_config.initialize_port_resources:
-        return
-
     port_client = ocean.port_client
     defaults = get_port_integration_defaults(
         config_class, integration_config.resources_path
@@ -274,9 +271,10 @@ async def _initialize_defaults(
     if (
         integration_config.create_port_resources_origin
         == CreatePortResourcesOrigin.Port
+        or not integration_config.initialize_port_resources
     ):
         logger.info(
-            "Skipping creating defaults resources due to `create_port_resources_origin` being `Port`"
+            "Skipping creating defaults resources due to `create_port_resources_origin` being `Port` or `initialize_port_resources` being `false`"
         )
         return
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.21.0"
+version = "0.21.1"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What - fixed wrong integration version showing in UI and API

Why - we did not patch the integration when `OCEAN__INITIALIZE_PORT_RESOURCES=false`

How - moved the check of `OCEAN__INITIALIZE_PORT_RESOURCES=false` to after the patch

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)


<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


