### PR TITLE
[Integration] Improve CursorPagination handling for no hasMore API

### DIFF
--- a/integrations/custom/CHANGELOG.md
+++ b/integrations/custom/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.3.5-beta (2026-02-08)
+
+
+### Bug Fixes
+
+- Improved cursor pagination to work with APIs that don't have a `has_more` field. The handler now relies on empty/null cursor to stop pagination when no `has_more` field is present, while maintaining backward compatibility for APIs that do provide `has_more`, `hasMore`, or `meta.has_more` fields.
+
+
 ## 0.3.4-beta (2026-02-02)
 
 

--- a/integrations/custom/pyproject.toml
+++ b/integrations/custom/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "custom"
-version = "0.3.4-beta"
+version = "0.3.5-beta"
 description = "Ocean Custom Integration"
 authors = ["Port Team <support@getport.io>"]
 

--- a/integrations/custom/tests/test_handlers.py
+++ b/integrations/custom/tests/test_handlers.py
@@ -1,0 +1,330 @@
+"""Tests for pagination handlers, particularly cursor pagination."""
+
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from http_server.handlers import CursorPagination
+
+
+class TestCursorPaginationHasMore:
+    """Tests for cursor pagination has_more behavior."""
+
+    @pytest.fixture
+    def mock_client(self) -> AsyncMock:
+        return AsyncMock(spec=httpx.AsyncClient)
+
+    def _get_nested_value(self, data: Dict[str, Any], path: str) -> Any:
+        """Helper to get nested value from dict."""
+        keys = path.split(".")
+        for key in keys:
+            if isinstance(data, dict) and key in data:
+                data = data[key]
+            else:
+                return None
+        return data
+
+    def _create_handler(
+        self, responses: List[httpx.Response], config: Dict[str, Any]
+    ) -> CursorPagination:
+        """Helper to create a CursorPagination handler with mocked request function."""
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+
+        # Create a mock request function that returns responses in order
+        response_iter = iter(responses)
+
+        async def mock_make_request(
+            url: str,
+            method: str,
+            params: Dict[str, Any],
+            headers: Dict[str, str],
+            body: Any = None,
+        ) -> httpx.Response:
+            return next(response_iter)
+
+        return CursorPagination(
+            client=mock_client,
+            config=config,
+            extract_items_fn=lambda x: x if isinstance(x, list) else [x],
+            make_request_fn=mock_make_request,
+            get_nested_value_fn=self._get_nested_value,
+        )
+
+    @pytest.mark.asyncio
+    async def test_slack_style_pagination_empty_cursor_stops(self) -> None:
+        """Test that pagination stops when cursor is empty (Slack-style API)."""
+        # Slack returns empty string for next_cursor when no more pages
+        responses = [
+            httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "members": [{"id": "U1"}],
+                    "response_metadata": {"next_cursor": "cursor_page2"},
+                },
+            ),
+            httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "members": [{"id": "U2"}],
+                    "response_metadata": {"next_cursor": ""},  # Empty = no more pages
+                },
+            ),
+        ]
+
+        handler = self._create_handler(
+            responses,
+            {
+                "page_size": 100,
+                "cursor_path": "response_metadata.next_cursor",
+            },
+        )
+
+        results: List[Any] = []
+        async for batch in handler.fetch_all(
+            "https://api.slack.com/users.list", "GET", {}, {}
+        ):
+            results.extend(batch)
+
+        assert len(results) == 2
+
+    @pytest.mark.asyncio
+    async def test_slack_style_pagination_null_cursor_stops(self) -> None:
+        """Test that pagination stops when cursor is null/None."""
+        responses = [
+            httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "items": [{"id": "1"}],
+                    "response_metadata": {"next_cursor": "abc123"},
+                },
+            ),
+            httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "items": [{"id": "2"}],
+                    "response_metadata": {},  # No next_cursor key
+                },
+            ),
+        ]
+
+        handler = self._create_handler(
+            responses,
+            {
+                "page_size": 100,
+                "cursor_path": "response_metadata.next_cursor",
+            },
+        )
+
+        results: List[Any] = []
+        async for batch in handler.fetch_all(
+            "https://api.example.com/items", "GET", {}, {}
+        ):
+            results.extend(batch)
+
+        assert len(results) == 2
+
+    @pytest.mark.asyncio
+    async def test_explicit_has_more_false_stops(self) -> None:
+        """Test that explicit has_more=False stops pagination even with cursor."""
+        responses = [
+            httpx.Response(
+                200,
+                json={
+                    "data": [{"id": "1"}],
+                    "next_cursor": "page2",
+                    "has_more": True,
+                },
+            ),
+            httpx.Response(
+                200,
+                json={
+                    "data": [{"id": "2"}],
+                    "next_cursor": "page3",  # Cursor exists but...
+                    "has_more": False,  # ...has_more is explicitly False
+                },
+            ),
+        ]
+
+        handler = self._create_handler(responses, {"page_size": 100})
+
+        results: List[Any] = []
+        async for batch in handler.fetch_all(
+            "https://api.example.com/data", "GET", {}, {}
+        ):
+            results.extend(batch)
+
+        assert len(results) == 2
+
+    @pytest.mark.asyncio
+    async def test_has_more_path_configured_uses_it(self) -> None:
+        """Test that has_more_path is used when configured."""
+        responses = [
+            httpx.Response(
+                200,
+                json={
+                    "data": [{"id": "1"}],
+                    "next_cursor": "page2",
+                    "pagination": {"continue": True},
+                },
+            ),
+            httpx.Response(
+                200,
+                json={
+                    "data": [{"id": "2"}],
+                    "next_cursor": "page3",
+                    "pagination": {"continue": False},  # Should stop
+                },
+            ),
+        ]
+
+        handler = self._create_handler(
+            responses,
+            {
+                "page_size": 100,
+                "has_more_path": "pagination.continue",
+            },
+        )
+
+        results: List[Any] = []
+        async for batch in handler.fetch_all(
+            "https://api.example.com/data", "GET", {}, {}
+        ):
+            results.extend(batch)
+
+        assert len(results) == 2
+
+    @pytest.mark.asyncio
+    async def test_no_has_more_field_continues_until_empty_cursor(self) -> None:
+        """Test that without has_more field, pagination continues until cursor is empty."""
+        responses = [
+            httpx.Response(
+                200,
+                json={
+                    "data": [{"id": "1"}],
+                    "next_cursor": "page2",
+                    # No has_more field at all
+                },
+            ),
+            httpx.Response(
+                200,
+                json={
+                    "data": [{"id": "2"}],
+                    "next_cursor": "page3",
+                    # No has_more field at all
+                },
+            ),
+            httpx.Response(
+                200,
+                json={
+                    "data": [{"id": "3"}],
+                    "next_cursor": "",  # Empty cursor stops pagination
+                },
+            ),
+        ]
+
+        handler = self._create_handler(responses, {"page_size": 100})
+
+        results: List[Any] = []
+        async for batch in handler.fetch_all(
+            "https://api.example.com/data", "GET", {}, {}
+        ):
+            results.extend(batch)
+
+        assert len(results) == 3
+
+    @pytest.mark.asyncio
+    async def test_hasMore_camelCase_field_works(self) -> None:
+        """Test that hasMore (camelCase) field is recognized."""
+        responses = [
+            httpx.Response(
+                200,
+                json={
+                    "data": [{"id": "1"}],
+                    "next_cursor": "page2",
+                    "hasMore": True,
+                },
+            ),
+            httpx.Response(
+                200,
+                json={
+                    "data": [{"id": "2"}],
+                    "next_cursor": "page3",
+                    "hasMore": False,
+                },
+            ),
+        ]
+
+        handler = self._create_handler(responses, {"page_size": 100})
+
+        results: List[Any] = []
+        async for batch in handler.fetch_all(
+            "https://api.example.com/data", "GET", {}, {}
+        ):
+            results.extend(batch)
+
+        assert len(results) == 2
+
+    @pytest.mark.asyncio
+    async def test_meta_has_more_field_works(self) -> None:
+        """Test that meta.has_more field is recognized."""
+        responses = [
+            httpx.Response(
+                200,
+                json={
+                    "data": [{"id": "1"}],
+                    "next_cursor": "page2",
+                    "meta": {"has_more": True},
+                },
+            ),
+            httpx.Response(
+                200,
+                json={
+                    "data": [{"id": "2"}],
+                    "next_cursor": "page3",
+                    "meta": {"has_more": False},
+                },
+            ),
+        ]
+
+        handler = self._create_handler(responses, {"page_size": 100})
+
+        results: List[Any] = []
+        async for batch in handler.fetch_all(
+            "https://api.example.com/data", "GET", {}, {}
+        ):
+            results.extend(batch)
+
+        assert len(results) == 2
+
+    @pytest.mark.asyncio
+    async def test_backward_compatibility_requires_both_cursor_and_has_more(
+        self,
+    ) -> None:
+        """Test backward compatibility: when has_more is explicitly False, stop even with cursor."""
+        responses = [
+            httpx.Response(
+                200,
+                json={
+                    "items": [{"id": "1"}],
+                    "cursor": "next_page",
+                    "has_more": False,  # Explicitly False should stop
+                },
+            ),
+        ]
+
+        handler = self._create_handler(responses, {"page_size": 100})
+
+        results: List[Any] = []
+        async for batch in handler.fetch_all(
+            "https://api.example.com/items", "GET", {}, {}
+        ):
+            results.extend(batch)
+
+        # Should only have 1 result because has_more=False
+        assert len(results) == 1


