### PR TITLE
add support for multiple hosts

### DIFF
--- a/integrations/custom/.port/spec.yaml
+++ b/integrations/custom/.port/spec.yaml
@@ -10,9 +10,20 @@ features:
         description: HTTP API resources - kind is the endpoint path (e.g., /api/v1/users)
 configurations:
   - name: baseUrl
-    required: true
+    required: false
     type: string
-    description: "The base URL of your HTTP API, for example: https://api.example.com"
+    description: "The base URL of your HTTP API, for example: https://api.example.com (required unless multipleHosts is enabled)"
+    dependencies:
+      - on: multipleHosts
+        when:
+          equals: false
+        then:
+          required: true
+  - name: multipleHosts
+    required: false
+    type: boolean
+    default: false
+    description: "When enabled, the kind contains the full URL instead of just the endpoint path. The baseUrl is ignored in this mode."
   - name: authType
     required: false
     type: string
@@ -160,6 +171,7 @@ interface:
   sections:
     - label: Advanced Configuration
       configurationNames:
+        - multipleHosts
         - paginationType
         - pageSize
         - paginationParam

--- a/integrations/custom/CHANGELOG.md
+++ b/integrations/custom/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.2.52-beta (2026-01-29)
+
+
+### Features
+
+- Added `multipleHosts` configuration option that enables fetching data from multiple different API hosts within a single integration instance. When enabled, the `kind` contains the full URL instead of just the endpoint path, and the `baseUrl` is ignored (PORT-000)
+
+
 ## 0.2.51-beta (2026-01-27)
 
 

--- a/integrations/custom/initialize_client.py
+++ b/integrations/custom/initialize_client.py
@@ -54,10 +54,11 @@ def init_client() -> HttpServerClient:
     custom_headers = _parse_custom_headers(config.get("custom_headers"))
 
     return HttpServerClient(
-        base_url=config["base_url"],
+        base_url=config.get("base_url", ""),
         auth_type=config.get("auth_type", "none"),
         auth_config=config,
         pagination_config=config,
+        multiple_hosts=config.get("multiple_hosts", False),
         verify_ssl=config.get("verify_ssl", True),
         max_concurrent_requests=int(config.get("max_concurrent_requests", 10)),
         custom_headers=custom_headers,

--- a/integrations/custom/pyproject.toml
+++ b/integrations/custom/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "custom"
-version = "0.2.51-beta"
+version = "0.2.52-beta"
 description = "Ocean Custom Integration"
 authors = ["Port Team <support@getport.io>"]
 

--- a/integrations/custom/tests/test_client.py
+++ b/integrations/custom/tests/test_client.py
@@ -384,3 +384,256 @@ class TestHttpServerClient:
         )
 
         assert client.custom_headers == {}
