### PR TITLE
[Integration][ADO] Removed folder and codeowners defaults from Azure DevOps integration

### DIFF
--- a/integrations/azure-devops/.port/resources/blueprints.json
+++ b/integrations/azure-devops/.port/resources/blueprints.json
@@ -333,49 +333,5 @@
         "many": false
       }
     }
-  },
-  {
-    "identifier": "azureDevopsCodeowners",
-    "description": "This blueprint represents a CODEOWNERS file in an Azure DevOps repository",
-    "title": "Azure DevOps Codeowners",
-    "icon": "AzureDevops",
-    "schema": {
-      "properties": {
-        "location": {
-          "type": "string",
-          "title": "File location",
-          "description": "File path to CODEOWNERS file"
-        },
-        "scope": {
-          "icon": "AzureDevops",
-          "type": "string",
-          "title": "Scope",
-          "description": "The scope which the user/team owns"
-        },
-        "users": {
-          "type": "array",
-          "title": "Users",
-          "description": "Users who own this scope"
-        },
-        "teams": {
-          "type": "array",
-          "title": "Teams",
-          "description": "Teams who own this scope"
-        }
-      },
-      "required": []
-    },
-    "mirrorProperties": {},
-    "calculationProperties": {},
-    "aggregationProperties": {},
-    "relations": {
-      "service": {
-        "title": "Service",
-        "description": "The repository which the CODEOWNERS file resides in",
-        "target": "service",
-        "required": false,
-        "many": false
-      }
-    }
   }
 ]

--- a/integrations/azure-devops/.port/resources/port-app-config.yaml
+++ b/integrations/azure-devops/.port/resources/port-app-config.yaml
@@ -32,23 +32,6 @@ resources:
             readme: file://README.md
           relations:
             project: .project.id | gsub(" "; "")
-  - kind: folder
-    selector:
-      query: "true"
-      folders:
-        - path: "*/*"
-    port:
-      entity:
-        mappings:
-          identifier: >-
-            "\(.__repository.project.name | ascii_downcase | gsub("[ ();]"; ""))/\(.__repository.name | ascii_downcase | gsub("[ ();]"; ""))/\(.path)"
-          title: .path
-          blueprint: '"service"'
-          properties:
-            url: .__repository.remoteUrl + "?path=/" + .path
-            readme: file://README.md
-          relations:
-            project: .__repository.project.id | gsub(" "; "")
   - kind: repository-policy
     selector:
       query: .type.displayName=="Minimum number of reviewers"
@@ -139,39 +122,3 @@ resources:
             link: ._links.web.href | gsub("_release?releaseId="; "")
           relations:
             project: .projectReference.id | gsub(" "; "")
-  - kind: file
-    selector:
-      query: 'true'
-      files:
-        path: '**/CODEOWNERS'
-    port:
-      itemsToParse: >-
-        (. as $root | .file.content.raw | split("\n") |
-        map(gsub("^[[:space:]]+|[[:space:]]+$"; "")) |
-        map(select((test("^[[:space:]]*#") | not) and (length > 0))) | map(
-            (split(" ") | map(select(length > 0))) as $tokens
-            | {
-                scope: ($tokens[0]),
-                identifier: ($tokens[0]
-                          | gsub("\\*\\*"; "doublestar")
-                          | gsub("\\*"; "star")),
-                users: ($tokens[1:] | map(select(contains("/") | not) | gsub("@"; ""))),
-                teams: ($tokens[1:] | map(select(test("^@[^ ]+/[^ ]+$")) | split("/") | .[-1])),
-                repoName: $root.repo.name,
-                projectName: $root.repo.project.name,
-                filePath: $root.file.path
-            }
-          )
-        )
-      entity:
-        mappings:
-          identifier: (.item.projectName | ascii_downcase | gsub("[ ();]"; "")) + "/" + (.item.repoName | ascii_downcase | gsub("[ ();]"; "")) + "_" + .item.identifier + "_codeowners"
-          title: .item.scope + " codeowners"
-          blueprint: '"azureDevopsCodeowners"'
-          properties:
-            scope: .item.scope
-            location: .item.filePath
-            users: .item.users
-            teams: .item.teams
-          relations:
-            service: (.item.projectName | ascii_downcase | gsub("[ ();]"; "")) + "/" + (.item.repoName | ascii_downcase | gsub("[ ();]"; ""))

--- a/integrations/azure-devops/CHANGELOG.md
+++ b/integrations/azure-devops/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.6.10 (2025-12-10)
+
+
+### Improvements
+
+- Removed codeowners mapping and blueprint from integration default resources
+- Removed folder kind from integration default
+
+
 ## 0.6.9 (2025-12-10)
 
 

--- a/integrations/azure-devops/pyproject.toml
+++ b/integrations/azure-devops/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "azure-devops"
-version = "0.6.9"
+version = "0.6.10"
 description = "An Azure Devops Ocean integration"
 authors = ["Matan Geva <matang@getport.io>"]
 


### PR DESCRIPTION
### **User description**
# Description

What - Removed folder kind, file kind (CODEOWNERS), and azureDevopsCodeowners blueprint from default resources.

Why -

How -

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.


___

### **PR Type**
Enhancement


___

### **Description**
- Removed azureDevopsCodeowners blueprint from default resources

- Removed folder kind mapping from integration configuration

- Removed CODEOWNERS file parsing and entity creation logic

- Updated version to 0.6.10 with changelog entry


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Azure DevOps Integration"] -->|Remove| B["azureDevopsCodeowners Blueprint"]
  A -->|Remove| C["Folder Kind Mapping"]
  A -->|Remove| D["CODEOWNERS File Parser"]
  A -->|Update| E["Version 0.6.10"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>blueprints.json</strong><dd><code>Remove azureDevopsCodeowners blueprint definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/azure-devops/.port/resources/blueprints.json

<ul><li>Removed entire azureDevopsCodeowners blueprint definition<br> <li> Removed blueprint properties for location, scope, users, and teams<br> <li> Removed relations configuration for service entity</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2544/files#diff-883c1a7b4e4496423bf61805483e71198829e6a8fb8b2611ed1bb9f3f4acaec2">+0/-44</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>port-app-config.yaml</strong><dd><code>Remove folder and CODEOWNERS resource mappings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/azure-devops/.port/resources/port-app-config.yaml

<ul><li>Removed folder kind resource mapping with path-based selector<br> <li> Removed CODEOWNERS file kind resource with complex parsing logic<br> <li> Removed itemsToParse configuration for CODEOWNERS content parsing<br> <li> Removed entity mappings for both folder and codeowners resources</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2544/files#diff-583fc09eda27e4b801bb21bda7ef9e6502dff16173d527aac0445005035a29e2">+0/-53</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Bump version to 0.6.10</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/azure-devops/pyproject.toml

- Updated version from 0.6.9 to 0.6.10


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2544/files#diff-067c63eae2423648d5f4f587433376d049963f0e9e2a57eb485817e5deb32f5a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Add changelog entry for version 0.6.10</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/azure-devops/CHANGELOG.md

<ul><li>Added version 0.6.10 release notes<br> <li> Documented removal of codeowners mapping and blueprint<br> <li> Documented removal of folder kind from integration defaults</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2544/files#diff-9b4f288c83afcf2c6cdce8a77deca105f812a5b9af7b7b6125bce0786dbfd6a6">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

