### PR TITLE
[Core] Made on_start tasks start regardless to the Uvicorn server startup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.24.4 (2025-06-09)
+
+### Improvements
+- Made on_start tasks start regardless to the Uvicorn server startup.
+
 ## 0.24.3 (2025-06-08)
 
 ### Improvements

--- a/port_ocean/core/integrations/base.py
+++ b/port_ocean/core/integrations/base.py
@@ -73,7 +73,7 @@ class BaseIntegration(SyncRawMixin, SyncMixin):
         self.started = True
 
         if self.event_strategy["start"]:
-            async def run_start_listeners() -> None:
+            async def run_on_start_tasks() -> None:
                 try:
                     async with event_context(
                         EventType.START,
@@ -85,7 +85,8 @@ class BaseIntegration(SyncRawMixin, SyncMixin):
                 except Exception as e:
                     logger.exception("Error in start event listeners: %s", str(e))
 
-            asyncio.create_task(run_start_listeners())
+            # This task will run the `on_start`s in the background and will not block the server startup
+            asyncio.create_task(run_on_start_tasks())
 
         logger.info("Initializing event listener")
         event_listener = await self.event_listener_factory.create_event_listener()

--- a/port_ocean/core/integrations/base.py
+++ b/port_ocean/core/integrations/base.py
@@ -72,13 +72,20 @@ class BaseIntegration(SyncRawMixin, SyncMixin):
 
         self.started = True
 
-        async with event_context(
-            EventType.START,
-            trigger_type="machine",
-        ):
-            await asyncio.gather(
-                *(listener() for listener in self.event_strategy["start"])
-            )
+        if self.event_strategy["start"]:
+            async def run_start_listeners() -> None:
+                try:
+                    async with event_context(
+                        EventType.START,
+                        trigger_type="machine",
+                    ):
+                        await asyncio.gather(
+                            *(listener() for listener in self.event_strategy["start"])
+                        )
+                except Exception as e:
+                    logger.exception("Error in start event listeners: %s", str(e))
+
+            asyncio.create_task(run_start_listeners())
 
         logger.info("Initializing event listener")
         event_listener = await self.event_listener_factory.create_event_listener()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.24.3"
+version = "0.24.4"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
### **User description**
# Description

What - on_start will now start async to the Uvicorn server startup

Why - The liveness prob failed pods before they finished running the on_start

How - Created an asyncio task instead of blocking the event loop

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.


___

### **PR Type**
Enhancement


___

### **Description**
- Refactored on_start tasks to run asynchronously with Uvicorn server startup

- Improved error handling for start event listeners

- Updated version and changelog to reflect enhancement


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base.py</strong><dd><code>Run on_start event listeners asynchronously and add error logging</code></dd></summary>
<hr>

port_ocean/core/integrations/base.py

<li>Changed on_start event listeners to run in an async task, decoupling <br>from server startup<br> <li> Added error handling and logging for start event listeners


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1745/files#diff-5376b7fcca6a5292acf7647668b956357c102a537febc1b4157329889b19c527">+14/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Documented async on_start enhancement in changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<li>Added entry for version 0.24.4 noting the on_start async enhancement


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1745/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Updated project version to 0.24.4</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

- Bumped version from 0.24.3 to 0.24.4 to reflect the new enhancement


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1745/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>