+
+
+class TestMultipleHostsMode:
+    """Test cases for multiple hosts mode"""
+
+    def test_client_initialization_with_multiple_hosts_enabled(self) -> None:
+        """Test client can be initialized with multiple_hosts enabled"""
+        client = HttpServerClient(
+            base_url="",
+            auth_type="none",
+            auth_config={},
+            pagination_config={},
+            multiple_hosts=True,
+        )
+        assert client.multiple_hosts is True
+        assert client.base_url == ""
+
+    def test_client_initialization_with_multiple_hosts_disabled(self) -> None:
+        """Test client defaults to multiple_hosts disabled"""
+        client = HttpServerClient(
+            base_url="https://api.example.com",
+            auth_type="none",
+            auth_config={},
+            pagination_config={},
+        )
+        assert client.multiple_hosts is False
+
+    async def test_multiple_hosts_uses_full_url_as_endpoint(self) -> None:
+        """Test that in multiple_hosts mode, the endpoint is used as the full URL"""
+        client = HttpServerClient(
+            base_url="",
+            auth_type="none",
+            auth_config={},
+            pagination_config={"pagination_type": "none"},
+            multiple_hosts=True,
+        )
+
+        captured_url: str | None = None
+
+        async def mock_make_request(
+            url: str, method: str, params: dict[str, Any], headers: dict[str, str]
+        ) -> AsyncMock:
+            nonlocal captured_url
+            captured_url = url
+            response = AsyncMock()
+            response.json = AsyncMock(return_value={"data": []})
+            response.raise_for_status = lambda: None
+            return response
+
+        with patch.object(client, "_make_request", mock_make_request):
+            async for _ in client.fetch_paginated_data(
+                endpoint="https://api.github.com/users"
+            ):
+                break
+
+        assert captured_url == "https://api.github.com/users"
+
+    async def test_multiple_hosts_with_http_url(self) -> None:
+        """Test that http:// URLs work in multiple_hosts mode"""
+        client = HttpServerClient(
+            base_url="",
+            auth_type="none",
+            auth_config={},
+            pagination_config={"pagination_type": "none"},
+            multiple_hosts=True,
+        )
+
+        captured_url: str | None = None
+
+        async def mock_make_request(
+            url: str, method: str, params: dict[str, Any], headers: dict[str, str]
+        ) -> AsyncMock:
+            nonlocal captured_url
+            captured_url = url
+            response = AsyncMock()
+            response.json = AsyncMock(return_value={"data": []})
+            response.raise_for_status = lambda: None
+            return response
+
+        with patch.object(client, "_make_request", mock_make_request):
+            async for _ in client.fetch_paginated_data(
+                endpoint="http://localhost:8080/api/v1/users"
+            ):
+                break
+
+        assert captured_url == "http://localhost:8080/api/v1/users"
+
+    async def test_multiple_hosts_ignores_base_url(self) -> None:
+        """Test that base_url is ignored in multiple_hosts mode"""
+        client = HttpServerClient(
+            base_url="https://should-be-ignored.com",
+            auth_type="none",
+            auth_config={},
+            pagination_config={"pagination_type": "none"},
+            multiple_hosts=True,
+        )
+
+        captured_url: str | None = None
+
+        async def mock_make_request(
+            url: str, method: str, params: dict[str, Any], headers: dict[str, str]
+        ) -> AsyncMock:
+            nonlocal captured_url
+            captured_url = url
+            response = AsyncMock()
+            response.json = AsyncMock(return_value={"data": []})
+            response.raise_for_status = lambda: None
+            return response
+
+        with patch.object(client, "_make_request", mock_make_request):
+            async for _ in client.fetch_paginated_data(
+                endpoint="https://api.different-host.com/v1/resources"
+            ):
+                break
+
+        # Should use the endpoint URL directly, not combine with base_url
+        assert captured_url == "https://api.different-host.com/v1/resources"
+
+    async def test_multiple_hosts_raises_error_for_non_url_endpoint(self) -> None:
+        """Test that non-URL endpoints raise an error in multiple_hosts mode"""
+        client = HttpServerClient(
+            base_url="",
+            auth_type="none",
+            auth_config={},
+            pagination_config={"pagination_type": "none"},
+            multiple_hosts=True,
+        )
+
+        with pytest.raises(ValueError, match="kind must be a full URL"):
+            await client.fetch_paginated_data(endpoint="/api/v1/users").__anext__()
+
+    async def test_multiple_hosts_raises_error_for_relative_path(self) -> None:
+        """Test that relative paths raise an error in multiple_hosts mode"""
+        client = HttpServerClient(
+            base_url="",
+            auth_type="none",
+            auth_config={},
+            pagination_config={"pagination_type": "none"},
+            multiple_hosts=True,
+        )
+
+        with pytest.raises(ValueError, match="kind must be a full URL"):
+            await client.fetch_paginated_data(endpoint="api/v1/users").__anext__()
+
+    async def test_default_mode_still_works_with_multiple_hosts_false(self) -> None:
+        """Test backward compatibility: default mode combines base_url + endpoint"""
+        client = HttpServerClient(
+            base_url="https://api.example.com",
+            auth_type="none",
+            auth_config={},
+            pagination_config={"pagination_type": "none"},
+            multiple_hosts=False,
+        )
+
+        captured_url: str | None = None
+
+        async def mock_make_request(
+            url: str, method: str, params: dict[str, Any], headers: dict[str, str]
+        ) -> AsyncMock:
+            nonlocal captured_url
+            captured_url = url
+            response = AsyncMock()
+            response.json = AsyncMock(return_value={"data": []})
+            response.raise_for_status = lambda: None
+            return response
+
+        with patch.object(client, "_make_request", mock_make_request):
+            async for _ in client.fetch_paginated_data(endpoint="/api/v1/users"):
+                break
+
+        assert captured_url == "https://api.example.com/api/v1/users"
+
+    async def test_default_mode_empty_base_url_raises_error(self) -> None:
+        """Test that empty base_url raises error in default mode"""
+        client = HttpServerClient(
+            base_url="",
+            auth_type="none",
+            auth_config={},
+            pagination_config={"pagination_type": "none"},
+            multiple_hosts=False,
+        )
+
+        with pytest.raises(
+            ValueError, match="base_url cannot be empty when multiple_hosts is disabled"
+        ):
+            await client.fetch_paginated_data(endpoint="/users").__anext__()
+
+    async def test_multiple_hosts_with_query_params(self) -> None:
+        """Test that query params work correctly in multiple_hosts mode"""
+        client = HttpServerClient(
+            base_url="",
+            auth_type="none",
+            auth_config={},
+            pagination_config={"pagination_type": "none"},
+            multiple_hosts=True,
+        )
+
+        captured_url: str | None = None
+        captured_params: dict[str, Any] | None = None
+
+        async def mock_make_request(
+            url: str, method: str, params: dict[str, Any], headers: dict[str, str]
+        ) -> AsyncMock:
+            nonlocal captured_url, captured_params
+            captured_url = url
+            captured_params = params
+            response = AsyncMock()
+            response.json = AsyncMock(return_value={"data": []})
+            response.raise_for_status = lambda: None
+            return response
+
+        with patch.object(client, "_make_request", mock_make_request):
+            async for _ in client.fetch_paginated_data(
+                endpoint="https://api.example.com/users",
+                query_params={"limit": 100, "offset": 0},
+            ):
+                break
+
+        assert captured_url == "https://api.example.com/users"
+        assert captured_params == {"limit": 100, "offset": 0}
+
+    async def test_multiple_hosts_with_custom_headers(self) -> None:
+        """Test that custom headers work correctly in multiple_hosts mode"""
+        client = HttpServerClient(
+            base_url="",
+            auth_type="none",
+            auth_config={},
+            pagination_config={"pagination_type": "none"},
+            multiple_hosts=True,
+            custom_headers={"X-Custom-Header": "test-value"},
+        )
+
+        captured_headers: dict[str, str] | None = None
+
+        async def mock_make_request(
+            url: str, method: str, params: dict[str, Any], headers: dict[str, str]
+        ) -> AsyncMock:
+            nonlocal captured_headers
+            merged_headers = {**client.custom_headers, **headers}
+            captured_headers = merged_headers
+            response = AsyncMock()
+            response.json = AsyncMock(return_value={"data": []})
+            response.raise_for_status = lambda: None
+            return response
+
+        with patch.object(client, "_make_request", mock_make_request):
+            async for _ in client.fetch_paginated_data(
+                endpoint="https://api.example.com/users"
+            ):
+                break
+
+        assert captured_headers is not None
+        assert captured_headers["X-Custom-Header"] == "test-value"


