### PR TITLE
[Core] change the jq classifier for single item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.29.10 (2025-11-20)
+
+### Bug fixes
+
+- JQ expression classifier would classify mixed single item and all payload context expressions to run on all of the payload
+
+
 ## 0.29.9 (2025-11-20)
 
 ### Improvements

--- a/port_ocean/tests/core/handlers/entity_processor/test_jq_entity_processor.py
+++ b/port_ocean/tests/core/handlers/entity_processor/test_jq_entity_processor.py
@@ -561,13 +561,13 @@ class TestJQEntityProcessor:
                 "function_with_middle_pattern": "map(.body.item.field)",  # Function with middle pattern - ALL
                 "select_with_pattern": 'select(.item.status == "active")',  # Select with pattern - SINGLE
                 "select_with_middle_pattern": 'select(.data.item.status == "active")',  # Select with middle pattern - ALL
-                "pipe_with_pattern": ".[] | .item.field",  # Pipe with pattern - SINGLE
+                "pipe_with_pattern": ".[] | .item.field",  # Pipe with pattern - ALL
                 "pipe_with_middle_pattern": ".[] | .body.item.field",  # Pipe with middle pattern - ALL
                 "array_with_pattern": "[.item.id, .item.name]",  # Array with pattern - SINGLE
                 "array_with_middle_pattern": "[.data.item.id, .body.item.name]",  # Array with middle pattern - ALL
                 "object_with_pattern": "{id: .item.id, name: .item.name}",  # Object with pattern - SINGLE
                 "object_with_middle_pattern": "{id: .data.item.id, name: .body.item.name}",  # Object with middle pattern - ALL
-                "nested_with_pattern": ".data.items[] | .item.field",  # Nested with pattern - SINGLE
+                "nested_with_pattern": ".data.items[] | .item.field",  # Nested with pattern - ALL
                 "nested_with_middle_pattern": ".data.items[] | .body.item.field",  # Nested with middle pattern - ALL
                 "conditional_with_pattern": "if .item.exists then .item.value else null end",  # Conditional with pattern - SINGLE
                 "conditional_with_middle_pattern": "if .data.item.exists then .body.item.value else null end",  # Conditional with middle pattern - ALL
@@ -597,10 +597,8 @@ class TestJQEntityProcessor:
                 "special_chars": ".item.field[0]",
                 "function_with_pattern": "map(.item.field)",
                 "select_with_pattern": 'select(.item.status == "active")',
-                "pipe_with_pattern": ".[] | .item.field",
                 "array_with_pattern": "[.item.id, .item.name]",
                 "object_with_pattern": "{id: .item.id, name: .item.name}",
