### PR TITLE
[Core] Allow scheduled builds for the base python image

### DIFF
--- a/.github/workflows/build-infra-images.yml
+++ b/.github/workflows/build-infra-images.yml
@@ -15,7 +15,7 @@ jobs:
   build-infra:
     runs-on: 'ubuntu-latest'
     needs: detect-changes
-    if: ${{ github.event_name == 'workflow_dispatch' || needs.detect-changes.outputs.infra == 'true' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || needs.detect-changes.outputs.infra == 'true' }}
     steps:
       - name: Check out code
         uses: actions/checkout@v5


### PR DESCRIPTION
### **User description**
Allow scheudled runs for the python base image


___

### **PR Type**
Enhancement


___

### **Description**
- Enable scheduled builds for Python base image

- Add schedule trigger to build-infra workflow

- Allow workflow to run on schedule events


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Workflow Trigger"] -->|workflow_dispatch| B["build-infra job"]
  A -->|schedule| B
  A -->|detect-changes| B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-infra-images.yml</strong><dd><code>Add schedule trigger to build-infra job</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/build-infra-images.yml

<ul><li>Modified the <code>if</code> condition for the <code>build-infra</code> job<br> <li> Added <code>github.event_name == 'schedule'</code> to allow scheduled workflow runs<br> <li> Preserves existing workflow_dispatch and detect-changes triggers</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2373/files#diff-08261b5d12d21aa3591648e504d3c1f2a59b9ede780da8f2243ba7b17ec56468">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

