### PR TITLE
[Core] feat: implement core change for group queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.26.2 (2025-07-30)
+### Improvements
+
+- Parallel queue implementation for better performance
+
 ## 0.26.1 (2025-07-20)
 
 ### Improvements

--- a/port_ocean/config/settings.py
+++ b/port_ocean/config/settings.py
@@ -9,6 +9,7 @@ from pydantic.main import BaseModel
 
 from port_ocean.config.base import BaseOceanModel, BaseOceanSettings
 from port_ocean.core.event_listener import EventListenerSettingsType
+
 from port_ocean.core.models import (
     CachingStorageMode,
     CreatePortResourcesOrigin,
@@ -88,6 +89,7 @@ class IntegrationConfiguration(BaseOceanSettings, extra=Extra.allow):
     event_listener: EventListenerSettingsType = Field(
         default=cast(EventListenerSettingsType, {"type": "POLLING"})
     )
+    event_workers_num: int = 1
     # If an identifier or type is not provided, it will be generated based on the integration name
     integration: IntegrationSettings = Field(
         default_factory=lambda: IntegrationSettings(type="", identifier="")

--- a/port_ocean/core/handlers/queue/__init__.py
+++ b/port_ocean/core/handlers/queue/__init__.py
@@ -1,4 +1,5 @@
 from .abstract_queue import AbstractQueue
 from .local_queue import LocalQueue
+from .group_queue import GroupQueue
 
-__all__ = ["AbstractQueue", "LocalQueue"]
+__all__ = ["AbstractQueue", "LocalQueue", "GroupQueue"]

--- a/port_ocean/core/handlers/queue/abstract_queue.py
+++ b/port_ocean/core/handlers/queue/abstract_queue.py
@@ -7,6 +7,9 @@ T = TypeVar("T")
 class AbstractQueue(ABC, Generic[T]):
     """Abstract interface for queues"""
 
+    def __init__(self, name: str | None = None):
+        pass
+
     @abstractmethod
     async def put(self, item: T) -> None:
         """Put an item into the queue"""
@@ -19,6 +22,11 @@ class AbstractQueue(ABC, Generic[T]):
 
     @abstractmethod
     async def teardown(self) -> None:
+        """Wait for all items to be processed"""
+        pass
+
+    @abstractmethod
+    async def size(self) -> int:
         """Wait for all items to be processed"""
         pass
 

--- a/port_ocean/core/handlers/queue/group_queue.py
+++ b/port_ocean/core/handlers/queue/group_queue.py
@@ -1,0 +1,156 @@
+import asyncio
+from collections import defaultdict, deque
+from typing import Deque, Dict, Optional, Set, Tuple, TypeVar
+
+from .abstract_queue import AbstractQueue  # unchanged
+from contextvars import ContextVar
+import uuid
+
+T = TypeVar("T")
+MaybeStr = str | None
+
+
+_worker_context: ContextVar[Optional[str]] = ContextVar("worker_context", default=None)
+
+
+class GroupQueue(AbstractQueue[T]):
+    """
+    A queue that guarantees *exclusive* processing per group.
+
+    Every item `T` must expose the attribute named in `group_key`
+    (or `group_key is None` → all items share the same group).
+
+    Rules
+    -----
+    • FIFO within each group.
+    • No two items with the same group key are ever handed
+      to workers concurrently.
+    • FIXED: Now properly supports multiple concurrent workers.
+    """
+
+    # ---------- construction ----------
+    def __init__(self, group_key: MaybeStr = None, name: MaybeStr = None):
+        super().__init__(name)
+        self.group_key = group_key  # str | None
+        self._queues: Dict[MaybeStr, Deque[T]] = defaultdict(deque)
+        self._locked: Set[MaybeStr] = set()
+        self._queue_not_empty = asyncio.Condition()
+
+        # FIX: Track multiple concurrent items instead of single _current_item
+        self._current_items: Dict[str, Tuple[MaybeStr, T]] = (
+            {}
+        )  # worker_id -> (group, item)
+        self._group_to_worker: Dict[MaybeStr, str] = (
+            {}
+        )  # group -> worker_id processing it
+
+    # ---------- helpers ----------
+    def _extract_group_key(self, item: T) -> MaybeStr:
+        if self.group_key is None:
+            return None
+        if not hasattr(item, self.group_key):
+            raise ValueError(
+                f"Item {item!r} lacks attribute '{self.group_key}' required for grouping"
+            )
+        return getattr(item, self.group_key)
+
+    def _get_worker_id(self) -> str:
+        """Get unique worker ID for current task/coroutine"""
+        worker_id = _worker_context.get()
+        if worker_id is None:
+            # Generate unique ID for this task
+            worker_id = str(uuid.uuid4())
+            _worker_context.set(worker_id)
+        return worker_id
+
+    # ---------- AbstractQueue API ----------
+    async def put(self, item: T) -> None:
+        """Put a single item into its group‑FIFO."""
+        group_key = self._extract_group_key(item)
+        async with self._queue_not_empty:
+            self._queues[group_key].append(item)
+            self._queue_not_empty.notify_all()
+
+    async def get(self) -> T:
+        """
+        Get the head item of the first *unlocked* group.
+        Locks that group until `commit()` is called.
+        """
+        worker_id = self._get_worker_id()
+
+        async with self._queue_not_empty:
+            while True:
+                for g, q in self._queues.items():
+                    if not q or g in self._locked:
+                        continue
+
+                    # Lock the group and track which worker is processing it
+                    self._locked.add(g)
+                    item = q[0]  # peek without pop
+                    self._current_items[worker_id] = (g, item)
+                    self._group_to_worker[g] = worker_id
+
+                    return item
+
+                await self._queue_not_empty.wait()
+
+    async def commit(self) -> None:
+        """
+        Mark the current item as processed and unlock its group.
+        Uses worker context to identify which item to commit.
+        """
+        worker_id = self._get_worker_id()
+
+        async with self._queue_not_empty:
+            if worker_id not in self._current_items:
+                return  # Nothing to commit for this worker
+
+            g, item = self._current_items[worker_id]
+            q = self._queues[g]
+
+            # Verify we're committing the right item (safety check)
+            if q and q[0] == item and self._group_to_worker.get(g) == worker_id:
+                q.popleft()  # remove the item we processed
+                if not q:
+                    del self._queues[g]  # tidy up empty queue
+
+                # Clean up tracking
+                self._locked.discard(g)
+                del self._current_items[worker_id]
+                if g in self._group_to_worker:
+                    del self._group_to_worker[g]
+
+                self._queue_not_empty.notify_all()
+
+    async def teardown(self) -> None:
+        """
+        Wait until **all items** are processed and no group is locked.
+        """
+        async with self._queue_not_empty:
+            while any(self._queues.values()) or self._locked:
+                await self._queue_not_empty.wait()
+
+    async def size(self) -> int:
+        """
+        Return **the current number of batched items waiting in the queue**,
+        aggregated across every group.
+
+        • Excludes the batches that are being processed right now
+          (i.e. those referenced by ``self._current_items``).
+        • Safe to call from multiple coroutines concurrently.
+        • Runs in O(#groups) time – negligible unless you have
+          millions of distinct group keys.
+        """
+        async with self._queue_not_empty:
+            return sum(len(dq) for dq in self._queues.values())
+
+    async def force_unlock_all(self) -> None:
+        """
+        Emergency method to unlock all groups and clear worker tracking.
+        Use only for cleanup in exceptional situations.
+        """
+        async with self._queue_not_empty:
+            self._locked.clear()
+            self._current_items.clear()
+            self._group_to_worker.clear()
+            self._queue_not_empty.notify_all()

--- a/port_ocean/core/handlers/queue/local_queue.py
+++ b/port_ocean/core/handlers/queue/local_queue.py
@@ -23,3 +23,6 @@ class LocalQueue(AbstractQueue[T]):
 
     async def commit(self) -> None:
         self._queue.task_done()
+
+    async def size(self) -> int:
+        return self._queue.qsize()

--- a/port_ocean/core/handlers/webhook/processor_manager.py
+++ b/port_ocean/core/handlers/webhook/processor_manager.py
@@ -1,4 +1,5 @@
-from typing import Dict, Type, Set
+from typing import Dict, Tuple, Type, Set, List
+
 from fastapi import APIRouter, Request
 from loguru import logger
 import asyncio
@@ -6,6 +7,7 @@ import asyncio
 from port_ocean.context.ocean import ocean
 from port_ocean.context.event import EventType, event_context
 from port_ocean.core.handlers.port_app_config.models import ResourceConfig
+from port_ocean.core.handlers.queue.abstract_queue import AbstractQueue
 from port_ocean.core.integrations.mixins.events import EventsMixin
 from port_ocean.core.integrations.mixins.live_events import LiveEventsMixin
 from port_ocean.exceptions.webhook_processor import WebhookEventNotSupportedError
@@ -15,7 +17,9 @@ from port_ocean.context.event import event
 
 from .abstract_webhook_processor import AbstractWebhookProcessor
 from port_ocean.utils.signal import SignalHandler
-from port_ocean.core.handlers.queue import AbstractQueue, LocalQueue
+from port_ocean.core.handlers.queue import LocalQueue
+
+CONCURRENCY_PER_PATH = 3
 
 
 class LiveEventsProcessorManager(LiveEventsMixin, EventsMixin):
@@ -37,16 +41,74 @@ class LiveEventsProcessorManager(LiveEventsMixin, EventsMixin):
         signal_handler.register(self.shutdown)
 
     async def start_processing_event_messages(self) -> None:
-        """Start processing events for all registered paths"""
+        """Start processing events for all registered paths with N workers each."""
         await self.initialize_handlers()
         loop = asyncio.get_event_loop()
+        config = ocean.integration.context.config
+
         for path in self._event_queues.keys():
-            try:
-                task = loop.create_task(self.process_queue(path))
+            for worker_id in range(0, config.event_workers_num):
+                task = loop.create_task(self._queue_worker(path, worker_id))
                 self._webhook_processor_tasks.add(task)
                 task.add_done_callback(self._webhook_processor_tasks.discard)
+
+    async def _queue_worker(self, path: str, worker_id: int) -> None:
+        """Single‐worker loop pulling from the queue for a given path."""
+        queue = self._event_queues[path]
+        while True:
+            event = None
+            matching: List[Tuple[ResourceConfig, AbstractWebhookProcessor]] = []
+            try:
+                event = await queue.get()
+                with logger.contextualize(
+                    worker=worker_id,
+                    webhook_path=path,
+                    trace_id=event.trace_id,
+                ):
+                    async with event_context(
+                        EventType.HTTP_REQUEST,
+                        trigger_type="machine",
+                    ):
+                        # refresh config, find processors, execute, etc.
+                        await ocean.integration.port_app_config_handler.get_port_app_config(
+                            use_cache=False
+                        )
+                        matching = await self._extract_matching_processors(event, path)
+                        results = await asyncio.gather(
+                            *(
+                                self._process_single_event(proc, path, res)
+                                for res, proc in matching
+                            ),
+                            return_exceptions=True,
+                        )
+
+                        good = [
+                            r for r in results if isinstance(r, WebhookEventRawResults)
+                        ]
+
+                        if good:
+                            logger.info(
+                                "Exporting raw event results to entities",
+                                ok=len(good),
+                            )
+                        await self.sync_raw_results(good)
+                        # handle good/bad, sync results…
+            except asyncio.CancelledError:
+                logger.info(f"Worker {worker_id} for {path} shutting down")
+                for _, proc in matching:
+                    await proc.cancel()
+                    self._timestamp_event_error(proc.event)
+                break
             except Exception as e:
-                logger.exception(f"Error starting queue processor for {path}: {str(e)}")
+                logger.exception(
+                    f"Unexpected error in worker {worker_id} for {path}: {e}"
+                )
+                for _, proc in matching:
+                    self._timestamp_event_error(proc.event)
+            finally:
+                if event is not None:
+                    logger.info(f"{event.group_id}")
+                    await queue.commit()
 
     async def _extract_matching_processors(
         self, webhook_event: WebhookEvent, path: str
@@ -90,70 +152,6 @@ class LiveEventsProcessorManager(LiveEventsMixin, EventsMixin):
             webhook_path=path,
         )
         return created_processors
-
-    async def process_queue(self, path: str) -> None:
-        """Process events for a specific path in order"""
-        while True:
-            matching_processors_with_resource: list[
-                tuple[ResourceConfig, AbstractWebhookProcessor]
-            ] = []
-            webhook_event: WebhookEvent | None = None
-            try:
-                queue = self._event_queues[path]
-                webhook_event = await queue.get()
-                with logger.contextualize(
-                    webhook_path=path, trace_id=webhook_event.trace_id
-                ):
-                    async with event_context(
-                        EventType.HTTP_REQUEST,
-                        trigger_type="machine",
-                    ):
-                        # This forces the Processor manager to fetch the latest port app config for each event
-                        await ocean.integration.port_app_config_handler.get_port_app_config(
-                            use_cache=False
-                        )
-                        matching_processors_with_resource = (
-                            await self._extract_matching_processors(webhook_event, path)
-                        )
-                        webhook_event_raw_results_for_all_resources = await asyncio.gather(
-                            *(
-                                self._process_single_event(processor, path, resource)
-                                for resource, processor in matching_processors_with_resource
-                            ),
-                            return_exceptions=True,
-                        )
-
-                        successful_raw_results: list[WebhookEventRawResults] = [
-                            result
-                            for result in webhook_event_raw_results_for_all_resources
-                            if isinstance(result, WebhookEventRawResults)
-                        ]
-
-                        if successful_raw_results:
-                            logger.info(
-                                "Exporting raw event results to entities",
-                                webhook_event_raw_results_for_all_resources_length=len(
-                                    successful_raw_results
-                                ),
-                            )
-                            await self.sync_raw_results(successful_raw_results)
-            except asyncio.CancelledError:
-                logger.info(f"Queue processor for {path} is shutting down")
-                for _, processor in matching_processors_with_resource:
-                    await processor.cancel()
-                    self._timestamp_event_error(processor.event)
-                break
-            except Exception as e:
-                logger.exception(
-                    f"Unexpected error in queue processor for {path}: {str(e)}"
-                )
-                for _, processor in matching_processors_with_resource:
-                    self._timestamp_event_error(processor.event)
-            finally:
-                if webhook_event:
-                    await self._event_queues[path].commit()
-                    # Prevents committing empty events for cases where we shutdown while processing
-                    webhook_event = None
 
     def _timestamp_event_error(self, event: WebhookEvent) -> None:
         """Timestamp an event as having an error"""

--- a/port_ocean/core/handlers/webhook/webhook_event.py
+++ b/port_ocean/core/handlers/webhook/webhook_event.py
@@ -51,11 +51,13 @@ class WebhookEvent(LiveEvent):
         payload: EventPayload,
         headers: EventHeaders,
         original_request: Request | None = None,
+        group_id: str | None = None,
     ) -> None:
         self.trace_id = trace_id
         self.payload = payload
         self.headers = headers
         self._original_request = original_request
+        self.group_id = group_id
 
     @classmethod
     async def from_request(

--- a/port_ocean/tests/core/handlers/queue/test_group_queue.py
+++ b/port_ocean/tests/core/handlers/queue/test_group_queue.py
@@ -1,0 +1,580 @@
+import asyncio
+import pytest
+from dataclasses import dataclass
+from port_ocean.core.handlers.queue.group_queue import GroupQueue
+from typing import Any
+
+
+@dataclass
+class TestItem:
+    group_id: str
+    value: int
+
+
+@dataclass
+class TestItemNoGroup:
+    value: int
+
+
+class TestGroupQueue:
+    """Test suite for GroupQueue lock mechanism"""
+
+    @pytest.fixture
+    def queue_with_group_key(self) -> GroupQueue[Any]:
+        """Create a GroupQueue with group_key='group_id'"""
+        return GroupQueue(group_key="group_id", name="test_queue")
+
+    @pytest.fixture
+    def queue_no_group_key(self) -> GroupQueue[Any]:
+        """Create a GroupQueue without group_key (all items in same group)"""
+        return GroupQueue(group_key=None, name="test_queue_no_group")
+
+    @pytest.mark.asyncio
+    async def test_basic_lock_mechanism(
+        self, queue_with_group_key: GroupQueue[Any]
+    ) -> None:
+        """Test that getting an item locks the group"""
+        queue = queue_with_group_key
+
+        # Add items to the same group
+        item1 = TestItem(group_id="group_a", value=1)
+        item2 = TestItem(group_id="group_a", value=2)
+
+        await queue.put(item1)
+        await queue.put(item2)
+
+        # Get first item - should lock group_a
+        retrieved_item = await queue.get()
+        assert retrieved_item == item1
+        assert "group_a" in queue._locked
+
+        # Check worker tracking (new implementation)
+        worker_id = queue._get_worker_id()
+        assert worker_id in queue._current_items
+        assert queue._current_items[worker_id] == ("group_a", item1)
+        assert queue._group_to_worker["group_a"] == worker_id
+
+    @pytest.mark.asyncio
+    async def test_locked_group_blocks_retrieval(
+        self, queue_with_group_key: GroupQueue[Any]
+    ) -> None:
+        """Test that locked groups cannot have items retrieved"""
+        queue = queue_with_group_key
+
+        # Add multiple items to same group
+        item1 = TestItem(group_id="group_a", value=1)
+        item2 = TestItem(group_id="group_a", value=2)
+        item3 = TestItem(group_id="group_b", value=3)
+
+        await queue.put(item1)
+        await queue.put(item2)
+        await queue.put(item3)
+
+        # Get first item from group_a
+        retrieved_item1 = await queue.get()
+        assert retrieved_item1 == item1
+        assert "group_a" in queue._locked
+
+        # Try to get another item - should get from group_b, not group_a
+        retrieved_item2 = await queue.get()
+        assert retrieved_item2 == item3  # From group_b
+        assert "group_b" in queue._locked
+        assert "group_a" in queue._locked  # group_a still locked
+
+    @pytest.mark.asyncio
+    async def test_commit_unlocks_group(
+        self, queue_with_group_key: GroupQueue[Any]
+    ) -> None:
+        """Test that commit() unlocks the group and allows next item retrieval"""
+        queue = queue_with_group_key
+
+        item1 = TestItem(group_id="group_a", value=1)
+        item2 = TestItem(group_id="group_a", value=2)
+
+        await queue.put(item1)
+        await queue.put(item2)
+
+        # Get and commit first item
+        retrieved_item1 = await queue.get()
+        assert retrieved_item1 == item1
+        assert "group_a" in queue._locked
+
+        worker_id = queue._get_worker_id()
+        await queue.commit()
+        assert "group_a" not in queue._locked
+        assert worker_id not in queue._current_items
+        assert "group_a" not in queue._group_to_worker
+
+        # Now we should be able to get the second item from group_a
+        retrieved_item2 = await queue.get()
+        assert retrieved_item2 == item2
+        assert "group_a" in queue._locked
+
+    @pytest.mark.asyncio
+    async def test_multiple_groups_concurrent_processing(
+        self, queue_with_group_key: GroupQueue[Any]
+    ) -> None:
+        """Test that different groups can be processed concurrently"""
+        queue = queue_with_group_key
+
+        # Add items to different groups
+        item_a1 = TestItem(group_id="group_a", value=1)
+        item_a2 = TestItem(group_id="group_a", value=2)
+        item_b1 = TestItem(group_id="group_b", value=3)
+        item_c1 = TestItem(group_id="group_c", value=4)
+
+        await queue.put(item_a1)
+        await queue.put(item_b1)
+        await queue.put(item_c1)
+        await queue.put(item_a2)
+
+        # Should be able to get items from different groups
+        retrieved_items = []
+        for _ in range(3):  # Get 3 items from 3 different groups
+            item = await queue.get()
+            retrieved_items.append(item)
+
+        # All three groups should be locked
+        assert len(queue._locked) == 3
+        assert "group_a" in queue._locked
+        assert "group_b" in queue._locked
+        assert "group_c" in queue._locked
+
+        # Should have gotten one item from each group
+        group_ids = [queue._extract_group_key(item) for item in retrieved_items]
+        assert set(group_ids) == {"group_a", "group_b", "group_c"}
+
+    @pytest.mark.asyncio
+    async def test_get_blocks_when_all_groups_locked(
+        self, queue_with_group_key: GroupQueue[Any]
+    ) -> None:
+        """Test that get() blocks when all available groups are locked"""
+        queue = queue_with_group_key
+
+        # Add items to single group
+        item1 = TestItem(group_id="group_a", value=1)
+        item2 = TestItem(group_id="group_a", value=2)
+
+        await queue.put(item1)
+        await queue.put(item2)
+
+        # Get first item (locks group_a)
+        await queue.get()
+        assert "group_a" in queue._locked
+
+        # Try to get second item - should block since group_a is locked
+        # We'll use asyncio.wait_for with a short timeout to test this
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(queue.get(), timeout=0.1)
+
+    @pytest.mark.asyncio
+    async def test_no_group_key_single_group_behavior(
+        self, queue_no_group_key: GroupQueue[Any]
+    ) -> None:
+        """Test behavior when group_key is None (all items in same group)"""
+        queue = queue_no_group_key
+
+        item1 = TestItemNoGroup(value=1)
+        item2 = TestItemNoGroup(value=2)
+
+        await queue.put(item1)
+        await queue.put(item2)
+
+        # Get first item
+        retrieved_item1 = await queue.get()
+        assert retrieved_item1 == item1
+        assert None in queue._locked  # group key is None
+
+        # Second get should block
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(queue.get(), timeout=0.1)
+
+        # After commit, should be able to get second item
+        await queue.commit()
+        assert None not in queue._locked
+
+        retrieved_item2 = await queue.get()
+        assert retrieved_item2 == item2
+
+    @pytest.mark.asyncio
+    async def test_commit_without_get_is_safe(
+        self, queue_with_group_key: GroupQueue[Any]
+    ) -> None:
+        """Test that calling commit() without get() doesn't break anything"""
+        queue = queue_with_group_key
+
+        # Should not raise any exceptions
+        await queue.commit()
+        assert len(queue._current_items) == 0
+        assert len(queue._group_to_worker) == 0
+        assert len(queue._locked) == 0
+
+    @pytest.mark.asyncio
+    async def test_multiple_commits_are_safe(
+        self, queue_with_group_key: GroupQueue[Any]
+    ) -> None:
+        """Test that multiple commits after a single get are safe"""
+        queue = queue_with_group_key
+
+        item = TestItem(group_id="group_a", value=1)
+        await queue.put(item)
+
+        retrieved_item = await queue.get()
+        assert retrieved_item == item
+
+        # First commit
+        await queue.commit()
+        assert "group_a" not in queue._locked
+
+        # Second commit should be safe
+        await queue.commit()
+        assert "group_a" not in queue._locked
+        assert len(queue._current_items) == 0
+
+    @pytest.mark.asyncio
+    async def test_fifo_within_group(
+        self, queue_with_group_key: GroupQueue[Any]
+    ) -> None:
+        """Test that items within a group are processed in FIFO order"""
+        queue = queue_with_group_key
+
+        # Add items to same group
+        items = [TestItem(group_id="group_a", value=i) for i in range(5)]
+        for item in items:
+            await queue.put(item)
+
+        # Process all items and verify FIFO order
+        processed_items = []
+        for _ in range(5):
+            item = await queue.get()
+            processed_items.append(item)
+            await queue.commit()
+
+        assert processed_items == items
+
+    @pytest.mark.asyncio
+    async def test_lock_prevents_queue_cleanup(
+        self, queue_with_group_key: GroupQueue[Any]
+    ) -> None:
+        """Test that locked groups prevent queue cleanup until unlocked"""
+        queue = queue_with_group_key
+
+        item = TestItem(group_id="group_a", value=1)
+        await queue.put(item)
+
+        # Get item (locks group and keeps queue entry)
+        await queue.get()
+        assert "group_a" in queue._queues
+        assert "group_a" in queue._locked
+
+        # Commit should clean up empty queue
+        await queue.commit()
+        assert "group_a" not in queue._queues  # Queue cleaned up
+        assert "group_a" not in queue._locked
+
+    @pytest.mark.asyncio
+    async def test_extract_group_key_missing_attribute(
+        self, queue_with_group_key: GroupQueue[Any]
+    ) -> None:
+        """Test that missing group key attribute raises ValueError"""
+        queue = queue_with_group_key
+
+        # Item without group_id attribute
+        bad_item = TestItemNoGroup(value=1)
+
+        with pytest.raises(ValueError, match="lacks attribute 'group_id'"):
+            await queue.put(bad_item)
+
+    @pytest.mark.asyncio
+    async def test_size_excludes_current_item(
+        self, queue_with_group_key: GroupQueue[Any]
+    ) -> None:
+        """Test that size() excludes the currently processed item"""
+        queue = queue_with_group_key
+
+        items = [TestItem(group_id="group_a", value=i) for i in range(3)]
+        for item in items:
+            await queue.put(item)
+
+        # Before get: size should be 3
+        assert await queue.size() == 3
+
+        # After get: size should be 2 (current item excluded)
+        await queue.get()
+        await queue.commit()
+        assert await queue.size() == 2
+
+        # After commit: size should be 2 (item removed)
+        await queue.commit()
+        assert await queue.size() == 2
+
+    # ===== CONCURRENT WORKER TESTS =====
+
+    @pytest.mark.asyncio
+    async def test_multiple_workers_different_groups(
+        self, queue_with_group_key: GroupQueue[Any]
+    ) -> None:
+        """Test multiple workers processing items from different groups concurrently"""
+        queue = queue_with_group_key
+        processed_items = []
+        processing_times = {}
+
+        async def worker(worker_id: int, process_time: float = 0.1) -> Any:
+            """Simulate a worker that processes items"""
+            try:
+                item = await queue.get()
+                start_time = asyncio.get_event_loop().time()
+
+                # Record when processing started
+                processing_times[item.value] = start_time
+                processed_items.append((worker_id, item))
+
+                # Simulate processing time
+                await asyncio.sleep(process_time)
+
+                await queue.commit()
+                return item
+            except Exception as e:
+                return f"Worker {worker_id} error: {e}"
+
+        # Add items from different groups
+        items = [
+            TestItem(group_id="group_a", value=1),
+            TestItem(group_id="group_b", value=2),
+            TestItem(group_id="group_c", value=3),
+            TestItem(group_id="group_d", value=4),
+        ]
+
+        for item in items:
+            await queue.put(item)
+
+        # Start 4 workers concurrently
+        results = await asyncio.gather(
+            worker(1), worker(2), worker(3), worker(4), return_exceptions=True
+        )
+
+        # All workers should have succeeded
+        assert len([r for r in results if isinstance(r, TestItem)]) == 4
+        assert len(processed_items) == 4
+
+        # All items should have been processed
+        processed_values = {item.value for _, item in processed_items}
+        assert processed_values == {1, 2, 3, 4}
+
+        # With the fixed implementation, no groups should be locked after completion
+        assert len(queue._locked) == 0
+        assert len(queue._current_items) == 0
+        assert len(queue._group_to_worker) == 0
+
+    @pytest.mark.asyncio
+    async def test_multiple_workers_same_group_exclusivity(
+        self, queue_with_group_key: GroupQueue[Any]
+    ) -> None:
+        """Test that multiple workers cannot process items from same group concurrently"""
+        queue = queue_with_group_key
+        processing_log = []
+
+        async def worker(worker_id: int, process_time: float = 0.2) -> Any:
+            """Worker that logs processing start and end times"""
+            try:
+                item = await queue.get()
+                start_time = asyncio.get_event_loop().time()
+                processing_log.append(("start", worker_id, item.value, start_time))
+
+                # Simulate processing
+                await asyncio.sleep(process_time)
+
+                end_time = asyncio.get_event_loop().time()
+                processing_log.append(("end", worker_id, item.value, end_time))
+
+                await queue.commit()
+                return item
+            except Exception as e:
+                return f"Worker {worker_id} error: {e}"
+
+        # Add multiple items to the same group
+        items = [TestItem(group_id="group_a", value=i) for i in range(4)]
+        for item in items:
+            await queue.put(item)
+
+        # Start 4 workers - they should process items from group_a sequentially
+        results = await asyncio.gather(
+            worker(1), worker(2), worker(3), worker(4), return_exceptions=True
+        )
+
+        # All should succeed
+        assert len([r for r in results if isinstance(r, TestItem)]) == 4
+
+        # Verify sequential processing: no overlapping processing times for same group
+        start_times = {}
+        end_times = {}
+
+        for event, worker_id, value, timestamp in processing_log:
+            if event == "start":
+                start_times[value] = timestamp
+            else:
+                end_times[value] = timestamp
+
+        # Sort by start time to verify sequential processing
+        sorted_items = sorted(start_times.items(), key=lambda x: x[1])
+
+        # Verify no overlap: each item should start after the previous one ends
+        for i in range(1, len(sorted_items)):
+            current_value = sorted_items[i][0]
+            previous_value = sorted_items[i - 1][0]
+
+            current_start = start_times[current_value]
+            previous_end = end_times[previous_value]
+
+            # Current should start after previous ends (allowing small timing tolerance)
+            assert (
+                current_start >= previous_end - 0.01
+            ), f"Item {current_value} started before item {previous_value} finished"
+
+        # With fixed implementation, perfect cleanup
+        assert len(queue._locked) == 0
+        assert len(queue._current_items) == 0
+        assert len(queue._group_to_worker) == 0
+
+    @pytest.mark.asyncio
+    async def test_mixed_groups_with_multiple_workers(
+        self, queue_with_group_key: GroupQueue[Any]
+    ) -> None:
+        """Test workers processing mixed groups - some concurrent, some sequential"""
+        queue = queue_with_group_key
+        processing_events = []
+
+        async def worker(worker_id: int) -> Any:
+            """Worker that tracks processing events"""
+            try:
+                item = await queue.get()
+                group = queue._extract_group_key(item)
+
+                start_time = asyncio.get_event_loop().time()
+                processing_events.append(
+                    ("start", worker_id, group, item.value, start_time)
+                )
+
+                # Variable processing time based on group
+                process_time = 0.1 if group == "fast_group" else 0.2
+                await asyncio.sleep(process_time)
+
+                end_time = asyncio.get_event_loop().time()
+                processing_events.append(
+                    ("end", worker_id, group, item.value, end_time)
+                )
+
+                await queue.commit()
+                return item
+            except Exception as e:
+                return f"Worker {worker_id} error: {e}"
+
+        # Add items: 3 to same group (sequential), 3 to different groups (concurrent)
+        items = [
+            TestItem(group_id="same_group", value=1),
+            TestItem(group_id="same_group", value=2),
+            TestItem(group_id="same_group", value=3),
+            TestItem(group_id="fast_group", value=4),
+            TestItem(group_id="other_group", value=5),
+            TestItem(group_id="another_group", value=6),
+        ]
+
+        for item in items:
+            await queue.put(item)
+
+        # Start 6 workers
+        results = await asyncio.gather(
+            *[worker(i) for i in range(1, 7)], return_exceptions=True
+        )
+
+        # All should succeed
+        successful_results = [r for r in results if isinstance(r, TestItem)]
+        assert len(successful_results) == 6
+
+        # Group processing events by group
+        group_events: dict[Any, Any] = {}
+        for event in processing_events:
+            _, worker_id, group, value, timestamp = event
+            if group not in group_events:
+                group_events[group] = []
+            group_events[group].append(event)
+
+        # Verify same_group items were processed sequentially
+        same_group_events = sorted(group_events["same_group"], key=lambda x: x[4])
+        starts = [e for e in same_group_events if e[0] == "start"]
+        ends = [e for e in same_group_events if e[0] == "end"]
+
+        # Each start should happen after previous end
+        for i in range(1, len(starts)):
+            assert starts[i][4] >= ends[i - 1][4] - 0.01
+
+        # Perfect cleanup with fixed implementation
+        assert len(queue._locked) == 0
+        assert len(queue._current_items) == 0
+        assert len(queue._group_to_worker) == 0
+
+    @pytest.mark.asyncio
+    async def test_high_concurrency_stress_test(
+        self, queue_with_group_key: GroupQueue[Any]
+    ) -> None:
+        """Stress test with many workers and items"""
+        queue = queue_with_group_key
+
+        async def worker(worker_id: int) -> Any:
+            """Simple worker"""
+            results = []
+            while True:
+                try:
+                    # Use timeout to avoid infinite waiting
+                    item = await asyncio.wait_for(queue.get(), timeout=1.0)
+                    results.append(item)
+
+                    # Small random delay to simulate processing
+                    await asyncio.sleep(0.01 + (worker_id % 3) * 0.01)
+
+                    await queue.commit()
+                except asyncio.TimeoutError:
+                    break
+                except Exception as e:
+                    print(f"Worker {worker_id} error: {e}")
+                    break
+            return results
+
+        # Add many items across multiple groups
+        num_groups = 5
+        items_per_group = 4
+
+        for group_id in range(num_groups):
+            for item_id in range(items_per_group):
+                item = TestItem(
+                    group_id=f"group_{group_id}", value=group_id * 100 + item_id
+                )
+                await queue.put(item)
+
+        # Start many workers
+        num_workers = 10
+        results = await asyncio.gather(
+            *[worker(i) for i in range(num_workers)], return_exceptions=True
+        )
+
+        # Collect all processed items
+        all_processed = []
+        for result in results:
+            if isinstance(result, list):
+                all_processed.extend(result)
+
+        # Should have processed all items
+        assert len(all_processed) == num_groups * items_per_group
+
+        # Verify all items were processed exactly once
+        processed_values = [item.value for item in all_processed]
+        expected_values = [
+            g * 100 + i for g in range(num_groups) for i in range(items_per_group)
+        ]
+        assert sorted(processed_values) == sorted(expected_values)
+
+        # Perfect cleanup with fixed implementation
+        assert len(queue._locked) == 0
+        assert len(queue._current_items) == 0
+        assert len(queue._group_to_worker) == 0
+        assert await queue.size() == 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.26.1"
+version = "0.26.2"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
### **User description**
# Description

Why
Problem: GitHub webhook events for the same resource (like a PR) were getting processed out of order when multiple workers ran concurrently. This broke temporal consistency - you'd get a "PR closed" event processed before "PR updated", leading to stale data.
Solution: Group events by resource ID and ensure only one worker processes events for any given resource at a time, while still allowing parallel processing across different resources.
What
Three core changes:

Group-based queuing: Added GroupQueue that partitions events by group_id and locks groups during processing
Resource identification: Created group_selector.py to extract consistent resource IDs from GitHub webhook payloads
Multi-worker coordination: Modified processor manager to spawn multiple workers that respect group locks

How
Resource Identification: Extract consistent IDs from GitHub events (e.g., pull_request-123, issue-456) to group related events together.
Group Queue: Queue implementation that enforces sequential processing within groups while allowing concurrent processing across groups. Workers lock groups on get() and unlock on commit().
Worker Pool: Multiple workers per webhook path, each pulling from the shared group queue. Integration automatically chooses group-aware or simple processing based on worker count configuration.
Result: Events for the same resource process in order, different resources process in parallel.

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Implement group-based parallel processing for GitHub webhooks

- Add GroupQueue to ensure sequential processing within resource groups

- Enable multiple workers while maintaining event ordering per resource

- Add resource identification logic for GitHub webhook events


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub Webhook Events"] --> B["Group Selector"]
  B --> C["GroupQueue"]
  C --> D["Multiple Workers"]
  D --> E["Sequential Processing per Group"]
  D --> F["Parallel Processing across Groups"]
  E --> G["Ordered Event Processing"]
  F --> G
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td><strong>group_selector.py</strong><dd><code>Add GitHub webhook resource identification logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/port-labs/ocean/pull/1935/files#diff-b25f8a7fb265617fceb24a8ee7f0f2d25e67a16674aeab9405f2dc5fac2c1bb7">+71/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>integration.py</strong><dd><code>Integrate group-based processing for GitHub webhooks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/port-labs/ocean/pull/1935/files#diff-352618668ce736511a5de564f4e299286cc93f0445a9f0300368ba6c93452eef">+99/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong><dd><code>Export GroupQueue class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/port-labs/ocean/pull/1935/files#diff-c9170904db583a716fd64819353c6319e176ef9dff07e4355d491a410627efa5">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>abstract_queue.py</strong><dd><code>Add size method to queue interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/port-labs/ocean/pull/1935/files#diff-c5f159796d2303aac77a0311758cafb17185c6b2ac983d3d6519754bb163ae5f">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>group_queue.py</strong><dd><code>Implement group-based queue with exclusive processing</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/port-labs/ocean/pull/1935/files#diff-8d8b3ee228422ff5eb26b7221858028a7bf52eb77712ffd81cf13daf7f7e619b">+156/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>local_queue.py</strong><dd><code>Add size method implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/port-labs/ocean/pull/1935/files#diff-334e57aa010cbd80d458171ffd86093c6076ef97648f4d26ad8db9ea05b133e7">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>processor_manager.py</strong><dd><code>Add multi-worker support for webhook processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/port-labs/ocean/pull/1935/files#diff-58a2a8bcf5e453cdb2b298a8edcb716c3c3454bb37eed3d6fb3c0c88b50e8b6d">+142/-63</a></td>

</tr>

<tr>
  <td><strong>webhook_event.py</strong><dd><code>Add group_id field to webhook events</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/port-labs/ocean/pull/1935/files#diff-b731c7033797cd3ff458c104fde99743a6ec09baa1c2da550975f1e383c3143e">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>settings.py</strong><dd><code>Add event workers configuration setting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/port-labs/ocean/pull/1935/files#diff-c4ab144128bdbbe50dd95b726ae9c2f4cbc7306025e07a9e1db3dff7c5d4b3bb">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>test_group_queue.py</strong><dd><code>Add comprehensive tests for GroupQueue functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/port-labs/ocean/pull/1935/files#diff-c6c81784c82c06f64808e8e6b211361fa4e24c31de973c7c9bc7ac544bbb1f26">+580/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