-                "nested_with_pattern": ".data.items[] | .item.field",
                 "conditional_with_pattern": "if .item.exists then .item.value else null end",
             },
             "relations": {
@@ -620,9 +618,11 @@ class TestJQEntityProcessor:
                 "function_with_middle_pattern": "map(.body.item.field)",
                 "select_with_middle_pattern": 'select(.data.item.status == "active")',
                 "item_in_string": 'select(.data.string == ".item")',
+                "pipe_with_pattern": ".[] | .item.field",
                 "pipe_with_middle_pattern": ".[] | .body.item.field",
                 "array_with_middle_pattern": "[.data.item.id, .body.item.name]",
                 "object_with_middle_pattern": "{id: .data.item.id, name: .body.item.name}",
+                "nested_with_pattern": ".data.items[] | .item.field",
                 "nested_with_middle_pattern": ".data.items[] | .body.item.field",
                 "conditional_with_middle_pattern": "if .data.item.exists then .body.item.value else null end",
                 "field_with_null_name": ".is_null",
@@ -664,10 +664,10 @@ class TestJQEntityProcessor:
                 # JQ expressions with functions that contain .item
                 "mapped_property": "map(.item.field)",  # Contains .item but starts with map - SINGLE
                 "selected_property": 'select(.item.status == "active")',  # Contains .item but starts with select - SINGLE
-                "filtered_property": '.[] | select(.item.type == "service")',  # Contains .item in pipe - SINGLE
+                "filtered_property": '.[] | select(.item.type == "service")',  # Main thread is based on the main object - ALL
                 "array_literal": "[.item.id, .item.name]",  # Contains .item in array - SINGLE
                 "object_literal": "{id: .item.id, name: .item.name}",  # Contains .item in object - SINGLE
-                "nested_access": ".data.items[] | .item.field",  # Contains .item in nested access - SINGLE
+                "nested_access": ".data.items[] | .item.field",  # Contains .item in nested access - ALL
                 "conditional": "if .item.exists then .item.value else null end",  # Contains .item in conditional - SINGLE
                 "function_call": "length(.item.array)",  # Contains .item in function call - SINGLE
                 "range_expression": "range(.item.start; .item.end)",  # Contains .item in range - SINGLE
@@ -790,10 +790,8 @@ class TestJQEntityProcessor:
             "properties": {
                 "mapped_property": "map(.item.field)",
                 "selected_property": 'select(.item.status == "active")',
-                "filtered_property": '.[] | select(.item.type == "service")',
                 "array_literal": "[.item.id, .item.name]",
                 "object_literal": "{id: .item.id, name: .item.name}",
-                "nested_access": ".data.items[] | .item.field",
                 "conditional": "if .item.exists then .item.value else null end",
                 "function_call": "length(.item.array)",
                 "range_expression": "range(.item.start; .item.end)",
@@ -892,6 +890,8 @@ class TestJQEntityProcessor:
         # ALL mappings - expressions with dots but not containing .item
         expected_all = {
             "properties": {
+                "filtered_property": '.[] | select(.item.type == "service")',
+                "nested_access": ".data.items[] | .item.field",
                 "external_map": "map(.external.field)",
                 "external_select": 'select(.external.status == "active")',
                 "external_array": "[.external.id, .external.name]",

--- a/port_ocean/tests/core/handlers/entity_processor/test_jq_input_evaluator.py
+++ b/port_ocean/tests/core/handlers/entity_processor/test_jq_input_evaluator.py
@@ -318,9 +318,13 @@ class TestCanExpressionRunOnSingleItem:
 
     def test_key_in_pipe(self) -> None:
         """Test key in pipe operations"""
-        assert _can_expression_run_on_single_item(".[] | .item.field", "item") is True
+        assert _can_expression_run_on_single_item(".[] | .item.field", "item") is False
         assert (
-            _can_expression_run_on_single_item(".data[] | .item.field", "item") is True
+            _can_expression_run_on_single_item(".data[] | .item.field", "item") is False
+        )
+        assert (
+            _can_expression_run_on_single_item("[1,2,3,4] | .item.field", "item")
+            is True
         )
 
     def test_key_in_array(self) -> None:
@@ -409,7 +413,7 @@ class TestCanExpressionRunOnSingleItem:
         """Test key in complex expressions"""
         assert (
             _can_expression_run_on_single_item(".data.items[] | .item.field", "item")
-            is True
+            is False
         )
         assert (
             _can_expression_run_on_single_item(
@@ -473,9 +477,7 @@ class TestClassifyInput:
             classify_input("select(.item.status)", "item")
             == InputClassifyingResult.SINGLE
         )
-        assert (
-            classify_input(".[] | .item.field", "item") == InputClassifyingResult.SINGLE
-        )
+        assert classify_input(".[] | .item.field", "item") == InputClassifyingResult.ALL
         assert (
             classify_input("[.item.id, .item.name]", "item")
             == InputClassifyingResult.SINGLE
@@ -538,7 +540,7 @@ class TestClassifyInput:
         # Complex single input expressions
         assert (
             classify_input(".data.items[] | .item.field", "item")
-            == InputClassifyingResult.SINGLE
+            == InputClassifyingResult.ALL
         )
         assert (
             classify_input("reduce .item.items[] as $item (0; . + $item.value)", "item")
@@ -835,9 +837,7 @@ class TestIntegration:
             classify_input('select(.item.status == "active")', "item")
             == InputClassifyingResult.SINGLE
         )
-        assert (
-            classify_input(".[] | .item.field", "item") == InputClassifyingResult.SINGLE
-        )
+        assert classify_input(".[] | .item.field", "item") == InputClassifyingResult.ALL
         assert (
             classify_input("[.item.id, .item.name]", "item")
             == InputClassifyingResult.SINGLE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.29.9"
+version = "0.29.10"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
### **User description**
# Description

What - Fix the behavior of jq classifier to classify mixed single item and all payload context expressions as ALL instead of ITEM

Why - bugfix

How -

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix jq classifier to correctly identify expressions with array operations as ALL context

- Reject expressions starting with root-level array access (`.[]` or `.[0]`) from SINGLE classification

- Update classifier logic to only match top-level paths that reference the target key

- Update test expectations to reflect corrected classification behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["JQ Expression"] --> B["Check for root array access"]
  B -->|Found `.[]` or `.[0]`| C["Return False - ALL context"]
  B -->|Not found| D["Extract top-level paths"]
  D --> E["Validate all paths reference target key"]
  E -->|All valid| F["Return True - SINGLE context"]
  E -->|Mixed paths| G["Return False - ALL context"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jq_input_evaluator.py</strong><dd><code>Refactor jq classifier to handle array operations correctly</code></dd></summary>
<hr>

port_ocean/core/handlers/entity_processor/jq_input_evaluator.py

<ul><li>Rewrote <code>_can_expression_run_on_single_item()</code> function to properly <br>detect root-level array operations<br> <li> Added regex check to reject expressions starting with <code>.[</code> (array <br>access)<br> <li> Changed logic to extract and validate all top-level paths in the <br>expression<br> <li> Now correctly classifies expressions like <code>.[] | .item.field</code> as <br>requiring ALL context instead of SINGLE</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2453/files#diff-9d75068f993a69e5d3272257158376a7efe2ab19978ab35707f5ebc74c2cda33">+30/-10</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_jq_entity_processor.py</strong><dd><code>Update test expectations for array operation classifications</code></dd></summary>
<hr>

port_ocean/tests/core/handlers/entity_processor/test_jq_entity_processor.py

<ul><li>Updated test expectations for <code>pipe_with_pattern</code> from SINGLE to ALL <br>classification<br> <li> Updated test expectations for <code>nested_with_pattern</code> from SINGLE to ALL <br>classification<br> <li> Moved affected test cases to the ALL mappings section in expected <br>results<br> <li> Updated comments to reflect corrected classification rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2453/files#diff-33ee55617b66e081dd2a05ea9cdf14ef13a910627f3b6a70c3d90cf1aa577076">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_jq_input_evaluator.py</strong><dd><code>Update unit tests for corrected classifier behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

port_ocean/tests/core/handlers/entity_processor/test_jq_input_evaluator.py

<ul><li>Updated <code>test_key_in_pipe()</code> to expect False for expressions with array <br>operations<br> <li> Added new test case for array literal pipe operations that should <br>return True<br> <li> Updated <code>test_key_in_complex_expressions()</code> to expect False for <br><code>.data.items[] | .item.field</code><br> <li> Updated <code>test_single_input()</code> and <code>test_complex_expressions()</code> to reflect <br>corrected classifications<br> <li> Updated <code>test_real_world_scenarios()</code> to expect ALL context for <code>.[] | </code><br><code>.item.field</code></ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2453/files#diff-b19bb71e2543fb758f5a6ecfa6dbf2b04296345ee42d311a9b404c17c73132fe">+10/-10</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Add changelog entry for version 0.29.10</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added version 0.29.10 release notes<br> <li> Documented bug fix for jq expression classifier handling of mixed <br>context expressions</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2453/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Update package version to 0.29.10</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

- Bumped version from 0.29.9 to 0.29.10


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2453/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

