### PR TITLE
[Integration][Dynatrace] Don't fetch related entities for SLOs without a filter

### DIFF
--- a/integrations/dynatrace/CHANGELOG.md
+++ b/integrations/dynatrace/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.178 (2025-09-17)
+
+
+### Improvements
+
+- Don't fetch related entities for SLOs without a filter
+
+
 ## 0.1.177 (2025-09-16)
 
 

--- a/integrations/dynatrace/client.py
+++ b/integrations/dynatrace/client.py
@@ -119,14 +119,16 @@ class DynatraceClient:
         logger.info(f"Fetching related entities for {len(slos)} slos")
 
         related_slo_tasks = [
-            self._get_slo_related_entities(slo["filter"]) for slo in slos
+            self._get_slo_related_entities(slo["filter"])
+            for slo in slos
+            if slo.get("filter")
         ]
         results = await asyncio.gather(*related_slo_tasks, return_exceptions=True)
 
         for slo, entities in zip(slos, results):
             if isinstance(entities, Exception):
                 logger.warning(
-                    f"Error {entities} occurred while fetching related entities for slo {slo['id']}"
+                    f"Error {entities} occurred while fetching related entities for slo {slo['name']}"
                 )
                 continue
             slo["__entities"] = entities

--- a/integrations/dynatrace/client.py
+++ b/integrations/dynatrace/client.py
@@ -125,6 +125,7 @@ class DynatraceClient:
         ]
         results = await asyncio.gather(*related_slo_tasks, return_exceptions=True)
 
+        # AI! due to the fact that a filter happens in related_slo_tasks list, a bug happens here if that list is out of order with the slos list
         for slo, entities in zip(slos, results):
             if isinstance(entities, Exception):
                 logger.warning(

--- a/integrations/dynatrace/client.py
+++ b/integrations/dynatrace/client.py
@@ -118,15 +118,13 @@ class DynatraceClient:
     ) -> list[dict[str, Any]]:
         logger.info(f"Fetching related entities for {len(slos)} slos")
 
+        slos_with_filter = [slo for slo in slos if slo.get("filter")]
         related_slo_tasks = [
-            self._get_slo_related_entities(slo["filter"])
-            for slo in slos
-            if slo.get("filter")
+            self._get_slo_related_entities(slo["filter"]) for slo in slos_with_filter
         ]
         results = await asyncio.gather(*related_slo_tasks, return_exceptions=True)
 