### PR DESCRIPTION
### **User description**
# Description

What - Improve Cursor based pagination for API's which don't return the "hasMore" field.

Why - Some API's Don't return the hasMore pagination param, and instead rely on returning an empty string/null. This PR introduces support for that.

How - Update the CursorPagination handler to support this case, while retaining backward compatibility.

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Improved cursor pagination to handle APIs without `has_more` field
  - Now stops pagination when cursor is empty/null
  - Maintains backward compatibility with explicit `has_more` checks

- Added comprehensive test suite for pagination scenarios
  - Tests Slack-style empty cursor pagination
  - Tests explicit `has_more` field behavior
  - Tests custom `has_more_path` configuration

- Updated version to 0.3.5-beta with changelog entry


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["API Response"] --> B["Check Cursor"]
  B -->|Empty/Null| C["Stop Pagination"]
  B -->|Has Value| D["Check has_more Field"]
  D -->|Explicitly False| C
  D -->|True or Missing| E["Continue to Next Page"]
  F["Custom has_more_path"] --> D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>handlers.py</strong><dd><code>Refactor cursor pagination logic for empty cursor handling</code></dd></summary>
<hr>

integrations/custom/http_server/handlers.py

<ul><li>Refactored pagination logic to check empty cursor first and stop <br>immediately<br> <li> Changed <code>has_more</code> detection to use sentinel value (None) to distinguish <br>between missing field and False value<br> <li> Added support for custom <code>has_more_path</code> configuration with early exit<br> <li> Improved handling of APIs that rely on empty cursor instead of <br>explicit <code>has_more</code> field</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2750/files#diff-02dc3c095592539a02313c909d4101d589faf4ba1be99db18f8bae910329a40b">+20/-13</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_handlers.py</strong><dd><code>Add comprehensive cursor pagination test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/custom/tests/test_handlers.py

