### PR TITLE
bug fix: transform array form of brokers to the correct brokers list

### DIFF
--- a/port_ocean/core/event_listener/kafka.py
+++ b/port_ocean/core/event_listener/kafka.py
@@ -16,6 +16,7 @@ from port_ocean.core.event_listener.base import (
     EventListenerEvents,
     EventListenerSettings,
 )
+from pydantic import validator
 
 
 class KafkaEventListenerSettings(EventListenerSettings):
@@ -45,6 +46,19 @@ class KafkaEventListenerSettings(EventListenerSettings):
     authentication_mechanism: str = "SCRAM-SHA-512"
     kafka_security_enabled: bool = True
     consumer_poll_timeout: int = 1
+
+    @validator("brokers")
+    @classmethod
+    def parse_brokers(cls, v: str) -> str:
+        # If it's a JSON array string, parse and join
+        if v.strip().startswith("[") and v.strip().endswith("]"):
+            try:
+                parsed = json.loads(v)
+                if isinstance(parsed, list):
+                    return ",".join(parsed)
+            except json.JSONDecodeError:
+                pass
+        return v
 
     def get_changelog_destination_details(self) -> dict[str, Any]:
         """

--- a/port_ocean/tests/core/event_listener/test_kafka.py
+++ b/port_ocean/tests/core/event_listener/test_kafka.py
@@ -1,0 +1,80 @@
+from port_ocean.core.event_listener.kafka import KafkaEventListenerSettings
+import pytest
+from pydantic import ValidationError
+
+
+def test_default_kafka_settings():
+    """Test default values are properly set"""
+    config = KafkaEventListenerSettings(type="KAFKA")
+
+    assert config.type == "KAFKA"
+    assert config.security_protocol == "SASL_SSL"
+    assert config.authentication_mechanism == "SCRAM-SHA-512"
+    assert config.kafka_security_enabled is True
+    assert config.consumer_poll_timeout == 1
+    assert "b-1-public.publicclusterprod" in config.brokers
+
+
+def test_brokers_json_array_parsing():
+    """Test that JSON array strings get converted to comma-separated"""
+    json_brokers = '["broker1:9092", "broker2:9092", "broker3:9092"]'
+
+    config = KafkaEventListenerSettings(type="KAFKA", brokers=json_brokers)
+
+    assert config.brokers == "broker1:9092,broker2:9092,broker3:9092"
+
+
+def test_brokers_regular_string_unchanged():
+    """Test that regular comma-separated strings pass through unchanged"""
+    regular_brokers = "broker1:9092,broker2:9092"
+
+    config = KafkaEventListenerSettings(type="KAFKA", brokers=regular_brokers)
+
+    assert config.brokers == regular_brokers
+
+
+def test_brokers_malformed_json_unchanged():
+    """Test that malformed JSON strings don't break validation"""
+    bad_json = "[broker1:9092, broker2:9092"
+
+    config = KafkaEventListenerSettings(type="KAFKA", brokers=bad_json)
+
+    assert config.brokers == bad_json
+
+
+def test_custom_values():
+    """Test overriding default values"""
+    config = KafkaEventListenerSettings(
+        type="KAFKA",
+        brokers="custom:9092",
+        security_protocol="PLAINTEXT",
+        authentication_mechanism="PLAIN",
+        kafka_security_enabled=False,
+        consumer_poll_timeout=5,
+    )
+
+    assert config.brokers == "custom:9092"
+    assert config.security_protocol == "PLAINTEXT"
+    assert config.authentication_mechanism == "PLAIN"
+    assert config.kafka_security_enabled is False
+    assert config.consumer_poll_timeout == 5
+
+
+def test_type_literal_validation():
+    """Test that type field only accepts KAFKA"""
+    with pytest.raises(ValidationError):
+        KafkaEventListenerSettings(type="RABBITMQ")
+
+
+def test_empty_brokers_array():
+    """Test empty JSON array becomes empty string"""
+    config = KafkaEventListenerSettings(type="KAFKA", brokers="[]")
+
+    assert config.brokers == ""
+
+
+def test_single_broker_array():
+    """Test single broker in JSON array"""
+    config = KafkaEventListenerSettings(type="KAFKA", brokers='["single:9092"]')
+
+    assert config.brokers == "single:9092"


### PR DESCRIPTION
# Description

What:
Azure integration deployments fail with container crash loops due to broker configuration format mismatch. The Terraform guide specifies Kafka brokers as JSON arrays, but Ocean expects comma-separated strings.

Why:
The Terraform variables.tf defines brokers as a list of strings, which serializes as JSON arrays in the OCEAN__EVENT_LISTENER environment variable. However, the underlying Kafka client library requires comma-delimited broker addresses. This format incompatibility prevents proper initialization and causes the container to repeatedly crash during startup.

How:
Implemented a Pydantic validator in KafkaEventListenerSettings that automatically converts JSON array broker strings to comma-separated format. The parse_brokers validator detects bracket-enclosed strings, parses them as JSON arrays, and joins the broker addresses with commas. The solution maintains full backward compatibility by preserving existing comma-separated configurations and gracefully handling malformed JSON inputs.

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
