### PR TITLE
[Integration][GitHub] Handle Transient 500s When Fetching Repository Teams

### DIFF
--- a/integrations/github/CHANGELOG.md
+++ b/integrations/github/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- Treat transient GitHub 500 errors when fetching repository teams as an empty teams list (and log the GitHub request id for correlation).
+- Retry transient GitHub 500 errors across GitHub API requests, and include the GitHub request id in error logs for correlation.
 
 
 ## 5.0.24 (2026-02-05)

--- a/integrations/github/github/clients/auth/abstract_authenticator.py
+++ b/integrations/github/github/clients/auth/abstract_authenticator.py
@@ -1,3 +1,4 @@
+from http import HTTPStatus
 from typing import Any, Dict, Optional
 from datetime import datetime, timezone, timedelta
 from abc import ABC, abstractmethod
@@ -63,6 +64,7 @@ class AbstractGitHubAuthenticator(ABC):
                     "Retry-After",
                     "X-RateLimit-Reset",
                 ],
+                additional_retry_status_codes=[HTTPStatus.INTERNAL_SERVER_ERROR],
                 max_backoff_wait=GITHUB_RETRY_MAX_BACKOFF,
             )
             self._http_client = OceanAsyncClient(

--- a/integrations/github/github/clients/http/base_client.py
+++ b/integrations/github/github/clients/http/base_client.py
@@ -120,9 +120,12 @@ class AbstractGithubClient(ABC):
                     ):
                         return Response(200, content=b"{}")
 
+                github_request_id = response.headers.get(
+                    "x-github-request-id", "unknown"
+                )
                 logger.error(
                     f"GitHub API error for endpoint '{resource}': Status {response.status_code}, "
-                    f"Method: {method}, Response: {response.text}"
+                    f"Method: {method}, GitHub Request ID: {github_request_id}, Response: {response.text}"
                 )
 
                 raise


### PR DESCRIPTION
### **User description**
# Description

What -
- Configure the GitHub integration HTTP client to retry on GitHub 500 responses.
- Include x-github-request-id in GitHub API error logs for easier correlation/debugging.

Why -
- GitHub can intermittently respond with 500 (sometimes with an empty body), which makes failures hard to diagnose and can break sync runs unnecessarily.
- The GitHub request id is the most actionable correlation key when the response body is empty.

How -
- Extend RetryConfig in AbstractGitHubAuthenticator.client with additional_retry_status_codes=[500].
- Update base_client.py error logging to include x-github-request-id.
- Add a test in tests/github/clients/auth/test_gh_authenticator.py that stubs the transport to return 500 then 200 and asserts the request is attempted twice.

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [x] Integration able to create all default resources from scratch
- [x] Resync finishes successfully
- [x] Resync able to create entities
- [x] Resync able to update entities
- [x] Resync able to detect and delete entities
- [x] Scheduled resync able to abort existing resync and start a new one
- [x] Tested with at least 2 integrations from scratch
- [x] Tested with Kafka and Polling event listeners
- [x] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.


___

### **PR Type**
Bug fix


___

### **Description**
- Handle transient GitHub 500 errors when fetching repository teams

- Catch HTTPStatusError, log request ID for correlation, continue with empty teams

- Add comprehensive test coverage for 500 error handling scenario

- Bump integration version to 5.0.25


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Repository Enrichment"] -->|Fetch Teams| B["GitHub API /teams"]
  B -->|500 Error| C["Catch HTTPStatusError"]
  C -->|Log Request ID| D["Continue with Empty Teams"]
  C -->|Other Status| E["Re-raise Exception"]
  D --> F["Complete Enrichment"]
  E --> G["Fail Batch"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>repository_exporter.py</strong><dd><code>Add 500 error handling for teams endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/github/github/core/exporters/repository_exporter.py

<ul><li>Import <code>httpx</code> module for exception handling<br> <li> Wrap teams pagination request in try-except block to catch <br>HTTPStatusError<br> <li> Only swallow 500 status code errors, re-raise other HTTP errors<br> <li> Extract and log GitHub request ID from response headers for <br>correlation<br> <li> Continue processing with empty teams list on transient 500 errors</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2748/files#diff-a78397614081ead248f876520e66b7beab791bb9d7b868766b7a87877f56b661">+25/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_repository_exporter.py</strong><dd><code>Add test for 500 error handling on teams endpoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/github/tests/github/core/exporters/test_repository_exporter.py

<ul><li>Add TEST_TEAMS constant with sample team data for test fixtures<br> <li> Add new test <br><code>test_get_paginated_resources_with_teams_500_does_not_fail_batch</code><br> <li> Mock HTTPStatusError with 500 status code and x-github-request-id <br>header<br> <li> Verify batch processing continues with empty teams list on 500 error<br> <li> Assert repositories are enriched with empty <code>__teams</code> field</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2748/files#diff-373a83b68b5b8586e0437cb79340234d24ad0c38cf3dcf21d9e1fa5cee0683cb">+56/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document version 5.0.25 release notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/github/CHANGELOG.md

<ul><li>Add version 5.0.25 release notes dated 2026-02-06<br> <li> Document bug fix for transient GitHub 500 errors on teams endpoint<br> <li> Note logging of GitHub request ID for correlation purposes</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2748/files#diff-092e2c8d25f45c5b95e709fe6ab651954f49369b5616cafe9dfbdb2ec0819147">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Bump integration version to 5.0.25</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/github/pyproject.toml

- Bump version from 5.0.24 to 5.0.25


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2748/files#diff-d1a301fa45068b9aa15404141d1303141fb46e768af1e5a05513f414faca0299">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

