### PR TITLE
[Integration][Github] Add Support to Only Ingest Closed Pull Request Within a Specified Date Range

### DIFF
--- a/integrations/github/CHANGELOG.md
+++ b/integrations/github/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 1.2.1-beta (2025-08-04)
+
+
+### Improvements
+
+- Added closedPullRequests config option to include closed PRs in exports with a 60-day time filter
+- Added Batch limiting (max 100 closed PRs) to prevent performance issues
+- Modified Webhook processor to update (not delete) closed PRs when flag is enabled
+
+
 ## 1.2.0-beta (2025-07-28)
 
 

--- a/integrations/github/github/core/exporters/pull_request_exporter.py
+++ b/integrations/github/github/core/exporters/pull_request_exporter.py
@@ -1,3 +1,5 @@
+from datetime import UTC, datetime, timedelta
+from typing import Any
 from github.helpers.utils import enrich_with_repository, extract_repo_params
 from port_ocean.core.ocean_types import ASYNC_GENERATOR_RESYNC_TYPE, RAW_ITEM
 from loguru import logger
@@ -7,6 +9,9 @@ from github.clients.http.rest_client import GithubRestClient
 
 
 class RestPullRequestExporter(AbstractGithubExporter[GithubRestClient]):
+    MAX_CLOSED_PR_AGE_DAYS = 60  # only include closed PRs updated in last 60 days
+    MAX_CLOSED_PULL_REQUESTS_TO_EXPORT = 100
+    CLOSED_PULL_REQUESTS_PER_PAGE = 100
 
     async def get_resource[
         ExporterOptionsT: SinglePullRequestOptions
@@ -24,17 +29,95 @@ class RestPullRequestExporter(AbstractGithubExporter[GithubRestClient]):
     async def get_paginated_resources[
         ExporterOptionsT: ListPullRequestOptions
     ](self, options: ExporterOptionsT) -> ASYNC_GENERATOR_RESYNC_TYPE:
-        """Get all pull requests in the organization's repositories with pagination."""
+        """Get pull requests in the organization's repositories with pagination."""
 
         repo_name, params = extract_repo_params(dict(options))
+        include_closed = params.get("include_closed", False)
 
-        endpoint = (
+        logger.info(
+            f"Starting export for repository {repo_name} (include_closed={include_closed})"
+        )
+
+        async for open_batch in self._fetch_open_pull_requests(repo_name, params):
+            yield open_batch
+
+        if include_closed:
+            async for closed_batch in self._fetch_closed_pull_requests(repo_name):
+                yield closed_batch
+
+    def _build_pull_request_paginated_endpoint(self, repo_name: str) -> str:
+        return (
             f"{self.client.base_url}/repos/{self.client.organization}/{repo_name}/pulls"
         )
 
+    async def _fetch_open_pull_requests(
+        self, repo_name: str, params: dict[str, Any]
+    ) -> ASYNC_GENERATOR_RESYNC_TYPE:
+        endpoint = self._build_pull_request_paginated_endpoint(repo_name)
+
         async for pull_requests in self.client.send_paginated_request(endpoint, params):
             logger.info(
-                f"Fetched batch of {len(pull_requests)} pull requests from repository {repo_name}"
+                f"Fetched batch of {len(pull_requests)} open pull requests from repository {repo_name}"
             )
             batch = [enrich_with_repository(pr, repo_name) for pr in pull_requests]
             yield batch
+
+    async def _fetch_closed_pull_requests(
+        self, repo_name: str
+    ) -> ASYNC_GENERATOR_RESYNC_TYPE:
+        endpoint = self._build_pull_request_paginated_endpoint(repo_name)
+        params = {
+            "state": "closed",
+            "sort": "updated",
+            "direction": "desc",
+        }
+
+        max_batches = (
+            self.MAX_CLOSED_PULL_REQUESTS_TO_EXPORT
+            // self.CLOSED_PULL_REQUESTS_PER_PAGE
+        )
+        batch_count = 0
+
+        logger.info(
+            f"[Closed PRs] Starting fetch (max_batches={max_batches}, cutoff_days={self.MAX_CLOSED_PR_AGE_DAYS})"
+        )
+
+        async for pull_requests in self.client.send_paginated_request(endpoint, params):
+            if not pull_requests:
+                logger.info(
+                    "[Closed PRs] No more PRs returned for repository {repo_name}; stopping."
+                )
+                break
+
+            if batch_count >= max_batches:
+                logger.info(
+                    f"[Closed PRs] Reached batch limit ({max_batches}) for repository {repo_name}; stopping."
+                )
+                break
+
+            filtered = self._filter_prs_by_updated_at(pull_requests)
+            if not filtered:
+                logger.info(
+                    f"[Closed PRs] All PRs in batch filtered out by updated_at cutoff for repository {repo_name}; stopping."
+                )
+                break
+
+            logger.info(
+                f"[Closed PRs] Batch {batch_count} from {repo_name}: {len(filtered)} PRs after filtering"
+            )
+            yield [enrich_with_repository(pr, repo_name) for pr in filtered]
+            batch_count += 1
+
+    def _filter_prs_by_updated_at(
+        self, prs: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        cutoff = datetime.now(UTC) - timedelta(days=self.MAX_CLOSED_PR_AGE_DAYS)
+
+        return [
+            pr
+            for pr in prs
+            if datetime.strptime(pr["updated_at"], "%Y-%m-%dT%H:%M:%SZ").replace(
+                tzinfo=UTC
+            )
+            >= cutoff
+        ]

--- a/integrations/github/github/core/options.py
+++ b/integrations/github/github/core/options.py
@@ -40,6 +40,7 @@ class ListPullRequestOptions(RepositoryIdentifier):
     """Options for listing pull requests."""
 
     state: Required[str]
+    include_closed: NotRequired[Optional[bool]]
 
 
 class SingleIssueOptions(RepositoryIdentifier):

--- a/integrations/github/github/webhook/webhook_processors/pull_request_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/pull_request_webhook_processor.py
@@ -42,7 +42,11 @@ class PullRequestWebhookProcessor(BaseRepositoryWebhookProcessor):
         logger.info(f"Processing pull request event: {action} for {repo_name}/{number}")
 
         config = cast(GithubPullRequestConfig, resource_config)
-        if action == "closed" and config.selector.state == "open":
+        if (
+            action == "closed"
+            and config.selector.state == "open"
+            and not config.selector.closed_pull_requests
+        ):
             logger.info(
                 f"Pull request {repo_name}/{number} was closed and will be deleted"
             )

--- a/integrations/github/integration.py
+++ b/integrations/github/integration.py
@@ -65,6 +65,11 @@ class GithubPullRequestSelector(Selector):
         default="open",
         description="Filter by pull request state (e.g., open, closed, all)",
     )
+    closed_pull_requests: bool = Field(
+        alias="closedPullRequests",
+        default=False,
+        description="Include closed pull requests in the export",
+    )
 
 
 class GithubPullRequestConfig(ResourceConfig):

--- a/integrations/github/main.py
+++ b/integrations/github/main.py
@@ -234,6 +234,7 @@ async def resync_pull_requests(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
                 ListPullRequestOptions(
                     repo_name=repo["name"],
                     state=config.selector.state,
+                    include_closed=config.selector.closed_pull_requests,
                 )
             )
             for repo in repos

--- a/integrations/github/pyproject.toml
+++ b/integrations/github/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "github-ocean"
-version = "1.2.0-beta"
+version = "1.2.1-beta"
 description = "This integration ingest data from github"
 authors = ["Chukwuemeka Nwaoma <joelchukks@gmail.com>", "Melody Anyaegbulam <melodyogonna@gmail.com>", "Michael Armah <mikeyarmah@gmail.com>"]
 

--- a/integrations/github/tests/github/core/exporters/test_pull_request_exporter.py
+++ b/integrations/github/tests/github/core/exporters/test_pull_request_exporter.py
@@ -6,7 +6,15 @@ from github.clients.http.rest_client import GithubRestClient
 from integration import GithubPullRequestSelector
 from port_ocean.context.event import event_context
 from github.core.options import SinglePullRequestOptions, ListPullRequestOptions
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
+
+# Calculate dates relative to current time to ensure they're within the 60-day window
+now = datetime.now(timezone.utc)
+recent_date = (now - timedelta(days=10)).strftime("%Y-%m-%dT%H:%M:%SZ")
+older_recent_date = (now - timedelta(days=30)).strftime("%Y-%m-%dT%H:%M:%SZ")
+old_date = (now - timedelta(days=70)).strftime(
+    "%Y-%m-%dT%H:%M:%SZ"
+)  # This will be filtered out
 
 TEST_PULL_REQUESTS = [
     {
@@ -15,7 +23,7 @@ TEST_PULL_REQUESTS = [
         "title": "Fix bug in login",
         "state": "open",
         "html_url": "https://github.com/test-org/repo1/pull/101",
-        "updated_at": datetime.now(timezone.utc).isoformat(),
+        "updated_at": recent_date,
     },
     {
         "id": 2,
@@ -23,7 +31,34 @@ TEST_PULL_REQUESTS = [
         "title": "Add new feature",
         "state": "open",
         "html_url": "https://github.com/test-org/repo1/pull/102",
-        "updated_at": datetime.now(timezone.utc).isoformat(),
+        "updated_at": older_recent_date,
+    },
+]
+
+TEST_CLOSED_PULL_REQUESTS = [
+    {
+        "id": 3,
+        "number": 103,
+        "title": "Closed PR 1",
+        "state": "closed",
+        "html_url": "https://github.com/test-org/repo1/pull/103",
+        "updated_at": recent_date,
+    },
+    {
+        "id": 4,
+        "number": 104,
+        "title": "Closed PR 2",
+        "state": "closed",
+        "html_url": "https://github.com/test-org/repo1/pull/104",
+        "updated_at": older_recent_date,
+    },
+    {
+        "id": 5,
+        "number": 105,
+        "title": "Old Closed PR",
+        "state": "closed",
+        "html_url": "https://github.com/test-org/repo1/pull/105",
+        "updated_at": old_date,
     },
 ]
 
@@ -56,8 +91,12 @@ class TestPullRequestExporter:
                 f"{rest_client.base_url}/repos/{rest_client.organization}/repo1/pulls/101"
             )
 
-    async def test_get_paginated_resources(self, rest_client: GithubRestClient) -> None:
-        selector = GithubPullRequestSelector(query="true", state="open")
+    async def test_get_paginated_resources_open_only(
+        self, rest_client: GithubRestClient
+    ) -> None:
+        selector = GithubPullRequestSelector(
+            query="true", state="open", closedPullRequests=False
+        )
         exporter = RestPullRequestExporter(rest_client)
 
         # Create async mocks for the nested requests
@@ -99,3 +138,173 @@ class TestPullRequestExporter:
                 f"{rest_client.base_url}/repos/{rest_client.organization}/repo1/pulls",
                 {"state": "open"},
             )
+
+    async def test_get_paginated_resources_with_closed(
+        self, rest_client: GithubRestClient
+    ) -> None:
+        selector = GithubPullRequestSelector(
+            query="true", state="open", closedPullRequests=True
+        )
+        exporter = RestPullRequestExporter(rest_client)
+
+        # Track call count to return different responses
+        call_count = 0
+
+        async def mock_paginated_request(
+            endpoint: str, *args: Any, **kwargs: Any
+        ) -> AsyncGenerator[list[dict[str, Any]], None]:
+            nonlocal call_count
+            call_count += 1
+
+            if call_count == 1:
+                # First call: open PRs
+                yield TEST_PULL_REQUESTS
+            elif call_count == 2:
+                # Second call: closed PRs
+                yield TEST_CLOSED_PULL_REQUESTS[:2]  # Only the recent ones
+
+        with patch.object(
+            rest_client, "send_paginated_request", side_effect=mock_paginated_request
+        ) as mock_paginated:
+            async with event_context("test_event"):
+                # Convert selector to options dict
+                options = ListPullRequestOptions(
+                    state=selector.state, repo_name="repo1", include_closed=True
+                )
+                prs: list[list[dict[str, Any]]] = [
+                    batch async for batch in exporter.get_paginated_resources(options)
+                ]
+
+                assert len(prs) == 2  # Open PRs batch + Closed PRs batch
+                assert len(prs[0]) == 2  # Open PRs
+                assert len(prs[1]) == 2  # Closed PRs (filtered)
+
+                expected_open_prs = [
+                    {**pr, "__repository": "repo1"} for pr in TEST_PULL_REQUESTS
+                ]
+                expected_closed_prs = [
+                    {**pr, "__repository": "repo1"}
+                    for pr in TEST_CLOSED_PULL_REQUESTS[:2]
+                ]
+                assert prs[0] == expected_open_prs
+                assert prs[1] == expected_closed_prs
+
+            # Should be called twice: once for open PRs, once for closed PRs
+            assert mock_paginated.call_count == 2
+
+    async def test_fetch_open_pull_requests(
+        self, rest_client: GithubRestClient
+    ) -> None:
+        exporter = RestPullRequestExporter(rest_client)
+        params = {"state": "open"}
+
+        async def mock_prs_request(
+            *args: Any, **kwargs: Any
+        ) -> AsyncGenerator[list[dict[str, Any]], None]:
+            yield TEST_PULL_REQUESTS
+
+        with patch.object(
+            rest_client, "send_paginated_request", side_effect=mock_prs_request
+        ) as mock_paginated:
+            batches = [
+                batch
+                async for batch in exporter._fetch_open_pull_requests("repo1", params)
+            ]
+
+            assert len(batches) == 1
+            assert len(batches[0]) == 2
+            expected_prs = [
+                {**pr, "__repository": "repo1"} for pr in TEST_PULL_REQUESTS
+            ]
+            assert batches[0] == expected_prs
+
+            mock_paginated.assert_called_once_with(
+                f"{rest_client.base_url}/repos/{rest_client.organization}/repo1/pulls",
+                {"state": "open"},
+            )
+
+    async def test_fetch_closed_pull_requests(
+        self, rest_client: GithubRestClient
+    ) -> None:
+        exporter = RestPullRequestExporter(rest_client)
+
+        async def mock_closed_prs_request(
+            *args: Any, **kwargs: Any
+        ) -> AsyncGenerator[list[dict[str, Any]], None]:
+            yield TEST_CLOSED_PULL_REQUESTS
+
+        with patch.object(
+            rest_client, "send_paginated_request", side_effect=mock_closed_prs_request
+        ) as mock_paginated:
+            batches = [
+                batch async for batch in exporter._fetch_closed_pull_requests("repo1")
+            ]
+
+            assert len(batches) == 1
+            assert len(batches[0]) == 2  # Only the recent ones (filtered)
+            expected_prs = [
+                {**pr, "__repository": "repo1"} for pr in TEST_CLOSED_PULL_REQUESTS[:2]
+            ]
+            assert batches[0] == expected_prs
+
+            mock_paginated.assert_called_once_with(
+                f"{rest_client.base_url}/repos/{rest_client.organization}/repo1/pulls",
+                {"state": "closed", "sort": "updated", "direction": "desc"},
+            )
+
+    async def test_fetch_closed_pull_requests_empty_batch(
+        self, rest_client: GithubRestClient
+    ) -> None:
+        exporter = RestPullRequestExporter(rest_client)
+
+        async def mock_empty_request(
+            *args: Any, **kwargs: Any
+        ) -> AsyncGenerator[list[dict[str, Any]], None]:
+            yield []  # Empty batch
+
+        with patch.object(
+            rest_client, "send_paginated_request", side_effect=mock_empty_request
+        ) as mock_paginated:
+            batches = [
+                batch async for batch in exporter._fetch_closed_pull_requests("repo1")
+            ]
+
+            assert len(batches) == 0  # No batches should be yielded
+            mock_paginated.assert_called_once()
+
+    async def test_fetch_closed_pull_requests_batch_limit(
+        self, rest_client: GithubRestClient
+    ) -> None:
+        exporter = RestPullRequestExporter(rest_client)
+
+        # Create more batches than the limit
+        async def mock_multiple_batches(
+            *args: Any, **kwargs: Any
+        ) -> AsyncGenerator[list[dict[str, Any]], None]:
+            for i in range(3):  # More than the limit (100/100 = 1 batch)
+                yield [{"id": i, "updated_at": recent_date}]
+
+        with patch.object(
+            rest_client, "send_paginated_request", side_effect=mock_multiple_batches
+        ) as mock_paginated:
+            batches = [
+                batch async for batch in exporter._fetch_closed_pull_requests("repo1")
+            ]
+
+            # Should only get 1 batch due to the limit
+            assert len(batches) == 1
+            assert mock_paginated.call_count == 1
+
+    def test_filter_prs_by_updated_at(self, rest_client: GithubRestClient) -> None:
+        exporter = RestPullRequestExporter(rest_client)
+
+        # Create PRs with different creation dates
+        recent_pr = {"id": 1, "updated_at": recent_date}
+        old_pr = {"id": 2, "updated_at": old_date}
+
+        prs = [recent_pr, old_pr]
+        filtered = exporter._filter_prs_by_updated_at(prs)
+
+        # Only the recent PR should be included
+        assert len(filtered) == 1
+        assert filtered[0]["id"] == 1

--- a/integrations/github/tests/github/webhook/webhook_processors/test_pull_request_webhook_processor.py
+++ b/integrations/github/tests/github/webhook/webhook_processors/test_pull_request_webhook_processor.py
@@ -31,7 +31,9 @@ def pull_request_webhook_processor(
 def resource_config() -> GithubPullRequestConfig:
     return GithubPullRequestConfig(
         kind="pull-request",
-        selector=GithubPullRequestSelector(query="true", state="open"),
+        selector=GithubPullRequestSelector(
+            query="true", state="open", closedPullRequests=False
+        ),
         port=PortResourceConfig(
             entity=MappingsConfig(
                 mappings=EntityMapping(
@@ -173,3 +175,184 @@ class TestPullRequestWebhookProcessor:
                 assert result.deleted_raw_results == [pr_data]
                 # Should not call get_resource when deleting
                 mock_exporter.get_resource.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "closed_pull_requests,action,expected_update,expected_delete",
+        [
+            (False, "closed", False, True),  # Default behavior - delete closed PRs
+            (True, "closed", True, False),  # New behavior - keep closed PRs
+        ],
+    )
+    async def test_handle_event_with_closed_pull_requests_flag(
+        self,
+        closed_pull_requests: bool,
+        action: str,
+        expected_update: bool,
+        expected_delete: bool,
+        pull_request_webhook_processor: PullRequestWebhookProcessor,
+        resource_config: GithubPullRequestConfig,
+    ) -> None:
+        # Create resource config with the specified closed_pull_requests setting
+        resource_config.selector.closed_pull_requests = closed_pull_requests
+
+        pr_data = {
+            "id": 1,
+            "number": 101,
+            "title": "Test PR",
+            "state": "closed",
+        }
+
+        repo_data = {"name": "test-repo", "full_name": "test-org/test-repo"}
+
+        payload = {"action": action, "pull_request": pr_data, "repository": repo_data}
+
+        # Create updated PR data that would be returned by the exporter
+        updated_pr_data = {**pr_data, "additional_data": "from_api"}
+
+        # Mock the exporter
+        mock_exporter = AsyncMock()
+        mock_exporter.get_resource.return_value = updated_pr_data
+
+        with patch(
+            "github.webhook.webhook_processors.pull_request_webhook_processor.RestPullRequestExporter",
+            return_value=mock_exporter,
+        ):
+            result = await pull_request_webhook_processor.handle_event(
+                payload, resource_config
+            )
+
+            # Verify results based on expected behavior
+            assert isinstance(result, WebhookEventRawResults)
+
+            if expected_update:
+                assert result.updated_raw_results == [updated_pr_data]
+                assert result.deleted_raw_results == []
+                mock_exporter.get_resource.assert_called_once_with(
+                    SinglePullRequestOptions(repo_name="test-repo", pr_number=101)
+                )
+            elif expected_delete:
+                assert result.updated_raw_results == []
+                assert result.deleted_raw_results == [pr_data]
+                # Should not call get_resource when deleting
+                mock_exporter.get_resource.assert_not_called()
+
+    async def test_handle_event_closed_action_with_closed_prs_enabled(
+        self,
+        pull_request_webhook_processor: PullRequestWebhookProcessor,
+        resource_config: GithubPullRequestConfig,
+    ) -> None:
+        """Test that when closed_pull_requests=True, closed PRs are updated instead of deleted."""
+
+        pr_data = {
+            "id": 1,
+            "number": 101,
+            "title": "Test PR",
+            "state": "closed",
+        }
+
+        repo_data = {"name": "test-repo", "full_name": "test-org/test-repo"}
+
+        payload = {"action": "closed", "pull_request": pr_data, "repository": repo_data}
+
+        # Create updated PR data that would be returned by the exporter
+        updated_pr_data = {**pr_data, "additional_data": "from_api"}
+
+        # Mock the exporter
+        mock_exporter = AsyncMock()
+        mock_exporter.get_resource.return_value = updated_pr_data
+
+        with patch(
+            "github.webhook.webhook_processors.pull_request_webhook_processor.RestPullRequestExporter",
+            return_value=mock_exporter,
+        ):
+            resource_config.selector.closed_pull_requests = True
+            result = await pull_request_webhook_processor.handle_event(
+                payload, resource_config
+            )
+
+            # Should update the PR instead of deleting it
+            assert result.updated_raw_results == [updated_pr_data]
+            # Should update the PR instead of deleting it
+            assert result.updated_raw_results == [updated_pr_data]
+            assert result.deleted_raw_results == []
+            mock_exporter.get_resource.assert_called_once_with(
+                SinglePullRequestOptions(repo_name="test-repo", pr_number=101)
+            )
+
+    async def test_handle_event_closed_action_with_closed_prs_disabled(
+        self,
+        resource_config: GithubPullRequestConfig,
+        pull_request_webhook_processor: PullRequestWebhookProcessor,
+    ) -> None:
+        """Test that when closed_pull_requests=False (default), closed PRs are deleted."""
+
+        pr_data = {
+            "id": 1,
+            "number": 101,
+            "title": "Test PR",
+            "state": "closed",
+        }
+
+        repo_data = {"name": "test-repo", "full_name": "test-org/test-repo"}
+
+        payload = {"action": "closed", "pull_request": pr_data, "repository": repo_data}
+
+        # Mock the exporter
+        mock_exporter = AsyncMock()
+
+        with patch(
+            "github.webhook.webhook_processors.pull_request_webhook_processor.RestPullRequestExporter",
+            return_value=mock_exporter,
+        ):
+            result = await pull_request_webhook_processor.handle_event(
+                payload, resource_config
+            )
+
+            # Should delete the PR instead of updating it
+            assert result.updated_raw_results == []
+            assert result.deleted_raw_results == [pr_data]
+            # Should not call get_resource when deleting
+            mock_exporter.get_resource.assert_not_called()
+
+    async def test_handle_event_opened_action_unaffected_by_closed_prs_flag(
+        self,
+        pull_request_webhook_processor: PullRequestWebhookProcessor,
+        resource_config: GithubPullRequestConfig,
+    ) -> None:
+        """Test that opened actions are unaffected by the closed_pull_requests flag."""
+
+        pr_data = {
+            "id": 1,
+            "number": 101,
+            "title": "Test PR",
+            "state": "open",
+        }
+
+        repo_data = {"name": "test-repo", "full_name": "test-org/test-repo"}
+
+        payload = {"action": "opened", "pull_request": pr_data, "repository": repo_data}
+
+        # Create updated PR data that would be returned by the exporter
+        updated_pr_data = {**pr_data, "additional_data": "from_api"}
+
+        # Mock the exporter
+        mock_exporter = AsyncMock()
+        mock_exporter.get_resource.return_value = updated_pr_data
+
+        with patch(
+            "github.webhook.webhook_processors.pull_request_webhook_processor.RestPullRequestExporter",
+            return_value=mock_exporter,
+        ):
+            resource_config.selector.closed_pull_requests = True
+            result = await pull_request_webhook_processor.handle_event(
+                payload, resource_config
+            )
+
+            # Should always update opened PRs regardless of closed_pull_requests flag
+            assert result.updated_raw_results == [updated_pr_data]
+            # Should always update opened PRs regardless of closed_pull_requests flag
+            assert result.updated_raw_results == [updated_pr_data]
+            assert result.deleted_raw_results == []
+            mock_exporter.get_resource.assert_called_once_with(
+                SinglePullRequestOptions(repo_name="test-repo", pr_number=101)
+            )


### PR DESCRIPTION
# Description

What - Adds optional closed pull request ingestion to GitHub integration with time-based filtering.

Why - Users need visibility into recently closed PRs for tracking and analysis, but ingesting all historical closed PRs would be impractical and slow.

How - 
- New closedPullRequests config flag controls whether closed PRs are included
- Only fetches closed PRs updated within last 60 days
- Limits to 100 closed PRs per repository
- Webhook processor updates (instead of deletes) closed PRs when flag is enabled
- Maintains backward compatibility with existing configs


## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
