### PR TITLE
[Integration][Jira] Fixed jira teams pagination bug

### DIFF
--- a/integrations/jira/CHANGELOG.md
+++ b/integrations/jira/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.4.34 (2025-06-23)
+
+
+### Bug Fixes
+
+- Fixed pagination for teams list and team members API
+
+
 ## 0.4.33 (2025-06-23)
 
 

--- a/integrations/jira/jira/client.py
+++ b/integrations/jira/jira/client.py
@@ -161,11 +161,14 @@ class JiraClient(OAuthClient):
 
             yield items
 
-            page_info = response_data.get("pageInfo", {})
-            cursor = page_info.get("endCursor")
-
-            if not page_info.get("hasNextPage", False):
-                break
+            if page_info := response_data.get("pageInfo", {}):
+                cursor = page_info.get("endCursor")
+                if not page_info.get("hasNextPage", False):
+                    break
+            else:
+                cursor = response_data.get("cursor")
+                if not cursor:
+                    break
 
     @staticmethod
     def _generate_base_req_params(

--- a/integrations/jira/pyproject.toml
+++ b/integrations/jira/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jira"
-version = "0.4.33"
+version = "0.4.34"
 description = "Integration to bring information from Jira into Port"
 authors = ["Mor Paz <mor@getport.io>"]
 


### PR DESCRIPTION
### **User description**
# Description

What - Fixed Jira Teams sync to retrieve all teams instead of stopping after first 50 teams

Why - Pagination logic was expecting `pageInfo` response format but Teams API returns cursor directly in response root

How - Updated `_get_cursor_paginated_data` to handle both Teams API (cursor field) and Team Members API (pageInfo structure) response formats

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed Jira Teams pagination to retrieve all teams beyond first 50

- Updated cursor handling for different API response formats

- Added comprehensive test coverage for multi-page scenarios


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>client.py</strong><dd><code>Enhanced cursor pagination handling for multiple API formats</code></dd></summary>
<hr>

integrations/jira/jira/client.py

<li>Modified <code>_get_cursor_paginated_data</code> to handle both <code>pageInfo</code> structure <br>and direct cursor field<br> <li> Added conditional logic to check for cursor in response root when <br><code>pageInfo</code> is absent<br> <li> Fixed pagination termination logic for Teams API format


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1828/files#diff-a98c78f4ca9c522a3bfdb5542ddb9f19e863b787dff0b39169b91f02facb53be">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_client.py</strong><dd><code>Added comprehensive multi-page pagination test coverage</code>&nbsp; &nbsp; </dd></summary>
<hr>

integrations/jira/tests/test_client.py

<li>Added <code>test_get_paginated_teams_multiple_pages</code> test function<br> <li> Created mock responses for multi-page pagination scenario<br> <li> Added assertions to verify cursor parameter passing between requests


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1828/files#diff-60921df7af01aa40bb94b945d9226ba1137e1e4c7f55aa67678f3e26a6e299a0">+39/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Updated changelog for pagination bug fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/jira/CHANGELOG.md

<li>Added version 0.4.34 entry with bug fix description<br> <li> Documented pagination fix for teams list and team members API


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1828/files#diff-7a3a5e341adb6a81f8d0177dfc07d8b2d4230c39ede5d93de91c7b205a0e29fa">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Version bump to 0.4.34</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/jira/pyproject.toml

- Bumped version from 0.4.33 to 0.4.34


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1828/files#diff-58a3ec0700a093f3b96dda2068e48b8e26665e1c83dd8207ef3c8cac8480e8cc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>