### PR TITLE
[Integration][Jira] Fix JQL Parentheses Handling in Issue Webhook Processor

### DIFF
--- a/integrations/jira/CHANGELOG.md
+++ b/integrations/jira/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.4.42 (2025-07-10)
+
+
+### Bug Fixes
+
+-  Fixes JQL bug in Jira integration by properly wrapping user filters in parentheses before appending the issue key, ensuring correct issue fetching during live events.
+
+
 ## 0.4.41 (2025-07-07)
 
 

--- a/integrations/jira/pyproject.toml
+++ b/integrations/jira/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jira"
-version = "0.4.41"
+version = "0.4.42"
 description = "Integration to bring information from Jira into Port"
 authors = ["Mor Paz <mor@getport.io>"]
 

--- a/integrations/jira/webhook_processors/issue_webhook_processor.py
+++ b/integrations/jira/webhook_processors/issue_webhook_processor.py
@@ -45,7 +45,7 @@ class IssueWebhookProcessor(AbstractWebhookProcessor):
         }
 
         if config.selector.jql:
-            params["jql"] = f"{config.selector.jql} AND key = {issue_key}"
+            params["jql"] = f"({config.selector.jql}) AND key = {issue_key}"
 
         issues: list[dict[str, Any]] = []
         async for issues_batch in client.get_paginated_issues(params):


### PR DESCRIPTION
### **User description**
# Description

What -

- Fixes a bug in the Jira integration where user-supplied JQL filters were not properly wrapped in parentheses before appending the issue key condition in the webhook processor. This ensures correct operator precedence and accurate issue fetching during live event processing.

Why -

- Without proper parentheses, Jira may interpret the combined JQL incorrectly, potentially returning more issues than intended or not filtering for the specific issue key. This could lead to incorrect data being ingested into Port during live events.

How -

- Updated the webhook processor to wrap user JQL filters in parentheses before appending the `AND key =` ... condition.
- Added/updated unit tests to verify correct JQL construction and prevent regressions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix JQL parentheses handling in Jira webhook processor

- Wrap user JQL filters in parentheses before appending issue key

- Add comprehensive test coverage for JQL construction

- Update version to 0.4.42


___

### **Changes diagram**

```mermaid
flowchart LR
  A["User JQL Filter"] --> B["Wrap in Parentheses"]
  B --> C["Append Issue Key Condition"]
  C --> D["Correct JQL Query"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>issue_webhook_processor.py</strong><dd><code>Fix JQL parentheses wrapping logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/jira/webhook_processors/issue_webhook_processor.py

<li>Wrap user JQL filters in parentheses before appending issue key <br>condition<br> <li> Ensure correct operator precedence in combined JQL queries


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1886/files#diff-cbca0851248319edaa2cfd095dbfdc48b76198085af08fcae99caa676c03c1d8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_processors.py</strong><dd><code>Update and add JQL parentheses tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/jira/tests/test_processors.py

<li>Update existing test assertions to expect parentheses-wrapped JQL<br> <li> Add new comprehensive test for complex JQL filter scenarios<br> <li> Import asyncio module for test execution


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1886/files#diff-f99b82b90ebbc327cb9a50e390c50079e5bbbc66e290454230429fa40302a83f">+52/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Add changelog entry for bug fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/jira/CHANGELOG.md

<li>Add changelog entry for version 0.4.42<br> <li> Document JQL parentheses bug fix


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1886/files#diff-7a3a5e341adb6a81f8d0177dfc07d8b2d4230c39ede5d93de91c7b205a0e29fa">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Version bump to 0.4.42</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/jira/pyproject.toml

- Bump version from 0.4.41 to 0.4.42


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1886/files#diff-58a3ec0700a093f3b96dda2068e48b8e26665e1c83dd8207ef3c8cac8480e8cc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>