### PR TITLE
[Core] Enforce jinja 3.1.6 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.25.2 (2025-14-07)
+
+### Improvements
+- Fix Dependabot vulnerability by enforcing jinja2 version requirement
+
 ## 0.25.1 (2025-07-07)
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
-## 0.25.2 (2025-14-07)
+## 0.25.2 (2025-07-14)
 
 ### Improvements
 - Fix Dependabot vulnerability by enforcing jinja2 version requirement

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.25.1"
+version = "0.25.2"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"
@@ -56,6 +56,7 @@ pydispatcher = "^2.0.7"
 tomli = "^2.0.1"
 aiostream = ">=0.5.2,<0.7.0"
 python-dateutil = "^2.9.0.post0"
+jinja2 = ">=3.1.6"
 
 # CLI
 click = { version = "^8.1.3", optional = true }


### PR DESCRIPTION
### **User description**
# Description
tl;dr
We wanted to resolve a security Vulnerability by updating jinja2 https://github.com/advisories/GHSA-cpwx-vrp4-4pq7
I think you will need to explicitly mention `jinja2 = ">=3.1.6"` in your port-ocean pyproject.toml.

You have already updated to jinja2 3.1.6 https://github.com/port-labs/ocean/pull/1478 but that doesn’t gets pulled with new port-ocean installations when there’s already a jinja2 version which stands in the pyproject.toml requirements (that is jinja2 >=2.7,<4.0.0).

I see 2 packages requiring jinja2
1.  towncrier = "^23.6.0" (23.11.0 actually)  --> jinja2 * (means any version)
2.  port_ocean = {extras = ["cli"], version = "^0.25.0"} (via cookiecutter) (see the tree below)
```
├── aiostream >=0.5.2,<0.7.0
│   └── typing-extensions * 
├── click >=8.1.3,<9.0.0
│   └── colorama * 
├── confluent-kafka >=2.10.1,<3.0.0
├── cookiecutter >=2.1.1,<3.0.0
│   ├── arrow * 
│   │   ├── python-dateutil >=2.7.0 
│   │   │   └── six >=1.5 
│   │   └── types-python-dateutil >=2.8.10 
│   ├── binaryornot >=0.4.4 
│   │   └── chardet >=3.0.2 
│   ├── click >=7.0,<9.0.0 
│   │   └── colorama * 
│   ├── jinja2 >=2.7,<4.0.0 
```
So (for our case) when it sees 3.1.5 in our lock file it stands in the requirements hence it doesn’t get’s updated.

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.


___

### **PR Type**
Bug fix


___

### **Description**
- Enforce jinja2 version requirement to fix security vulnerability

- Update version to 0.25.2 with changelog entry


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Security Vulnerability"] --> B["Update jinja2 requirement"]
  B --> C["Version bump to 0.25.2"]
  C --> D["Changelog update"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Add changelog entry for security fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

- Add version 0.25.2 entry with security fix description


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1889/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Update version and enforce jinja2 requirement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

<li>Bump version from 0.25.1 to 0.25.2<br> <li> Add explicit jinja2 >=3.1.6 dependency requirement


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1889/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>