### PR DESCRIPTION
### **User description**
# Description

What - Adding support for "Multiple Hosts" mode of the integration.

Why - Currently, the integration builds the URL for the API requests by a concatenation of the base URL and the kind endpoint. For organizations with multiple internal tools that all follow the same schema, this requires an integration per service. This PR solves this issue by allowing users to pass full URL in the kind name

How - Adding a new parameter to the integration which defines how the URL of the endpoint should be resolved, along with validations to ensure the URL is correct, and tests.

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.


___

### **PR Type**
Enhancement


___

### **Description**
- Add `multiple_hosts` mode to support full URLs in kind parameter

- Allow `baseUrl` to be optional when `multipleHosts` is enabled

- Implement URL validation for multiple hosts mode with proper error handling

- Add comprehensive test coverage for both single and multiple hosts modes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Client Initialization"] --> B{multiple_hosts enabled?}
  B -->|Yes| C["Use endpoint as full URL"]
  B -->|No| D["Combine baseUrl + endpoint"]
  C --> E["Validate URL format"]
  D --> F["Validate baseUrl and endpoint"]
  E --> G["Fetch data"]
  F --> G
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>client.py</strong><dd><code>Implement multiple hosts URL resolution logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/custom/http_server/client.py

<ul><li>Add <code>multiple_hosts</code> boolean parameter to client initialization<br> <li> Implement conditional URL construction logic based on <code>multiple_hosts</code> <br>flag<br> <li> Add validation for full URLs in multiple hosts mode (http:// or <br>https://)<br> <li> Add validation for baseUrl and endpoint in default mode<br> <li> Allow empty <code>base_url</code> when multiple hosts mode is enabled</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2714/files#diff-2b82e0d6b02d32f4e41a6b3fff5bf55aae7911b7da426a8e675d1a54e3820766">+24/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>initialize_client.py</strong><dd><code>Wire multiple hosts config to client initialization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/custom/initialize_client.py

<ul><li>Pass <code>multiple_hosts</code> configuration from integration config to client<br> <li> Change <code>base_url</code> from required to optional using <code>.get()</code> method<br> <li> Default <code>multiple_hosts</code> to <code>False</code> for backward compatibility</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2714/files#diff-511fea9e90c6ad3de90c59bf89f6c47ce21158b3cb915d212f5d9e2b1a58bd47">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_client.py</strong><dd><code>Add comprehensive multiple hosts mode test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/custom/tests/test_client.py

<ul><li>Add <code>TestMultipleHostsMode</code> test class with 11 comprehensive test cases<br> <li> Test client initialization with multiple hosts enabled and disabled<br> <li> Test full URL usage as endpoint in multiple hosts mode<br> <li> Test validation errors for non-URL endpoints in multiple hosts mode<br> <li> Test backward compatibility with default mode URL construction<br> <li> Test query parameters and custom headers in multiple hosts mode</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2714/files#diff-f2344e94ef1e598d1e915f5cd1c98058bb96f0913dfd84177011ad675f6c680f">+253/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>spec.yaml</strong><dd><code>Update spec with multipleHosts configuration and dependencies</code></dd></summary>
<hr>

integrations/custom/.port/spec.yaml

<ul><li>Change <code>baseUrl</code> from required to conditionally required based on <br><code>multipleHosts</code><br> <li> Add dependency configuration so <code>baseUrl</code> is required only when <br><code>multipleHosts</code> is false<br> <li> Add new <code>multipleHosts</code> boolean configuration option with default value <br>false<br> <li> Update <code>baseUrl</code> description to clarify it's required unless <br>multipleHosts is enabled<br> <li> Add <code>multipleHosts</code> to Advanced Configuration section in UI</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2714/files#diff-c428ac234d25ce406220e723ad1ff477fe4ccfedeae9670a3662a8af37b3779d">+14/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document multiple hosts feature in changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/custom/CHANGELOG.md

<ul><li>Add new version 0.2.52-beta entry documenting the multiple hosts <br>feature<br> <li> Document that <code>multipleHosts</code> enables fetching from multiple API hosts<br> <li> Clarify that <code>kind</code> contains full URL and <code>baseUrl</code> is ignored in this <br>mode</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2714/files#diff-fb2baecf0e2f18c4437d00a27df028ce92bcc3978262d29691fc1a2604b4f96a">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

