### PR TITLE
[Integration][AWS-v3] convert to use organizations strategy by default

### DIFF
--- a/integrations/aws-v3/.port/spec.yaml
+++ b/integrations/aws-v3/.port/spec.yaml
@@ -10,7 +10,12 @@ configurations:
     required: false
     type: string
     sensitive: false
-    description: AWS Account Role ARN, used for single account access and organizations.
+    description: AWS Account Role ARN for organizations access. When provided, the integration will attempt to use AWS Organizations to discover accounts, falling back to single account mode if organizations is not available.
+  - name: accountRoleArns
+    required: false
+    type: array
+    sensitive: false
+    description: Array of AWS Account Role ARNs for direct multi-account access. Use this when you don't have AWS Organizations enabled or want to specify exact accounts to access.
   - name: externalId
     required: false
     type: string

--- a/integrations/aws-v3/.port/spec.yaml
+++ b/integrations/aws-v3/.port/spec.yaml
@@ -8,19 +8,14 @@ features:
 configurations:
   - name: accountRoleArn
     required: false
-    type: array
-    sensitive: true
-    description: An array of AWS Account Role ARNs, used for multi-account access.
-  - name: useOrganizations
-    required: false
-    default: false
-    type: boolean
-    description: When enabled, uses AWS Organizations API to automatically discover all accounts. Requires the first role ARN from accountRoleArn to be the organization management account role.
+    type: string
+    sensitive: false
+    description: AWS Account Role ARN, used for single account access and organizations.
   - name: externalId
     required: false
     type: string
-    sensitive: true
-    description: The external ID used for the AWS Account Read Role.
+    sensitive: false
+    description: The external ID used for the AWS Account Read Role used in assume role.
   - name: aws_access_key_id
     required: false
     type: string
@@ -36,11 +31,6 @@ configurations:
     type: string
     sensitive: true
     description: AWS Session Token for temporary static credentials (optional).
-  - name: use_organizations
-    required: false
-    type: boolean
-    default: false
-    description: When enabled, uses AWS Organizations API to automatically discover all accounts. Requires the first role ARN from accountRoleArn to be the organization management account role.
 saas:
   enabled: true
   liveEvents:

--- a/integrations/aws-v3/CHANGELOG.md
+++ b/integrations/aws-v3/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 1.0.0-beta (2025-08-31)
+
+### Features
+
+- Breaking changes: accountRoleArn -> accountRoleArns
+- accountRoleArn is now used for both multi-account (using organizations) and single-account modes
+- accountRoleArns is now used for multi-account mode for direct arn access
+
+
 ## 0.3.7-beta (2025-08-28)
 
 

--- a/integrations/aws-v3/aws/auth/providers/assume_role_with_web_identity_provider.py
+++ b/integrations/aws-v3/aws/auth/providers/assume_role_with_web_identity_provider.py
@@ -28,11 +28,15 @@ class AssumeRoleWithWebIdentityProvider(CredentialProvider):
         super().__init__(config)
         # This is required for the STS client to work
         # Since the STS client checks for the AWS_ROLE_ARN environment variable and if it's not set, it will fail
-        role_arn_list = config.get("account_role_arn", [])
-        if not role_arn_list:
+        account_role = config.get("account_role_arn")
+        account_roles = config.get("account_role_arns", [])
+
+        role_arn_input = account_role or (account_roles[0] if account_roles else None)
+
+        if not role_arn_input:
             raise CredentialsProviderError("No account role ARN found in config")
 
-        os.environ["AWS_ROLE_ARN"] = role_arn_list[0]
+        os.environ["AWS_ROLE_ARN"] = role_arn_input
 
     @property
     def is_refreshable(self) -> bool:

--- a/integrations/aws-v3/aws/auth/session_factory.py
+++ b/integrations/aws-v3/aws/auth/session_factory.py
@@ -49,18 +49,13 @@ class ResyncStrategyFactory:
         """
         Detect the appropriate strategy type based on the global configuration.
         """
-        account_role_arn = config.get("account_role_arn", [])
-        use_organizations = config.get("use_organizations", False)
 
