### PR TITLE
[Integration][Sentry] Pagination BugFix

### DIFF
--- a/integrations/sentry/CHANGELOG.md
+++ b/integrations/sentry/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.186 (2025-08-05)
+
+
+### Fix
+
+- Fixed issue with pagination looping when params is not reset after initial API call
+
+
 ## 0.1.185 (2025-08-05)
 
 

--- a/integrations/sentry/clients/sentry.py
+++ b/integrations/sentry/clients/sentry.py
@@ -1,7 +1,7 @@
 import asyncio
 from itertools import chain
 import time
-from typing import Any, AsyncGenerator, AsyncIterator, cast
+from typing import Any, AsyncGenerator, AsyncIterator, Optional, cast
 from loguru import logger
 
 
@@ -121,7 +121,7 @@ class SentryClient:
     async def _get_paginated_resource(
         self, url: str, semaphore: asyncio.Semaphore | None = None
     ) -> AsyncGenerator[list[dict[str, Any]], None]:
-        params: dict[str, Any] = {"per_page": PAGE_SIZE}
+        params: Optional[dict[str, Any]] = {"per_page": PAGE_SIZE}
         logger.debug(f"Getting paginated resource from Sentry for URL: {url}")
 
         while url:
@@ -139,6 +139,7 @@ class SentryClient:
                 yield records
 
                 url = self.get_next_link(response.headers.get("link", ""))
+                params = None
 
             except httpx.HTTPStatusError as e:
                 logger.error(

--- a/integrations/sentry/pyproject.toml
+++ b/integrations/sentry/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sentry"
-version = "0.1.186"
+version = "0.1.187"
 description = "Sentry Integration"
 authors = ["Dvir Segev <dvir@getport.io>","Matan Geva <matang@getport.io>"]
 

--- a/integrations/sentry/pyproject.toml
+++ b/integrations/sentry/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sentry"
-version = "0.1.185"
+version = "0.1.186"
 description = "Sentry Integration"
 authors = ["Dvir Segev <dvir@getport.io>","Matan Geva <matang@getport.io>"]
 


### PR DESCRIPTION
### **User description**
# Description
A recent upgrade to HTTPX 0.28.1 introduced a behavioral change that overwrites existing query-string parameters whenever a separate params= argument is supplied. Any of our integrations that rely on the full “next” URL returned by the upstream API now request the first page in a loop until they exhaust the provider’s rate-limit.

What

Why

How
- Reset `params` to `None` after fetching paginated data.

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [x] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [x] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix pagination bug in Sentry integration caused by HTTPX 0.28.1 upgrade

- Reset `params` to `None` after fetching paginated data to prevent infinite loops

- Update version to 0.1.185 with changelog entry


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["HTTPX 0.28.1 upgrade"] --> B["Query params overwrite issue"]
  B --> C["Infinite pagination loop"]
  C --> D["Reset params to None"]
  D --> E["Fixed pagination"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sentry.py</strong><dd><code>Fix pagination params handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/sentry/clients/sentry.py

<ul><li>Add Optional type import for better type annotation<br> <li> Change <code>params</code> type annotation to <code>Optional[dict[str, Any]]</code><br> <li> Reset <code>params</code> to <code>None</code> after getting next URL in pagination loop</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1958/files#diff-e8ff97914457eee76c6da224f2db9fe08ca357d45f43401dbf6f3d83be4c5a36">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Add changelog entry for pagination fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/sentry/CHANGELOG.md

<ul><li>Add new version 0.1.185 entry with date 2025-08-05<br> <li> Document fix section for pagination bug</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1958/files#diff-81f83bbb242dfb4dd0998e1a3c06c076a896e0ecd803a2e878f9ca098a531dfa">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Version bump to 0.1.185</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/sentry/pyproject.toml

- Bump version from 0.1.184 to 0.1.185


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/1958/files#diff-1b34a0efd046a624b363b4e829ae54f207766496982be14402b2237b1a3a1e77">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

