### PR TITLE
[Docs][Integration][Argo CD] Canonicalize name to "Argo CD"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 # Ocean framework
 /port_ocean/** @port-labs/ecosystem-team
 
-# argocd integration
+# argo cd integration
 /integrations/argocd/** @port-labs/ecosystem-team
 
 # aws integration

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -76,7 +76,7 @@
       "cwd": "${workspaceFolder}/integrations/argocd",
       "envFile": "${workspaceFolder}/integrations/argocd/.env",
       "justMyCode": true,
-      "name": "Run argocd integration",
+      "name": "Run argo cd integration",
       "program": "${workspaceFolder}/integrations/argocd/debug.py",
       "python": "${workspaceFolder}/integrations/argocd/.venv/bin/python",
       "request": "launch",

--- a/docs/framework-guides/CONTRIBUTING.md
+++ b/docs/framework-guides/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Contributions are very welcome. If you think you need help planning your contrib
    3. **Notice/tip/info boxes** - All letters will be capital letters.
    4. **Other** - discuss the matter with the rest of the team and decide together.
 2. **Links** - unless the link is at a start of a new sentence, it should not be with capital letters.
-3. **General product names** - well known products such as Lambda, Kubernetes, ArgoCD, etc. should follow their standard capitalization rules and styling.
+3. **General product names** - well known products such as Lambda, Kubernetes, Argo CD, etc. should follow their standard capitalization rules and styling.
 4. **Button names** - will be capitalized according to the exact way the term is written in Port.
 5. **After brackets or a colon (`:`)** - there is no need to put a capital letter.
 

--- a/docs/framework-guides/docs/deployment/argocd.md
+++ b/docs/framework-guides/docs/deployment/argocd.md
@@ -1,6 +1,6 @@
 ---
-title: ArgoCD Deployment
-sidebar_label: 🐙 ArgoCD
+title: Argo CD Deployment
+sidebar_label: 🐙 Argo CD
 sidebar_position: 4
 ---
 
@@ -10,9 +10,9 @@ import CheckInstallation from './\_check_installation.md';
 import Image from "@theme/IdealImage";
 import Credentials from "/static/img/credentials-modal.png"
 
-# ⚓️ ArgoCD Deployment
+# ⚓️ Argo CD Deployment
 
-This guide will walk you through deploying an integration of the Ocean framework using ArgoCD, utilizing it's [Helm Capabilities](https://argo-cd.readthedocs.io/en/stable/user-guide/helm/).
+This guide will walk you through deploying an integration of the Ocean framework using Argo CD, utilizing it's [Helm Capabilities](https://argo-cd.readthedocs.io/en/stable/user-guide/helm/).
 
 :::info
 - You can observe the Helm chart and the available parameters [here](https://github.com/port-labs/helm-charts/tree/main/charts/port-ocean).
@@ -26,7 +26,7 @@ This guide will walk you through deploying an integration of the Ocean framework
 - [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) must be installed to apply your installation manifest.
 - [Helm](https://helm.sh/docs/intro/install/) installed.
 - [Kubernetes](https://kubernetes.io/docs/tasks/tools/) cluster to deploy the integration to.
-- [ArgoCD](https://argoproj.github.io/cd/) must be installed in your Kubernetes cluster. Please refer to ArgoCD's [documentation](https://argo-cd.readthedocs.io/en/stable/getting_started/#1-install-argo-cd) for further details about the installation.
+- [Argo CD](https://argoproj.github.io/cd/) must be installed in your Kubernetes cluster. Please refer to Argo CD's [documentation](https://argo-cd.readthedocs.io/en/stable/getting_started/#1-install-argo-cd) for further details about the installation.
 - The integration's required configurations.
 - Your organization [Port credentials](https://docs.port.io/build-your-software-catalog/sync-data-to-catalog/api/#find-your-port-credentials).
 
@@ -45,7 +45,7 @@ To get your Port API credentials go to your [Port application](https://app.getpo
 :::
 
 :::warning
-This guide will install the ArgoCD Application using the current Kubernetes context. Make sure you have the correct context set before continuing.
+This guide will install the Argo CD Application using the current Kubernetes context. Make sure you have the correct context set before continuing.
 :::
 
 ## Deploying the integration
@@ -87,15 +87,15 @@ More information about the available event listener types and optional configura
 the [event listeners](../framework/features/event-listener.md) guide.
 :::
 
-4. Install the `my-ocean-integration` ArgoCD Application by creating the following `my-ocean-integration.yaml` manifest:
+4. Install the `my-ocean-integration` Argo CD Application by creating the following `my-ocean-integration.yaml` manifest:
 :::note
 Remember to replace the placeholders for `YOUR_PORT_CLIENT_ID` `YOUR_PORT_CLIENT_SECRET` and `YOUR_GIT_REPO_URL`.
 
-Multiple sources ArgoCD documentation can be found [here](https://argo-cd.readthedocs.io/en/stable/user-guide/multiple_sources/#helm-value-files-from-external-git-repository).
+Multiple sources Argo CD documentation can be found [here](https://argo-cd.readthedocs.io/en/stable/user-guide/multiple_sources/#helm-value-files-from-external-git-repository).
 :::
 
 <details>
-  <summary>ArgoCD Application</summary>
+  <summary>Argo CD Application</summary>
 
 ```yaml showLineNumbers
 apiVersion: argoproj.io/v1alpha1

--- a/docs/framework-guides/docs/developing-an-integration/publishing-your-integration.md
+++ b/docs/framework-guides/docs/developing-an-integration/publishing-your-integration.md
@@ -6,7 +6,7 @@ sidebar_position: 8
 
 # 📦 Publishing Your Integration
 
-With your integration developed and tested, you have several options for deployment. You can deploy it directly using [Helm](../deployment/helm.md), [Terraform](../deployment/terraform.md), [Docker](../deployment/docker.md), or [ArgoCD](../deployment/argocd.md). However, if you want to make your integration available to other Port users, you'll need to publish it to the Ocean repository. This guide will walk you through the process of publishing your integration.
+With your integration developed and tested, you have several options for deployment. You can deploy it directly using [Helm](../deployment/helm.md), [Terraform](../deployment/terraform.md), [Docker](../deployment/docker.md), or [Argo CD](../deployment/argocd.md). However, if you want to make your integration available to other Port users, you'll need to publish it to the Ocean repository. This guide will walk you through the process of publishing your integration.
 
 ## Prerequisites
 

--- a/docs/framework-guides/docs/developing-an-integration/testing-the-integration.md
+++ b/docs/framework-guides/docs/developing-an-integration/testing-the-integration.md
@@ -95,7 +95,7 @@ You can find these credentials by following the [Find Your Port Credentials guid
 
 ## Running the Integration
 
-We will be running the integration locally using the Ocean CLI. You can run the integration with other means such as [Helm](../deployment/helm.md), [Terraform](../deployment/terraform.md), [Docker](../deployment//docker.md), and [ArgoCD](../deployment/argocd.md).
+We will be running the integration locally using the Ocean CLI. You can run the integration with other means such as [Helm](../deployment/helm.md), [Terraform](../deployment/terraform.md), [Docker](../deployment//docker.md), and [Argo CD](../deployment/argocd.md).
 
 Create a `.env` file in the integration directory to store the environment variables required to run the integration. Add the following environment variables to the file:
 
@@ -230,7 +230,7 @@ If you are satisfied with the integration and would like to deploy it, you can f
 - [Helm](../deployment/helm.md)
 - [Terraform](../deployment/terraform.md)
 - [Docker](../deployment/docker.md)
-- [ArgoCD](../deployment/argocd.md)
+- [Argo CD](../deployment/argocd.md)
 
 ## Conclusion
 Having developed and tested your integration, you can decide to use it locally or contribute to the Port community by following the guide in the next section.

--- a/docs/framework-guides/docs/ocean-overview.md
+++ b/docs/framework-guides/docs/ocean-overview.md
@@ -71,7 +71,7 @@ The goal of Ocean is to provide a layer of abstraction for a multitude of common
   - Trigger by querying configuration from Port
   - Trigger by reading a message from a Kafka topic provided by Port
 - Support a multitude of deployment methods to account for any environment, infrastructure or architecture:
-  - Kubernetes (using helm or ArgoCD)
+  - Kubernetes (using helm or Argo CD)
   - AWS ECS (using Terraform module)
   - Azure Container App (using Terraform module)
   - Docker

--- a/integrations/argocd/.port/resources/blueprints.json
+++ b/integrations/argocd/.port/resources/blueprints.json
@@ -1,8 +1,8 @@
 [
   {
     "identifier": "argocdCluster",
-    "description": "This blueprint represents an ArgoCD cluster",
-    "title": "ArgoCD Cluster",
+    "description": "This blueprint represents an Argo CD cluster",
+    "title": "Argo CD Cluster",
     "icon": "Argo",
     "schema": {
       "properties": {
@@ -45,8 +45,8 @@
   },
   {
     "identifier": "argocdNamespace",
-    "description": "This blueprint represents an ArgoCD namespace",
-    "title": "ArgoCD Namespace",
+    "description": "This blueprint represents an Argo CD namespace",
+    "title": "Argo CD Namespace",
     "icon": "Argo",
     "schema": {
       "properties": {},
@@ -57,7 +57,7 @@
     "calculationProperties": {},
     "relations": {
       "cluster": {
-        "title": "ArgoCD Cluster",
+        "title": "Argo CD Cluster",
         "target": "argocdCluster",
         "required": false,
         "many": false
@@ -66,8 +66,8 @@
   },
   {
     "identifier": "argocdProject",
-    "description": "This blueprint represents an ArgoCD Project",
-    "title": "ArgoCD Project",
+    "description": "This blueprint represents an Argo CD Project",
+    "title": "Argo CD Project",
     "icon": "Argo",
     "schema": {
       "properties": {
@@ -92,7 +92,7 @@
   },
   {
     "identifier": "argocdApplication",
-    "description": "This blueprint represents an ArgoCD Application",
+    "description": "This blueprint represents an Argo CD Application",
     "title": "Running Service",
     "icon": "Argo",
     "schema": {
@@ -182,19 +182,19 @@
     "calculationProperties": {},
     "relations": {
       "project": {
-        "title": "ArgoCD Project",
+        "title": "Argo CD Project",
         "target": "argocdProject",
         "required": false,
         "many": false
       },
       "cluster": {
-        "title": "ArgoCD Cluster",
+        "title": "Argo CD Cluster",
         "target": "argocdCluster",
         "required": false,
         "many": false
       },
       "namespace": {
-        "title": "ArgoCD Namespace",
+        "title": "Argo CD Namespace",
         "target": "argocdNamespace",
         "required": false,
         "many": false
@@ -203,8 +203,8 @@
   },
   {
     "identifier": "argocdDeploymentHistory",
-    "description": "This blueprint represents an ArgoCD deployment history",
-    "title": "ArgoCD Deployment History",
+    "description": "This blueprint represents an Argo CD deployment history",
+    "title": "Argo CD Deployment History",
     "icon": "Argo",
     "schema": {
       "properties": {
@@ -251,7 +251,7 @@
   },
   {
     "identifier": "argocdKubernetesResource",
-    "description": "This blueprint represents an ArgoCD kubernetes resource",
+    "description": "This blueprint represents an Argo CD kubernetes resource",
     "title": "Kubernetes Resource",
     "icon": "Argo",
     "schema": {

--- a/integrations/argocd/.port/resources/pages.json
+++ b/integrations/argocd/.port/resources/pages.json
@@ -1,7 +1,7 @@
 [
   {
     "icon": "Argo",
-    "title": "ArgoCD Dashboard",
+    "title": "Argo CD Dashboard",
     "protected": false,
     "widgets": [
       {

--- a/integrations/argocd/.port/spec.yaml
+++ b/integrations/argocd/.port/spec.yaml
@@ -17,22 +17,22 @@ saas:
 configurations:
   - name: token
     required: true
-    description: ArgoCD API token. To create an API token, see the <a href="https://argoproj.github.io/argo-cd/getting_started/#4-create-an-api-access-token" target="_blank">ArgoCD documentation</a>.
+    description: Argo CD API token. To create an API token, see the <a href="https://argoproj.github.io/argo-cd/getting_started/#4-create-an-api-access-token" target="_blank">Argo CD documentation</a>.
     type: string
     sensitive: true
   - name: serverUrl
     type: string
     required: true
-    description: The URL of the ArgoCD server. For example, https://argocd.example.com. Found in the URL field of your browser when you launch your ArgoCD instance
+    description: The URL of the Argo CD server. For example, https://argocd.example.com. Found in the URL field of your browser when you launch your Argo CD instance
   - name: ignoreServerError
     type: boolean
     required: false
-    description: Whether to ignore server errors when fetching data from ArgoCD. If set to true, the exporter will continue to fetch data and ingest entities in Port without failing the resync event even if the ArgoCD server returns an error. If set to false, the exporter will stop fetching data and fail the resync event when the ArgoCD server returns an error. Default is false.
+    description: Whether to ignore server errors when fetching data from Argo CD. If set to true, the exporter will continue to fetch data and ingest entities in Port without failing the resync event even if the Argo CD server returns an error. If set to false, the exporter will stop fetching data and fail the resync event when the Argo CD server returns an error. Default is false.
     default: false
   - name: allowInsecure
     type: boolean
     required: false
-    description: Whether to allow insecure connections to the ArgoCD server. If set to true, the exporter will allow insecure connections to the ArgoCD server. If set to false, the exporter will only allow secure connections to the ArgoCD server. Default is false.
+    description: Whether to allow insecure connections to the Argo CD server. If set to true, the exporter will allow insecure connections to the Argo CD server. If set to false, the exporter will only allow secure connections to the Argo CD server. Default is false.
     default: false
 installationDocs:
   saas:

--- a/integrations/argocd/CHANGELOG.md
+++ b/integrations/argocd/CHANGELOG.md
@@ -864,7 +864,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
-- Added support for optional insecure connections to Argocd with SSL verification disabled when allow_insecure is set to True (0.1.95)
+- Added support for optional insecure connections to Argo CD with SSL verification disabled when allow_insecure is set to True (0.1.95)
 
 
 ## 0.1.94 (2024-10-14)
@@ -880,7 +880,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- Updated the error handling mechanims by allowing users to specify how they want to handle ArgoCD server error using the `ignoreServerError` flag (0.1.93)
+- Updated the error handling mechanims by allowing users to specify how they want to handle Argo CD server error using the `ignoreServerError` flag (0.1.93)
 
 
 ## 0.1.92 (2024-10-09)
@@ -1343,7 +1343,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
-- Added support for ArgoCD kubernetes resources (PORT-6911)
+- Added support for Argo CD kubernetes resources (PORT-6911)
 
 
 ## 0.1.31 (2024-03-20)
@@ -1435,14 +1435,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
-- Added default page for ArgoCD (PORT-5959)
+- Added default page for Argo CD (PORT-5959)
 
 
 ## 0.1.18 (2024-01-12)
 
 ### Features
 
-- Added support for ArgoCD deployments history (#5704)
+- Added support for Argo CD deployments history (#5704)
 
 
 ## 0.1.17 (2024-01-11)
@@ -1512,7 +1512,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- Updated ArgoCD application gitRepo property format from URL to string, allowing for various formats and resolving sync errors with private repositories (#8)
+- Updated Argo CD application gitRepo property format from URL to string, allowing for various formats and resolving sync errors with private repositories (#8)
 
 
 ## 0.1.7 (2023-12-04)
@@ -1569,4 +1569,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
-- Implemented ArgoCD integration
+- Implemented Argo CD integration

--- a/integrations/argocd/README.md
+++ b/integrations/argocd/README.md
@@ -1,6 +1,6 @@
-# ArgoCD
+# Argo CD
 
-An integration used to import ArgoCD resources into Port.
+An integration used to import Argo CD resources into Port.
 
 #### Install & use the integration - [Integration documentation](https://docs.port.io/build-your-software-catalog/sync-data-to-catalog/argocd/)
 

--- a/integrations/argocd/client.py
+++ b/integrations/argocd/client.py
@@ -37,7 +37,7 @@ class ArgocdClient:
         if self.allow_insecure:
             # This is not recommended for production use
             logger.warning(
-                "Insecure mode is enabled. This will disable SSL verification for the ArgoCD API client, which is not recommended for production use."
+                "Insecure mode is enabled. This will disable SSL verification for the Argo CD API client, which is not recommended for production use."
             )
             self.http_client = httpx.AsyncClient(verify=False)
         else:
@@ -51,7 +51,7 @@ class ArgocdClient:
         query_params: Optional[dict[str, Any]] = None,
         json_data: Optional[dict[str, Any]] = None,
     ) -> dict[str, Any]:
-        logger.info(f"Sending request to ArgoCD API: {method} {url}")
+        logger.info(f"Sending request to Argo CD API: {method} {url}")
         try:
             response = await self.http_client.request(
                 method=method,
@@ -94,7 +94,7 @@ class ArgocdClient:
         return application
 
     async def get_deployment_history(self) -> list[dict[str, Any]]:
-        """The ArgoCD application route returns a history of all deployments. This function reuses the output of the application endpoint"""
+        """The Argo CD application route returns a history of all deployments. This function reuses the output of the application endpoint"""
         logger.warning(
             f"get_deployment_history is deprecated as of 0.1.34. {DEPRECATION_WARNING}"
         )
@@ -113,7 +113,7 @@ class ArgocdClient:
         return all_history
 
     async def get_kubernetes_resource(self) -> list[dict[str, Any]]:
-        """The ArgoCD application returns a list of managed kubernetes resources. This function reuses the output of the application endpoint"""
+        """The Argo CD application returns a list of managed kubernetes resources. This function reuses the output of the application endpoint"""
         logger.warning(
             f"get_kubernetes_resource is deprecated as of 0.1.34. {DEPRECATION_WARNING}"
         )


### PR DESCRIPTION
Adopt upstream spelling (Argo CD) in docs, logs, changelogs, VS Code tasks and blueprint titles/descriptions.

# Description

What - Argo CD naming.

Why - Argo CD is the canonical name upstream.

## Type of change

Please leave one option from the following and delete the rest:
- [x] Non-breaking change (fix of existing functionality that will not change current behavior)
- [x] Documentation (added/updated documentation)