-        # If organizations flag is enabled, use organizations strategy
-        if use_organizations:
+        if config.get("account_role_arn", None):
             return OrganizationsStrategy
 
-        # If we have any role ARNs, use multi-account strategy
-        if len(account_role_arn) > 0:
+        if len(config.get("account_role_arns", [])) > 0:
             return MultiAccountStrategy
 
-        # Default to single account strategy
         return SingleAccountStrategy
 
     @classmethod

--- a/integrations/aws-v3/aws/auth/strategies/multi_account_strategy.py
+++ b/integrations/aws-v3/aws/auth/strategies/multi_account_strategy.py
@@ -47,9 +47,9 @@ class MultiAccountHealthCheckMixin(AWSSessionStrategy, HealthCheckMixin):
             return None
 
     async def healthcheck(self) -> bool:
-        arns = normalize_arn_list(self.config.get("account_role_arn", []))
+        arns = normalize_arn_list(self.config.get("account_role_arns", []))
         if not arns:
-            logger.error("No account_role_arn(s) provided for healthcheck")
+            logger.error("No account_role_arns provided for healthcheck")
             return False
 
         logger.info(f"Starting AWS account health check for {len(arns)} role ARNs")

--- a/integrations/aws-v3/aws/auth/utils.py
+++ b/integrations/aws-v3/aws/auth/utils.py
@@ -2,16 +2,16 @@ from typing import Optional, Union, List
 from botocore.utils import ArnParser
 
 
-class AWSOrganizationsNotInUseError(Exception):
-    """Raised when AWS Organizations is not in use."""
-
-
 class AWSSessionError(Exception):
     """Raised when an AWS session or assume role operation fails."""
 
 
 class CredentialsProviderError(Exception):
     """Raised when there is a credentials provider or assume role error."""
+
+
+class AWSOrganizationsNotInUseError(Exception):
+    """Raised when AWS Organizations is not enabled or accessible."""
 
 
 def normalize_arn_list(arn_input: Optional[Union[str, List[str]]]) -> List[str]:

--- a/integrations/aws-v3/aws/auth/utils.py
+++ b/integrations/aws-v3/aws/auth/utils.py
@@ -2,6 +2,10 @@ from typing import Optional, Union, List
 from botocore.utils import ArnParser
 
 
+class AWSOrganizationsNotInUseError(Exception):
+    """Raised when AWS Organizations is not in use."""
+
+
 class AWSSessionError(Exception):
     """Raised when an AWS session or assume role operation fails."""
 

--- a/integrations/aws-v3/pyproject.toml
+++ b/integrations/aws-v3/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-v3"
-version = "0.3.7-beta"
+version = "1.0.0-beta"
 description = "AWS"
 authors = ["Shariff Mohammed <mohammed.s@getport.io>"]
 

--- a/integrations/aws-v3/tests/auth/test_providers.py
+++ b/integrations/aws-v3/tests/auth/test_providers.py
@@ -466,7 +466,7 @@ class TestAssumeRoleWithWebIdentityProvider:
 
     def test_is_refreshable_property(self) -> None:
         """Test is_refreshable property returns True."""
-        config = {"account_role_arn": ["arn:aws:iam::123456789012:role/test-role"]}
+        config = {"account_role_arn": "arn:aws:iam::123456789012:role/test-role"}
         provider = AssumeRoleWithWebIdentityProvider(config=config)
         assert provider.is_refreshable is True
 
@@ -477,7 +477,7 @@ class TestAssumeRoleWithWebIdentityProvider:
         self, mock_aiofiles_open: MagicMock
     ) -> None:
         """Test successful reading of web identity token."""
-        config = {"account_role_arn": ["arn:aws:iam::123456789012:role/test-role"]}
+        config = {"account_role_arn": "arn:aws:iam::123456789012:role/test-role"}
         provider = AssumeRoleWithWebIdentityProvider(config=config)
         mock_file = AsyncMock()
         mock_file.read.return_value = "test-token-content\n"