-        # AI! due to the fact that a filter happens in related_slo_tasks list, a bug happens here if that list is out of order with the slos list
-        for slo, entities in zip(slos, results):
+        for slo, entities in zip(slos_with_filter, results):
             if isinstance(entities, Exception):
                 logger.warning(
                     f"Error {entities} occurred while fetching related entities for slo {slo['name']}"

--- a/integrations/dynatrace/pyproject.toml
+++ b/integrations/dynatrace/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dynatrace"
-version = "0.1.177"
+version = "0.1.178"
 description = "An integration used to import Dynatrace resources into Port"
 authors = ["Ayodeji Adeoti <<ayodeji.adeoti@getport.io>>"]
 

--- a/integrations/dynatrace/pyproject.toml
+++ b/integrations/dynatrace/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dynatrace"
-version = "0.1.178"
+version = "0.1.179"
 description = "An integration used to import Dynatrace resources into Port"
 authors = ["Ayodeji Adeoti <<ayodeji.adeoti@getport.io>>"]
 

--- a/integrations/dynatrace/tests/test_client.py
+++ b/integrations/dynatrace/tests/test_client.py
@@ -46,8 +46,18 @@ async def test_enrich_slos_with_related_entities(monkeypatch: MonkeyPatch) -> No
     enriched_slos = await client.enrich_slos_with_related_entities(slos_to_enrich)
 
     expected_slos = [
-        {"id": "slo-1", "name": "slo-1-name", "filter": "filter-1", "__entities": related_entities_slo_1},
-        {"id": "slo-2", "name": "slo-2-name", "filter": "filter-2", "__entities": related_entities_slo_2},
+        {
+            "id": "slo-1",
+            "name": "slo-1-name",
+            "filter": "filter-1",
+            "__entities": related_entities_slo_1,
+        },
+        {
+            "id": "slo-2",
+            "name": "slo-2-name",
+            "filter": "filter-2",
+            "__entities": related_entities_slo_2,
+        },
     ]
 
     assert enriched_slos == expected_slos
@@ -109,7 +119,12 @@ async def test_enrich_slos_with_empty_or_missing_filter(
     enriched_slos = await client.enrich_slos_with_related_entities(slos_to_enrich)
 
     expected_slos = [
-        {"id": "slo-1", "name": "slo-1-name", "filter": "filter-1", "__entities": related_entities_slo_1},
+        {
+            "id": "slo-1",
+            "name": "slo-1-name",
+            "filter": "filter-1",
+            "__entities": related_entities_slo_1,
+        },
         {"id": "slo-2", "name": "slo-2-name", "filter": ""},
         {"id": "slo-3", "name": "slo-3-name"},
     ]

--- a/integrations/dynatrace/tests/test_client.py
+++ b/integrations/dynatrace/tests/test_client.py
@@ -26,8 +26,8 @@ async def test_enrich_slos_with_related_entities(monkeypatch: MonkeyPatch) -> No
     client = DynatraceClient(host_url="http://test.com", api_key="test_key")
 
     slos_to_enrich = [
-        {"id": "slo-1", "filter": "filter-1"},
-        {"id": "slo-2", "filter": "filter-2"},
+        {"id": "slo-1", "name": "slo-1-name", "filter": "filter-1"},
+        {"id": "slo-2", "name": "slo-2-name", "filter": "filter-2"},
     ]
 
     related_entities_slo_1 = [{"entityId": "SERVICE-123"}]
@@ -46,8 +46,8 @@ async def test_enrich_slos_with_related_entities(monkeypatch: MonkeyPatch) -> No
     enriched_slos = await client.enrich_slos_with_related_entities(slos_to_enrich)
 
     expected_slos = [
-        {"id": "slo-1", "filter": "filter-1", "__entities": related_entities_slo_1},
-        {"id": "slo-2", "filter": "filter-2", "__entities": related_entities_slo_2},
+        {"id": "slo-1", "name": "slo-1-name", "filter": "filter-1", "__entities": related_entities_slo_1},
+        {"id": "slo-2", "name": "slo-2-name", "filter": "filter-2", "__entities": related_entities_slo_2},
     ]
 
     assert enriched_slos == expected_slos
@@ -66,7 +66,7 @@ async def test_enrich_slos_with_related_entities_exception(
     client = DynatraceClient(host_url="http://test.com", api_key="test_key")
 
     slos_to_enrich = [
-        {"id": "slo-1", "filter": "filter-1"},
+        {"id": "slo-1", "name": "slo-1-name", "filter": "filter-1"},
     ]
 
     # Mock the internal method to raise an exception
@@ -91,9 +91,9 @@ async def test_enrich_slos_with_empty_or_missing_filter(
     client = DynatraceClient(host_url="http://test.com", api_key="test_key")
 
     slos_to_enrich = [
-        {"id": "slo-1", "filter": "filter-1"},
-        {"id": "slo-2", "filter": ""},  # SLO with empty filter
-        {"id": "slo-3"},  # SLO without filter
+        {"id": "slo-1", "name": "slo-1-name", "filter": "filter-1"},
+        {"id": "slo-2", "name": "slo-2-name", "filter": ""},  # SLO with empty filter
+        {"id": "slo-3", "name": "slo-3-name"},  # SLO without filter
     ]
 
     related_entities_slo_1 = [{"entityId": "SERVICE-123"}]
@@ -109,9 +109,9 @@ async def test_enrich_slos_with_empty_or_missing_filter(
     enriched_slos = await client.enrich_slos_with_related_entities(slos_to_enrich)
 
     expected_slos = [
-        {"id": "slo-1", "filter": "filter-1", "__entities": related_entities_slo_1},
-        {"id": "slo-2", "filter": ""},
-        {"id": "slo-3"},
+        {"id": "slo-1", "name": "slo-1-name", "filter": "filter-1", "__entities": related_entities_slo_1},
+        {"id": "slo-2", "name": "slo-2-name", "filter": ""},
+        {"id": "slo-3", "name": "slo-3-name"},
     ]
 
     assert enriched_slos == expected_slos


### PR DESCRIPTION
### **User description**
# Description

What - `filter` key can sometimes be an empty string, don't fetch related slo entities when this is the case.

Why - The current fix correctly prevents the resulting error from crashing the resync. However, it's better if the errors do not occur in the first place. The customer is also still complaining because of the request failures.

How - Take out SLOs without a filter from the list of entities we want to fetch related entities for. 

## Type of change

Please leave one option from the following and delete the rest:

- [ x ] Bug fix (non-breaking change which fixes an issue)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.


___

### **PR Type**
Bug fix


___

### **Description**
- Skip SLO entities without filters to prevent API errors

- Improve error logging with SLO names instead of IDs

- Add comprehensive test coverage for empty/missing filters


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["All SLOs"] --> B["Filter SLOs with valid filters"]
  B --> C["Fetch related entities"]
  C --> D["Enrich SLOs with entities"]
  E["SLOs without filters"] --> F["Skip API requests"]
  F --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>client.py</strong><dd><code>Filter SLOs and improve error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/dynatrace/client.py

<ul><li>Filter out SLOs without valid filters before making API requests<br> <li> Update error logging to use SLO name instead of ID<br> <li> Maintain correct association between SLOs and fetched entities</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2165/files#diff-288f159a5da96554a0187df9c8b5177ae96cc206ae08cd1f8865214958c95b6a">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_client.py</strong><dd><code>Add comprehensive SLO filtering tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/dynatrace/tests/test_client.py

<ul><li>Add name field to existing SLO test objects<br> <li> Create new test for SLOs with empty/missing filters<br> <li> Verify only valid SLOs trigger API requests</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2165/files#diff-544f10f1af1044960e478e269c712ed7463860712376594fbb07b20c6b9da63f">+45/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update changelog for SLO improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/dynatrace/CHANGELOG.md

<ul><li>Document improvement for SLO filter handling<br> <li> Version bump to 0.1.178</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2165/files#diff-e065e1378d7c0fc7010c8abdf489676c4980f697897d64b1568c0b21a4f5d07b">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Version bump to 0.1.178</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/dynatrace/pyproject.toml

- Bump version from 0.1.177 to 0.1.178


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2165/files#diff-62c7f6710c13c08f498d6a9c9c647d149bbb22e1ae9512f7a64500dd9ae13d78">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

