### PR TITLE
[Integration][Github] Properly handle errors when files and folders are being retrieved from an empty repository

### DIFF
--- a/integrations/github/CHANGELOG.md
+++ b/integrations/github/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 1.1.1-beta (2025-07-24)
+
+
+### Improvements
+
+- Properly handle empty repo errors when ingesting files
+
+
 ## 1.1.0-beta (2025-07-23)
 
 

--- a/integrations/github/github/clients/http/base_client.py
+++ b/integrations/github/github/clients/http/base_client.py
@@ -61,7 +61,6 @@ class AbstractGithubClient(ABC):
         resource: str,
         ignored_errors: Optional[List[IgnoredError]] = None,
     ) -> bool:
-
         all_ignored_errors = (ignored_errors or []) + self._DEFAULT_IGNORED_ERRORS
         status_code = error.response.status_code
 

--- a/integrations/github/github/core/exporters/file_exporter/core.py
+++ b/integrations/github/github/core/exporters/file_exporter/core.py
@@ -2,7 +2,7 @@ from typing import AsyncGenerator, Dict, List, Any, Tuple, cast
 from urllib.parse import quote
 from github.core.exporters.abstract_exporter import AbstractGithubExporter
 from github.clients.client_factory import create_github_client
-from github.helpers.utils import GithubClientType
+from github.helpers.utils import GithubClientType, IgnoredError
 from port_ocean.core.ocean_types import (
     ASYNC_GENERATOR_RESYNC_TYPE,
     RAW_ITEM,
@@ -30,6 +30,9 @@ from github.core.exporters.file_exporter.file_processor import FileProcessor
 
 
 class RestFileExporter(AbstractGithubExporter[GithubRestClient]):
+    _IGNORED_ERRORS = [
+        IgnoredError(status=409, message="empty repository"),
+    ]
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -42,9 +45,9 @@ class RestFileExporter(AbstractGithubExporter[GithubRestClient]):
 
         return await self.client.send_api_request(url)
 
-    async def get_resource[
-        ExporterOptionsT: FileContentOptions
-    ](self, options: ExporterOptionsT) -> RAW_ITEM:
+    async def get_resource[ExporterOptionsT: FileContentOptions](
+        self, options: ExporterOptionsT
+    ) -> RAW_ITEM:
         """
         Fetch the content of a file from a repository using the Contents API.
         """
@@ -74,9 +77,9 @@ class RestFileExporter(AbstractGithubExporter[GithubRestClient]):
 
         return {**response, "content": content}
 
-    async def get_paginated_resources[
-        ExporterOptionsT: List[ListFileSearchOptions]
-    ](self, options: ExporterOptionsT) -> ASYNC_GENERATOR_RESYNC_TYPE:
+    async def get_paginated_resources[ExporterOptionsT: List[ListFileSearchOptions]](
+        self, options: ExporterOptionsT
+    ) -> ASYNC_GENERATOR_RESYNC_TYPE:
         """Search for files across repositories and fetch their content."""
 
         graphql_files = []
@@ -120,6 +123,9 @@ class RestFileExporter(AbstractGithubExporter[GithubRestClient]):
                 f"Processing pattern '{pattern}' on branch '{branch}' for {repo_name}"
             )
             tree_sha = await self.get_branch_tree_sha(repo_name, branch)
+            if not tree_sha:
+                logger.warning(f"no sha returned for {repo_name}, skipping ...")
+                continue
             tree = await self.get_tree_recursive(repo_name, tree_sha)
 
             matched = filter_github_tree_entries_by_pattern(tree, pattern)
@@ -323,7 +329,11 @@ class RestFileExporter(AbstractGithubExporter[GithubRestClient]):
     async def get_branch_tree_sha(self, repo: str, branch: str) -> str:
         """Retrieve the full recursive tree for a given branch."""
         commit_url = f"{self.client.base_url}/repos/{self.client.organization}/{repo}/commits/{branch}"
-        response = await self.client.send_api_request(commit_url)
+        response = await self.client.send_api_request(
+            commit_url, ignored_errors=self._IGNORED_ERRORS
+        )
+        if not response:
+            return ""
 
         tree_sha = response["commit"]["tree"]["sha"]
         logger.info(f"Retrieved branch tree sha for {repo}@{branch}: {tree_sha[:8]}")
@@ -333,7 +343,11 @@ class RestFileExporter(AbstractGithubExporter[GithubRestClient]):
     async def get_tree_recursive(self, repo: str, sha: str) -> List[Dict[str, Any]]:
         """Retrieve the full recursive tree for a given branch."""
         tree_url = f"{self.client.base_url}/repos/{self.client.organization}/{repo}/git/trees/{sha}?recursive=1"
