### PR TITLE
[Integration][Github] Temporally trim default resources included in Ocean integration 

### DIFF
--- a/integrations/github/.port/resources/blueprints.json
+++ b/integrations/github/.port/resources/blueprints.json
@@ -2,7 +2,7 @@
     {
         "identifier": "githubRepository",
         "title": "Repository",
-        "icon": "Microservice",
+        "icon": "Github",
         "schema": {
             "properties": {
                 "description": {
@@ -31,6 +31,10 @@
                 "language": {
                     "type": "string",
                     "title": "Primary Language"
+                },
+                "readme": {
+                    "type": "markdown",
+                    "title": "Readme"
                 }
             },
             "required": []
@@ -110,71 +114,6 @@
                 "target": "githubRepository",
                 "required": false,
                 "many": false
-            }
-        }
-    },
-    {
-        "identifier": "githubUser",
-        "title": "Github User",
-        "icon": "Github",
-        "schema": {
-            "properties": {
-                "login": {
-                    "title": "Login",
-                    "type": "string"
-                }
-            },
-            "required": []
-        },
-        "mirrorProperties": {},
-        "calculationProperties": {},
-        "aggregationProperties": {},
-        "relations": {}
-    },
-    {
-        "identifier": "githubTeam",
-        "title": "GitHub Team",
-        "icon": "Github",
-        "schema": {
-            "properties": {
-                "slug": {
-                    "title": "Slug",
-                    "type": "string"
-                },
-                "description": {
-                    "title": "Description",
-                    "type": "string"
-                },
-                "link": {
-                    "title": "Link",
-                    "icon": "Link",
-                    "type": "string",
-                    "format": "url"
-                },
-                "permission": {
-                    "title": "Permission",
-                    "type": "string"
-                },
-                "notification_setting": {
-                    "title": "Notification Setting",
-                    "type": "string"
-                },
-                "members": {
-                    "title": "Members",
-                    "type": "array"
-                }
-            },
-            "required": []
-        },
-        "mirrorProperties": {},
-        "calculationProperties": {},
-        "aggregationProperties": {},
-        "relations": {
-            "githubUser": {
-                "title": "Github User",
-                "target": "githubUser",
-                "required": false,
-                "many": true
             }
         }
     }

--- a/integrations/github/.port/resources/port-app-config.yml
+++ b/integrations/github/.port/resources/port-app-config.yml
@@ -15,38 +15,9 @@ resources:
             description: if .description then .description else "" end
             visibility: if .private then "private" else "public" end
             defaultBranch: .default_branch
+            readme: file://README.md
             url: .html_url
             language: if .language then .language else "" end
-  - kind: user
-    selector:
-      query: "true"
-    port:
-      entity:
-        mappings:
-          identifier: .login
-          title: .login
-          blueprint: '"githubUser"'
-          properties:
-            login: .login
-  - kind: team
-    selector:
-      query: "true"
-      members: true
-    port:
-      entity:
-        mappings:
-          identifier: .id | tostring
-          title: .name
-          blueprint: '"githubTeam"'
-          properties:
-            slug: .slug
-            description: .description
-            link: .url
-            permission: .permission
-            notification_setting: .notificationSetting
-            members: '[.members.nodes[].login]'
-          relations:
-            githubUser: '[.members.nodes[].login]'
   - kind: pull-request
     selector:
       query: 'true'

--- a/integrations/github/CHANGELOG.md
+++ b/integrations/github/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 1.0.2-beta (2025-07-08)
+
+
+### Improvements
+
+- Temporally trim default resources to just repository and pull request
+
+
 ## 1.0.1-beta (2025-07-07)
 
 

--- a/integrations/github/pyproject.toml
+++ b/integrations/github/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "github-ocean"
-version = "1.0.1-beta"
+version = "1.0.2-beta"
 description = "This integration ingest data from github"
 authors = ["Chukwuemeka Nwaoma <joelchukks@gmail.com>", "Melody Anyaegbulam <melodyogonna@gmail.com>", "Michael Armah <mikeyarmah@gmail.com>"]
 


### PR DESCRIPTION
### **User description**
# Description

Since we're focusing on the file kind for now, temporally trim the default resources included in the Ocean integration to just repositories and pull request.

What - Trim default resources, fix repository blueprint icon, add readme markdown content to the repository blueprint to show that the file is working.

## Type of change

Please leave one option from the following and delete the rest:

- [ x ] Non-breaking change (fix of existing functionality that will not change current behavior)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

![Screen Shot 2025-07-07 at 14 08 45](https://github.com/user-attachments/assets/583f23c9-ed62-48d8-8bfe-7bae1cab394f)


___

### **PR Type**
Enhancement


___

### **Description**
- Temporarily trim GitHub integration to focus on repositories and pull requests only

- Remove user and team blueprints and mappings from default resources

- Add readme markdown property to repository blueprint

- Fix repository blueprint icon from Microservice to Github


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Full GitHub Integration"] --> B["Trimmed Integration"]
  B --> C["Repository Blueprint"]
  B --> D["Pull Request Blueprint"]
  C --> E["Added Readme Property"]
  C --> F["Fixed Icon"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>blueprints.json</strong><dd><code>Trim blueprints and enhance repository schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/github/.port/resources/blueprints.json

<li>Changed repository blueprint icon from "Microservice" to "Github"<br> <li> Added "readme" property with markdown type to repository schema<br> <li> Removed "githubUser" and "githubTeam" blueprint definitions entirely


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1880/files#diff-ded9f4bb4541bc44a5a0088b507f672fec1ad56b55d30a15c19db0cd56332932">+5/-66</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>port-app-config.yml</strong><dd><code>Simplify resource mappings to repositories and pull requests</code></dd></summary>
<hr>

integrations/github/.port/resources/port-app-config.yml

<li>Added <code>readme: file://README.md</code> mapping to repository entity<br> <li> Removed entire "user" kind resource configuration<br> <li> Removed entire "team" kind resource configuration


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1880/files#diff-88ace5f7a1250c1083e923dd691dd8f7944416774570bce03865db7e2692ec8b">+1/-30</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>