### PR TITLE
[Integration][bitbucket-cloud] Ensure Files Are Properly Deleted in Port For File Kind Live Events

### DIFF
--- a/integrations/bitbucket-cloud/CHANGELOG.md
+++ b/integrations/bitbucket-cloud/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.47 (2025-06-26)
+
+
+### Bug Fix
+- Fixed bug in file kind live events where tracked file does not get upserted to port
+
+- Fixed bug in file kind live event causing tracked file not getting deleted from port when file has been deleted from bitbucket repo.
+
+
 ## 0.1.46 (2025-06-25)
 
 

--- a/integrations/bitbucket-cloud/pyproject.toml
+++ b/integrations/bitbucket-cloud/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bitbucket-cloud"
-version = "0.1.48"
+version = "0.1.49"
 description = "This integration ingest data from bitbucket"
 authors = ["Adebayo Iyanuoluwa <ioluwadunsinadebayo@gmail.com>", "Michael Armah <mikeyarmah@gmail.com>"]
 

--- a/integrations/bitbucket-cloud/pyproject.toml
+++ b/integrations/bitbucket-cloud/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bitbucket-cloud"
-version = "0.1.47"
+version = "0.1.48"
 description = "This integration ingest data from bitbucket"
 authors = ["Adebayo Iyanuoluwa <ioluwadunsinadebayo@gmail.com>", "Michael Armah <mikeyarmah@gmail.com>"]
 

--- a/integrations/bitbucket-cloud/pyproject.toml
+++ b/integrations/bitbucket-cloud/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bitbucket-cloud"
-version = "0.1.49"
+version = "0.1.50"
 description = "This integration ingest data from bitbucket"
 authors = ["Adebayo Iyanuoluwa <ioluwadunsinadebayo@gmail.com>", "Michael Armah <mikeyarmah@gmail.com>"]
 

--- a/integrations/bitbucket-cloud/pyproject.toml
+++ b/integrations/bitbucket-cloud/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "bitbucket-cloud"
-version = "0.1.46"
+version = "0.1.47"
 description = "This integration ingest data from bitbucket"
 authors = ["Adebayo Iyanuoluwa <ioluwadunsinadebayo@gmail.com>", "Michael Armah <mikeyarmah@gmail.com>"]
 


### PR DESCRIPTION
# Description

What -

- Fixes bug in file kind live event where tracked files don't get upserted to port 
- Fixes a bug in File kind live events where files deleted from the bitbucket-cloud repository were not being properly unregistered (deleted) from Port. The webhook processor now correctly builds a minimal entity for deleted files, ensuring they are removed from Port when deleted in the source repository.

Why -

- The `get_file_paths` function was failing when `diff_stat.get("old")` or `diff_stat.get("new")` returned `None`, causing `NoneType` object has no attribute `get` exceptions that prevented file processing entirely

- Previously, when a file was deleted in bitbucket-cloud, the corresponding entity was not always removed from Port due to incomplete or missing entity construction for deletions. This led to stale file entities persisting in Port, causing data inconsistency and confusion for users tracking file state.

How -

- Fixed the `get_file_paths` function to handle None values
- Refactored the webhook processor’s deletion logic to include all required parameters for entity for deleted files using metadata from the event payload.

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
