### PR TITLE
[Core] Fixed reconciliation bug & __runtime__ metrics reporting

### DIFF
--- a/.github/workflows/claude-generic.yml
+++ b/.github/workflows/claude-generic.yml
@@ -11,7 +11,7 @@ permissions:
   contents: write
   packages: write
   pull-requests: write
-        
+
 jobs:
   claude-generic:
     env:
@@ -19,12 +19,12 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     permissions:
       contents: write
-      pull-requests: write 
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Configure Git 
+      - name: Configure Git
         run: |
           git config --global user.name "Port Claude AI"
           git config --global user.email "port-claude-ai@port.io"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.27.9 (2025-08-20)
+
+### Improvements
+
+- Fixed reconciliation metrics not updating properly during sync
+- Removed premature cleanup of Prometheus metrics after subprocess finish to fix reconciliation stuck on pending
+- Enhanced sync state tracking across different phases
+
+
 ## 0.27.8 (2025-08-18)
 
 ### Improvements

--- a/port_ocean/clients/port/mixins/integrations.py
+++ b/port_ocean/clients/port/mixins/integrations.py
@@ -212,7 +212,7 @@ class IntegrationClientMixin:
     async def post_integration_sync_metrics(
         self, metrics: list[dict[str, Any]]
     ) -> None:
-        logger.info("starting POST metrics request", metrics=metrics)
+        logger.debug("starting POST metrics request", metrics=metrics)
         metrics_attributes = await self.get_metrics_attributes()
         headers = await self.auth.headers()
         url = metrics_attributes["ingestUrl"] + "/syncMetrics"
@@ -224,7 +224,7 @@ class IntegrationClientMixin:
             },
         )
         handle_port_status_code(response, should_log=False)
-        logger.info("Finished POST metrics request")
+        logger.debug("Finished POST metrics request")
 
     async def put_integration_sync_metrics(self, kind_metrics: dict[str, Any]) -> None:
         logger.debug("starting PUT metrics request", kind_metrics=kind_metrics)

--- a/port_ocean/core/handlers/resync_state_updater/updater.py
+++ b/port_ocean/core/handlers/resync_state_updater/updater.py
@@ -91,6 +91,8 @@ class ResyncStateUpdater:
             value=int(status == IntegrationStateStatus.Completed),
         )
 
+        ocean.metrics.sync_state = status.value
+
         await ocean.metrics.send_metrics_to_webhook(
             kind=ocean.metrics.current_resource_kind()
         )

--- a/port_ocean/core/integrations/mixins/sync_raw.py
+++ b/port_ocean/core/integrations/mixins/sync_raw.py
@@ -976,6 +976,11 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
             ocean.metrics.initialize_metrics(kinds)
             await ocean.metrics.report_sync_metrics(kinds=kinds, blueprints=blueprints)
 
+            async with metric_resource_context(MetricResourceKind.RUNTIME):
+                ocean.metrics.sync_state = SyncState.SYNCING
+                await ocean.metrics.send_metrics_to_webhook(kind=MetricResourceKind.RUNTIME)
+                await ocean.metrics.report_sync_metrics(kinds=[MetricResourceKind.RUNTIME])
+
             # Clear cache
             await ocean.app.cache_provider.clear()
 
@@ -1010,8 +1015,18 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                 logger.warning(
                     "Resync aborted successfully, skipping delete phase. This leads to an incomplete state"
                 )
+
+                async with metric_resource_context(MetricResourceKind.RUNTIME):
+                    ocean.metrics.sync_state = SyncState.FAILED
+                    await ocean.metrics.send_metrics_to_webhook(kind=MetricResourceKind.RUNTIME)
+                    await ocean.metrics.report_sync_metrics(kinds=[MetricResourceKind.RUNTIME])
                 raise
             else:
+                async with metric_resource_context(MetricResourceKind.RECONCILIATION):
+                    ocean.metrics.sync_state = SyncState.SYNCING
+                    await ocean.metrics.send_metrics_to_webhook(kind=MetricResourceKind.RECONCILIATION)
+                    await ocean.metrics.report_sync_metrics(kinds=[MetricResourceKind.RECONCILIATION])
+
                 success = await self.resync_reconciliation(
                     creation_results,
                     did_fetched_current_state,
@@ -1019,9 +1034,12 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                     app_config,
                     silent,
                 )
-                await ocean.metrics.report_sync_metrics(
-                    kinds=[MetricResourceKind.RECONCILIATION]
-                )
+
+                async with metric_resource_context(MetricResourceKind.RECONCILIATION):
+                    ocean.metrics.sync_state = SyncState.COMPLETED if success else SyncState.FAILED
+                    await ocean.metrics.send_metrics_to_webhook(kind=MetricResourceKind.RECONCILIATION)
+                    await ocean.metrics.report_sync_metrics(kinds=[MetricResourceKind.RECONCILIATION])
+
                 return success
             finally:
                 await ocean.app.cache_provider.clear()

