### PR TITLE
[Integration][ArgoCD] Iteration over Null Values Breaking ReSync

### DIFF
--- a/integrations/argocd/.env.example
+++ b/integrations/argocd/.env.example
@@ -1,3 +1,8 @@
-APPLICATION__LOG_LEVEL="DEBUG",
-PORT_CLIENT_ID="<port-client-id>",
-PORT_CLIENT_SECRET="<port-client-secret>",
+APPLICATION__LOG_LEVEL="DEBUG"
+OCEAN__PORT__CLIENT_ID=<your-port-client-id>
+OCEAN__PORT__CLIENT_SECRET=<your-port-client-secret>
+OCEAN__BASE_URL=https://api.port.io
+OCEAN__EVENT_LISTENER__TYPE=POLLING
+OCEAN__INTEGRATION__CONFIG__TOKEN=<your-account-token>
+OCEAN__INTEGRATION__CONFIG__SERVER_URL=<your-server-url>
+OCEAN__INTEGRATION__CONFIG__ALLOW_INSECURE=<true|false>

--- a/integrations/argocd/CHANGELOG.md
+++ b/integrations/argocd/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+
+## 0.1.196 (2025-07-31)
+
+
+## Fix
+
+- Iteration over null values breaking resyncs
+
+
 ## 0.1.195 (2025-07-27)
 
 

--- a/integrations/argocd/CHANGELOG.md
+++ b/integrations/argocd/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for installationDocs param for feature embed docs in installation
 
 
+## 0.1.194 (2025-07-28)
+
+
+- Added null checks for resources yielded from `managed_resources` and `get_deployment_history`
+
+
 ## 0.1.193 (2025-07-20)
 
 

--- a/integrations/argocd/client.py
+++ b/integrations/argocd/client.py
@@ -100,7 +100,7 @@ class ArgocdClient:
             f"get_deployment_history is deprecated as of 0.1.34. {DEPRECATION_WARNING}"
         )
         applications = await self.get_resources(resource_kind=ObjectKind.APPLICATION)
-        if not applications:
+        if applications is None:
             return []
         all_history = [
             {**history_item, "__applicationId": application["metadata"]["uid"]}
@@ -116,6 +116,8 @@ class ArgocdClient:
             f"get_kubernetes_resource is deprecated as of 0.1.34. {DEPRECATION_WARNING}"
         )
         applications = await self.get_resources(resource_kind=ObjectKind.APPLICATION)
+        if applications is None:
+            return []
         all_k8s_resources = [
             {**resource, "__applicationId": application["metadata"]["uid"]}
             for application in applications

--- a/integrations/argocd/client.py
+++ b/integrations/argocd/client.py
@@ -105,7 +105,7 @@ class ArgocdClient:
         all_history = [
             {**history_item, "__applicationId": application["metadata"]["uid"]}
             for application in applications
-            if application
+            if application and application.get("metadata", {}).get("uid")
             for history_item in application.get("status", {}).get("history", [])
         ]
         return all_history
@@ -121,7 +121,7 @@ class ArgocdClient:
         all_k8s_resources = [
             {**resource, "__applicationId": application["metadata"]["uid"]}
             for application in applications
-            if application
+            if application and application.get("metadata", {}).get("uid")
             for resource in application.get("status", {}).get("resources", [])
         ]
         return all_k8s_resources

--- a/integrations/argocd/client.py
+++ b/integrations/argocd/client.py
@@ -3,7 +3,6 @@ from typing import Any, Optional
 
 import httpx
 from loguru import logger
-
 from port_ocean.utils import http_async_client
 
 
@@ -106,7 +105,7 @@ class ArgocdClient:
             )
             return []
         all_history = [
-            {**history_item, "__applicationId": application["metadata"]["uid"]}
+            {**history_item}
             for application in applications
             if application
             for history_item in application.get("status", {}).get("history", [])
@@ -125,9 +124,9 @@ class ArgocdClient:
             )
             return []
         all_k8s_resources = [
-            {**resource, "__applicationId": application["metadata"]["uid"]}
+            {**resource}
             for application in applications
-            if application and application.get("metadata", {}).get("uid")
+            if application and application["metadata"]["uid"]
             for resource in application.get("status", {}).get("resources", [])
         ]
         return all_k8s_resources
@@ -137,14 +136,7 @@ class ArgocdClient:
     ) -> list[dict[str, Any]] | None:
         errors = []
         try:
-            application_name = application.get("metadata", {}).get("name")
-            application_id = application.get("metadata", {}).get("uid")
-            if not application_name or not application_id:
-                logger.error(
-                    "Application metadata is missing 'name' or 'uid', skipping..."
-                )
-                return []
-
+            application_name = application["metadata"]["name"]
             logger.info(
                 f"Fetching managed resources for application: {application_name}"
             )
@@ -154,7 +146,6 @@ class ArgocdClient:
                 {
                     **managed_resource,
                     "__application": application,
-                    "__applicationId": application_id,
                 }
                 for managed_resource in managed_resources
                 if managed_resource

--- a/integrations/argocd/client.py
+++ b/integrations/argocd/client.py
@@ -101,6 +101,9 @@ class ArgocdClient:
         )
         applications = await self.get_resources(resource_kind=ObjectKind.APPLICATION)
         if applications is None:
+            logger.error(
+                "No applications were found. Skipping deployment history ingestion"
+            )
             return []
         all_history = [
             {**history_item, "__applicationId": application["metadata"]["uid"]}
@@ -117,6 +120,9 @@ class ArgocdClient:
         )
         applications = await self.get_resources(resource_kind=ObjectKind.APPLICATION)
         if applications is None:
+            logger.error(
+                "No applications were found. Skipping managed resources ingestion"
+            )
             return []
         all_k8s_resources = [
             {**resource, "__applicationId": application["metadata"]["uid"]}

--- a/integrations/argocd/client.py
+++ b/integrations/argocd/client.py
@@ -100,10 +100,13 @@ class ArgocdClient:
             f"get_deployment_history is deprecated as of 0.1.34. {DEPRECATION_WARNING}"
         )
         applications = await self.get_resources(resource_kind=ObjectKind.APPLICATION)
+        if not applications:
+            return []
         all_history = [
             {**history_item, "__applicationId": application["metadata"]["uid"]}
             for application in applications
-            for history_item in application["status"].get("history", [])
+            if application
+            for history_item in application.get("status", {}).get("history", [])
         ]
         return all_history
 
@@ -116,7 +119,8 @@ class ArgocdClient:
         all_k8s_resources = [
             {**resource, "__applicationId": application["metadata"]["uid"]}
             for application in applications
-            for resource in application["status"].get("resources", [])
+            if application
+            for resource in application.get("status", {}).get("resources", [])
         ]
         return all_k8s_resources
 

--- a/integrations/argocd/client.py
+++ b/integrations/argocd/client.py
@@ -105,7 +105,7 @@ class ArgocdClient:
         all_history = [
             {**history_item, "__applicationId": application["metadata"]["uid"]}
             for application in applications
-            if application and application.get("metadata", {}).get("uid")
+            if application
             for history_item in application.get("status", {}).get("history", [])
         ]
         return all_history

--- a/integrations/argocd/main.py
+++ b/integrations/argocd/main.py
@@ -28,14 +28,12 @@ async def on_resources_resync(kind: str) -> RAW_RESULT:
 @ocean.on_resync(kind=ResourceKindsWithSpecialHandling.DEPLOYMENT_HISTORY)
 async def on_history_resync(kind: str) -> RAW_RESULT:
     argocd_client = init_client()
-
     return await argocd_client.get_deployment_history()
 
 
 @ocean.on_resync(kind=ResourceKindsWithSpecialHandling.KUBERNETES_RESOURCE)
 async def on_managed_k8s_resources_resync(kind: str) -> RAW_RESULT:
     argocd_client = init_client()
-
     return await argocd_client.get_kubernetes_resource()
 
 
