### PR TITLE
[CI] adding actions:read permissions

### DIFF
--- a/.github/workflows/release-integrations.yml
+++ b/.github/workflows/release-integrations.yml
@@ -49,7 +49,6 @@ jobs:
       id-token: write
       packages: write
       contents: read
-      actions: read
     needs: [prepare-matrix]
     strategy:
       # limit the number of parallel jobs to avoid hitting the ghcr.io rate limit
@@ -106,50 +105,50 @@ jobs:
           docker-user: ${{ secrets.DOCKER_MACHINE_USER }}
           docker-password: ${{ secrets.DOCKER_MACHINE_TOKEN }}
 
-      - name: Get image sizes
-        id: image_size
-        run: |
-          IMAGE="ghcr.io/port-labs/port-ocean-${{ steps.prepare_tags.outputs.type }}:${{ steps.prepare_tags.outputs.version }}"
+      # - name: Get image sizes
+      #   id: image_size
+      #   run: |
+      #     IMAGE="ghcr.io/port-labs/port-ocean-${{ steps.prepare_tags.outputs.type }}:${{ steps.prepare_tags.outputs.version }}"
 
-          # Get manifest with sizes for each platform
-          MANIFEST=$(docker buildx imagetools inspect "${IMAGE}" --raw)
+      #     # Get manifest with sizes for each platform
+      #     MANIFEST=$(docker buildx imagetools inspect "${IMAGE}" --raw)
 
-          AMD64_SIZE=$(echo "${MANIFEST}" | jq '[.manifests[] | select(.platform.architecture=="amd64") | .size] | add')
-          ARM64_SIZE=$(echo "${MANIFEST}" | jq '[.manifests[] | select(.platform.architecture=="arm64") | .size] | add')
+      #     AMD64_SIZE=$(echo "${MANIFEST}" | jq '[.manifests[] | select(.platform.architecture=="amd64") | .size] | add')
+      #     ARM64_SIZE=$(echo "${MANIFEST}" | jq '[.manifests[] | select(.platform.architecture=="arm64") | .size] | add')
 
-          AMD64_MB=$(jq -n "${AMD64_SIZE} / 1048576" | xargs printf "%.2f")
-          ARM64_MB=$(jq -n "${ARM64_SIZE} / 1048576" | xargs printf "%.2f")
+      #     AMD64_MB=$(jq -n "${AMD64_SIZE} / 1048576" | xargs printf "%.2f")
+      #     ARM64_MB=$(jq -n "${ARM64_SIZE} / 1048576" | xargs printf "%.2f")
 
-          echo "size_mb_linux-amd64=${AMD64_MB}" >> $GITHUB_OUTPUT
-          echo "size_mb_linux-arm64=${ARM64_MB}" >> $GITHUB_OUTPUT
+      #     echo "size_mb_linux-amd64=${AMD64_MB}" >> $GITHUB_OUTPUT
+      #     echo "size_mb_linux-arm64=${ARM64_MB}" >> $GITHUB_OUTPUT
 
-      - name: Track image size in New Relic (amd64)
-        uses: port-labs/infra-utils/.github/actions/new-relic-metric@main
-        with:
-          metric_name: "image.size"
-          metric_value: ${{ steps.image_size.outputs.size_mb_linux-amd64 }}
-          new_relic_api_key: ${{ secrets.NEW_RELIC_INGEST_API_KEY }}
-          metric_attributes: |
-            {
-              "image_name": "port-ocean-${{ steps.prepare_tags.outputs.type }}",
-              "image_version": "${{ steps.prepare_tags.outputs.version }}",
-              "platform": "linux/amd64",
-              "size_mb": "${{ steps.image_size.outputs.size_mb_linux-amd64 }}"
-            }
+      # - name: Track image size in New Relic (amd64)
+      #   uses: port-labs/infra-utils/.github/actions/new-relic-metric@main
+      #   with:
+      #     metric_name: "image.size"
+      #     metric_value: ${{ steps.image_size.outputs.size_mb_linux-amd64 }}
+      #     new_relic_api_key: ${{ secrets.NEW_RELIC_INGEST_API_KEY }}
+      #     metric_attributes: |
+      #       {
+      #         "image_name": "port-ocean-${{ steps.prepare_tags.outputs.type }}",
+      #         "image_version": "${{ steps.prepare_tags.outputs.version }}",
+      #         "platform": "linux/amd64",
+      #         "size_mb": "${{ steps.image_size.outputs.size_mb_linux-amd64 }}"
+      #       }
 
-      - name: Track image size in New Relic (arm64)
-        uses: port-labs/infra-utils/.github/actions/new-relic-metric@main
-        with:
-          metric_name: "image.size"
-          metric_value: ${{ steps.image_size.outputs.size_mb_linux-arm64 }}
-          new_relic_api_key: ${{ secrets.NEW_RELIC_INGEST_API_KEY}}
-          metric_attributes: |
-            {
-              "image_name": "port-ocean-${{ steps.prepare_tags.outputs.type }}",
-              "image_version": "${{ steps.prepare_tags.outputs.version }}",
-              "platform": "linux/arm64",
-              "size_mb": "${{ steps.image_size.outputs.size_mb_linux-arm64 }}"
-            }
+      # - name: Track image size in New Relic (arm64)
+      #   uses: port-labs/infra-utils/.github/actions/new-relic-metric@main
+      #   with:
+      #     metric_name: "image.size"
+      #     metric_value: ${{ steps.image_size.outputs.size_mb_linux-arm64 }}
+      #     new_relic_api_key: ${{ secrets.NEW_RELIC_INGEST_API_KEY}}
+      #     metric_attributes: |
+      #       {
+      #         "image_name": "port-ocean-${{ steps.prepare_tags.outputs.type }}",
+      #         "image_version": "${{ steps.prepare_tags.outputs.version }}",
+      #         "platform": "linux/arm64",
+      #         "size_mb": "${{ steps.image_size.outputs.size_mb_linux-arm64 }}"
+      #       }
 
       - name: Configure AWS Credentials 🔒
         if: steps.prepare_tags.outputs.is_dev_version == 'false'


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add `actions: read` permission to release workflow

- Enables workflow to access GitHub Actions data


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Release Workflow Permissions"] -- "add actions: read" --> B["Enhanced Access to Actions Data"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release-integrations.yml</strong><dd><code>Add actions read permission to build job</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release-integrations.yml

<ul><li>Added <code>actions: read</code> permission to the build job permissions block<br> <li> Allows workflow to read GitHub Actions-related information<br> <li> Maintains existing permissions for id-token, packages, and contents</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2506/files#diff-0bfc63cb9cdeb757623f2351012ba27ea9d48e0ca67cc593e7fdf5a44c15497a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

