### PR TITLE
[Core] fix ingest logs errors in ocean

### DIFF
--- a/port_ocean/log/handlers.py
+++ b/port_ocean/log/handlers.py
@@ -3,16 +3,16 @@ import logging
 import sys
 import threading
 import time
+from copy import deepcopy
 from datetime import datetime
 from logging.handlers import MemoryHandler
+from traceback import format_exception
 from typing import Any
 
 from loguru import logger
 
 from port_ocean import Ocean
 from port_ocean.context.ocean import ocean
-from copy import deepcopy
-from traceback import format_exception
 
 
 def _serialize_record(record: logging.LogRecord) -> dict[str, Any]:
@@ -53,7 +53,6 @@ class HTTPMemoryHandler(MemoryHandler):
         return None
 
     def emit(self, record: logging.LogRecord) -> None:
-
         self._serialized_buffer.append(_serialize_record(record))
         super().emit(record)
 
@@ -106,4 +105,4 @@ class HTTPMemoryHandler(MemoryHandler):
         try:
             await _ocean.port_client.ingest_integration_logs(logs_to_send)
         except Exception as e:
-            logger.debug(f"Failed to send logs to Port with error: {e}")
+            logger.error(f"Failed to send logs to Port with error: {e}")


### PR DESCRIPTION
# Description

What - fixed log from debug to error

Why - to show the log in the correct level

How - changed from debug to error

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