-        response = await self.client.send_api_request(tree_url)
+        response = await self.client.send_api_request(
+            tree_url, ignored_errors=self._IGNORED_ERRORS
+        )
+        if not response:
+            return []
 
         tree_items = response["tree"]
         logger.info(f"Retrieved tree for {repo}@{sha[:8]}: {len(tree_items)} items")

--- a/integrations/github/github/core/exporters/file_exporter/core.py
+++ b/integrations/github/github/core/exporters/file_exporter/core.py
@@ -45,9 +45,9 @@ class RestFileExporter(AbstractGithubExporter[GithubRestClient]):
 
         return await self.client.send_api_request(url)
 
-    async def get_resource[ExporterOptionsT: FileContentOptions](
-        self, options: ExporterOptionsT
-    ) -> RAW_ITEM:
+    async def get_resource[
+        ExporterOptionsT: FileContentOptions
+    ](self, options: ExporterOptionsT) -> RAW_ITEM:
         """
         Fetch the content of a file from a repository using the Contents API.
         """
@@ -77,9 +77,9 @@ class RestFileExporter(AbstractGithubExporter[GithubRestClient]):
 
         return {**response, "content": content}
 
-    async def get_paginated_resources[ExporterOptionsT: List[ListFileSearchOptions]](
-        self, options: ExporterOptionsT
-    ) -> ASYNC_GENERATOR_RESYNC_TYPE:
+    async def get_paginated_resources[
+        ExporterOptionsT: List[ListFileSearchOptions]
+    ](self, options: ExporterOptionsT) -> ASYNC_GENERATOR_RESYNC_TYPE:
         """Search for files across repositories and fetch their content."""
 
         graphql_files = []

--- a/integrations/github/github/core/exporters/file_exporter/core.py
+++ b/integrations/github/github/core/exporters/file_exporter/core.py
@@ -122,11 +122,7 @@ class RestFileExporter(AbstractGithubExporter[GithubRestClient]):
             logger.debug(
                 f"Processing pattern '{pattern}' on branch '{branch}' for {repo_name}"
             )
-            tree_sha = await self.get_branch_tree_sha(repo_name, branch)
-            if not tree_sha:
-                logger.warning(f"no sha returned for {repo_name}, skipping ...")
-                continue
-            tree = await self.get_tree_recursive(repo_name, tree_sha)
+            tree = await self.get_tree_recursive(repo_name, branch)
 
             matched = filter_github_tree_entries_by_pattern(tree, pattern)
 

--- a/integrations/github/pyproject.toml
+++ b/integrations/github/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "github-ocean"
-version = "1.1.0-beta"
+version = "1.1.1-beta"
 description = "This integration ingest data from github"
 authors = ["Chukwuemeka Nwaoma <joelchukks@gmail.com>", "Melody Anyaegbulam <melodyogonna@gmail.com>", "Michael Armah <mikeyarmah@gmail.com>"]
 

--- a/integrations/github/tests/github/core/exporters/test_file_exporter.py
+++ b/integrations/github/tests/github/core/exporters/test_file_exporter.py
@@ -442,6 +442,21 @@ class TestRestFileExporter:
                 f"{rest_client.base_url}/repos/{rest_client.organization}/repo1/git/trees/tree-sha?recursive=1"
             )
 
+    async def test_get_tree_recursive_empty_repo(
+        self, rest_client: GithubRestClient
+    ) -> None:
+        exporter = RestFileExporter(rest_client)
+
+        with patch.object(
+            rest_client, "send_api_request", AsyncMock(return_value=None)
+        ) as mock_request:
+            tree = await exporter.get_tree_recursive("repo1", "tree-sha")
+
+            assert tree == []
+            mock_request.assert_called_once_with(
+                f"{rest_client.base_url}/repos/{rest_client.organization}/repo1/git/trees/tree-sha?recursive=1"
+            )
+
     async def test_fetch_commit_diff(self, rest_client: GithubRestClient) -> None:
         exporter = RestFileExporter(rest_client)
 

