### PR TITLE
[Core] Add integration identifier and uname to the log

### DIFF
--- a/port_ocean/log/logger_setup.py
+++ b/port_ocean/log/logger_setup.py
@@ -13,10 +13,14 @@ from port_ocean.log.sensetive import sensitive_log_filter
 from port_ocean.utils.signal import signal_handler
 
 
-def setup_logger(level: LogLevelType, enable_http_handler: bool) -> None:
+def setup_logger(
+    level: LogLevelType, enable_http_handler: bool, integration_id: str
+) -> None:
     try:
         logger.remove()
-        logger.configure(extra={"hostname": os.uname().nodename})
+        logger.configure(
+            extra={"hostname": os.uname().nodename, "integration_id": integration_id}
+        )
         _stdout_loguru_handler(level)
         if enable_http_handler:
             _http_loguru_handler(level)
@@ -31,6 +35,7 @@ def _stdout_loguru_handler(level: LogLevelType) -> None:
     logger_format = (
         "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | "
         "<level>{level: <8}</level> | "
+        "<cyan>{extra[integration_id]}</cyan> | "
         "<level>{message}</level>"
     )
     if level == "DEBUG":

--- a/port_ocean/log/logger_setup.py
+++ b/port_ocean/log/logger_setup.py
@@ -13,13 +13,9 @@ from port_ocean.log.sensetive import sensitive_log_filter
 from port_ocean.utils.signal import signal_handler
 
 
-def setup_logger(
-    level: LogLevelType, enable_http_handler: bool, integration_id: str
-) -> None:
+def setup_logger(level: LogLevelType, enable_http_handler: bool, instance: str) -> None:
     logger.remove()
-    logger.configure(
-        extra={"hostname": try_get_hostname(), "integration_id": integration_id}
-    )
+    logger.configure(extra={"hostname": try_get_hostname(), "instance": instance})
     _stdout_loguru_handler(level)
     if enable_http_handler:
         _http_loguru_handler(level)

--- a/port_ocean/log/logger_setup.py
+++ b/port_ocean/log/logger_setup.py
@@ -16,19 +16,13 @@ from port_ocean.utils.signal import signal_handler
 def setup_logger(
     level: LogLevelType, enable_http_handler: bool, integration_id: str
 ) -> None:
-    try:
-        logger.remove()
-        logger.configure(
-            extra={"hostname": os.uname().nodename, "integration_id": integration_id}
-        )
-        _stdout_loguru_handler(level)
-        if enable_http_handler:
-            _http_loguru_handler(level)
-    except Exception:
-        logger.remove()
-        _stdout_loguru_handler(level)
-        if enable_http_handler:
-            _http_loguru_handler(level)
+    logger.remove()
+    logger.configure(
+        extra={"hostname": try_get_hostname(), "integration_id": integration_id}
+    )
+    _stdout_loguru_handler(level)
+    if enable_http_handler:
+        _http_loguru_handler(level)
 
 
 def _stdout_loguru_handler(level: LogLevelType) -> None:
@@ -86,3 +80,10 @@ def exception_deserializer(record: "loguru.Record") -> None:
     if exception is not None:
         fixed = Exception(str(exception.value))
         record["exception"] = exception._replace(value=fixed)
+
+
+def try_get_hostname() -> str:
+    try:
+        return os.uname().nodename
+    except AttributeError:
+        return "unknown"

--- a/port_ocean/log/logger_setup.py
+++ b/port_ocean/log/logger_setup.py
@@ -85,5 +85,5 @@ def exception_deserializer(record: "loguru.Record") -> None:
 def try_get_hostname() -> str:
     try:
         return os.uname().nodename
-    except AttributeError:
+    except Exception:
         return "unknown"

--- a/port_ocean/log/logger_setup.py
+++ b/port_ocean/log/logger_setup.py
@@ -36,6 +36,7 @@ def _stdout_loguru_handler(level: LogLevelType) -> None:
         "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | "
         "<level>{level: <8}</level> | "
         "<cyan>{extra[integration_id]}</cyan> | "