--- a/port_ocean/core/integrations/mixins/utils.py
+++ b/port_ocean/core/integrations/mixins/utils.py
@@ -120,7 +120,6 @@ class ProcessWrapper(multiprocessing.Process):
             logger.error(f"Process {self.pid} failed with exit code {self.exitcode}")
         else:
             logger.info(f"Process {self.pid} finished with exit code {self.exitcode}")
-        ocean.metrics.cleanup_prometheus_metrics(self.pid)
         return super().join()
 
 def clear_http_client_context() -> None:

--- a/port_ocean/helpers/metric/metric.py
+++ b/port_ocean/helpers/metric/metric.py
@@ -296,7 +296,6 @@ class Metrics:
         if kinds is None:
             return None
 
-        logger.info("Reporting sync metrics for kinds", kinds=kinds)
         metrics = []
 
         if blueprints is None:
@@ -305,8 +304,6 @@ class Metrics:
         for kind, blueprint in zip(kinds, blueprints):
             metric = self.generate_metrics(metric_name, kind, blueprint)
             metrics.extend(metric)
-
-        logger.info("Generated metrics", metrics=metrics, kinds=kinds)
 
         try:
             await self.port_client.post_integration_sync_metrics(metrics)

--- a/port_ocean/helpers/metric/metric.py
+++ b/port_ocean/helpers/metric/metric.py
@@ -62,6 +62,7 @@ class SyncState:
 class MetricResourceKind:
     RECONCILIATION = "__reconciliation__"
     RESYNC = "__resync__"
+    RUNTIME = "__runtime__"
 
 
 # Registry for core and custom metrics
@@ -279,7 +280,7 @@ class Metrics:
         try:
             return metric_resource.metric_resource.metric_resource_kind
         except ResourceContextNotFoundError:
-            return "__runtime__"
+            return MetricResourceKind.RUNTIME
 
     def generate_latest(self) -> str:
         return prometheus_client.openmetrics.exposition.generate_latest(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.27.8"
+version = "0.27.9"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
### **User description**
# Description

What - fixed 2 major bugs - reconciliation stuck on pending & the entire state of resync being wrong. also updated the post of reconciliation phase. 

Why - in port, the ui showed wrong data and mismatch between parts of the tab

How - not cleaning the dir after each subprocess ends, adding more reports of the metrics and fixing the state of the resync kind

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector



___

### **PR Type**
Bug fix


___

### **Description**
- Fixed reconciliation metrics not updating properly during sync

- Added proper `__runtime__` metrics reporting for sync states

- Removed premature cleanup of Prometheus metrics after subprocess finish

- Enhanced sync state tracking across different phases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Sync Start"] --> B["Runtime Metrics"]
  B --> C["Resource Processing"]
  C --> D["Reconciliation Phase"]
  D --> E["Metrics Update"]
  E --> F["Sync Complete"]
  G["Process Cleanup"] --> H["Metrics Preserved"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>updater.py</strong><dd><code>Add sync state update after resync</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

port_ocean/core/handlers/resync_state_updater/updater.py

<ul><li>Added <code>sync_state</code> assignment after resync completion<br> <li> Ensures metrics reflect actual integration status</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2019/files#diff-3dc062ad1f3dae81cc1000de426e064cb0c04c2605c2da0bfadcc1eea3b192d5">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>sync_raw.py</strong><dd><code>Enhanced sync metrics reporting and state tracking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

port_ocean/core/integrations/mixins/sync_raw.py

<ul><li>Added runtime metrics reporting at sync start<br> <li> Enhanced reconciliation phase metrics with proper state tracking<br> <li> Added failure state reporting for cancelled operations<br> <li> Improved metrics context management throughout sync process</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2019/files#diff-7087c0350a44c64c6ca1e4333b34e158b354bdd15932e51860efaddda535cddc">+21/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>utils.py</strong><dd><code>Remove premature metrics cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

port_ocean/core/integrations/mixins/utils.py

<ul><li>Removed premature cleanup of Prometheus metrics after subprocess <br>finish<br> <li> Prevents metrics loss during process lifecycle</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2019/files#diff-7459ee67d5bdb7c3d4f122b015af9402d100aa32eee18c957c195867caae82d0">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>metric.py</strong><dd><code>Add runtime metric resource kind constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

port_ocean/helpers/metric/metric.py

<ul><li>Added <code>RUNTIME</code> constant to <code>MetricResourceKind</code> class<br> <li> Updated default metric resource kind to use constant instead of <br>hardcoded string</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2019/files#diff-417f5cc56a87b7b79de3357469c3793dde206e5398aff18a9e253f1f250b51b2">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

