### PR TITLE
[Core] - decrease bulks concurrency to 5 to reduce load on port-api

### DIFF
--- a/port_ocean/clients/port/mixins/entities.py
+++ b/port_ocean/clients/port/mixins/entities.py
@@ -24,6 +24,7 @@ from port_ocean.helpers.metric.metric import MetricPhase, MetricType
 ENTITIES_BULK_SAMPLES_SIZE = 10
 ENTITIES_BULK_ESTIMATED_SIZE_MULTIPLIER = 1.5
 ENTITIES_BULK_MINIMUM_BATCH_SIZE = 1
+ENTITIES_BULK_UPSERT_CONCURRENCY = 5
 
 
 class EntityClientMixin:
@@ -199,7 +200,8 @@ class EntityClientMixin:
         :return: httpx.HTTPStatusError if there was an HTTP error and should_raise is False
         """
         validation_only = request_options["validation_only"]
-        async with self.semaphore:
+        bulk_semaphore = asyncio.Semaphore(ENTITIES_BULK_UPSERT_CONCURRENCY)
+        async with bulk_semaphore:
             logger.debug(
                 f"{'Validating' if validation_only else 'Upserting'} {len(entities)} of blueprint: {blueprint}"
             )


### PR DESCRIPTION
### **User description**
# Description

What - decrease bulks concurrency to 5 to reduce load on port-api

Why - when we added the bulk upsert we kept the previous concurrency (50) which increased the load on port-api. Now we are doing 5 upserts of 20 entities in parallel. This is still higher rate then before when it was 50 single upserts in parallel

How - use different semaphore for the bulk upserts

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.


___

### **PR Type**
Enhancement


___

### **Description**
- Reduce bulk upsert concurrency from 50 to 5

- Add dedicated semaphore for bulk operations

- Optimize load on port-api while maintaining throughput


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>entities.py</strong><dd><code>Add dedicated bulk upsert concurrency control</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

port_ocean/clients/port/mixins/entities.py

<li>Add <code>ENTITIES_BULK_UPSERT_CONCURRENCY</code> constant set to 5<br> <li> Replace shared semaphore with dedicated bulk semaphore<br> <li> Create separate concurrency control for bulk operations


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1809/files#diff-1cd3dc7778947127c84baab24278808bee9c4ded96b1c320e28ece0f4d55ba7f">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>