@@ -53,6 +51,9 @@ async def on_managed_resources_resync(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     for application in applications:
         managed_resources = await argocd_client.get_managed_resources(
             application=application
+        )
+        logger.info(
+            f"Ingesting managed resources for application: {application.get('metadata', {}).get('name')}"
         )
         if managed_resources:
             yield managed_resources

--- a/integrations/argocd/main.py
+++ b/integrations/argocd/main.py
@@ -49,14 +49,15 @@ async def on_managed_resources_resync(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
         return
 
     for application in applications:
-        managed_resources = await argocd_client.get_managed_resources(
-            application=application
-        )
-        logger.info(
-            f"Ingesting managed resources for application: {application.get('metadata', {}).get('name')}"
-        )
-        if managed_resources:
-            yield managed_resources
+        if application:
+            managed_resources = await argocd_client.get_managed_resources(
+                application=application
+            )
+            logger.info(
+                f"Ingesting managed resources for application: {application.get('metadata', {}).get('name')}"
+            )
+            if managed_resources:
+                yield managed_resources
 
 
 @ocean.router.post("/webhook")

--- a/integrations/argocd/main.py
+++ b/integrations/argocd/main.py
@@ -1,8 +1,9 @@
+from fastapi import Request
 from loguru import logger
 from port_ocean.context.ocean import ocean
 from port_ocean.core.ocean_types import RAW_RESULT, ASYNC_GENERATOR_RESYNC_TYPE
+
 from client import ArgocdClient, ObjectKind, ResourceKindsWithSpecialHandling
-from fastapi import Request
 
 
 def init_client() -> ArgocdClient:
@@ -46,36 +47,15 @@ async def on_managed_resources_resync(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
         resource_kind=ObjectKind.APPLICATION
     )
     if not applications:
-        logger.info("No applications found. Skipping managed resources ingestion")
+        logger.info("No applications were found. Skipping managed resources ingestion")
         return
 
-    errors = []
     for application in applications:
-        try:
-            managed_resources = await argocd_client.get_managed_resources(
-                application_name=application["metadata"]["name"]
-            )
-            # TODO: Remove __applicationId in the future version
-            application_resource = [
-                {
-                    **managed_resource,
-                    "__application": application,
-                    "__applicationId": application["metadata"]["uid"],
-                }
-                for managed_resource in managed_resources
-            ]
-            yield application_resource
-        except Exception as e:
-            logger.error(
-                f"Failed to fetch managed resources for application {application['metadata']['name']}: {e}"
-            )
-            errors.append(e)
-
-    # If there were errors and we are not ignoring server errors, raise a general exception
-    if errors and not argocd_client.ignore_server_error:
-        raise ExceptionGroup(
-            "Errors occurred during managed resource ingestion", errors
+        managed_resources = await argocd_client.get_managed_resources(
+            application=application
         )
+        if managed_resources:
+            yield managed_resources
 
 
 @ocean.router.post("/webhook")

--- a/integrations/argocd/pyproject.toml
+++ b/integrations/argocd/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "argocd"
-version = "0.1.195"
+version = "0.1.196"
 description = "Argo CD integration powered by Ocean"
 authors = ["Isaac Coffie <isaac@getport.io>"]
 

--- a/integrations/argocd/tests/test_client.py
+++ b/integrations/argocd/tests/test_client.py
@@ -1,0 +1,33 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from client import ArgocdClient, ObjectKind
+
+
+@pytest.fixture(autouse=True)
+def mock_argocd_client() -> ArgocdClient:
+    ArgocdClient(
+        token="test_token",
+        server_url="test_server_url",
+        ignore_server_error=False,
+        allow_insecure=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_resources(mock_argocd_client: ArgocdClient) -> None:
+    kinds = [ObjectKind.CLUSTER, ObjectKind.PROJECT, ObjectKind.APPLICATION]
+    for kind in kinds:
+        response_data = {"metadata": {"resourceVersion": "614680"}, "items": []}
+
+        with patch.object(
+            mock_argocd_client, "_send_api_request", new_callable=AsyncMock
+        ) as mock_request:
+            mock_request.side_effect = response_data
+
+        resources = []
+        async for resource in mock_argocd_client.get_resources(resource_kind=kind):
+            resources.extend(resource)
+
+        assert resources == response_data["items"]
+        mock_request.assert_called_with(f"{mock_argocd_client.api_url}/{kind}s")

--- a/integrations/argocd/tests/test_client.py
+++ b/integrations/argocd/tests/test_client.py
@@ -4,12 +4,12 @@ import pytest
 from client import ArgocdClient, ObjectKind
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture
 def mock_argocd_client() -> ArgocdClient:
-    ArgocdClient(
+    return ArgocdClient(
         token="test_token",
-        server_url="test_server_url",
-        ignore_server_error=False,
+        server_url="https://localhost:8080",
+        ignore_server_error=True,
         allow_insecure=True,
     )
 
@@ -17,17 +17,251 @@ def mock_argocd_client() -> ArgocdClient:
 @pytest.mark.asyncio
 async def test_get_resources(mock_argocd_client: ArgocdClient) -> None:
     kinds = [ObjectKind.CLUSTER, ObjectKind.PROJECT, ObjectKind.APPLICATION]
-    for kind in kinds:
-        response_data = {"metadata": {"resourceVersion": "614680"}, "items": []}
 
+    for kind in kinds:
+        response_data = {}
+        if kind == ObjectKind.CLUSTER:
+            response_data = {
+                "items": [
+                    {
+                        "server": "test-server",
+                        "name": "test-cluster",
+                        "connectionState": {"status": "Successful"},
+                    }
+                ]
+            }
+        elif kind == ObjectKind.PROJECT:
+            response_data = {
+                "items": [
+                    {
+                        "spec": {"destinations": [{"server": "*", "namespace": "*"}]},
+                        "metadata": {"name": "test-project"},
+                    }
+                ]
+            }
+        elif kind == ObjectKind.APPLICATION:
+            response_data = {
+                "items": [
+                    {
+                        "spec": {
+                            "destinations": [
+                                {
+                                    "server": "https://kubernetes.default.svc",
+                                    "namespace": "default",
+                                }
+                            ],
+                            "project": "default",
+                        },
+                        "metadata": {"name": "test-project"},
+                    }
+                ]
+            }
         with patch.object(
             mock_argocd_client, "_send_api_request", new_callable=AsyncMock
         ) as mock_request:
-            mock_request.side_effect = response_data
+            mock_request.return_value = response_data
+            resources = await mock_argocd_client.get_resources(resource_kind=kind)
 
-        resources = []
-        async for resource in mock_argocd_client.get_resources(resource_kind=kind):
-            resources.extend(resource)
+            assert resources == response_data["items"]
+            mock_request.assert_called_with(url=f"{mock_argocd_client.api_url}/{kind}s")
 
+
+@pytest.mark.asyncio
+async def test_get_application_by_name(mock_argocd_client: ArgocdClient) -> None:
+    application_name = "test-application"
+    response_data = {
+        "spec": {
+            "destinations": [
+                {
+                    "server": "https://kubernetes.default.svc",
+                    "namespace": "default",
+                }
+            ],
+            "project": "default",
+        },
+        "metadata": {"name": "test-project"},
+    }
+    with patch.object(
+        mock_argocd_client, "_send_api_request", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.return_value = response_data
+        application = await mock_argocd_client.get_application_by_name(
+            name=application_name
+        )
+        assert application == response_data
+
+
+@pytest.mark.asyncio
+async def test_get_deployment_history(mock_argocd_client: ArgocdClient) -> None:
+    response_data = {
+        "items": [
+            {
+                "spec": {
+                    "destinations": [
+                        {
+                            "server": "https://kubernetes.default.svc",
+                            "namespace": "default",
+                        }
+                    ],
+                    "project": "default",
+                },
+                "metadata": {"name": "test-project", "uid": "test-uid"},
+                "status": {
+                    "history": [
+                        {
+                            "revision": "f58c7ed8cfe28ad70701c5923fdbd0154388ea9f",
+                            "deployedAt": "2025-07-23T16:18:43Z",
+                            "id": 0,
+                            "source": {
+                                "repoURL": "https://github.com/argoproj/argocd-example-apps.git",
+                                "path": "guestbook",
+                            },
+                            "deployStartedAt": "2025-07-23T16:18:43Z",
+                            "initiatedBy": {"username": "admin"},
+                        }
+                    ]
+                },
+            }
+        ]
+    }
+    with patch.object(
+        mock_argocd_client, "get_resources", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.return_value = response_data["items"]
+        kind = ObjectKind.APPLICATION
+        all_history = await mock_argocd_client.get_deployment_history()
+        assert len(all_history) == 1
+        mock_request.assert_called_with(resource_kind=kind)
+
+
+@pytest.mark.asyncio
+async def test_get_deployment_history_without_history_data(
+    mock_argocd_client: ArgocdClient,
+) -> None:
+    response_data = {
+        "items": [
+            {
+                "spec": {
+                    "destinations": [
+                        {
+                            "server": "https://kubernetes.default.svc",
+                            "namespace": "default",
+                        }
+                    ],
+                    "project": "default",
+                },
+                "metadata": {"name": "test-project", "uid": "test-uid"},
+                "status": {},
+            }
+        ]
+    }
+    with patch.object(
+        mock_argocd_client, "get_resources", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.return_value = response_data["items"]
+        kind = ObjectKind.APPLICATION
+        all_history = await mock_argocd_client.get_deployment_history()
+        assert len(all_history) == 0
+        mock_request.assert_called_with(resource_kind=kind)
+
+
+@pytest.mark.asyncio
+async def test_get_kubernetes_resource(mock_argocd_client: ArgocdClient) -> None:
+    response_data = {
+        "items": [
+            {
+                "spec": {
+                    "destinations": [
+                        {
+                            "server": "https://kubernetes.default.svc",
+                            "namespace": "default",
+                        }
+                    ],
+                    "project": "default",
+                },
+                "metadata": {"name": "test-project", "uid": "test-uid"},
+                "status": {
+                    "resources": [
+                        {
+                            "version": "v1",
+                            "kind": "Service",
+                            "namespace": "default",
+                            "name": "guestbook-ui",
+                            "status": "Synced",
+                            "health": {"status": "Healthy"},
+                        }
+                    ]
+                },
+            }
+        ]
+    }
+    with patch.object(
+        mock_argocd_client, "get_resources", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.return_value = response_data["items"]
+        kind = ObjectKind.APPLICATION
+        resources = await mock_argocd_client.get_kubernetes_resource()
+        assert len(resources) == 1
+        mock_request.assert_called_with(resource_kind=kind)
+
+
+@pytest.mark.asyncio
+async def test_get_kubernetes_resource_without_resource_data(
+    mock_argocd_client: ArgocdClient,
+) -> None:
+    response_data = {
+        "items": [
+            {
+                "spec": {
+                    "destinations": [
+                        {
+                            "server": "https://kubernetes.default.svc",
+                            "namespace": "default",
+                        }
+                    ],
+                    "project": "default",
+                },
+                "metadata": {"name": "test-project", "uid": "test-uid"},
+                "status": {},
+            }
+        ]
+    }
+    with patch.object(
+        mock_argocd_client, "get_resources", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.return_value = response_data["items"]
+        kind = ObjectKind.APPLICATION
+        resources = await mock_argocd_client.get_kubernetes_resource()
+        assert len(resources) == 0
+        mock_request.assert_called_with(resource_kind=kind)
+
+
+@pytest.mark.asyncio
+async def test_get_managed_resources(
+    mock_argocd_client: ArgocdClient,
+) -> None:
+    response_data = {
+        "items": [
+            {
+                "kind": "Service",
+                "namespace": "default",
+                "name": "test-svc-ui",
+            },
+            {
+                "kind": "Deployment",
+                "namespace": "default",
+                "name": "test-deployment",
+            },
+        ]
+    }
+    with patch.object(
+        mock_argocd_client, "_send_api_request", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.return_value = response_data
+        kind = ObjectKind.APPLICATION
+        application_name = "test-app"
+        resources = await mock_argocd_client.get_managed_resources(application_name)
         assert resources == response_data["items"]
-        mock_request.assert_called_with(f"{mock_argocd_client.api_url}/{kind}s")
+        mock_request.assert_called_with(
+            url=f"{mock_argocd_client.api_url}/{kind}s/{application_name}/managed-resources"
+        )

--- a/integrations/argocd/tests/test_client.py
+++ b/integrations/argocd/tests/test_client.py
@@ -35,7 +35,7 @@ async def test_get_resources(mock_argocd_client: ArgocdClient) -> None:
                 "items": [
                     {
                         "spec": {"destinations": [{"server": "*", "namespace": "*"}]},
-                        "metadata": {"name": "test-project"},
+                        "metadata": {"name": "test-project", "uid": "test-uid"},
                     }
                 ]
             }
@@ -52,7 +52,7 @@ async def test_get_resources(mock_argocd_client: ArgocdClient) -> None:
                             ],
                             "project": "default",
                         },
-                        "metadata": {"name": "test-project"},
+                        "metadata": {"name": "test-project", "uid": "test-uid"},
                     }
                 ]
             }
@@ -79,7 +79,7 @@ async def test_get_application_by_name(mock_argocd_client: ArgocdClient) -> None
             ],
             "project": "default",
         },
-        "metadata": {"name": "test-project"},
+        "metadata": {"name": "test-project", "uid": "test-uid"},
     }
     with patch.object(
         mock_argocd_client, "_send_api_request", new_callable=AsyncMock

--- a/integrations/argocd/tests/test_client.py
+++ b/integrations/argocd/tests/test_client.py
@@ -230,10 +230,9 @@ async def test_get_kubernetes_resource_without_resource_data(
         mock_argocd_client, "get_resources", new_callable=AsyncMock
     ) as mock_request:
         mock_request.return_value = response_data["items"]
-        kind = ObjectKind.APPLICATION
         resources = await mock_argocd_client.get_kubernetes_resource()
         assert len(resources) == 0
-        mock_request.assert_called_with(resource_kind=kind)
+        mock_request.assert_called_with(resource_kind=ObjectKind.APPLICATION)
 
 
 @pytest.mark.asyncio
@@ -258,10 +257,9 @@ async def test_get_managed_resources(
         mock_argocd_client, "_send_api_request", new_callable=AsyncMock
     ) as mock_request:
         mock_request.return_value = response_data
-        kind = ObjectKind.APPLICATION
         application_name = "test-app"
         resources = await mock_argocd_client.get_managed_resources(application_name)
         assert resources == response_data["items"]
         mock_request.assert_called_with(
-            url=f"{mock_argocd_client.api_url}/{kind}s/{application_name}/managed-resources"
+            url=f"{mock_argocd_client.api_url}/{ObjectKind.APPLICATION}s/{application_name}/managed-resources"
         )

--- a/integrations/argocd/tests/test_client.py
+++ b/integrations/argocd/tests/test_client.py
@@ -267,7 +267,6 @@ async def test_get_managed_resources(
                 {
                     **resource,
                     "__application": application,
-                    "__applicationId": application["metadata"]["uid"],
                 }
                 for resource in response_data["items"]
                 if resource

--- a/integrations/argocd/tests/test_sample.py
+++ b/integrations/argocd/tests/test_sample.py
@@ -1,2 +1,0 @@
-def test_example() -> None:
-    assert 1 == 1


### PR DESCRIPTION
### **User description**
…s` from API

# Description

What
Added null check for application resources from the ArgoCD API

Why
This provides a better null safety check to resolve issues arising from null values being returned for the resources queried.

How

Implemented a check against instances where:
* `applications` is `None`
* `application` has missing `metadata.uid` field

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [x] Integration able to create all default resources from scratch
- [x] Resync finishes successfully
- [x] Resync able to create entities
- [x] Resync able to update entities
- [x] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [x] Integration able to create all default resources from scratch
- [x] Resync able to create entities
- [x] Resync able to update entities
- [x] Resync able to detect and delete entities
- [x] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed null value iteration errors in ArgoCD deployment history and Kubernetes resources

- Added comprehensive test coverage for client methods

- Updated environment configuration example


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ArgoCD API"] --> B["get_deployment_history()"]
  A --> C["get_kubernetes_resource()"]
  B --> D["Null Check Added"]
  C --> E["Null Check Added"]
  D --> F["Safe Iteration"]
  E --> F
  F --> G["Prevent ReSync Failures"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>client.py</strong><dd><code>Add null value protection for API responses</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/argocd/client.py

<ul><li>Added null checks for applications list in <code>get_deployment_history()</code><br> <li> Added null checks for applications list in <code>get_kubernetes_resource()</code><br> <li> Added safe navigation for status fields using <code>.get()</code> method<br> <li> Added application existence validation in list comprehensions</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1923/files#diff-9a9063248e255966830297ae5cbb17c9b2b93bb6d1a7e4760f5b0a4152619ead">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_client.py</strong><dd><code>Add comprehensive client method test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/argocd/tests/test_client.py

<ul><li>Created comprehensive test suite for ArgocdClient methods<br> <li> Added tests for <code>get_resources()</code>, <code>get_application_by_name()</code>, <br><code>get_deployment_history()</code><br> <li> Added tests for <code>get_kubernetes_resource()</code> and <code>get_managed_resources()</code><br> <li> Included edge case tests for missing data scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1923/files#diff-5f1ed807123aa649375fce61a8b3487e3a13508bdee48b160c9e3b6b04d3c944">+265/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_sample.py</strong><dd><code>Remove placeholder test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/argocd/tests/test_sample.py

- Removed placeholder test function


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1923/files#diff-a44bae4e4a6b52850253e021f675bdf8a9ee045757d6f0e63728045ca95a0d31">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.env.example</strong><dd><code>Update environment configuration example</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/argocd/.env.example

<ul><li>Updated environment variable format to use OCEAN__ prefix<br> <li> Added missing configuration variables for integration setup<br> <li> Fixed syntax formatting for environment variables</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1923/files#diff-5e07e76794162cad3e12563d3f03a86c082fd2a5e115a07ea8a9e6bd4007d71d">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

