### PR TITLE
[Core] Send failed mapping examples.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.24.23 (2025-07-07)
+
+### Improvements
+- Add failed mapping if all values filtered out
+
 ## 0.24.22 (2025-07-02)
 
 ### Bug Fixes

--- a/integrations/jira/CHANGELOG.md
+++ b/integrations/jira/CHANGELOG.md
@@ -7,12 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
-## 0.4.40 (2025-07-02)
+## 0.4.41 (2025-07-07)
 
+### Improvements
+
+- Send examples even when integration fails
+
+## 0.4.40 (2025-07-02)
 
 ### Bug Fixes
 
--  Fix `JIRA_HOST` from str type to url 
+-  Fix `JIRA_HOST` from str type to url
+
 ## 0.4.39 (2025-07-02)
 
 

--- a/integrations/jira/CHANGELOG.md
+++ b/integrations/jira/CHANGELOG.md
@@ -7,18 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
-## 0.4.41 (2025-07-07)
-
-### Improvements
-
-- Send examples even when integration fails
-
 ## 0.4.40 (2025-07-02)
+
 
 ### Bug Fixes
 
 -  Fix `JIRA_HOST` from str type to url
-
 ## 0.4.39 (2025-07-02)
 
 

--- a/integrations/jira/pyproject.toml
+++ b/integrations/jira/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jira"
-version = "0.4.41"
+version = "0.4.40"
 description = "Integration to bring information from Jira into Port"
 authors = ["Mor Paz <mor@getport.io>"]
 

--- a/integrations/jira/pyproject.toml
+++ b/integrations/jira/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jira"
-version = "0.4.40"
+version = "0.4.41"
 description = "Integration to bring information from Jira into Port"
 authors = ["Mor Paz <mor@getport.io>"]
 

--- a/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
+++ b/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
@@ -275,13 +275,13 @@ class JQEntityProcessor(BaseEntityProcessor):
 
             if result.entity.get("identifier") and result.entity.get("blueprint"):
                 parsed_entity = Entity.parse_obj(result.entity)
+                if (
+                    len(examples_to_send) < send_raw_data_examples_amount
+                    and result.raw_data is not None
+                ):
+                    examples_to_send.append(result.raw_data)
                 if result.did_entity_pass_selector:
                     passed_entities.append(parsed_entity)
-                    if (
-                        len(examples_to_send) < send_raw_data_examples_amount
-                        and result.raw_data is not None
-                    ):
-                        examples_to_send.append(result.raw_data)
                 else:
                     failed_entities.append(parsed_entity)
             else:

--- a/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
+++ b/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
@@ -45,8 +45,8 @@ class ExampleStates:
     def add(self, succeed: bool, item: object):
         if succeed:
             self.__succeed.append(item)
-
-        self.__errors.append(item)
+        else:
+            self.__errors.append(item)
 
     def __len__(self) -> int:
         """

--- a/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
+++ b/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
@@ -230,7 +230,12 @@ class JQEntityProcessor(BaseEntityProcessor):
                 misconfigurations=misconfigurations,
             )
 
-        return MappedEntity()
+        return MappedEntity(
+            {},
+            did_entity_pass_selector=False,
+            raw_data=data,
+            misconfigurations=misconfigurations,
+        )
 
     async def _calculate_entity(
         self,

--- a/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
+++ b/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
@@ -39,7 +39,7 @@ class ExampleStates:
           - errors:  items that failed
         """
         self._succeed = []
-        self._errors = []
+        self.__errors = []
         self.__max_size = max_size
 
     def add(self, succeed: bool, item: object):
@@ -52,7 +52,7 @@ class ExampleStates:
         """
         Total number of items (successes + errors).
         """
