### PR TITLE
[Integration][Gitlab-v2] Removed folder and codeowners defaults from GitLab v2 integration

### DIFF
--- a/integrations/gitlab-v2/.port/resources/blueprints.json
+++ b/integrations/gitlab-v2/.port/resources/blueprints.json
@@ -203,49 +203,5 @@
         "many": false
       }
     }
-  },
-  {
-    "identifier": "gitlabCodeowners",
-    "description": "This blueprint represents a CODEOWNERS file in a GitLab project",
-    "title": "GitLab Codeowners",
-    "icon": "GitLab",
-    "schema": {
-      "properties": {
-        "location": {
-          "type": "string",
-          "title": "File location",
-          "description": "File path to CODEOWNERS file"
-        },
-        "scope": {
-          "icon": "GitLab",
-          "type": "string",
-          "title": "Scope",
-          "description": "The scope which the user/team owns"
-        },
-        "users": {
-          "type": "array",
-          "title": "Users",
-          "description": "Users who own this scope"
-        },
-        "teams": {
-          "type": "array",
-          "title": "Teams",
-          "description": "Teams who own this scope"
-        }
-      },
-      "required": []
-    },
-    "mirrorProperties": {},
-    "calculationProperties": {},
-    "aggregationProperties": {},
-    "relations": {
-      "project": {
-        "title": "Service",
-        "description": "The project which the CODEOWNERS file resides in",
-        "target": "service",
-        "required": false,
-        "many": false
-      }
-    }
   }
 ]

--- a/integrations/gitlab-v2/.port/resources/port-app-config.yml
+++ b/integrations/gitlab-v2/.port/resources/port-app-config.yml
@@ -15,23 +15,6 @@ resources:
             url: .web_url
             readme: file://README.md
             language: .__languages | to_entries | max_by(.value) | .key
-  - kind: folder
-    selector:
-      query: "true"
-      folders:
-        - path: "*/*"
-    port:
-      entity:
-        mappings:
-          identifier: .repo.path_with_namespace + "/" + .folder.path | gsub(" "; "")
-          title: .folder.name
-          blueprint: '"service"'
-          properties:
-            url: >-
-              .repo.web_url + "/tree/" + .repo.default_branch + "/" +
-              .folder.path
-            readme: file://README.md
-            description: .repo.description
   - kind: member
     selector:
       query: 'true'
@@ -88,35 +71,3 @@ resources:
             reviewers: .reviewers | map(.name)
           relations:
             project: .references.full | gsub("!.+"; "")
-  - kind: file
-    selector:
-      query: 'true'
-      files:
-        path: CODEOWNERS
-        skipParsing: 'true'
-    port:
-      itemsToParse: >-
-        .file.content.content | split("\n") |
-        map(gsub("^[[:space:]]+|[[:space:]]+$"; "")) |
-        map(select((test("^[[:space:]]*#") | not) and (length > 0))) |
-        map(split(" ") | map(select(length > 0))) |
-        map({
-          scope: .[0],
-          identifier: (.[0] | gsub("\\*\\*"; "doublestar") | gsub("\\*"; "star")),
-          users: (.[1:] | map(select(contains("/") | not) | gsub("@"; ""))),
-          teams: (.[1:] | map(select(test("^@[^ ]+/[^ ]+$")) | split("/") | .[-1]))
-        })
-      entity:
-        mappings:
-          identifier: >-
-            (.file.repo.path_with_namespace | gsub(" "; "")) + "_" +
-            .item.identifier + "_codeowners"
-          title: .item.scope + " codeowners"
-          blueprint: '"gitlabCodeowners"'
-          properties:
-            scope: .item.scope
-            location: .file.path
-            users: .item.users
-            teams: .item.teams
-          relations:
-            project: .file.repo.path_with_namespace | gsub(" "; "")

--- a/integrations/gitlab-v2/CHANGELOG.md
+++ b/integrations/gitlab-v2/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.5.8 (2025-12-10)
+
+
+### Improvements
+
+- Removed codeowners mapping and blueprint from integration default resources
+- Removed folder kind from integration default
+
+
 ## 0.5.7 (2025-12-10)
 
 

--- a/integrations/gitlab-v2/pyproject.toml
+++ b/integrations/gitlab-v2/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gitlab-v2"
-version = "0.5.7"
+version = "0.5.8"
 description = "Gitlab"
 authors = ["Shariff <mohammed.s@getport.io>"]
 


### PR DESCRIPTION
### **User description**
# Description

What - Removed folder kind, file kind (CODEOWNERS), and gitlabCodeowners blueprint from default resources.

Why -

How -

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.


___

### **PR Type**
Enhancement


___

### **Description**
- Removed `gitlabCodeowners` blueprint from default resources

- Removed folder kind mapping from integration configuration

- Removed file kind (CODEOWNERS) mapping from integration configuration

- Updated version to 0.5.8 with changelog entry


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitLab v2 Integration"] -->|Remove| B["gitlabCodeowners Blueprint"]
  A -->|Remove| C["Folder Kind Mapping"]
  A -->|Remove| D["File Kind CODEOWNERS Mapping"]
  A -->|Update| E["Version 0.5.8"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>blueprints.json</strong><dd><code>Remove gitlabCodeowners blueprint definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/gitlab-v2/.port/resources/blueprints.json

<ul><li>Removed the entire <code>gitlabCodeowners</code> blueprint definition (44 lines)<br> <li> Removed blueprint properties for location, scope, users, and teams<br> <li> Removed project relation from codeowners blueprint</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2546/files#diff-643023e08a676647dd51641b0c8cd3dfeb81de8e67d855303ee30ec7f9470ea7">+0/-44</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>port-app-config.yml</strong><dd><code>Remove folder and file kind mappings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/gitlab-v2/.port/resources/port-app-config.yml

<ul><li>Removed folder kind resource mapping with path selector<br> <li> Removed file kind resource mapping for CODEOWNERS files<br> <li> Removed itemsToParse logic for parsing CODEOWNERS content<br> <li> Kept project and member kind mappings intact</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2546/files#diff-1da49cc15ff5e38bc7cfed355587bf763d910e6affc39a0ea46fc46dab603470">+0/-49</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Bump version to 0.5.8</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/gitlab-v2/pyproject.toml

- Updated version from 0.5.7 to 0.5.8


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2546/files#diff-3d3559f33cb8792e0b0724f93bfc87fe42318e91aa6d78aa616b5cb914e837a2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Add changelog entry for version 0.5.8</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/gitlab-v2/CHANGELOG.md

<ul><li>Added version 0.5.8 release notes<br> <li> Documented removal of codeowners mapping and blueprint<br> <li> Documented removal of folder kind from integration defaults</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2546/files#diff-fa549dfca83e908e603381bb974e4505c70cb46b8ba916cccaeda7709d376051">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