--- a/integrations/github/tests/github/core/exporters/test_file_exporter.py
+++ b/integrations/github/tests/github/core/exporters/test_file_exporter.py
@@ -245,9 +245,6 @@ class TestRestFileExporter:
 
         with (
             patch.object(
-                exporter, "get_branch_tree_sha", AsyncMock(return_value="tree-sha")
-            ),
-            patch.object(
                 exporter,
                 "get_tree_recursive",
                 AsyncMock(return_value=TEST_TREE_ENTRIES),
@@ -306,9 +303,6 @@ class TestRestFileExporter:
 
         with (
             patch.object(
-                exporter, "get_branch_tree_sha", AsyncMock(return_value="tree-sha")
-            ),
-            patch.object(
                 exporter,
                 "get_tree_recursive",
                 AsyncMock(return_value=tree_entries_with_sizes),
@@ -343,9 +337,6 @@ class TestRestFileExporter:
         exporter = RestFileExporter(rest_client)
 
         with (
-            patch.object(
-                exporter, "get_branch_tree_sha", AsyncMock(return_value="tree-sha")
-            ),
             patch.object(
                 exporter,
                 "get_tree_recursive",
@@ -435,11 +426,11 @@ class TestRestFileExporter:
         with patch.object(
             rest_client, "send_api_request", AsyncMock(return_value=tree_response)
         ) as mock_request:
-            tree = await exporter.get_tree_recursive("repo1", "tree-sha")
+            tree = await exporter.get_tree_recursive("repo1", "main")
 
             assert tree == TEST_TREE_ENTRIES
             mock_request.assert_called_once_with(
-                f"{rest_client.base_url}/repos/{rest_client.organization}/repo1/git/trees/tree-sha?recursive=1",
+                f"{rest_client.base_url}/repos/{rest_client.organization}/repo1/git/trees/main?recursive=1",
                 ignored_errors=[IgnoredError(status=409, message="empty repository")],
             )
 
@@ -451,11 +442,11 @@ class TestRestFileExporter:
         with patch.object(
             rest_client, "send_api_request", AsyncMock(return_value=None)
         ) as mock_request:
-            tree = await exporter.get_tree_recursive("repo1", "tree-sha")
+            tree = await exporter.get_tree_recursive("repo1", "main")
 
             assert tree == []
             mock_request.assert_called_once_with(
-                f"{rest_client.base_url}/repos/{rest_client.organization}/repo1/git/trees/tree-sha?recursive=1",
+                f"{rest_client.base_url}/repos/{rest_client.organization}/repo1/git/trees/main?recursive=1",
                 ignored_errors=[IgnoredError(status=409, message="empty repository")],
             )
 

--- a/integrations/github/tests/github/core/exporters/test_file_exporter.py
+++ b/integrations/github/tests/github/core/exporters/test_file_exporter.py
@@ -21,7 +21,7 @@ from github.core.options import (
     FileSearchOptions,
     ListFileSearchOptions,
 )
-from github.helpers.utils import GithubClientType
+from github.helpers.utils import GithubClientType, IgnoredError
 from port_ocean.context.event import event_context
 from typing import AsyncGenerator, List, Dict, Any
 
@@ -439,7 +439,8 @@ class TestRestFileExporter:
 
             assert tree == TEST_TREE_ENTRIES
             mock_request.assert_called_once_with(
-                f"{rest_client.base_url}/repos/{rest_client.organization}/repo1/git/trees/tree-sha?recursive=1"
+                f"{rest_client.base_url}/repos/{rest_client.organization}/repo1/git/trees/tree-sha?recursive=1",
+                ignored_errors=[IgnoredError(status=409, message="empty repository")],
             )
 
     async def test_get_tree_recursive_empty_repo(
@@ -454,7 +455,8 @@ class TestRestFileExporter:
 
             assert tree == []
             mock_request.assert_called_once_with(
-                f"{rest_client.base_url}/repos/{rest_client.organization}/repo1/git/trees/tree-sha?recursive=1"
+                f"{rest_client.base_url}/repos/{rest_client.organization}/repo1/git/trees/tree-sha?recursive=1",
+                ignored_errors=[IgnoredError(status=409, message="empty repository")],
             )
 
     async def test_fetch_commit_diff(self, rest_client: GithubRestClient) -> None:

--- a/integrations/github/tests/github/core/exporters/test_file_exporter.py
+++ b/integrations/github/tests/github/core/exporters/test_file_exporter.py
@@ -427,29 +427,6 @@ class TestRestFileExporter:
 
             assert len(results) == 0
 
-    async def test_get_branch_tree_sha(self, rest_client: GithubRestClient) -> None:
-        exporter = RestFileExporter(rest_client)
-
-        # Fix the mock response structure to match what the method expects
-        branch_response = {
-            "sha": "commit-sha",
-            "commit": {
-                "tree": {
-                    "sha": "tree-sha",
-                }
-            },
-        }
-
-        with patch.object(
-            rest_client, "send_api_request", AsyncMock(return_value=branch_response)
-        ) as mock_request:
-            tree_sha = await exporter.get_branch_tree_sha("repo1", "main")
-
-            assert tree_sha == "tree-sha"
-            mock_request.assert_called_once_with(
-                f"{rest_client.base_url}/repos/{rest_client.organization}/repo1/commits/main"
-            )
-
     async def test_get_tree_recursive(self, rest_client: GithubRestClient) -> None:
         exporter = RestFileExporter(rest_client)
 


### PR DESCRIPTION
# Description

What - Handle situations where files or folders are getting retrieved from an empty repository

Why - We don't want to crash the resync

How - Add `409` to ignored error in this situation, properly log the problem

## Type of change

Please leave one option from the following and delete the rest:

- [ x ] Non-breaking change (fix of existing functionality that will not change current behavior)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