@@ -490,7 +490,7 @@ class TestAssumeRoleWithWebIdentityProvider:
     @pytest.mark.asyncio
     async def test_read_web_identity_token_missing_env_var(self) -> None:
         """Test error when AWS_WEB_IDENTITY_TOKEN_FILE is not set."""
-        config = {"account_role_arn": ["arn:aws:iam::123456789012:role/test-role"]}
+        config = {"account_role_arn": "arn:aws:iam::123456789012:role/test-role"}
         provider = AssumeRoleWithWebIdentityProvider(config=config)
         with patch.dict("os.environ", {}, clear=True):
             with pytest.raises(CredentialsProviderError) as exc_info:
@@ -507,7 +507,7 @@ class TestAssumeRoleWithWebIdentityProvider:
         self, mock_aiofiles_open: MagicMock
     ) -> None:
         """Test error when token file doesn't exist."""
-        config = {"account_role_arn": ["arn:aws:iam::123456789012:role/test-role"]}
+        config = {"account_role_arn": "arn:aws:iam::123456789012:role/test-role"}
         provider = AssumeRoleWithWebIdentityProvider(config=config)
         with pytest.raises(CredentialsProviderError) as exc_info:
             await provider._read_web_identity_token()
@@ -522,7 +522,7 @@ class TestAssumeRoleWithWebIdentityProvider:
         self, mock_aiofiles_open: MagicMock
     ) -> None:
         """Test error when token file is empty."""
-        config = {"account_role_arn": ["arn:aws:iam::123456789012:role/test-role"]}
+        config = {"account_role_arn": "arn:aws:iam::123456789012:role/test-role"}
         provider = AssumeRoleWithWebIdentityProvider(config=config)
         mock_file = AsyncMock()
         mock_file.read.return_value = ""
@@ -538,7 +538,7 @@ class TestAssumeRoleWithWebIdentityProvider:
     @patch.dict("os.environ", {"AWS_WEB_IDENTITY_TOKEN_FILE": "/tmp/test-token"})
     async def test_get_credentials_success(self) -> None:
         """Test successful get_credentials with web identity."""
-        config = {"account_role_arn": ["arn:aws:iam::123456789012:role/test-role"]}
+        config = {"account_role_arn": "arn:aws:iam::123456789012:role/test-role"}
         provider = AssumeRoleWithWebIdentityProvider(config=config)
         mock_session = MagicMock()
         mock_sts_client = AsyncMock()
@@ -594,7 +594,7 @@ class TestAssumeRoleWithWebIdentityProvider:
     @pytest.mark.asyncio
     async def test_get_credentials_missing_role_arn(self) -> None:
         """Test error when role_arn is not provided."""
-        config = {"account_role_arn": ["arn:aws:iam::123456789012:role/test-role"]}
+        config = {"account_role_arn": "arn:aws:iam::123456789012:role/test-role"}
         provider = AssumeRoleWithWebIdentityProvider(config=config)
         with pytest.raises(CredentialsProviderError) as exc_info:
             await provider.get_credentials()
@@ -604,7 +604,7 @@ class TestAssumeRoleWithWebIdentityProvider:
     @patch.dict("os.environ", {"AWS_WEB_IDENTITY_TOKEN_FILE": "/tmp/test-token"})
     async def test_get_credentials_with_optional_parameters(self) -> None:
         """Test get_credentials with optional parameters."""
-        config = {"account_role_arn": ["arn:aws:iam::123456789012:role/test-role"]}
+        config = {"account_role_arn": "arn:aws:iam::123456789012:role/test-role"}
         provider = AssumeRoleWithWebIdentityProvider(config=config)
         mock_session = MagicMock()
         mock_sts_client = AsyncMock()
@@ -659,7 +659,7 @@ class TestAssumeRoleWithWebIdentityProvider:
     @patch.dict("os.environ", {"AWS_WEB_IDENTITY_TOKEN_FILE": "/tmp/test-token"})
     async def test_get_session_success(self) -> None:
         """Test successful get_session with web identity."""