+        "<magenta>{extra[hostname]}</magenta> | "
         "<level>{message}</level>"
     )
     if level == "DEBUG":

--- a/port_ocean/log/logger_setup.py
+++ b/port_ocean/log/logger_setup.py
@@ -1,4 +1,5 @@
 import sys
+import os
 from logging import LogRecord
 from logging.handlers import QueueHandler, QueueListener
 from queue import Queue
@@ -13,10 +14,17 @@ from port_ocean.utils.signal import signal_handler
 
 
 def setup_logger(level: LogLevelType, enable_http_handler: bool) -> None:
-    logger.remove()
-    _stdout_loguru_handler(level)
-    if enable_http_handler:
-        _http_loguru_handler(level)
+    try:
+        logger.remove()
+        logger.configure(extra={"hostname": os.uname().nodename})
+        _stdout_loguru_handler(level)
+        if enable_http_handler:
+            _http_loguru_handler(level)
+    except Exception:
+        logger.remove()
+        _stdout_loguru_handler(level)
+        if enable_http_handler:
+            _http_loguru_handler(level)
 
 
 def _stdout_loguru_handler(level: LogLevelType) -> None:

--- a/port_ocean/run.py
+++ b/port_ocean/run.py
@@ -1,6 +1,7 @@
 import asyncio
 from inspect import getmembers
 from typing import Dict, Any, Type
+import uuid
 
 import uvicorn
 from pydantic import BaseModel
@@ -33,11 +34,13 @@ def run(
     config_override: Dict[str, Any] | None = None,
 ) -> None:
     application_settings = ApplicationSettings(log_level=log_level, port=port)
+    integration_id = str(uuid.uuid4())
 
     init_signal_handler()
     setup_logger(
         application_settings.log_level,
         enable_http_handler=application_settings.enable_http_logging,
+        integration_id=integration_id,
     )
 
     config_factory = _get_default_config_factory()

--- a/port_ocean/run.py
+++ b/port_ocean/run.py
@@ -34,13 +34,13 @@ def run(
     config_override: Dict[str, Any] | None = None,
 ) -> None:
     application_settings = ApplicationSettings(log_level=log_level, port=port)
-    integration_id = str(uuid.uuid4())
+    instance = str(uuid.uuid4())
 
     init_signal_handler()
     setup_logger(
         application_settings.log_level,
         enable_http_handler=application_settings.enable_http_logging,
-        integration_id=integration_id,
+        instance=instance,
     )
 
     config_factory = _get_default_config_factory()


### PR DESCRIPTION
### **User description**
# Description

What - Add integration identifier and uname to the log

Why - To monitor self hosted integrations , to know on what container they run on and identify each one

How - generated a uuid to each integration and used `os.uname()` to get the machine node name 

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector



### **PR Type**
Enhancement


___

### **Description**
- Added `integration_id` and `hostname` to logger configuration.

- Updated `setup_logger` function to include `integration_id`.

- Generated unique `integration_id` in `run` function.

- Enhanced log format to include `integration_id`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>logger_setup.py</strong><dd><code>Enhanced logger setup with `integration_id` and `hostname`</code></dd></summary>
<hr>

port_ocean/log/logger_setup.py

<li>Added <code>integration_id</code> and <code>hostname</code> to logger configuration.<br> <li> Updated <code>setup_logger</code> to handle <code>integration_id</code>.<br> <li> Enhanced log format to include <code>integration_id</code>.<br> <li> Added exception handling for logger setup.


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1566/files#diff-114a3b03c16ae42272d8da3104d8409bc8b358734c23db36de4d308835b61bc5">+18/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>run.py</strong><dd><code>Added `integration_id` generation and logger integration</code>&nbsp; </dd></summary>
<hr>

port_ocean/run.py

<li>Generated unique <code>integration_id</code> using <code>uuid</code>.<br> <li> Passed <code>integration_id</code> to <code>setup_logger</code> during initialization.


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1566/files#diff-73672904a7798f9abb593c646339ea5c132e648258cd5400645b3d870cd5870b">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>