### PR TITLE
[Core] Fixed mixed blueprint entities sent to wrong endpoint in batch upsert operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- towncrier release notes start -->
+<!-- towncrier release notes start -->\
+## 0.24.18 (2025-06-23)
+
+### Bug Fixes
+- Fixed issue with upserts when there are entities with different blueprints in the same batch from live events
+
 ## 0.24.17 (2025-06-23)
 
 ### Bug Fixes

--- a/port_ocean/core/integrations/mixins/live_events.py
+++ b/port_ocean/core/integrations/mixins/live_events.py
@@ -17,7 +17,14 @@ class LiveEventsMixin(HandlerMixin):
         """
         entities_to_create, entities_to_delete = await self._parse_raw_event_results_to_entities(webhook_events_raw_result)
         if entities_to_create:
-            await self.entities_state_applier.upsert(entities_to_create, UserAgentType.exporter)
+            blueprint_groups: dict[str, list[Entity]] = {}
+            for entity in entities_to_create:
+                if entity.blueprint not in blueprint_groups:
+                    blueprint_groups[entity.blueprint] = []
+                blueprint_groups[entity.blueprint].append(entity)
+            
+            for blueprint_entities in blueprint_groups.values():
+                await self.entities_state_applier.upsert(blueprint_entities, UserAgentType.exporter)
         if entities_to_delete:
             await self._delete_entities(entities_to_delete)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.24.17"
+version = "0.24.18"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What - Fixed bug where entities with different blueprints from multiple webhook processors were sent to wrong API endpoints causing silent data loss.

Why - The `upsert_entities_in_batches` method assums all entities shared the same blueprint using `entities[0].blueprint` for mixed-blueprint lists from live events.

How - Added blueprint grouping logic in LiveEventsMixin.sync_raw_results() to separate entities by blueprint before upserting, ensuring each group goes to the correct API endpoint.

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
