### PR TITLE
[Core] Add integration instance to the log - code review fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.22.4 (2025-04-15)
+
+### Features
+-Refactored logger setup to generate unique instance IDs.
+-Renamed try_get_hostname to resolve_hostname for clarity.
+-Removed redundant instance parameter from setup_logger.
+
 ## 0.22.3 (2025-04-15)
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Features
 - Added inctance and hostname to logger configuration.
-
 - Updated setup_logger function to include inctance.
-
 - Generated unique inctance in run function.
-
 - Enhanced log format to include inctance.
 
 ## 0.22.2 (2025-04-06)

--- a/port_ocean/log/logger_setup.py
+++ b/port_ocean/log/logger_setup.py
@@ -3,6 +3,7 @@ import os
 from logging import LogRecord
 from logging.handlers import QueueHandler, QueueListener
 from queue import Queue
+import uuid
 
 import loguru
 from loguru import logger
@@ -13,9 +14,11 @@ from port_ocean.log.sensetive import sensitive_log_filter
 from port_ocean.utils.signal import signal_handler
 
 
-def setup_logger(level: LogLevelType, enable_http_handler: bool, instance: str) -> None:
+def setup_logger(level: LogLevelType, enable_http_handler: bool) -> None:
     logger.remove()
-    logger.configure(extra={"hostname": try_get_hostname(), "instance": instance})
+    logger.configure(
+        extra={"hostname": resolve_hostname(), "instance": str(uuid.uuid4())}
+    )
     _stdout_loguru_handler(level)
     if enable_http_handler:
         _http_loguru_handler(level)
@@ -78,7 +81,7 @@ def exception_deserializer(record: "loguru.Record") -> None:
         record["exception"] = exception._replace(value=fixed)
 
 
-def try_get_hostname() -> str:
+def resolve_hostname() -> str:
     try:
         return os.uname().nodename
     except Exception:

--- a/port_ocean/log/logger_setup.py
+++ b/port_ocean/log/logger_setup.py
@@ -28,8 +28,6 @@ def _stdout_loguru_handler(level: LogLevelType) -> None:
     logger_format = (
         "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | "
         "<level>{level: <8}</level> | "
-        "<cyan>{extra[integration_id]}</cyan> | "
-        "<magenta>{extra[hostname]}</magenta> | "
         "<level>{message}</level>"
     )
     if level == "DEBUG":

--- a/port_ocean/run.py
+++ b/port_ocean/run.py
@@ -1,7 +1,6 @@
 import asyncio
 from inspect import getmembers
 from typing import Dict, Any, Type
-import uuid
 
 import uvicorn
 from pydantic import BaseModel
@@ -34,13 +33,11 @@ def run(
     config_override: Dict[str, Any] | None = None,
 ) -> None:
     application_settings = ApplicationSettings(log_level=log_level, port=port)
-    instance = str(uuid.uuid4())
 
     init_signal_handler()
     setup_logger(
         application_settings.log_level,
         enable_http_handler=application_settings.enable_http_logging,
-        instance=instance,
     )
 
     config_factory = _get_default_config_factory()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.22.3"
+version = "0.22.4"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
### **User description**
# Description

What - fixed code review comments

How - moved the uui to the logger setup, and renamed function

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Refactored logger setup to generate unique instance IDs.

- Renamed `try_get_hostname` to `resolve_hostname` for clarity.

- Removed redundant `instance` parameter from `setup_logger`.

- Updated CHANGELOG to reflect logger configuration changes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>logger_setup.py</strong><dd><code>Refactored logger setup for instance and hostname handling</code></dd></summary>
<hr>

port_ocean/log/logger_setup.py

<li>Removed <code>instance</code> parameter from <code>setup_logger</code>.<br> <li> Added automatic generation of unique instance IDs using <code>uuid</code>.<br> <li> Renamed <code>try_get_hostname</code> to <code>resolve_hostname</code>.<br> <li> Adjusted logger configuration to include new hostname and instance <br>logic.


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1572/files#diff-114a3b03c16ae42272d8da3104d8409bc8b358734c23db36de4d308835b61bc5">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>run.py</strong><dd><code>Simplified logger setup in `run` function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

port_ocean/run.py

<li>Removed manual generation of <code>instance</code> in <code>run</code> function.<br> <li> Updated <code>setup_logger</code> call to align with new signature.


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1572/files#diff-73672904a7798f9abb593c646339ea5c132e648258cd5400645b3d870cd5870b">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Updated CHANGELOG for logger configuration changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<li>Updated to reflect changes in logger configuration.<br> <li> Removed references to manual instance generation.


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1572/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+0/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>