-        return len(self._succeed) + len(self._errors)
+        return len(self._succeed) + len(self.__errors)
 
     def take(self, n: int = 0):
         """
@@ -66,14 +66,14 @@ class ExampleStates:
         # how many more from errors?
         e_count = n - s_count
         if e_count > 0:
-            result.extend(self._errors[:e_count])
+            result.extend(self.__errors[:e_count])
         return result
 
     def take_iter(self, n: int):
         """
         Lazy version: return an iterator over up to n items
         """
-        return islice(chain(self._succeed, self._errors), n)
+        return islice(chain(self._succeed, self.__errors), n)
 
 
 @dataclass

--- a/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
+++ b/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
@@ -182,7 +182,7 @@ class JQEntityProcessor(BaseEntityProcessor):
             return MappedEntity(
                 mapped_entity,
                 did_entity_pass_selector=should_run,
-                raw_data=data if should_run else None,
+                raw_data=data,
                 misconfigurations=misconfigurations,
             )
 
@@ -273,13 +273,14 @@ class JQEntityProcessor(BaseEntityProcessor):
             if len(result.misconfigurations) > 0:
                 entity_misconfigurations |= result.misconfigurations
 
+            if (
+                len(examples_to_send) < send_raw_data_examples_amount
+                and result.raw_data is not None
+            ):
+                examples_to_send.append(result.raw_data)
+
             if result.entity.get("identifier") and result.entity.get("blueprint"):
                 parsed_entity = Entity.parse_obj(result.entity)
-                if (
-                    len(examples_to_send) < send_raw_data_examples_amount
-                    and result.raw_data is not None
-                ):
-                    examples_to_send.append(result.raw_data)
                 if result.did_entity_pass_selector:
                     passed_entities.append(parsed_entity)
                 else:

--- a/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
+++ b/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
@@ -24,15 +24,12 @@ from port_ocean.exceptions.core import EntityProcessorException
 from port_ocean.utils.queue_utils import process_in_queue
 
 
-from itertools import islice, chain
-
-
 class ExampleStates:
-    __succeed: list
-    __errors: list
+    __succeed: list[dict[str, Any]]
+    __errors: list[dict[str, Any]]
     __max_size: int
 
-    def __init__(self, max_size=0):
+    def __init__(self, max_size: int = 0) -> None:
         """
         Store two sequences:
           - succeed: items that succeeded
@@ -42,7 +39,7 @@ class ExampleStates:
         self.__errors = []
         self.__max_size = max_size
 
-    def add(self, succeed: bool, item: object):
+    def add(self, succeed: bool, item: dict[str, Any]) -> None:
         if succeed:
             self.__succeed.append(item)
         else:
@@ -54,7 +51,7 @@ class ExampleStates:
         """
         return len(self.__succeed) + len(self.__errors)
 
-    def take(self, n: int = 0):
+    def take(self, n: int = 0) -> list[dict[str, Any]]:
         """
         Return a list of up to n items, taking successes first,
         """
@@ -68,12 +65,6 @@ class ExampleStates:
         if e_count > 0:
             result.extend(self.__errors[:e_count])
         return result
-
-    def take_iter(self, n: int):
-        """
-        Lazy version: return an iterator over up to n items
-        """
-        return islice(chain(self.__succeed, self.__errors), n)
 
 
 @dataclass

--- a/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
+++ b/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
@@ -39,7 +39,7 @@ class ExampleStates:
         self.__errors = []
         self.__max_size = max_size
 
-    def add(self, succeed: bool, item: dict[str, Any]) -> None:
+    def add_example(self, succeed: bool, item: dict[str, Any]) -> None:
         if succeed:
             self.__succeed.append(item)
         else:
@@ -51,17 +51,17 @@ class ExampleStates:
         """
         return len(self.__succeed) + len(self.__errors)
 
-    def take(self, n: int = 0) -> list[dict[str, Any]]:
+    def get_examples(self, number: int = 0) -> list[dict[str, Any]]:
         """
-        Return a list of up to n items, taking successes first,
+        Return a list of up to number items, taking successes first,
         """
-        if n <= 0:
-            n = self.__max_size
+        if number <= 0:
+            number = self.__max_size
         # how many from succeed?
-        s_count = min(n, len(self.__succeed))
+        s_count = min(number, len(self.__succeed))
         result = list(self.__succeed[:s_count])
         # how many more from errors?
-        e_count = n - s_count
+        e_count = number - s_count
         if e_count > 0:
             result.extend(self.__errors[:e_count])
         return result
@@ -325,7 +325,9 @@ class JQEntityProcessor(BaseEntityProcessor):
                 len(examples_to_send) < send_raw_data_examples_amount
                 and result.raw_data is not None
             ):
-                examples_to_send.add(result.did_entity_pass_selector, result.raw_data)
+                examples_to_send.add_example(
+                    result.did_entity_pass_selector, result.raw_data
+                )
 
             if result.entity.get("identifier") and result.entity.get("blueprint"):
                 parsed_entity = Entity.parse_obj(result.entity)
