### PR TITLE
[Integration][Github] Gracefully handle permission failure when fetching saml external identities

### DIFF
--- a/integrations/github/CHANGELOG.md
+++ b/integrations/github/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 1.0.1-beta (2025-07-04)
+
+
+### Bugfix
+
+- Gracefully handle failure while fetching from saml identity provider
+
+
 ## 1.0.0-beta (2025-07-04)
 
 

--- a/integrations/github/github/core/exporters/user_exporter.py
+++ b/integrations/github/github/core/exporters/user_exporter.py
@@ -12,9 +12,9 @@ from github.helpers.gql_queries import (
 
 
 class GraphQLUserExporter(AbstractGithubExporter[GithubGraphQLClient]):
-    async def get_resource[
-        ExporterOptionT: SingleUserOptions
-    ](self, options: ExporterOptionT) -> RAW_ITEM:
+    async def get_resource[ExporterOptionT: SingleUserOptions](
+        self, options: ExporterOptionT
+    ) -> RAW_ITEM:
         variables = {"login": options["login"]}
         payload = self.client.build_graphql_payload(FETCH_GITHUB_USER_GQL, variables)
         response = await self.client.send_api_request(
@@ -87,3 +87,9 @@ class GraphQLUserExporter(AbstractGithubExporter[GithubGraphQLClient]):
         except TypeError:
             logger.info("SAML not enabled for organization")
             return
+        # AI! I added an exception handler here, create a new test case in test_user_exporter.py that factors for when graphql API request fails.
+        except ExceptionGroup as e:
+            for exception in e.exceptions:
+                logger.warning(
+                    f"Error while fetching external saml identity: {exception}"
+                )

--- a/integrations/github/github/core/exporters/user_exporter.py
+++ b/integrations/github/github/core/exporters/user_exporter.py
@@ -87,7 +87,6 @@ class GraphQLUserExporter(AbstractGithubExporter[GithubGraphQLClient]):
         except TypeError:
             logger.info("SAML not enabled for organization")
             return
-        # AI! I added an exception handler here, create a new test case in test_user_exporter.py that factors for when graphql API request fails.
         except ExceptionGroup as e:
             for exception in e.exceptions:
                 logger.warning(

--- a/integrations/github/pyproject.toml
+++ b/integrations/github/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "github-ocean"
-version = "1.0.0-beta"
+version = "1.0.1-beta"
 description = "This integration ingest data from github"
 authors = ["Chukwuemeka Nwaoma <joelchukks@gmail.com>", "Melody Anyaegbulam <melodyogonna@gmail.com>", "Michael Armah <mikeyarmah@gmail.com>"]
 


### PR DESCRIPTION
# Description

When running Integration with Github app details, fetching user identity from an external saml provider could fail because the app requires enterprise permission, this failure should not stop the resync handler from completing.

## Type of change

Please leave one option from the following and delete the rest:

- [ x ] Bug fix (non-breaking change which fixes an issue)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)
