### PR TITLE
[Core] Update unprocessed kinds to be 'Aborted' on resync abortion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.29.5 (2025-11-10)
+
+### Bug fixes
+
+- Update unprocessed kinds metrics to have 'aborted' status when a resync is aborted
+
 ## 0.29.4 (2025-11-10)
 
 ### Bug fixes

--- a/port_ocean/core/integrations/mixins/sync_raw.py
+++ b/port_ocean/core/integrations/mixins/sync_raw.py
@@ -1030,6 +1030,18 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                     ocean.metrics.sync_state = SyncState.ABORTED
                     await ocean.metrics.send_metrics_to_webhook(kind=MetricResourceKind.RUNTIME)
                     await ocean.metrics.report_sync_metrics(kinds=[MetricResourceKind.RUNTIME])
+
+                for pending_index in range(len(creation_results), len(app_config.resources)):
+                    pending_resource = app_config.resources[pending_index]
+                    pending_kind_id = f"{pending_resource.kind}-{pending_index}"
+                    async with metric_resource_context(pending_kind_id):
+                        ocean.metrics.sync_state = SyncState.ABORTED
+                        await ocean.metrics.send_metrics_to_webhook(kind=pending_kind_id)
+                        await ocean.metrics.report_kind_sync_metrics(
+                            kind=pending_kind_id,
+                            blueprint=pending_resource.port.entity.mappings.blueprint,
+                        )
+
                 raise
             else:
                 async with metric_resource_context(MetricResourceKind.RECONCILIATION):

--- a/port_ocean/core/integrations/mixins/sync_raw.py
+++ b/port_ocean/core/integrations/mixins/sync_raw.py
@@ -1042,6 +1042,15 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                             blueprint=pending_resource.port.entity.mappings.blueprint,
                         )
 
+                async with metric_resource_context(MetricResourceKind.RECONCILIATION):
+                    ocean.metrics.sync_state = SyncState.ABORTED
+                    ocean.metrics.set_metric(
+                        name=MetricType.SUCCESS_NAME,
+                        labels=[MetricResourceKind.RECONCILIATION, MetricPhase.RESYNC],
+                        value=0,
+                    )
+                    await ocean.metrics.send_metrics_to_webhook(kind=MetricResourceKind.RECONCILIATION)
+                    await ocean.metrics.report_sync_metrics(kinds=[MetricResourceKind.RECONCILIATION])
                 raise
             else:
                 async with metric_resource_context(MetricResourceKind.RECONCILIATION):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.29.4"
+version = "0.29.5"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
### **User description**
# Description

What -
Update kinds that were pending/syncing during a resync to be aborted when a resync is aborted

Why -
Poor UI experience on abortion shows 'pending' or 'syncing' even though the integration status is aborted

How -
Get difference (using the app config) in kinds and update metrics to be aborted

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.


___

### **PR Type**
Bug fix


___

### **Description**
- Update unprocessed kinds metrics to 'Aborted' status on resync abortion

- Mark pending and syncing kinds with abort state when resync is aborted

- Set reconciliation metrics to aborted on resync abortion

- Improve UI experience by reflecting correct abort status for all kinds


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Resync Aborted"] --> B["Get Unprocessed Kinds"]
  B --> C["Update Kind Metrics to ABORTED"]
  C --> D["Update Reconciliation Metrics"]
  D --> E["Send Metrics to Webhook"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sync_raw.py</strong><dd><code>Mark pending kinds as aborted on resync abortion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

port_ocean/core/integrations/mixins/sync_raw.py

<ul><li>Added logic to iterate through unprocessed kinds (pending/syncing) <br>when resync is aborted<br> <li> Set sync state to ABORTED for each pending kind and send metrics to <br>webhook<br> <li> Added reconciliation metrics update with ABORTED state and zero <br>success count<br> <li> Ensures all unprocessed kinds reflect correct abort status in UI</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2409/files#diff-7087c0350a44c64c6ca1e4333b34e158b354bdd15932e51860efaddda535cddc">+21/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document unprocessed kinds abort fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added version 0.29.5 release notes<br> <li> Documented bug fix for unprocessed kinds metrics on resync abortion</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2409/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Bump port-ocean version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

- Bumped version from 0.29.4 to 0.29.5


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2409/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

