### PR TITLE
[Integration][GitHub] Allow Custom Port App Config File Names

### DIFF
--- a/integrations/github/CHANGELOG.md
+++ b/integrations/github/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 5.0.23 (2026-02-05)
+
+
+### Improvements
+
+- Added support for configuring the organization Port app config filename (supports `.yml`/`.yaml`) and updated the config-change webhook handler to trigger resync only when that specific file changes.
+
+
 ## 5.0.22 (2026-02-03)
 
 

--- a/integrations/github/integration.py
+++ b/integrations/github/integration.py
@@ -460,7 +460,9 @@ class GithubIntegration(BaseIntegration, GithubHandlerMixin):
                         "from the integration configuration."
                     )
                     raise EmptyPortAppConfigError()
-                return await load_org_port_app_config(github_org)
+                return await load_org_port_app_config(
+                    github_org, raw_config.get("configFileName")
+                )
 
             if raw_config:
                 logger.debug("Using Port integration config from API")

--- a/integrations/github/pyproject.toml
+++ b/integrations/github/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "github-ocean"
-version = "5.0.22"
+version = "5.0.23"
 description = "This integration ingest data from github"
 authors = ["Chukwuemeka Nwaoma <joelchukks@gmail.com>", "Melody Anyaegbulam <melodyogonna@gmail.com>", "Michael Armah <mikeyarmah@gmail.com>"]
 

--- a/integrations/github/tests/github/helpers/test_port_app_config.py
+++ b/integrations/github/tests/github/helpers/test_port_app_config.py
@@ -1,0 +1,45 @@
+import pytest
+
+from github.helpers.port_app_config import ORG_CONFIG_FILE, validate_config_file_name
+
+
+class TestValidateConfigFileName:
+    def test_defaults_to_port_app_config_yml_when_not_provided(self) -> None:
+        assert validate_config_file_name(None) == f"{ORG_CONFIG_FILE}.yml"
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            f"{ORG_CONFIG_FILE}.yml",
+            f"{ORG_CONFIG_FILE}.yaml",
+            f"{ORG_CONFIG_FILE}-custom.yaml",
+        ],
+    )
+    def test_accepts_valid_yaml_names(self, name: str) -> None:
+        assert validate_config_file_name(name) == name
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "not-port-app-config.yml",
+            "foo.yaml",
+            "port.yml",
+        ],
+    )
+    def test_rejects_names_that_do_not_start_with_expected_prefix(
+        self, name: str
+    ) -> None:
+        with pytest.raises(ValueError, match="must start with"):
+            validate_config_file_name(name)
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            f"{ORG_CONFIG_FILE}.json",
+            f"{ORG_CONFIG_FILE}.txt",
+            ORG_CONFIG_FILE,  # no suffix
+        ],
+    )
+    def test_rejects_names_that_are_not_yaml(self, name: str) -> None:
+        with pytest.raises(ValueError, match="must end with"):
+            validate_config_file_name(name)

--- a/integrations/github/tests/github/webhook/webhook_processors/test_port_app_config_webhook_processor.py
+++ b/integrations/github/tests/github/webhook/webhook_processors/test_port_app_config_webhook_processor.py
@@ -126,11 +126,11 @@ class TestPortAppConfigWebhookProcessor:
         payload: EventPayload,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        # Arrange: mock diff to include ORG_CONFIG_FILE
+        # Arrange: mock diff to include the (default) config file name
         mock_exporter = AsyncMock()
         mock_exporter.fetch_commit_diff.return_value = {
             "files": [
-                {"filename": ORG_CONFIG_FILE, "status": "modified"},
+                {"filename": f"{ORG_CONFIG_FILE}.yml", "status": "modified"},
             ]
         }
 


### PR DESCRIPTION
### **User description**
# Description

What -
Added support for configuring the GitHub org Port app config filename (YAML) instead of being limited to the default port-app-config.yml.

Why -
- Enables orgs to use custom naming conventions while keeping the same repo-managed mapping flow.
- Avoids triggering full resyncs for unrelated file changes in the org config repository.

How -
- Introduced validate_config_file_name(...) to validate/normalize the configured filename (must start with port-app-config and end with .yml/.yaml, defaulting to port-app-config.yml).
- Passed configFileName from integration config into load_org_port_app_config(...).
- Updated the config-change webhook processor to only trigger a resync when the configured config file is part of the commit diff.

## Type of change

Please leave one option from the following and delete the rest:

