### PR TITLE
[Integration][Pagerduty] Add url validation

### DIFF
--- a/integrations/pagerduty/.port/spec.yaml
+++ b/integrations/pagerduty/.port/spec.yaml
@@ -19,12 +19,12 @@ configurations:
     description: The PagerDuty API token. To create a token, see the <a href="https://support.pagerduty.com/docs/api-access-keys" target="_blank">PagerDuty documentation</a>
   - name: apiUrl
     required: true
-    type: string
+    type: url
     default: https://api.pagerduty.com
     description: Pagerduty Api URL. If not specified, the default will be <a href="https://api.pagerduty.com" target="_blank">https://api.pagerduty.com</a>. Customers on the EU data centers should set this to https://api.eu.pagerduty.com
   - name: appHost
     required: false
-    type: string
+    type: url
     description: The host of the Port Ocean app. Used to set up the integration endpoint as the target for Webhooks created in PagerDuty
 saas:
   enabled: true

--- a/integrations/pagerduty/CHANGELOG.md
+++ b/integrations/pagerduty/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.3.5 (2025-03-21)
+
+### Bug Fixes
+
+- Fixed URL validation by changing apiUrl and appHost configuration types from string to url
+
+
 ## 0.3.4 (2025-03-13)
 
 

--- a/integrations/pagerduty/pyproject.toml
+++ b/integrations/pagerduty/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pagerduty"
-version = "0.3.4"
+version = "0.3.5"
 description = "PagerDuty Integration"
 authors = ["Port Team <support@getport.io>"]
 


### PR DESCRIPTION
### **User description**
# Description

What:
- Changed PagerDuty integration configuration field types from `string` to `url` for `apiUrl` and `appHost` fields in spec.yaml
- Added proper URL validation at configuration time

Why:
- Customers were encountering issues with malformed URLs (e.g., `"https://api.pagerduty.com (https://api.pagerduty.com/)"`) that weren't being caught early
- The integration would fail at runtime with unclear error messages instead of validating URLs at configuration time
- Better to catch URL formatting issues during configuration rather than during API calls

How:
- Updated spec.yaml to use `type: url` instead of `type: string` for URL fields
- This leverages Pydantic's built-in URL validation to catch malformed URLs early
- Provides clearer error messages when URLs are incorrectly formatted

Testing:
- Verified that malformed URLs are now caught during configuration
- Confirmed valid URLs still work as expected

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Updated `apiUrl` and `appHost` fields to use URL validation.

- Enhanced error handling for malformed URLs during configuration.

- Updated changelog to reflect the URL validation fix.

- Bumped integration version to 0.3.5 in `pyproject.toml`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>spec.yaml</strong><dd><code>Updated field types for URL validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/pagerduty/.port/spec.yaml

<li>Changed <code>apiUrl</code> and <code>appHost</code> field types from <code>string</code> to <code>url</code>.<br> <li> Improved validation for configuration fields to catch malformed URLs.


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1504/files#diff-c507549aa9a670fb1e7d646d836847d99569767289949d0feb64f5afe57888a2">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Updated changelog for version 0.3.5</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/pagerduty/CHANGELOG.md

<li>Added changelog entry for version 0.3.5.<br> <li> Documented the fix for URL validation in configuration fields.


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1504/files#diff-c45e12ac890e8ded370bbeaf51628dc3377baedbeae3a3bf083f406923b5b813">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Updated integration version to 0.3.5</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/pagerduty/pyproject.toml

- Bumped version from 0.3.4 to 0.3.5.


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1504/files#diff-18835376b907755feaa49186a6b680ab836bd4462435f2ad4071272cf67d3b68">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>