### PR TITLE
[Core] Batch upsert for create missing related entities false and support null check in entities diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.22.1 (2025-04-02)
+
+### Features
+
+- Added support for team search query in entity mapping
+- Enhanced batch_upsert_entities to return tuples with success status.
+- Improved null property handling in entity field comparisons.
+- Updated upsert logic to use batch upsert consistently.
+- Added unit tests for null property handling in entity comparisons.
 
 ## 0.22.0 (2025-03-17)
 

--- a/port_ocean/clients/port/mixins/entities.py
+++ b/port_ocean/clients/port/mixins/entities.py
@@ -149,7 +149,7 @@ class EntityClientMixin:
 
         result_tuples: list[tuple[bool, Entity]] = []
         for original_entity, result in zip(entities, modified_entities_results):
-            if isinstance(result, Exception):
+            if isinstance(result, Exception) and should_raise:
                 raise result
             elif isinstance(result, Entity):
                 result_tuples.append((True, result))

--- a/port_ocean/clients/port/mixins/entities.py
+++ b/port_ocean/clients/port/mixins/entities.py
@@ -133,7 +133,7 @@ class EntityClientMixin:
         request_options: RequestOptions,
         user_agent_type: UserAgentType | None = None,
         should_raise: bool = True,
-    ) -> list[Entity]:
+    ) -> list[tuple[bool, Entity]]:
         modified_entities_results = await asyncio.gather(
             *(
                 self.upsert_entity(
@@ -146,17 +146,17 @@ class EntityClientMixin:
             ),
             return_exceptions=True,
         )
-        entity_results = [
-            entity for entity in modified_entities_results if isinstance(entity, Entity)
-        ]
-        if not should_raise:
-            return entity_results
 
-        for entity_result in modified_entities_results:
-            if isinstance(entity_result, Exception):
-                raise entity_result
+        result_tuples: list[tuple[bool, Entity]] = []
+        for original_entity, result in zip(entities, modified_entities_results):
+            if isinstance(result, Exception) and should_raise:
+                raise result
+            elif isinstance(result, Entity):
+                result_tuples.append((True, result))
+            elif result is False:
+                result_tuples.append((False, original_entity))
 
-        return entity_results
+        return result_tuples
 
     async def delete_entity(
         self,

--- a/port_ocean/clients/port/mixins/entities.py
+++ b/port_ocean/clients/port/mixins/entities.py
@@ -147,16 +147,16 @@ class EntityClientMixin:
             return_exceptions=True,
         )
 
-        result_tuples: list[tuple[bool, Entity]] = []
+        entities_results: list[tuple[bool, Entity]] = []
         for original_entity, result in zip(entities, modified_entities_results):
             if isinstance(result, Exception) and should_raise:
                 raise result
             elif isinstance(result, Entity):
-                result_tuples.append((True, result))
+                entities_results.append((True, result))
             elif result is False:
-                result_tuples.append((False, original_entity))
+                entities_results.append((False, original_entity))
 
-        return result_tuples
+        return entities_results
 
     async def delete_entity(
         self,

--- a/port_ocean/clients/port/mixins/entities.py
+++ b/port_ocean/clients/port/mixins/entities.py
@@ -149,7 +149,7 @@ class EntityClientMixin:
 
         result_tuples: list[tuple[bool, Entity]] = []
         for original_entity, result in zip(entities, modified_entities_results):
-            if isinstance(result, Exception) and should_raise:
+            if isinstance(result, Exception):
                 raise result
             elif isinstance(result, Entity):
                 result_tuples.append((True, result))

--- a/port_ocean/core/handlers/entities_state_applier/port/applier.py
+++ b/port_ocean/core/handlers/entities_state_applier/port/applier.py
@@ -121,16 +121,16 @@ class HttpEntitiesStateApplier(BaseEntitiesStateApplier):
     ) -> list[Entity]:
         logger.info(f"Upserting {len(entities)} entities")
         modified_entities: list[Entity] = []
-        upsertedEntities: list[tuple[bool, Entity]] = []
+        upserted_entities: list[tuple[bool, Entity]] = []
 
-        upsertedEntities = await self.context.port_client.batch_upsert_entities(
+        upserted_entities = await self.context.port_client.batch_upsert_entities(
             entities,
             event.port_app_config.get_port_request_options(),
             user_agent_type,
             should_raise=False,
         )
 
-        for is_upserted, entity in upsertedEntities:
+        for is_upserted, entity in upserted_entities:
             if is_upserted:
                 modified_entities.append(entity)
             else:

--- a/port_ocean/core/handlers/entities_state_applier/port/applier.py
+++ b/port_ocean/core/handlers/entities_state_applier/port/applier.py
@@ -130,8 +130,8 @@ class HttpEntitiesStateApplier(BaseEntitiesStateApplier):
             should_raise=False,
         )
 
-        for isUpserted, entity in upsertedEntities:
-            if isUpserted:
+        for is_upserted, entity in upsertedEntities:
+            if is_upserted:
                 modified_entities.append(entity)
             else:
                 event.entity_topological_sorter.register_entity(entity)

--- a/port_ocean/core/handlers/entities_state_applier/port/applier.py
+++ b/port_ocean/core/handlers/entities_state_applier/port/applier.py
@@ -121,26 +121,20 @@ class HttpEntitiesStateApplier(BaseEntitiesStateApplier):
     ) -> list[Entity]:
         logger.info(f"Upserting {len(entities)} entities")
         modified_entities: list[Entity] = []