- [x] New feature (non-breaking change which adds functionality)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [x] Integration able to create all default resources from scratch
- [x] Resync finishes successfully
- [x] Resync able to create entities
- [x] Resync able to update entities
- [x] Resync able to detect and delete entities
- [x] Scheduled resync able to abort existing resync and start a new one
- [x] Tested with at least 2 integrations from scratch
- [x] Tested with Kafka and Polling event listeners
- [x] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.


___

### **PR Type**
Enhancement


___

### **Description**
- Added support for custom GitHub org config filenames with validation

- Updated webhook processor to detect changes only for configured file

- Implemented validate_config_file_name() for filename normalization

- Added comprehensive tests for config filename validation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Integration Config"] -->|configFileName| B["validate_config_file_name()"]
  B -->|validated filename| C["load_org_port_app_config()"]
  C -->|fetch config| D["GitHub Org Repo"]
  E["Webhook Event"] -->|commit diff| F["Webhook Processor"]
  F -->|check filename| G["Resync Trigger"]
  B -->|validation rules| H["Must start with port-app-config<br/>Must end with .yml/.yaml"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>port_app_config.py</strong><dd><code>Add config filename validation and customization support</code>&nbsp; </dd></summary>
<hr>

integrations/github/github/helpers/port_app_config.py

<ul><li>Added <code>validate_config_file_name()</code> function to validate and normalize <br>config filenames<br> <li> Updated <code>load_org_port_app_config()</code> to accept optional <code>config_file_name</code> <br>parameter<br> <li> Changed <code>ORG_CONFIG_FILE</code> constant from full filename to base name<br> <li> Added <code>YAML_FILE_SUFFIX</code> constant for supported file extensions<br> <li> Updated all logging and file path references to use dynamic filename</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2745/files#diff-8750d3bbe59035bfbb9dc43a7173dbc4b71f21d518b433e2a60993b4532c8fc8">+36/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>port_app_config_webhook_processor.py</strong><dd><code>Update webhook processor for custom config filenames</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/github/github/webhook/webhook_processors/port_app_config_webhook_processor.py

<ul><li>Imported <code>validate_config_file_name()</code> helper function<br> <li> Updated webhook processor to validate configured filename from <br>integration config<br> <li> Changed file detection logic to check for configured filename instead <br>of hardcoded constant<br> <li> Added additional validation check to ensure configured file is in <br>changed paths<br> <li> Improved logging to include configured filename in debug output</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2745/files#diff-8c3fcaf3422402684a08b84f9b4472e0d2876ad0c211f7733841684180dcabb1">+25/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>integration.py</strong><dd><code>Pass custom config filename to loader function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/github/integration.py

<ul><li>Updated <code>_get_port_app_config()</code> to pass <code>configFileName</code> from integration <br>config<br> <li> Modified call to <code>load_org_port_app_config()</code> to include custom filename <br>parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2745/files#diff-352618668ce736511a5de564f4e299286cc93f0445a9f0300368ba6c93452eef">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_port_app_config.py</strong><dd><code>Add validation tests for config filenames</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/github/tests/github/helpers/test_port_app_config.py

<ul><li>Added new test class <code>TestValidateConfigFileName</code> with comprehensive <br>test coverage<br> <li> Tests default behavior when no filename provided<br> <li> Tests acceptance of valid YAML filenames with different suffixes<br> <li> Tests rejection of invalid prefixes and file extensions<br> <li> Uses parametrized tests for multiple scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2745/files#diff-b45a885433becc078f869e1ec351ca1068df47de9e8f5a5697ded54d178c705f">+45/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_port_app_config_webhook_processor.py</strong><dd><code>Update webhook processor test for new filename format</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/github/tests/github/webhook/webhook_processors/test_port_app_config_webhook_processor.py

<ul><li>Updated test to use full filename with <code>.yml</code> extension instead of base <br>name<br> <li> Adjusted mock data to reflect new filename format in webhook processor</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2745/files#diff-2cbd7298711ad2783eadf39ec9242b297135749f57ae702f18f8928a0e346279">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document custom config filename feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/github/CHANGELOG.md

<ul><li>Added release notes for version 5.0.23<br> <li> Documented new feature for custom config filename support<br> <li> Listed improvements section with feature description</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2745/files#diff-092e2c8d25f45c5b95e709fe6ab651954f49369b5616cafe9dfbdb2ec0819147">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Update version number</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/github/pyproject.toml

- Bumped version from 5.0.22 to 5.0.23


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2745/files#diff-d1a301fa45068b9aa15404141d1303141fb46e768af1e5a05513f414faca0299">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