-        config = {"account_role_arn": ["arn:aws:iam::123456789012:role/test-role"]}
+        config = {"account_role_arn": "arn:aws:iam::123456789012:role/test-role"}
         provider = AssumeRoleWithWebIdentityProvider(config=config)
         mock_session = MagicMock()
         mock_sts_client = AsyncMock()
@@ -705,7 +705,7 @@ class TestAssumeRoleWithWebIdentityProvider:
     @pytest.mark.asyncio
     async def test_get_session_missing_role_arn(self) -> None:
         """Test error when role_arn is not provided for get_session."""
-        config = {"account_role_arn": ["arn:aws:iam::123456789012:role/test-role"]}
+        config = {"account_role_arns": ["arn:aws:iam::123456789012:role/test-role"]}
         provider = AssumeRoleWithWebIdentityProvider(config=config)
         with pytest.raises(CredentialsProviderError) as exc_info:
             await provider.get_session()

--- a/integrations/aws-v3/tests/conftest.py
+++ b/integrations/aws-v3/tests/conftest.py
@@ -126,7 +126,7 @@ def mock_aws_config() -> Dict[str, Any]:
 def mock_multi_account_config() -> Dict[str, Any]:
     """Mocks multi-account AWS configuration."""
     return {
-        "account_role_arn": [
+        "account_role_arns": [
             "arn:aws:iam::123456789012:role/test-role-1",
             "arn:aws:iam::987654321098:role/test-role-2",
         ],


### PR DESCRIPTION
- **[Integration][AWS-v3] Update AWS Account Role configuration in spec.yaml**
- **feat: Enhance AWS Account Role configuration in spec.yaml**
- **refactor: Update ResyncStrategyFactory to use account_role_arns**
- **feat: Introduce AWSOrganizationsNotInUseError for better error handling**
- **fix: Update healthcheck method to use account_role_arns**
- **refactor: Improve account role ARN handling in AssumeRoleWithWebIdentityProvider**
- **refactor: Revise AWSOrganizationsNotInUseError for clarity**
- **refactor: Update account role ARN handling across tests**

# Description

This PR implements a new organizations-first strategy for the AWS v3 integration that automatically attempts to use AWS Organizations for account discovery, with graceful fallback to single account mode when organizations is not available. This provides a better user experience for most users while maintaining backward compatibility.

Previously, users had to manually choose between organizations strategy and single account strategy. This created friction for users who:
- Have AWS Organizations enabled but don't know how to configure it
- Want to use organizations but fall back gracefully when it's not available
- Need to specify exact accounts when organizations isn't an option

### ✨ Solution
Implement an intelligent strategy selection system that:
1. **Prioritizes organizations strategy** when a single role ARN is provided
2. **Automatically falls back** to single account mode when organizations is not available
3. **Supports direct multi-account access** for users without organizations

### 🔧 Technical Changes

#### 1. Updated Configuration Schema
- **Added** `accountRoleArn` (string) for organizations access with fallback
- **Added** `accountRoleArns` (array) for direct multi-account access

#### 2. Session Factory
- **Modified** strategy detection logic to prioritize organizations when single ARN is provided
- **Added** support for both configuration formats
- **Updated** strategy selection to handle fallback scenarios

#### 3. Organizations Strategy
- **Added** automatic fallback to single account mode when organizations fails
- **Implemented** graceful error handling for organizations-specific failures

#### 4. Multi-Account Strategy
- **Modified** to use new `accountRoleArns` configuration
- **Maintained** existing functionality for direct account access

#### 5. Web Identity Provider
- **Added** backward compatibility for both configuration formats
- **Updated** to handle string and array inputs gracefully


#### For Organizations Users (Default Path)
```yaml
configurations:
  - name: accountRoleArn
    type: string
    description: "AWS Account Role ARN for organizations access. When provided, the integration will attempt to use AWS Organizations to discover accounts, falling back to single account mode if organizations is not available."
```

#### For Direct Multi-Account Access
```yaml
configurations:
  - name: accountRoleArns
    type: array
    description: "Array of AWS Account Role ARNs for direct multi-account access. Use this when you don't have AWS Organizations enabled or want to specify exact accounts to access."
```

---
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
