### PR TITLE
[Integration][Gitlab-v2] Added Support For Ingesting Merge Requests In Different States

### DIFF
--- a/integrations/gitlab-v2/CHANGELOG.md
+++ b/integrations/gitlab-v2/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
-## 0.1.28 (2025-06-09)
+## 0.1.30 (2025-06-09)
 
 
 ### Improvements
@@ -15,12 +15,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for ingesting merge requests in different states (opened, closed, merged) through a new state selector configuration, allowing users to specify which merge request states they want to track
 
 
-## 0.1.27 (2025-06-09)
+## 0.1.29 (2025-06-11)
 
 
 ### Improvements
 
 - Changed job fetching to use pipeline context instead of project context to establish proper parent-child relationships between pipelines and jobs
+
+
+## 0.1.28 (2025-06-11)
+
+
+### Improvements
+
+
+- Bumped ocean version to ^0.24.8
+
+
+## 0.1.27 (2025-06-11)
+
+
+### Improvements
+
+- Bumped ocean version to ^0.24.7
 
 
 ## 0.1.26 (2025-06-09)

--- a/integrations/gitlab-v2/CHANGELOG.md
+++ b/integrations/gitlab-v2/CHANGELOG.md
@@ -7,29 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
-## 0.1.29 (2025-06-11)
+## 0.1.28 (2025-06-09)
+
+
+### Improvements
+
+- Added support for ingesting merge requests in different states (opened, closed, merged) through a new state selector configuration, allowing users to specify which merge request states they want to track
+
+
+## 0.1.27 (2025-06-09)
 
 
 ### Improvements
 
 - Changed job fetching to use pipeline context instead of project context to establish proper parent-child relationships between pipelines and jobs
-
-
-## 0.1.28 (2025-06-11)
-
-
-### Improvements
-
-
-- Bumped ocean version to ^0.24.8
-
-
-## 0.1.27 (2025-06-11)
-
-
-### Improvements
-
-- Bumped ocean version to ^0.24.7
 
 
 ## 0.1.26 (2025-06-09)

--- a/integrations/gitlab-v2/gitlab/webhook/webhook_processors/_gitlab_abstract_webhook_processor.py
+++ b/integrations/gitlab-v2/gitlab/webhook/webhook_processors/_gitlab_abstract_webhook_processor.py
@@ -19,6 +19,9 @@ class _GitlabAbstractWebhookProcessor(AbstractWebhookProcessor):
         return True
 
     async def should_process_event(self, event: WebhookEvent) -> bool:
+        from loguru import logger
+
+        logger.error(event.payload)
         event_identifier = (
             event.payload.get("event_name")
             or event.payload.get("event_type")

--- a/integrations/gitlab-v2/gitlab/webhook/webhook_processors/_gitlab_abstract_webhook_processor.py
+++ b/integrations/gitlab-v2/gitlab/webhook/webhook_processors/_gitlab_abstract_webhook_processor.py
@@ -19,9 +19,6 @@ class _GitlabAbstractWebhookProcessor(AbstractWebhookProcessor):
         return True
 
     async def should_process_event(self, event: WebhookEvent) -> bool:
-        from loguru import logger
-
-        logger.error(event.payload)
         event_identifier = (
             event.payload.get("event_name")
             or event.payload.get("event_type")

--- a/integrations/gitlab-v2/gitlab/webhook/webhook_processors/merge_request_webhook_processor.py
+++ b/integrations/gitlab-v2/gitlab/webhook/webhook_processors/merge_request_webhook_processor.py
@@ -10,6 +10,8 @@ from gitlab.helpers.utils import ObjectKind
 from gitlab.webhook.webhook_processors._gitlab_abstract_webhook_processor import (
     _GitlabAbstractWebhookProcessor,
 )
+from integration import GitlabMergeRequestResourceConfig
+from typing import cast
 
 
 class MergeRequestWebhookProcessor(_GitlabAbstractWebhookProcessor):
@@ -28,11 +30,11 @@ class MergeRequestWebhookProcessor(_GitlabAbstractWebhookProcessor):
         logger.info(
             f"Handling merge request webhook event for project {project_id} and merge request {merge_request_id} with state {state}"
         )
+        config = cast(GitlabMergeRequestResourceConfig, resource_config)
 
-        # Only process merge requests that match the configured state
-        if state != resource_config.selector.state:
+        if state != config.selector.state:
             logger.info(
-                f"Skipping merge request {merge_request_id} as state {state} does not match configured state {resource_config.selector.state}"
+                f"Skipping merge request {merge_request_id} as state {state} does not match configured state {config.selector.state}"
             )
             return WebhookEventRawResults(
                 updated_raw_results=[],

--- a/integrations/gitlab-v2/gitlab/webhook/webhook_processors/merge_request_webhook_processor.py
+++ b/integrations/gitlab-v2/gitlab/webhook/webhook_processors/merge_request_webhook_processor.py
@@ -5,6 +5,8 @@ from port_ocean.core.handlers.webhook.webhook_event import (
     WebhookEvent,
     WebhookEventRawResults,
 )
+from dateutil import parser
+from datetime import timezone
 
 from gitlab.helpers.utils import ObjectKind
 from gitlab.webhook.webhook_processors._gitlab_abstract_webhook_processor import (
@@ -21,31 +23,67 @@ class MergeRequestWebhookProcessor(_GitlabAbstractWebhookProcessor):
     async def get_matching_kinds(self, event: WebhookEvent) -> list[str]:
         return [ObjectKind.MERGE_REQUEST]
 
+    def _is_valid_state(self, state: str) -> bool:
+        """Validate if the state is one of the allowed states."""
+        return state in ["opened", "closed", "merged"]
+
     async def handle_event(
         self, payload: EventPayload, resource_config: ResourceConfig
     ) -> WebhookEventRawResults:
-        merge_request_id = payload["object_attributes"]["id"]
+
+        object_attrs = payload["object_attributes"]
+
+        merge_request_id = object_attrs["iid"]
         project_id = payload["project"]["id"]
-        state = payload["object_attributes"]["state"]
+        state = object_attrs["state"]
+        created_at = parser.parse(object_attrs["created_at"]).replace(
+            tzinfo=timezone.utc
+        )
+
         logger.info(
             f"Handling merge request webhook event for project {project_id} and merge request {merge_request_id} with state {state}"
         )
+
         config = cast(GitlabMergeRequestResourceConfig, resource_config)
 
-        if state != config.selector.state:
+        if not self._is_valid_state(state):
             logger.info(
-                f"Skipping merge request {merge_request_id} as state {state} does not match configured state {config.selector.state}"
+                f"Invalid state {state} for merge request {merge_request_id}. Skipping."
             )
             return WebhookEventRawResults(
                 updated_raw_results=[],
                 deleted_raw_results=[],
             )
 
+        if state != config.selector.state:
+            logger.info(
+                f"State {state} does not match configured state {config.selector.state} for merge request {merge_request_id}. Skipping."
+            )
+            return WebhookEventRawResults(
+                updated_raw_results=[],
+                deleted_raw_results=[],
+            )
+
+        if created_at < config.selector.created_after_datetime:
+            logger.info(
+                f"Deleting merge request {merge_request_id} as created at {created_at} is before {config.selector.created_after_datetime}"
+            )
+            return WebhookEventRawResults(
+                updated_raw_results=[],
+                deleted_raw_results=[object_attrs],
+            )
+
         merge_request = await self._gitlab_webhook_client.get_merge_request(
             project_id, merge_request_id
         )
 
-        return WebhookEventRawResults(
+        raw_merge_request_result = WebhookEventRawResults(
             updated_raw_results=[merge_request],
             deleted_raw_results=[],
         )
+
+        logger.info(
+            f"Successfully created result for merge request {merge_request_id} in {state} state"
+        )
+
+        return raw_merge_request_result

--- a/integrations/gitlab-v2/integration.py
+++ b/integrations/gitlab-v2/integration.py
@@ -111,6 +111,18 @@ class GitlabFolderSelector(Selector):
     )
 
 
+class GitlabMergeRequestSelector(Selector):
+    state: str = Field(
+        alias="state",
+        description="Specify the state of the merge request to match",
+    )
+
+
+class GitlabMergeRequestResourceConfig(ResourceConfig):
+    selector: GitlabMergeRequestSelector
+    kind: Literal["merge-request"]
+
+
 class GitLabFoldersResourceConfig(ResourceConfig):
     selector: GitlabFolderSelector
     kind: Literal["folder"]
@@ -123,6 +135,7 @@ class GitlabPortAppConfig(PortAppConfig):
         | GitlabMemberResourceConfig
         | GitLabFoldersResourceConfig
         | GitLabFilesResourceConfig
+        | GitlabMergeRequestResourceConfig
         | ResourceConfig
     ] = Field(default_factory=list)
 

--- a/integrations/gitlab-v2/integration.py
+++ b/integrations/gitlab-v2/integration.py
@@ -17,7 +17,7 @@ from port_ocean.utils.signal import signal_handler
 
 from gitlab.entity_processors.file_entity_processor import FileEntityProcessor
 from gitlab.entity_processors.search_entity_processor import SearchEntityProcessor
-
+from datetime import datetime, timedelta, timezone
 
 FILE_PROPERTY_PREFIX = "file://"
 SEARCH_PROPERTY_PREFIX = "search://"
@@ -117,6 +117,16 @@ class GitlabMergeRequestSelector(Selector):
         description="Specify the state of the merge request to match",
         default="opened",
     )
+    created_after: float = Field(
+        alias="createdAfter",
+        description="Specify the number of days to look back for merge requests (e.g. 90 for last 90 days)",
+        default=90,
+    )
+
+    @property
+    def created_after_datetime(self) -> datetime:
+        """Convert the created_after days to a timezone-aware datetime object."""
+        return datetime.now(timezone.utc) - timedelta(days=self.created_after)
 
 
 class GitlabMergeRequestResourceConfig(ResourceConfig):

--- a/integrations/gitlab-v2/integration.py
+++ b/integrations/gitlab-v2/integration.py
@@ -1,4 +1,4 @@
-from typing import Literal, Any, Type
+from typing import Literal, Any, Type, List
 from pydantic import BaseModel, Field
 
 from port_ocean.context.ocean import PortOceanContext
@@ -112,21 +112,21 @@ class GitlabFolderSelector(Selector):
 
 
 class GitlabMergeRequestSelector(Selector):
-    state: Literal["opened", "closed", "merged"] = Field(
+    states: List[Literal["opened", "closed", "merged"]] = Field(
         alias="state",
         description="Specify the state of the merge request to match",
-        default="opened",
+        default=["opened"],
     )
-    created_after: float = Field(
-        alias="createdAfter",
+    updated_after: float = Field(
+        alias="updatedAfter",
         description="Specify the number of days to look back for merge requests (e.g. 90 for last 90 days)",
         default=90,
     )
 
     @property
-    def created_after_datetime(self) -> datetime:
+    def updated_after_datetime(self) -> datetime:
         """Convert the created_after days to a timezone-aware datetime object."""
-        return datetime.now(timezone.utc) - timedelta(days=self.created_after)
+        return datetime.now(timezone.utc) - timedelta(days=self.updated_after)
 
 
 class GitlabMergeRequestResourceConfig(ResourceConfig):

--- a/integrations/gitlab-v2/integration.py
+++ b/integrations/gitlab-v2/integration.py
@@ -113,8 +113,8 @@ class GitlabFolderSelector(Selector):
 
 class GitlabMergeRequestSelector(Selector):
     states: List[Literal["opened", "closed", "merged"]] = Field(
-        alias="state",
-        description="Specify the state of the merge request to match",
+        alias="states",
+        description="Specify the state of the merge request to match. Allowed values: opened, closed, merged",
         default=["opened"],
     )
     updated_after: float = Field(

--- a/integrations/gitlab-v2/integration.py
+++ b/integrations/gitlab-v2/integration.py
@@ -112,9 +112,10 @@ class GitlabFolderSelector(Selector):
 
 
 class GitlabMergeRequestSelector(Selector):
-    state: str = Field(
+    state: Literal["opened", "closed", "merged"] = Field(
         alias="state",
         description="Specify the state of the merge request to match",
+        default="opened",
     )
 
 

--- a/integrations/gitlab-v2/main.py
+++ b/integrations/gitlab-v2/main.py
@@ -133,13 +133,15 @@ async def on_resync_jobs(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
 async def on_resync_merge_requests(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     client = create_gitlab_client()
     selector = cast(GitlabMergeRequestResourceConfig, event.resource_config).selector
+
     state = selector.state
+    created_after = selector.created_after_datetime
 
     async for groups_batch in client.get_groups():
         logger.info(
-            f"Processing batch of {len(groups_batch)} groups for merge requests"
+            f"Processing batch of {len(groups_batch)} groups for {state} merge requests created after {created_after}"
         )
-        params = {"state": state}
+        params = {"state": state, "created_after": created_after}
 
         async for merge_requests_batch in client.get_groups_resource(
             groups_batch, "merge_requests", params=params

--- a/integrations/gitlab-v2/main.py
+++ b/integrations/gitlab-v2/main.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import cast, Any, Dict
 
 from loguru import logger
 from port_ocean.context.event import event
@@ -143,7 +143,7 @@ async def on_resync_merge_requests(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
                 f"Processing batch of {len(groups_batch)} groups for {state} merge requests"
                 + (f" updated after {updated_after}" if state != "opened" else "")
             )
-            params = {"state": state}
+            params: Dict[str, Any] = {"state": state}
             if state != "opened":
                 params["updated_after"] = updated_after
 

--- a/integrations/gitlab-v2/main.py
+++ b/integrations/gitlab-v2/main.py
@@ -16,6 +16,7 @@ from integration import (
     GitLabFoldersResourceConfig,
     GitlabGroupWithMembersResourceConfig,
     GitlabMemberResourceConfig,
+    GitlabMergeRequestResourceConfig,
 )
 
 from gitlab.webhook.webhook_processors.merge_request_webhook_processor import (
@@ -131,12 +132,15 @@ async def on_resync_jobs(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
 @ocean.on_resync(ObjectKind.MERGE_REQUEST)
 async def on_resync_merge_requests(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     client = create_gitlab_client()
+    selector = cast(GitlabMergeRequestResourceConfig, event.resource_config).selector
+    state = selector.state
+    logger.warning(f"state: {state}")
 
     async for groups_batch in client.get_groups():
         logger.info(
             f"Processing batch of {len(groups_batch)} groups for merge requests"
         )
-        params = {"state": "opened"}
+        params = {"state": state}
 
         async for merge_requests_batch in client.get_groups_resource(
             groups_batch, "merge_requests", params=params

--- a/integrations/gitlab-v2/main.py
+++ b/integrations/gitlab-v2/main.py
@@ -134,7 +134,6 @@ async def on_resync_merge_requests(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     client = create_gitlab_client()
     selector = cast(GitlabMergeRequestResourceConfig, event.resource_config).selector
     state = selector.state
-    logger.warning(f"state: {state}")
 
     async for groups_batch in client.get_groups():
         logger.info(

--- a/integrations/gitlab-v2/pyproject.toml
+++ b/integrations/gitlab-v2/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gitlab-v2"
-version = "0.1.29"
+version = "0.1.30"
 description = "Gitlab"
 authors = ["Shariff <mohammed.s@getport.io>"]
 

--- a/integrations/gitlab-v2/tests/webhook/webhook_processors/test_merge_request_webhook_processor.py
+++ b/integrations/gitlab-v2/tests/webhook/webhook_processors/test_merge_request_webhook_processor.py
@@ -85,7 +85,8 @@ class TestMergeRequestWebhookProcessor:
         """Test handling a merge request event when state matches"""
         resource_config = MagicMock()
         resource_config.selector.state = "opened"
-        resource_config.selector.created_after_datetime = datetime(
+        resource_config.selector.states = ["opened"]
+        resource_config.selector.updated_after_datetime = datetime(
             2022, 1, 1, tzinfo=timezone.utc
         )
 
@@ -117,8 +118,8 @@ class TestMergeRequestWebhookProcessor:
         """Test handling a merge request event when state doesn't match"""
         resource_config = MagicMock()
         resource_config.selector.state = "merged"
-
-        resource_config.selector.created_after_datetime = datetime(
+        resource_config.selector.states = ["merged"]
+        resource_config.selector.updated_after_datetime = datetime(
             2022, 1, 1, tzinfo=timezone.utc
         )
 

--- a/integrations/gitlab-v2/tests/webhook/webhook_processors/test_merge_request_webhook_processor.py
+++ b/integrations/gitlab-v2/tests/webhook/webhook_processors/test_merge_request_webhook_processor.py
@@ -84,7 +84,6 @@ class TestMergeRequestWebhookProcessor:
     ) -> None:
         """Test handling a merge request event when state matches"""
         resource_config = MagicMock()
-        resource_config.selector.state = "opened"
         resource_config.selector.states = ["opened"]
         resource_config.selector.updated_after_datetime = datetime(
             2022, 1, 1, tzinfo=timezone.utc
@@ -117,7 +116,6 @@ class TestMergeRequestWebhookProcessor:
     ) -> None:
         """Test handling a merge request event when state doesn't match"""
         resource_config = MagicMock()
-        resource_config.selector.state = "merged"
         resource_config.selector.states = ["merged"]
         resource_config.selector.updated_after_datetime = datetime(
             2022, 1, 1, tzinfo=timezone.utc
@@ -130,4 +128,4 @@ class TestMergeRequestWebhookProcessor:
 
         processor._gitlab_webhook_client.get_merge_request.assert_not_called()
         assert not result.updated_raw_results
-        assert not result.deleted_raw_results
+        assert result.deleted_raw_results

--- a/integrations/gitlab-v2/tests/webhook/webhook_processors/test_merge_request_webhook_processor.py
+++ b/integrations/gitlab-v2/tests/webhook/webhook_processors/test_merge_request_webhook_processor.py
@@ -14,6 +14,8 @@ from port_ocean.core.handlers.webhook.webhook_event import (
 )
 from typing import Any
 
+from datetime import datetime, timezone
+
 
 @pytest.fixture(autouse=True)
 def mock_ocean_context() -> None:
@@ -82,9 +84,13 @@ class TestMergeRequestWebhookProcessor:
     ) -> None:
         """Test handling a merge request event when state matches"""
         resource_config = MagicMock()
-        resource_config.selector.state = "opened"  # Match the state in mr_payload
+        resource_config.selector.state = "opened"
+        resource_config.selector.created_after_datetime = datetime(
+            2022, 1, 1, tzinfo=timezone.utc
+        )
+
         project_id = mr_payload["project"]["id"]
-        mr_id = mr_payload["object_attributes"]["id"]
+        mr_id = mr_payload["object_attributes"]["iid"]  # Use iid instead of id
         expected_mr = {
             "id": mr_id,
             "object_kind": "merge_request",
@@ -110,7 +116,11 @@ class TestMergeRequestWebhookProcessor:
     ) -> None:
         """Test handling a merge request event when state doesn't match"""
         resource_config = MagicMock()
-        resource_config.selector.state = "merged"  # Different from mr_payload state
+        resource_config.selector.state = "merged"
+
+        resource_config.selector.created_after_datetime = datetime(
+            2022, 1, 1, tzinfo=timezone.utc
+        )
 
         processor._gitlab_webhook_client = MagicMock()
         processor._gitlab_webhook_client.get_merge_request = AsyncMock()


### PR DESCRIPTION
# Description

**What**
- Added support for filtering merge requests by their state (opened, closed, merged) in the GitLab v2 integration. This enhancement allows users to selectively track merge requests based on their preferred state through a new state selector configuration while still maintain integration performance by only syncing desired states.

**Why**
- Currently, the integration fetches all merge requests regardless of their state, which can lead to unnecessary data synchronization and potential performance issues. By adding state-based filtering, users can:
- Focus on relevant merge requests based on their workflow needs
- Better align with specific use cases and DORA requirements

**How**
- Added a new state selector configuration in the merge request resource config
- Modified the merge request resync logic to respect the state filter
- Updated the webhook processor to maintain consistency with the state filtering
- Added appropriate documentation and changelog entries

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.


___

### **PR Type**
Enhancement


___

### **Description**
• Added state selector configuration for merge request filtering
• Modified resync logic to respect state-based filtering
• Updated webhook processing for state consistency
• Enhanced GitLab v2 integration performance and flexibility


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Implement configurable merge request state filtering</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/gitlab-v2/main.py

• Added import for <code>GitlabMergeRequestResourceConfig</code><br> • Modified <br><code>on_resync_merge_requests</code> to extract state from selector configuration<br> <br>• Updated merge request fetching to use configurable state parameter <br>instead of hardcoded "opened"


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1784/files#diff-0863b6f5aa347d648ed8ec779bf541736547be7c6d485d3d7a60bb9e520bfd1d">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document merge request state filtering feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/gitlab-v2/CHANGELOG.md

• Added changelog entry for version 0.1.28 documenting the new merge <br>request state filtering feature<br> • Reorganized version entries with <br>proper chronological order


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1784/files#diff-fa549dfca83e908e603381bb974e4505c70cb46b8ba916cccaeda7709d376051">+4/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>