### PR TITLE
[Core] Make cache_iterator_result preserve the chunks of items which were added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.30.5 (2025-11-26)
+
+### Improvements
+
+- `cache_iterator_result` preserves the chunks that got inserted.
+
+
 ## 0.30.4 (2025-11-26)
 - Updated upsert (load) metrics to be calculated directly from response
 - Updated log on duplicate count

--- a/port_ocean/utils/cache.py
+++ b/port_ocean/utils/cache.py
@@ -86,7 +86,8 @@ def cache_iterator_result() -> Callable[[AsyncIteratorCallable], AsyncIteratorCa
             # Check if the result is already in the cache
             try:
                 if cache := await ocean.app.cache_provider.get(cache_key):
-                    yield cache
+                    for chunk in cache:
+                        yield chunk
                     return
             except FailedToReadCacheError as e:
                 logger.warning(f"Failed to read cache for {cache_key}: {str(e)}")
@@ -94,7 +95,7 @@ def cache_iterator_result() -> Callable[[AsyncIteratorCallable], AsyncIteratorCa
             # If not in cache, fetch the data
             cached_results = list()
             async for result in func(*args, **kwargs):
-                cached_results.extend(result)
+                cached_results.append(result)
                 yield result
 
             # Cache the results

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.30.4"
+version = "0.30.5"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
### **User description**
# Description

What - Cache_iterator_result should preserve cached items in the same chunks they're retrieved in.

Why - Some integrations have assumptions about how items are returned, and use this assumptions in other parts of the program (e.g to batch requests based on chunks of responses from an API).

How - Don't merge cache items together.

## Type of change

Please leave one option from the following and delete the rest:

- [ x ] Non-breaking change (fix of existing functionality that will not change current behavior)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Preserve chunk structure in `cache_iterator_result` to maintain API assumptions

- Changed caching logic from merging chunks to storing individual chunks

- Added test to verify chunks remain separate when retrieved from cache

- Updated version to 0.30.5 with changelog entry


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["cache_iterator_result decorator"] -->|"Before: extend/merge"| B["Single merged list"]
  A -->|"After: append/preserve"| C["List of chunks"]
  C -->|"On cache hit"| D["Yield individual chunks"]
  B -->|"On cache hit"| E["Yield merged result"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cache.py</strong><dd><code>Preserve chunks in cache storage and retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

port_ocean/utils/cache.py

<ul><li>Changed <code>cached_results.extend(result)</code> to <code>cached_results.append(result)</code> <br>to preserve chunk structure<br> <li> Modified cache retrieval to iterate over cached chunks and yield them <br>individually<br> <li> Maintains original chunk boundaries instead of merging items together</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2486/files#diff-b2937e586fb75a8ca9c268b913059d53bbae6fba06d4aaf7ef60942d077079c3">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_cache.py</strong><dd><code>Add test for cache chunk preservation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

port_ocean/tests/utils/test_cache.py

<ul><li>Added new test <code>test_cache_iterator_maintains_chunks</code> to verify chunk <br>preservation<br> <li> Tests that multiple yields are cached as separate chunks<br> <li> Verifies both first call (cache population) and second call (cache <br>retrieval) maintain chunk structure</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2486/files#diff-373230008ed442f0ffb5301b54ebee3dacfe433a084efb53938feffb6399e8c6">+34/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document cache chunk preservation improvement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added entry for version 0.30.5 release<br> <li> Documents improvement: <code>cache_iterator_result</code> preserves chunks</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2486/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Update version to 0.30.5</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

- Bumped version from 0.30.4 to 0.30.5


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2486/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

