### PR TITLE
[Core] Change extractionTimestamp from string to int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.28.11 (2025-09-28)
+
+### Bug fixes
+
+- Change raw data timestamp from sting to int
+
 ## 0.28.10 (2025-09-26)
 
 ### Bug fixes

--- a/port_ocean/clients/port/mixins/integrations.py
+++ b/port_ocean/clients/port/mixins/integrations.py
@@ -295,13 +295,16 @@ class IntegrationClientMixin:
         self, raw_data: list[dict[Any, Any]], sync_id: str, kind: str
     ) -> None:
         logger.debug("starting POST raw data request", raw_data=raw_data)
+        now = datetime.datetime.now()
+        timestamp_as_int = int(now.timestamp())
+
         headers = await self.auth.headers()
         response = await self.client.post(
             f"{self.auth.ingest_url}/lakehouse/integration-type/{self.auth.integration_type}/integration/{self.integration_identifier}/sync/{sync_id}/kind/{kind}/items",
             headers=headers,
             json={
                 "items": raw_data,
-                "extractionTimestamp": datetime.now().isoformat(),
+                "extractionTimestamp": timestamp_as_int,
             },
         )
         handle_port_status_code(response, should_log=False)

--- a/port_ocean/clients/port/mixins/integrations.py
+++ b/port_ocean/clients/port/mixins/integrations.py
@@ -295,16 +295,13 @@ class IntegrationClientMixin:
         self, raw_data: list[dict[Any, Any]], sync_id: str, kind: str
     ) -> None:
         logger.debug("starting POST raw data request", raw_data=raw_data)
-        now = datetime.datetime.now()
-        timestamp_as_int = int(now.timestamp())
-
         headers = await self.auth.headers()
         response = await self.client.post(
             f"{self.auth.ingest_url}/lakehouse/integration-type/{self.auth.integration_type}/integration/{self.integration_identifier}/sync/{sync_id}/kind/{kind}/items",
             headers=headers,
             json={
                 "items": raw_data,
-                "extractionTimestamp": timestamp_as_int,
+                "extractionTimestamp": int(datetime.now().timestamp()),
             },
         )
         handle_port_status_code(response, should_log=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.28.10"
+version = "0.28.11"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What - Change extractionTimestamp from string to int

Why - To make a unified template for timestamps

How - Cast to int

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