@@ -343,7 +345,7 @@ class JQEntityProcessor(BaseEntityProcessor):
             entity_mapping_fault_counter,
         )
 
-        await self._send_examples(examples_to_send.take(), mapping.kind)
+        await self._send_examples(examples_to_send.get_examples(), mapping.kind)
 
         return CalculationResult(
             EntitySelectorDiff(passed=passed_entities, failed=failed_entities),

--- a/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
+++ b/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
@@ -38,21 +38,21 @@ class ExampleStates:
           - succeed: items that succeeded
           - errors:  items that failed
         """
-        self.__succeed = []
-        self.__errors = []
+        self._succeed = []
+        self._errors = []
         self.__max_size = max_size
 
     def add(self, succeed: bool, item: object):
         if succeed:
             self.__succeed.append(item)
-        else:
-            self.__errors.append(item)
+
+        self.__errors.append(item)
 
     def __len__(self) -> int:
         """
         Total number of items (successes + errors).
         """
-        return len(self.__succeed) + len(self.__errors)
+        return len(self._succeed) + len(self._errors)
 
     def take(self, n: int = 0):
         """
@@ -61,19 +61,19 @@ class ExampleStates:
         if n <= 0:
             n = self.__max_size
         # how many from succeed?
-        s_count = min(n, len(self.__succeed))
-        result = list(self.__succeed[:s_count])
+        s_count = min(n, len(self._succeed))
+        result = list(self._succeed[:s_count])
         # how many more from errors?
         e_count = n - s_count
         if e_count > 0:
-            result.extend(self.__errors[:e_count])
+            result.extend(self._errors[:e_count])
         return result
 
     def take_iter(self, n: int):
         """
         Lazy version: return an iterator over up to n items
         """
-        return islice(chain(self.__succeed, self._errors), n)
+        return islice(chain(self._succeed, self._errors), n)
 
 
 @dataclass
@@ -317,7 +317,7 @@ class JQEntityProcessor(BaseEntityProcessor):
 
         passed_entities = []
         failed_entities = []
-        examples_to_send = ExampleStates(send_raw_data_examples_amount)
+        examples_to_send = ExampleStates()
         entity_misconfigurations: dict[str, str] = {}
         missing_required_fields: bool = False
         entity_mapping_fault_counter: int = 0
@@ -352,5 +352,5 @@ class JQEntityProcessor(BaseEntityProcessor):
         return CalculationResult(
             EntitySelectorDiff(passed=passed_entities, failed=failed_entities),
             errors,
-            misonfigured_entity_keys=entity_misconfigurations,
+            misconfigured_entity_keys=entity_misconfigurations,
         )

--- a/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
+++ b/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
@@ -234,7 +234,7 @@ class JQEntityProcessor(BaseEntityProcessor):
             {},
             did_entity_pass_selector=False,
             raw_data=data,
-            misconfigurations=misconfigurations,
+            misconfigurations={},
         )
 
     async def _calculate_entity(

--- a/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
+++ b/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
@@ -38,7 +38,7 @@ class ExampleStates:
           - succeed: items that succeeded
           - errors:  items that failed
         """
-        self._succeed = []
+        self.__succeed = []
         self.__errors = []
         self.__max_size = max_size
 
@@ -52,7 +52,7 @@ class ExampleStates:
         """
         Total number of items (successes + errors).
         """
-        return len(self._succeed) + len(self.__errors)
+        return len(self.__succeed) + len(self.__errors)
 
     def take(self, n: int = 0):
         """
@@ -61,8 +61,8 @@ class ExampleStates:
         if n <= 0:
             n = self.__max_size
         # how many from succeed?
-        s_count = min(n, len(self._succeed))
-        result = list(self._succeed[:s_count])
+        s_count = min(n, len(self.__succeed))
+        result = list(self.__succeed[:s_count])
         # how many more from errors?
         e_count = n - s_count
         if e_count > 0:
@@ -73,7 +73,7 @@ class ExampleStates:
         """
         Lazy version: return an iterator over up to n items
         """
-        return islice(chain(self._succeed, self.__errors), n)
+        return islice(chain(self.__succeed, self.__errors), n)
 
 
 @dataclass

--- a/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
+++ b/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
@@ -317,7 +317,7 @@ class JQEntityProcessor(BaseEntityProcessor):
 
         passed_entities = []
         failed_entities = []
-        examples_to_send = ExampleStates()
+        examples_to_send = ExampleStates(send_raw_data_examples_amount)
         entity_misconfigurations: dict[str, str] = {}
         missing_required_fields: bool = False
         entity_mapping_fault_counter: int = 0

--- a/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
+++ b/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
@@ -66,7 +66,7 @@ class ExampleStates:
         # how many more from errors?
         e_count = n - s_count
         if e_count > 0:
-            result.extend(self._errors[:e_count])
+            result.extend(self.__errors[:e_count])
         return result
 
     def take_iter(self, n: int):

--- a/port_ocean/core/integrations/mixins/sync_raw.py
+++ b/port_ocean/core/integrations/mixins/sync_raw.py
@@ -332,7 +332,7 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                 passed=modified_objects
             ),
             errors=objects_diff[0].errors,
