### PR TITLE
[Core] Image size correction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
           fi
 
           BASELINE_SIZE_BYTES=$(docker images "${BASELINE_IMAGE}" --format '{{.VirtualSize}}' | \
-            awk '{
+            awk 'BEGIN{IGNORECASE=1} {
               val = $0
               gsub(/[^0-9.]/,"",val)
               if ($0 ~ /GB/) print int(val * 1073741824)
@@ -187,7 +187,7 @@ jobs:
           THRESHOLD="${{ env.SIZE_INCREASE_THRESHOLD }}"
 
           NEW_SIZE_BYTES=$(docker images "${NEW_IMAGE}" --format '{{.VirtualSize}}' | \
-            awk '{
+            awk 'BEGIN{IGNORECASE=1} {
               val = $0
               gsub(/[^0-9.]/,"",val)
               if ($0 ~ /GB/) print int(val * 1073741824)

--- a/.github/workflows/release-integrations.yml
+++ b/.github/workflows/release-integrations.yml
@@ -125,7 +125,7 @@ jobs:
             fi
 
             SIZE=$(docker images "${IMAGE}" --format '{{.VirtualSize}}' | \
-              awk '{
+              awk 'BEGIN{IGNORECASE=1} {
                 val = $0
                 gsub(/[^0-9.]/,"",val)
                 if ($0 ~ /GB/) print int(val * 1073741824)


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Replace `docker image inspect` with `docker images` for accurate image size measurement

- Implement unit conversion logic to handle GB/MB/KB size formats correctly

- Simplify size calculation by removing decimal formatting and using raw values

- Refactor image size retrieval in release workflow to use direct pull and measurement


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["docker image inspect<br/>Size command"] -->|"Replace with"| B["docker images<br/>VirtualSize command"]
  B -->|"Parse output"| C["AWK conversion<br/>GB/MB/KB to bytes"]
  C -->|"Calculate"| D["Accurate image<br/>size in bytes"]
  D -->|"Remove formatting"| E["Simplified output<br/>without decimals"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Improve image size measurement accuracy in CI workflow</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yml

<ul><li>Replace <code>docker image inspect</code> with <code>docker images</code> command for baseline <br>and new image size retrieval<br> <li> Add AWK-based unit conversion to handle GB/MB/KB format strings and <br>convert to bytes<br> <li> Extract <code>baseline_mb</code> calculation to separate step output for reuse<br> <li> Remove decimal formatting (printf) and use raw jq-calculated values <br>for consistency<br> <li> Simplify size comparison logic by removing intermediate formatting <br>variables</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2607/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+29/-17</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release-integrations.yml</strong><dd><code>Simplify image size retrieval in release workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/release-integrations.yml

<ul><li>Replace manifest inspection approach with direct <code>docker pull</code> and <br><code>docker images</code> commands<br> <li> Implement same AWK-based unit conversion for consistent size <br>calculation across workflows<br> <li> Remove complex manifest digest and layer manifest parsing logic<br> <li> Add cleanup step to remove pulled images and free disk space between <br>architecture pulls<br> <li> Simplify error handling by checking pull success instead of manifest <br>validity</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2607/files#diff-0bfc63cb9cdeb757623f2351012ba27ea9d48e0ca67cc593e7fdf5a44c15497a">+19/-19</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