<ul><li>Added new test file with comprehensive cursor pagination test suite<br> <li> Tests cover Slack-style empty/null cursor pagination scenarios<br> <li> Tests verify explicit <code>has_more</code> field behavior and custom <code>has_more_path</code> <br>configuration<br> <li> Tests ensure backward compatibility with APIs providing <code>has_more</code>, <br><code>hasMore</code>, or <code>meta.has_more</code> fields</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2750/files#diff-a86ab082a154fd8727e4787cf73eb715235999390e1d1f443c35e8fdd27d58b8">+330/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Add changelog entry for version 0.3.5-beta</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/custom/CHANGELOG.md

<ul><li>Added version 0.3.5-beta release notes dated 2026-02-08<br> <li> Documented bug fix for cursor pagination with APIs lacking <code>has_more</code> <br>field<br> <li> Noted backward compatibility maintenance for existing <code>has_more</code> <br>implementations</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2750/files#diff-fb2baecf0e2f18c4437d00a27df028ce92bcc3978262d29691fc1a2604b4f96a">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Bump version to 0.3.5-beta</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/custom/pyproject.toml

- Updated version from 0.3.4-beta to 0.3.5-beta


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2750/files#diff-3ccbf74a6831bd381a6d5e8a40d5db2648ebdfb25a370e7aab4a5075440fcb18">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