-            misonfigured_entity_keys=objects_diff[0].misonfigured_entity_keys,
+            misconfigured_entity_keys=objects_diff[0].misconfigured_entity_keys
         )
 
     async def _unregister_resource_raw(

--- a/port_ocean/core/ocean_types.py
+++ b/port_ocean/core/ocean_types.py
@@ -42,7 +42,7 @@ class CalculationResult(NamedTuple):
     entity_selector_diff: EntitySelectorDiff
     errors: list[Exception]
     number_of_transformed_entities: int = 0
-    misonfigured_entity_keys: dict[str, str] = field(default_factory=dict)
+    misconfigured_entity_keys: dict[str, str] = field(default_factory=dict)
 
 
 class IntegrationEventsCallbacks(TypedDict):

--- a/port_ocean/tests/core/handlers/entity_processor/test_jq_entity_processor.py
+++ b/port_ocean/tests/core/handlers/entity_processor/test_jq_entity_processor.py
@@ -300,7 +300,9 @@ class TestJQEntityProcessor:
         with patch(
             "port_ocean.core.handlers.entity_processor.jq_entity_processor.JQEntityProcessor._send_examples"
         ) as mock_send_examples:
-            result = await mocked_processor._parse_items(mapping, raw_results)
+            result = await mocked_processor._parse_items(
+                mapping, raw_results, send_raw_data_examples_amount=1
+            )
             assert len(result.misonfigured_entity_keys) > 0
             assert len(result.misonfigured_entity_keys) == 4
             assert result.misonfigured_entity_keys == {
@@ -309,7 +311,7 @@ class TestJQEntityProcessor:
                 "url": ".foobar",
                 "defaultBranch": ".bar.baz",
             }
-            mock_send_examples.assert_called()
+            assert len(mock_send_examples.await_args[0][0]) > 0
 
     async def test_parse_items_empty_required(
         self, mocked_processor: JQEntityProcessor

--- a/port_ocean/tests/core/handlers/entity_processor/test_jq_entity_processor.py
+++ b/port_ocean/tests/core/handlers/entity_processor/test_jq_entity_processor.py
@@ -11,6 +11,7 @@ from port_ocean.core.handlers.entity_processor.jq_entity_processor import (
 from port_ocean.core.ocean_types import CalculationResult
 from port_ocean.exceptions.core import EntityProcessorException
 from unittest.mock import patch
+from typing import cast
 
 
 @pytest.mark.asyncio
@@ -311,7 +312,8 @@ class TestJQEntityProcessor:
                 "url": ".foobar",
                 "defaultBranch": ".bar.baz",
             }
-            assert len(mock_send_examples.await_args[0][0]) > 0
+            args, _ = mock_send_examples.await_args
+            assert len(cast(list, args[0])) > 0
 
     async def test_parse_items_empty_required(
         self, mocked_processor: JQEntityProcessor

--- a/port_ocean/tests/core/handlers/entity_processor/test_jq_entity_processor.py
+++ b/port_ocean/tests/core/handlers/entity_processor/test_jq_entity_processor.py
@@ -10,6 +10,7 @@ from port_ocean.core.handlers.entity_processor.jq_entity_processor import (
 )
 from port_ocean.core.ocean_types import CalculationResult
 from port_ocean.exceptions.core import EntityProcessorException
+from unittest.mock import patch
 
 
 @pytest.mark.asyncio
@@ -296,15 +297,19 @@ class TestJQEntityProcessor:
             },
             {"foo": "bar", "baz": "bazbar", "bar": {"foobar": "foobar"}},
         ]
-        result = await mocked_processor._parse_items(mapping, raw_results)
-        assert len(result.misonfigured_entity_keys) > 0
-        assert len(result.misonfigured_entity_keys) == 4
-        assert result.misonfigured_entity_keys == {
-            "identifier": ".ark",
-            "description": ".bazbar",
-            "url": ".foobar",
-            "defaultBranch": ".bar.baz",
-        }
+        with patch(
+            "port_ocean.core.handlers.entity_processor.jq_entity_processor.JQEntityProcessor._send_examples"
+        ) as mock_send_examples:
+            result = await mocked_processor._parse_items(mapping, raw_results)
+            assert len(result.misonfigured_entity_keys) > 0
+            assert len(result.misonfigured_entity_keys) == 4
+            assert result.misonfigured_entity_keys == {
+                "identifier": ".ark",
+                "description": ".bazbar",
+                "url": ".foobar",
+                "defaultBranch": ".bar.baz",
+            }
+            mock_send_examples.assert_called()
 
     async def test_parse_items_empty_required(
         self, mocked_processor: JQEntityProcessor

--- a/port_ocean/tests/core/handlers/entity_processor/test_jq_entity_processor.py
+++ b/port_ocean/tests/core/handlers/entity_processor/test_jq_entity_processor.py
@@ -333,15 +333,15 @@ class TestJQEntityProcessor:
             {"foo": "identifierMapped", "bar": ""},
         ]
         result = await mocked_processor._parse_items(mapping, raw_results)
-        assert "identifier" not in result.misonfigured_entity_keys
-        assert "blueprint" not in result.misonfigured_entity_keys
+        assert "identifier" not in result.misconfigured_entity_keys
+        assert "blueprint" not in result.misconfigured_entity_keys
 
         raw_results = [
             {"foo": "identifierMapped", "bar": None},
             {"foo": None, "bar": ""},
         ]
         result = await mocked_processor._parse_items(mapping, raw_results)
-        assert result.misonfigured_entity_keys == {
+        assert result.misconfigured_entity_keys == {
             "identifier": ".foo",
             "blueprint": ".bar",
         }

--- a/port_ocean/tests/core/handlers/entity_processor/test_jq_entity_processor.py
+++ b/port_ocean/tests/core/handlers/entity_processor/test_jq_entity_processor.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import cast, Any
 from unittest.mock import AsyncMock, Mock
 from loguru import logger
 import pytest
@@ -11,7 +11,6 @@ from port_ocean.core.handlers.entity_processor.jq_entity_processor import (
 from port_ocean.core.ocean_types import CalculationResult
 from port_ocean.exceptions.core import EntityProcessorException
 from unittest.mock import patch
-from typing import cast
 
 
 @pytest.mark.asyncio
@@ -312,8 +311,9 @@ class TestJQEntityProcessor:
                 "url": ".foobar",
                 "defaultBranch": ".bar.baz",
             }
+            assert mock_send_examples.await_args is not None, "mock was not awaited"
             args, _ = mock_send_examples.await_args
-            assert len(cast(list, args[0])) > 0
+            assert len(cast(list[Any], args[0])) > 0
 
     async def test_parse_items_empty_required(
         self, mocked_processor: JQEntityProcessor

--- a/port_ocean/tests/core/handlers/entity_processor/test_jq_entity_processor.py
+++ b/port_ocean/tests/core/handlers/entity_processor/test_jq_entity_processor.py
@@ -303,9 +303,9 @@ class TestJQEntityProcessor:
             result = await mocked_processor._parse_items(
                 mapping, raw_results, send_raw_data_examples_amount=1
             )
-            assert len(result.misonfigured_entity_keys) > 0
-            assert len(result.misonfigured_entity_keys) == 4
-            assert result.misonfigured_entity_keys == {
+            assert len(result.misconfigured_entity_keys) > 0
+            assert len(result.misconfigured_entity_keys) == 4
+            assert result.misconfigured_entity_keys == {
                 "identifier": ".ark",
                 "description": ".bazbar",
                 "url": ".foobar",

--- a/port_ocean/tests/core/handlers/mixins/test_live_events.py
+++ b/port_ocean/tests/core/handlers/mixins/test_live_events.py
@@ -334,7 +334,7 @@ async def test_parse_raw_event_results_to_entities_creation(
     calculation_result = CalculationResult(
         entity_selector_diff=EntitySelectorDiff(passed=[entity], failed=[]),
         errors=[],
-        misonfigured_entity_keys={},
+        misconfigured_entity_keys={},
     )
     mock_live_events_mixin.entity_processor.parse_items.return_value = (
         calculation_result
@@ -361,7 +361,7 @@ async def test_parse_raw_event_results_to_entities_deletion(
     calculation_result = CalculationResult(
         entity_selector_diff=EntitySelectorDiff(passed=[entity], failed=[]),
         errors=[],
-        misonfigured_entity_keys={},
+        misconfigured_entity_keys={},
     )
     mock_live_events_mixin.entity_processor.parse_items.return_value = (
         calculation_result

--- a/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
+++ b/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
@@ -113,7 +113,7 @@ async def test_sync_raw_mixin_self_dependency(
     calc_result_mock.number_of_transformed_entities = len(
         entities
     )  # Add this to match real behavior
-    calc_result_mock.misonfigured_entity_keys = {}  # Add this to match real behavior
+    calc_result_mock.misconfigured_entity_keys = {}  # Add this to match real behavior
 
     mock_sync_raw_mixin.entity_processor.parse_items = AsyncMock(return_value=calc_result_mock)  # type: ignore
 
@@ -234,7 +234,7 @@ async def test_sync_raw_mixin_circular_dependency(
     calc_result_mock.number_of_transformed_entities = len(
         entities
     )  # Add this to match real behavior
-    calc_result_mock.misonfigured_entity_keys = {}  # Add this to match real behavior
+    calc_result_mock.misconfigured_entity_keys = {}  # Add this to match real behavior
 
     mock_sync_raw_mixin.entity_processor.parse_items = AsyncMock(return_value=calc_result_mock)  # type: ignore
 
@@ -378,7 +378,7 @@ async def test_sync_raw_mixin_dependency(
     calc_result_mock.number_of_transformed_entities = len(
         entities
     )  # Add this to match real behavior
-    calc_result_mock.misonfigured_entity_keys = {}  # Add this to match real behavior
+    calc_result_mock.misconfigured_entity_keys = {}  # Add this to match real behavior
 
     # Mock the parse_items method to return our realistic mock
     mock_sync_raw_mixin.entity_processor.parse_items = AsyncMock(return_value=calc_result_mock)  # type: ignore
@@ -773,7 +773,7 @@ class CalculationResult:
     entity_selector_diff: EntitySelectorDiff
     errors: List[Any]
     misconfigurations: List[Any]
-    misonfigured_entity_keys: Optional[List[Any]] = None
+    misconfigured_entity_keys: Optional[List[Any]] = None
 
 
 @pytest.mark.asyncio
@@ -782,7 +782,7 @@ async def test_register_resource_raw_no_changes_upsert_not_called_entitiy_is_ret
     mock_port_app_config: PortAppConfig,
 ) -> None:
     entity = Entity(identifier="1", blueprint="service")
-    mock_sync_raw_mixin._calculate_raw = AsyncMock(return_value=[CalculationResult(entity_selector_diff=EntitySelectorDiff(passed=[entity], failed=[]), errors=[], misconfigurations=[], misonfigured_entity_keys=[])])  # type: ignore
+    mock_sync_raw_mixin._calculate_raw = AsyncMock(return_value=[CalculationResult(entity_selector_diff=EntitySelectorDiff(passed=[entity], failed=[]), errors=[], misconfigurations=[], misconfigured_entity_keys=[])])  # type: ignore
     mock_sync_raw_mixin._map_entities_compared_with_port = AsyncMock(return_value=([]))  # type: ignore
     mock_sync_raw_mixin.entities_state_applier.upsert = AsyncMock()  # type: ignore
 
@@ -809,7 +809,7 @@ async def test_register_resource_raw_with_changes_upsert_called_and_entities_are
     mock_port_app_config: PortAppConfig,
 ) -> None:
     entity = Entity(identifier="1", blueprint="service")
-    mock_sync_raw_mixin._calculate_raw = AsyncMock(return_value=[CalculationResult(entity_selector_diff=EntitySelectorDiff(passed=[entity], failed=[]), errors=[], misconfigurations=[], misonfigured_entity_keys=[])])  # type: ignore
+    mock_sync_raw_mixin._calculate_raw = AsyncMock(return_value=[CalculationResult(entity_selector_diff=EntitySelectorDiff(passed=[entity], failed=[]), errors=[], misconfigurations=[], misconfigured_entity_keys=[])])  # type: ignore
     mock_sync_raw_mixin._map_entities_compared_with_port = AsyncMock(return_value=([entity]))  # type: ignore
     mock_sync_raw_mixin.entities_state_applier.upsert = AsyncMock(return_value=[entity])  # type: ignore
 
@@ -836,7 +836,7 @@ async def test_register_resource_raw_with_errors(
 ) -> None:
     failed_entity = Entity(identifier="1", blueprint="service")
     error = Exception("Test error")
-    mock_sync_raw_mixin._calculate_raw = AsyncMock(return_value=[CalculationResult(entity_selector_diff=EntitySelectorDiff(passed=[], failed=[failed_entity]), errors=[error], misconfigurations=[], misonfigured_entity_keys=[])])  # type: ignore
+    mock_sync_raw_mixin._calculate_raw = AsyncMock(return_value=[CalculationResult(entity_selector_diff=EntitySelectorDiff(passed=[], failed=[failed_entity]), errors=[error], misconfigurations=[], misconfigured_entity_keys=[])])  # type: ignore
     mock_sync_raw_mixin._map_entities_compared_with_port = AsyncMock(return_value=([]))  # type: ignore
     mock_sync_raw_mixin.entities_state_applier.upsert = AsyncMock()  # type: ignore
 
@@ -873,7 +873,7 @@ async def test_register_resource_raw_skip_event_type_http_request_upsert_called_
         entity_selector_diff=EntitySelectorDiff(passed=[entity], failed=[]),
         errors=[],
         misconfigurations=[],
-        misonfigured_entity_keys=[],
+        misconfigured_entity_keys=[],
     )
     mock_sync_raw_mixin._calculate_raw = AsyncMock(return_value=[calculation_result])  # type: ignore
     mock_sync_raw_mixin._map_entities_compared_with_port = AsyncMock()  # type: ignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.24.22"
+version = "0.24.23"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
### **User description**
# Description

What -

Examples are not sent when all mappings are failed, this change would make them to be sent regardless

Why -

Client should see examples for failed mappings, so he could fix them

How -

Made the examples be sent regardless of being failed or not

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.


___

### **PR Type**
Enhancement


___

### **Description**
- Send examples for failed entity mappings to help debugging

- Move example collection logic before selector validation

- Add test coverage for example sending on failures


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Raw Data"] --> B["Entity Processing"]
  B --> C["Example Collection"]
  C --> D["Selector Validation"]
  D --> E["Passed Entities"]
  D --> F["Failed Entities"]
  C --> G["Examples Sent"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jq_entity_processor.py</strong><dd><code>Move example collection before selector validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

port_ocean/core/handlers/entity_processor/jq_entity_processor.py

<li>Moved example collection logic before selector validation<br> <li> Examples now collected for both passed and failed entities<br> <li> Ensures debugging data available for failed mappings


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1870/files#diff-28d9b2ac4a86bc467437b181a2035101bdf8c0f308cc7b73652857fe462667ae">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_jq_entity_processor.py</strong><dd><code>Add test coverage for example sending</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

port_ocean/tests/core/handlers/entity_processor/test_jq_entity_processor.py

<li>Added mock patch for <code>_send_examples</code> method<br> <li> Added assertion to verify examples are sent on failures<br> <li> Enhanced test coverage for new behavior


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1870/files#diff-33ee55617b66e081dd2a05ea9cdf14ef13a910627f3b6a70c3d90cf1aa577076">+14/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update changelog for new version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/jira/CHANGELOG.md

<li>Added entry for version 0.4.41<br> <li> Documented improvement for sending examples on failures


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1870/files#diff-7a3a5e341adb6a81f8d0177dfc07d8b2d4230c39ede5d93de91c7b205a0e29fa">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Bump version to 0.4.41</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/jira/pyproject.toml

- Bumped version from 0.4.40 to 0.4.41


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1870/files#diff-58a3ec0700a093f3b96dda2068e48b8e26665e1c83dd8207ef3c8cac8480e8cc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>