-        if event.port_app_config.create_missing_related_entities:
-            modified_entities = await self.context.port_client.batch_upsert_entities(
-                entities,
-                event.port_app_config.get_port_request_options(),
-                user_agent_type,
-                should_raise=False,
-            )
-        else:
-            for entity in entities:
-                upsertedEntity = await self.context.port_client.upsert_entity(
-                    entity,
-                    event.port_app_config.get_port_request_options(),
-                    user_agent_type,
-                    should_raise=False,
-                )
-                if upsertedEntity:
-                    modified_entities.append(upsertedEntity)
-                # condition to false to differentiate from `result_entity.is_using_search_identifier`
-                if upsertedEntity is False:
-                    event.entity_topological_sorter.register_entity(entity)
+        upsertedEntities: list[tuple[bool, Entity]] = []
+
+        upsertedEntities = await self.context.port_client.batch_upsert_entities(
+            entities,
+            event.port_app_config.get_port_request_options(),
+            user_agent_type,
+            should_raise=False,
+        )
+
+        for isUpserted, entity in upsertedEntities:
+            if isUpserted:
+                modified_entities.append(entity)
+            else:
+                event.entity_topological_sorter.register_entity(entity)
         return modified_entities
 
     async def delete(

--- a/port_ocean/core/utils/utils.py
+++ b/port_ocean/core/utils/utils.py
@@ -122,6 +122,7 @@ def are_entities_fields_equal(
 ) -> bool:
     """
     Compare two entity fields by serializing them to JSON and comparing their SHA-256 hashes.
+    Removes keys with None values before comparison if the corresponding key doesn't exist in the other dict.
 
     Args:
         first_entity_field: First entity field dictionary to compare
@@ -130,7 +131,13 @@ def are_entities_fields_equal(
     Returns:
         bool: True if the entity fields have identical content
     """
-    first_props = json.dumps(first_entity_field, sort_keys=True)
+    first_entity_field_copy = first_entity_field.copy()
+
+    for key in list(first_entity_field.keys()):
+        if first_entity_field[key] is None and key not in second_entity_field:
+            del first_entity_field_copy[key]
+
+    first_props = json.dumps(first_entity_field_copy, sort_keys=True)
     second_props = json.dumps(second_entity_field, sort_keys=True)
     first_hash = hashlib.sha256(first_props.encode()).hexdigest()
     second_hash = hashlib.sha256(second_props.encode()).hexdigest()

--- a/port_ocean/core/utils/utils.py
+++ b/port_ocean/core/utils/utils.py
@@ -110,8 +110,8 @@ def get_port_diff(before: Iterable[Entity], after: Iterable[Entity]) -> EntityPo
 
 
 def are_teams_different(
-    first_team: str | None | list[Any],
-    second_team: str | None | list[Any],
+    first_team: str | None | list[Any] | dict[str, Any],
+    second_team: str | None | list[Any] | dict[str, Any],
 ) -> bool:
     if isinstance(first_team, list) and isinstance(second_team, list):
         return sorted(first_team) != sorted(second_team)

--- a/port_ocean/tests/clients/port/mixins/test_entities.py
+++ b/port_ocean/tests/clients/port/mixins/test_entities.py
@@ -41,8 +41,9 @@ async def test_batch_upsert_entities_read_timeout_should_raise_false(
         result_entities = await entity_client.batch_upsert_entities(
             entities=all_entities, request_options=MagicMock(), should_raise=False
         )
+        entities_only = [entity for _, entity in result_entities]
 
-        assert result_entities == expected_result_entities
+        assert entities_only == expected_result_entities
 
 
 async def test_batch_upsert_entities_read_timeout_should_raise_true(

--- a/port_ocean/tests/core/handlers/entities_state_applier/test_applier.py
+++ b/port_ocean/tests/core/handlers/entities_state_applier/test_applier.py
@@ -131,6 +131,74 @@ async def test_applier_with_mock_context(
 
 
 @pytest.mark.asyncio
+async def test_applier_one_not_upserted(
+    mock_ocean: Ocean,
+    mock_context: PortOceanContext,
+    mock_port_app_config: PortAppConfig,
+) -> None:
+    # Create an applier using the mock_context fixture
+    applier = HttpEntitiesStateApplier(mock_context)
+
+    # Create test entities
+    entity = Entity(identifier="test_entity", blueprint="test_blueprint")
+
+    async with event_context(EventType.RESYNC, trigger_type="machine") as event:
+        # Mock the register_entity method
+        event.entity_topological_sorter.register_entity = Mock()
+        event.port_app_config = mock_port_app_config
+
+        # Test the upsert method with mocked client
+        with patch.object(mock_ocean.port_client.client, "post") as mock_post:
+            mock_post.return_value = Mock(
+                status_code=404,
+                json=lambda: {"ok": False, "error": "not_found"},
+            )
+
+            result = await applier.upsert([entity], UserAgentType.exporter)
+
+            # Assert that the post method was called
+            mock_post.assert_called_once()
+            assert len(result) == 0
+            event.entity_topological_sorter.register_entity.assert_called_once_with(
+                entity
+            )
+
+
+@pytest.mark.asyncio
+async def test_applier_error_upserting(
+    mock_ocean: Ocean,
+    mock_context: PortOceanContext,
+    mock_port_app_config: PortAppConfig,
+) -> None:
+    # Create an applier using the mock_context fixture
+    applier = HttpEntitiesStateApplier(mock_context)
+
+    # Create test entities
+    entity = Entity(identifier="test_entity", blueprint="test_blueprint")
+
+    async with event_context(EventType.RESYNC, trigger_type="machine") as event:
+        # Mock the register_entity method
+        event.entity_topological_sorter.register_entity = Mock()
+        event.port_app_config = mock_port_app_config
+
+        # Test the upsert method with mocked client
+        with patch.object(mock_ocean.port_client.client, "post") as mock_post:
+            mock_post.return_value = Mock(
+                status_code=404,
+                json=lambda: {"ok": False, "error": "not_found"},
+            )
+
+            result = await applier.upsert([entity], UserAgentType.exporter)
+
+            # Assert that the post method was called
+            mock_post.assert_called_once()
+            assert len(result) == 0
+            event.entity_topological_sorter.register_entity.assert_called_once_with(
+                entity
+            )
+
+
+@pytest.mark.asyncio
 async def test_using_create_entity_helper(
     mock_ocean: Ocean,
     mock_context: PortOceanContext,

--- a/port_ocean/tests/core/handlers/entities_state_applier/test_applier.py
+++ b/port_ocean/tests/core/handlers/entities_state_applier/test_applier.py
@@ -144,7 +144,7 @@ async def test_applier_one_not_upserted(
 
     async with event_context(EventType.RESYNC, trigger_type="machine") as event:
         # Mock the register_entity method
-        event.entity_topological_sorter.register_entity = Mock()
+        event.entity_topological_sorter.register_entity = Mock()  # type: ignore
         event.port_app_config = mock_port_app_config
 
         # Test the upsert method with mocked client
@@ -178,7 +178,7 @@ async def test_applier_error_upserting(
 
     async with event_context(EventType.RESYNC, trigger_type="machine") as event:
         # Mock the register_entity method
-        event.entity_topological_sorter.register_entity = Mock()
+        event.entity_topological_sorter.register_entity = Mock()  # type: ignore
         event.port_app_config = mock_port_app_config
 
         # Test the upsert method with mocked client

--- a/port_ocean/tests/core/utils/test_resolve_entities_diff.py
+++ b/port_ocean/tests/core/utils/test_resolve_entities_diff.py
@@ -246,6 +246,58 @@ def test_are_entities_fields_equal_different_nested_relations_should_be_false() 
     )
 
 
+def test_are_entities_fields_equal_null_properties_should_be_true() -> None:
+    assert (
+        are_entities_fields_equal(
+            {
+                "team": None,
+                "members": ["user1", "user2"],
+                "metadata": {"role": "admin"},
+            },
+            {"members": ["user1", "user2"], "metadata": {"role": "admin"}},
+        )
+        is True
+    )
+
+
+def test_are_entities_fields_equal_null_properties_and_real_data_in_other_entity_should_be_false() -> (
+    None
+):
+    assert (
+        are_entities_fields_equal(
+            {
+                "team": None,
+                "members": ["user1", "user2"],
+                "metadata": {"role": "admin"},
+            },
+            {
+                "team": "team_id1",
+                "members": ["user1", "user2"],
+                "metadata": {"role": "admin"},
+            },
+        )
+        is False
+    )
+
+
+def test_are_entities_fields_equal_null_properties_in_both_should_be_true() -> None:
+    assert (
+        are_entities_fields_equal(
+            {
+                "team": None,
+                "members": ["user1", "user2"],
+                "metadata": {"role": "admin"},
+            },
+            {
+                "team": None,
+                "members": ["user1", "user2"],
+                "metadata": {"role": "admin"},
+            },
+        )
+        is True
+    )
+
+
 def test_are_entities_different_identical_entities_should_be_false() -> None:
     entity1 = create_test_entity(
         "",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.22.0"
+version = "0.22.1"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
### **User description**
# Description


What - Batch upsert for create missing related entities false and support null check in entities diff Port 13782 

Why - Resync takes too long and could be more efficient  

How -  changed upsert function to only use batch upsert and removed null properties 

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector





___

### **PR Type**
Enhancement, Tests, Bug fix


___

### **Description**
- Enhanced `batch_upsert_entities` to return tuples with success status.

- Improved null property handling in entity field comparisons.

- Updated `upsert` logic to use batch upsert consistently.

- Added unit tests for null property handling in entity comparisons.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>entities.py</strong><dd><code>Refactored batch upsert to include success status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

port_ocean/clients/port/mixins/entities.py

<li>Modified <code>batch_upsert_entities</code> to return tuples with success status.<br> <li> Enhanced error handling and result processing for upsert operations.


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1532/files#diff-1cd3dc7778947127c84baab24278808bee9c4ded96b1c320e28ece0f4d55ba7f">+10/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>applier.py</strong><dd><code>Streamlined upsert logic with batch processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

port_ocean/core/handlers/entities_state_applier/port/applier.py

<li>Updated <code>upsert</code> logic to consistently use batch upsert.<br> <li> Simplified handling of upserted entities and registration of failed <br>entities.


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1532/files#diff-85a698350ddea8afa3c487e967e2adf858de11f8128446fa5db05ad1472132ea">+14/-20</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>utils.py</strong><dd><code>Improved entity field comparison logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

port_ocean/core/utils/utils.py

<li>Enhanced <code>are_entities_fields_equal</code> to ignore null properties.<br> <li> Added logic to remove keys with <code>None</code> values if absent in the other <br>dictionary.


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1532/files#diff-187b8268f2779c6fc01221ccc64a1bffcf8b5f5c96c5e951b4c8777fcd425d15">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_resolve_entities_diff.py</strong><dd><code>Added tests for null property handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

port_ocean/tests/core/utils/test_resolve_entities_diff.py

<li>Added tests for null property handling in entity field comparisons.<br> <li> Verified behavior for various null property scenarios.


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1532/files#diff-02c79454e69f00481fb87d141083f6f3678477e9f7248b77da3414c08d332a61">+52/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>