### PR TITLE
[Core] Added `on_start` for specific event listeners

### DIFF
--- a/port_ocean/__init__.py
+++ b/port_ocean/__init__.py
@@ -6,11 +6,13 @@ warnings.filterwarnings("ignore", category=FutureWarning)
 from .ocean import Ocean  # noqa: E402
 from .run import run  # noqa: E402
 from .version import __integration_version__, __version__  # noqa: E402
+from .core.ocean_types import EventListenerType  # noqa: E402
 
 
 __all__ = [
     "Ocean",
     "run",
+    "EventListenerType",
     "__version__",
     "__integration_version__",
 ]

--- a/port_ocean/context/ocean.py
+++ b/port_ocean/context/ocean.py
@@ -15,6 +15,7 @@ from port_ocean.core.ocean_types import (
     EntityDiff,
     BEFORE_RESYNC_EVENT_LISTENER,
     AFTER_RESYNC_EVENT_LISTENER,
+    EventListenerType,
 )
 from port_ocean.exceptions.context import (
     PortOceanContextNotFoundError,
@@ -94,11 +95,43 @@ class PortOceanContext:
 
         return wrapper
 
-    def on_start(self) -> Callable[[START_EVENT_LISTENER], START_EVENT_LISTENER]:
-        def wrapper(function: START_EVENT_LISTENER) -> START_EVENT_LISTENER:
-            return self.integration.on_start(function)
+    def on_start(
+        self,
+        function: START_EVENT_LISTENER | None = None,
+        event_listener: EventListenerType | None = None,
+    ) -> START_EVENT_LISTENER | Callable[[START_EVENT_LISTENER], START_EVENT_LISTENER]:
+        """Register a function as a listener for the "start" event.
 
-        return wrapper
+        This allows integrations to define different startup behavior for different event listener types.
+        When both general and event listener-specific functions are defined, the event listener-specific
+        functions take precedence.
+
+        Args:
+            function: The function to register (when used directly)
+            event_listener: Optional event listener type for specific startup behavior.
+                          Accepts both EventListenerType enum values and string literals.
+
+        Returns:
+            The original function or a decorator function
+
+        Examples:
+            >>> # General startup (fallback for all event listener types)
+            >>> @ocean.on_start()
+            ... async def on_start() -> None:
+            ...     logger.info("General startup logic")
+            ...
+            >>> # Event listener-specific startup using enum (recommended)
+            >>> @ocean.on_start(event_listener=EventListenerType.ONCE)
+            ... async def on_start_once() -> None:
+            ...     logger.info("Starting in ONCE mode - skipping webhook setup")
+            ...
+            >>> # Event listener-specific startup using string (also works)
+            >>> @ocean.on_start(event_listener="ONCE")
+            ... async def on_start_webhook() -> None:
+            ...     logger.info("Starting in ONCE mode")
+            ...     await setup_webhooks()
+        """
+        return self.integration.on_start(function, event_listener)
 
     def on_resync_start(
         self,

--- a/port_ocean/core/integrations/mixins/events.py
+++ b/port_ocean/core/integrations/mixins/events.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Any
+from typing import Any, Callable
 
 from loguru import logger
 
@@ -9,6 +9,7 @@ from port_ocean.core.ocean_types import (
     RESYNC_EVENT_LISTENER,
     BEFORE_RESYNC_EVENT_LISTENER,
     AFTER_RESYNC_EVENT_LISTENER,
+    EventListenerType,
 )
 
 
@@ -25,6 +26,7 @@ class EventsMixin:
     def __init__(self) -> None:
         self.event_strategy: IntegrationEventsCallbacks = {
             "start": [],
+            "start_for_listener": defaultdict(list),  # New: event listener-specific start functions
             "resync": defaultdict(list),
             "resync_start": [],
             "resync_complete": [],
@@ -34,11 +36,54 @@ class EventsMixin:
     def available_resync_kinds(self) -> list[str]:
         return list(self.event_strategy["resync"].keys())
 
-    def on_start(self, function: START_EVENT_LISTENER) -> START_EVENT_LISTENER:
-        """Register a function as a listener for the "start" event."""
-        logger.debug(f"Registering {function} as a start event listener")
-        self.event_strategy["start"].append(function)
-        return function
+    def on_start(
+        self,
+        function: START_EVENT_LISTENER | None = None,
+        event_listener: EventListenerType | None = None
+    ) -> START_EVENT_LISTENER | Callable[[START_EVENT_LISTENER], START_EVENT_LISTENER]:
+        """Register a function as a listener for the "start" event.
+
+        Args:
+            function: The function to register (when used directly)
+            event_listener: Optional event listener type to register for specific startup behavior.
+                          Accepts both EventListenerType enum values and string literals.
+
+        Returns:
+            The original function or a decorator function
+
+        Usage:
+            # General startup (fallback)
+            @ocean.on_start()
+            async def on_start() -> None:
+                pass
+
+            # Event listener-specific startup using enum (recommended)
+            @ocean.on_start(event_listener=EventListenerType.ONCE)
+            async def on_start_once() -> None:
+                pass
+
+            # Event listener-specific startup using string (also works)
+            @ocean.on_start(event_listener="ONCE")
+            async def on_start_once() -> None:
+                pass
+        """
+        def decorator(func: START_EVENT_LISTENER) -> START_EVENT_LISTENER:
+            if event_listener is not None:
+                # Convert enum to string value for storage
+                listener_key = event_listener.value if isinstance(event_listener, EventListenerType) else event_listener
+                logger.debug(f"Registering {func} as a start event listener for {listener_key}")
+                self.event_strategy["start_for_listener"][listener_key].append(func)
+            else:
+                logger.debug(f"Registering {func} as a general start event listener")
+                self.event_strategy["start"].append(func)
+            return func
+
+        if function is not None:
+            # Called directly without parentheses: @ocean.on_start
+            return decorator(function)
+        else:
+            # Called with parentheses: @ocean.on_start() or @ocean.on_start(event_listener=EventListenerType.ONCE)
+            return decorator
 
     def on_resync(
         self, function: RESYNC_EVENT_LISTENER | None, kind: str | None = None

--- a/port_ocean/core/ocean_types.py
+++ b/port_ocean/core/ocean_types.py
@@ -7,6 +7,8 @@ from typing import (
     NamedTuple,
 )
 
+from enum import Enum
+
 from dataclasses import field
 from port_ocean.core.models import Entity
 
@@ -21,6 +23,20 @@ START_EVENT_LISTENER = Callable[[], Awaitable[None]]
 
 BEFORE_RESYNC_EVENT_LISTENER = Callable[[], Awaitable[None]]
 AFTER_RESYNC_EVENT_LISTENER = Callable[[], Awaitable[None]]
+
+
+class EventListenerType(str, Enum):
+    """Enumeration of supported event listener types.
+
+    This enum provides type safety and better IDE support for event listener types.
+    Since it extends str, it automatically accepts both enum values and string literals.
+    """
+
+    WEBHOOK = "WEBHOOK"
+    KAFKA = "KAFKA"
+    POLLING = "POLLING"
+    ONCE = "ONCE"
+    WEBHOOKS_ONLY = "WEBHOOKS_ONLY"
 
 
 class RawEntityDiff(TypedDict):
@@ -47,6 +63,9 @@ class CalculationResult(NamedTuple):
 
 class IntegrationEventsCallbacks(TypedDict):
     start: list[START_EVENT_LISTENER]
+    start_for_listener: dict[
+        str, list[START_EVENT_LISTENER]
+    ]  # New: event listener-specific start functions
     resync: dict[str | None, list[RESYNC_EVENT_LISTENER]]
     resync_start: list[BEFORE_RESYNC_EVENT_LISTENER]
     resync_complete: list[AFTER_RESYNC_EVENT_LISTENER]

--- a/port_ocean/tests/core/integrations/test_event_listener_startup.py
+++ b/port_ocean/tests/core/integrations/test_event_listener_startup.py
@@ -1,0 +1,218 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+import pytest
+
+from port_ocean.core.integrations.base import BaseIntegration
+from port_ocean.context.ocean import PortOceanContext
+from port_ocean.core.ocean_types import EventListenerType
+
+
+class TestEventListenerStartup:
+    """Test event listener-specific startup functionality."""
+
+    @pytest.fixture
+    def mock_context(self):
+        """Create a mock PortOceanContext for testing."""
+        context = MagicMock(spec=PortOceanContext)
+        context.config.integration.type = "test"
+        context.config.event_listener.type = "ONCE"
+        context.config.event_listener.should_resync = False  # Disable resync requirement for tests
+        return context
+
+    @pytest.fixture
+    def integration(self, mock_context):
+        """Create a BaseIntegration instance for testing."""
+        integration = BaseIntegration(mock_context)
+        # Mock the initialize_handlers method to prevent actual initialization
+        integration.initialize_handlers = AsyncMock()
+        return integration
+
+    async def test_event_listener_specific_startup_preferred(self, integration, mock_context):
+        """Test that event listener-specific startup functions take precedence over general ones."""
+        # Setup
+        general_startup_called = False
+        specific_startup_called = False
+
+        async def general_startup():
+            nonlocal general_startup_called
+            general_startup_called = True
+
+        async def specific_startup():
+            nonlocal specific_startup_called
+            specific_startup_called = True
+
+        # Register both general and specific startup functions
+        integration.on_start(general_startup)
+        integration.on_start(specific_startup, event_listener=EventListenerType.ONCE)
+
+        # Mock the event listener factory
+        mock_event_listener = AsyncMock()
+        integration.event_listener_factory.create_event_listener = AsyncMock(return_value=mock_event_listener)
+
+        # Execute
+        await integration.start()
+
+        # Allow async tasks to complete
+        await asyncio.sleep(0.1)
+
+        # Verify
+        assert specific_startup_called is True, "Event listener-specific startup should be called"
+        assert general_startup_called is False, "General startup should NOT be called when specific one exists"
+
+    async def test_general_startup_fallback(self, integration, mock_context):
+        """Test that general startup functions are used when no specific ones exist."""
+        # Setup
+        general_startup_called = False
+
+        async def general_startup():
+            nonlocal general_startup_called
+            general_startup_called = True
+
+        # Register only general startup function
+        integration.on_start(general_startup)
+
+        # Mock the event listener factory
+        mock_event_listener = AsyncMock()
+        integration.event_listener_factory.create_event_listener = AsyncMock(return_value=mock_event_listener)
+
+        # Execute
+        await integration.start()
+
+        # Allow async tasks to complete
+        await asyncio.sleep(0.1)
+
+        # Verify
+        assert general_startup_called is True, "General startup should be called as fallback"
+
+    async def test_multiple_specific_startup_functions(self, integration, mock_context):
+        """Test that multiple event listener-specific startup functions can be registered for the same type."""
+        # Setup
+        startup1_called = False
+        startup2_called = False
+
+        async def startup1():
+            nonlocal startup1_called
+            startup1_called = True
+
+        async def startup2():
+            nonlocal startup2_called
+            startup2_called = True
+
+        # Register multiple startup functions for the same event listener type
+        integration.on_start(startup1, event_listener=EventListenerType.ONCE)
+        integration.on_start(startup2, event_listener=EventListenerType.ONCE)
+
+        # Mock the event listener factory
+        mock_event_listener = AsyncMock()
+        integration.event_listener_factory.create_event_listener = AsyncMock(return_value=mock_event_listener)
+
+        # Execute
+        await integration.start()
+
+        # Allow async tasks to complete
+        await asyncio.sleep(0.1)
+
+        # Verify
+        assert startup1_called is True, "First startup function should be called"
+        assert startup2_called is True, "Second startup function should be called"
+
+    async def test_different_event_listener_types(self, integration, mock_context):
+        """Test that only the correct startup function is called for each event listener type."""
+        # Setup
+        once_startup_called = False
+        webhook_startup_called = False
+
+        async def once_startup():
+            nonlocal once_startup_called
+            once_startup_called = True
+
+        async def webhook_startup():
+            nonlocal webhook_startup_called
+            webhook_startup_called = True
+
+        # Register startup functions for different event listener types
+        integration.on_start(once_startup, event_listener="ONCE")
+        integration.on_start(webhook_startup, event_listener="WEBHOOK")
+
+        # Mock the event listener factory
+        mock_event_listener = AsyncMock()
+        integration.event_listener_factory.create_event_listener = AsyncMock(return_value=mock_event_listener)
+
+        # Test with ONCE event listener type
+        mock_context.config.event_listener.type = "ONCE"
+
+        # Execute
+        await integration.start()
+
+        # Allow async tasks to complete
+        await asyncio.sleep(0.1)
+
+        # Verify
+        assert once_startup_called is True, "ONCE startup should be called for ONCE event listener"
+        assert webhook_startup_called is False, "WEBHOOK startup should NOT be called for ONCE event listener"
+
+    async def test_no_startup_functions_registered(self, integration, mock_context):
+        """Test that integration starts successfully even when no startup functions are registered."""
+        # Mock the event listener factory
+        mock_event_listener = AsyncMock()
+        integration.event_listener_factory.create_event_listener = AsyncMock(return_value=mock_event_listener)
+
+        # Execute - should not fail
+        await integration.start()
+
+        # Verify integration is marked as started
+        assert integration.started is True
+
+    async def test_startup_function_error_handling(self, integration, mock_context):
+        """Test that startup function errors are properly handled and logged."""
+        # Setup
+        async def failing_startup():
+            raise Exception("Startup failed")
+
+        # Register failing startup function
+        integration.on_start(failing_startup, event_listener="ONCE")
+
+        # Mock the event listener factory
+        mock_event_listener = AsyncMock()
+        integration.event_listener_factory.create_event_listener = AsyncMock(return_value=mock_event_listener)
+
+        # Execute - should not fail despite startup function error
+        await integration.start()
+
+        # Allow async tasks to complete
+        await asyncio.sleep(0.1)
+
+        # Verify integration is still marked as started
+        assert integration.started is True
+
+    async def test_enum_and_string_compatibility(self, integration, mock_context):
+        """Test that EventListenerType (str, Enum) accepts both enum and string values seamlessly."""
+        # Setup
+        enum_startup_called = False
+        string_startup_called = False
+
+        async def enum_startup():
+            nonlocal enum_startup_called
+            enum_startup_called = True
+
+        async def string_startup():
+            nonlocal string_startup_called
+            string_startup_called = True
+
+        # Register startup functions using both enum and string
+        integration.on_start(enum_startup, event_listener=EventListenerType.ONCE)
+        integration.on_start(string_startup, event_listener="ONCE")
+
+        # Mock the event listener factory
+        mock_event_listener = AsyncMock()
+        integration.event_listener_factory.create_event_listener = AsyncMock(return_value=mock_event_listener)
+
+        # Execute
+        await integration.start()
+
+        # Allow async tasks to complete
+        await asyncio.sleep(0.1)
+
+        # Verify both functions are called (they should be treated as the same event listener type)
+        assert enum_startup_called is True, "Enum-based startup should be called"
+        assert string_startup_called is True, "String-based startup should be called"


### PR DESCRIPTION
# Description

What - Added `on_start` for specific event listeners

Why - currently integrations are specifying inside of the code what to do in case of each event listener, this causes quite a few problems as we might want to have different on_start capabilities for different eventListener types.

How - added a configurable parameter to the `on_start` method that allows the user to specify the event listener type

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
