### PR TITLE
[Integration][Bitbucket-Server] Fixed the shared client mutation leading to auth error

### DIFF
--- a/integrations/bitbucket-server/CHANGELOG.md
+++ b/integrations/bitbucket-server/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.116-beta (2026-02-09)
+
+
+### Bug Fixes
+
+- Fixed authentication not persisting across resource kinds by passing auth per-request instead of mutating the shared HTTP client state
+
+
 ## 0.1.115-beta (2025-02-05)
 
 

--- a/integrations/bitbucket-server/pyproject.toml
+++ b/integrations/bitbucket-server/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "bitbucket-server"
 
-version = "0.1.115-beta"
+version = "0.1.116-beta"
 
 description = "Bitbucket Server integration for Port"
 authors = ["Ayodeji Adeoti <ayodeji.adeoti@getport.io>"]


### PR DESCRIPTION
### **User description**
# Description

What - Fixed 401 authentication failures during resync after the first resource kind completes.

Why - The BitbucketClient was setting auth and timeout directly on the LocalProxy-backed HTTP client causing all subsequent requests after reset to go out unauthenticated

How - Pass `auth=self.bitbucket_auth` per-request in `_send_api_request` instead of mutating the shared client's state in `__init__`

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed authentication failures by passing auth per-request instead of mutating shared HTTP client

- Removed direct mutation of client auth and timeout in `__init__`

- Increased default page size from 25 to 100 for better performance

- Removed `@cache_iterator_result()` decorator from `get_pull_requests` method


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Shared HTTP Client"] -->|"Previously: mutated in __init__"| B["Auth/Timeout Set Once"]
  B -->|"Issue: Lost after reset"| C["401 Auth Errors"]
  A -->|"Now: auth per-request"| D["Auth Passed in _send_api_request"]
  D -->|"Persists across requests"| E["Successful Authentication"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>client.py</strong><dd><code>Pass auth per-request instead of mutating client</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/bitbucket-server/client.py

<ul><li>Removed mutation of <code>self.client.auth</code> and <code>self.client.timeout</code> in <br><code>__init__</code> method<br> <li> Added <code>auth=self.bitbucket_auth</code> parameter to <code>self.client.request()</code> call <br>in <code>_send_api_request</code><br> <li> Updated default <code>page_size</code> parameter from 25 to 100 in docstring<br> <li> Removed <code>@cache_iterator_result()</code> decorator from <code>get_pull_requests</code> <br>method</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2753/files#diff-e5bff2e43c6a49a20c5f14ab0bbb1c87a7fb2a878a238e5e2356bfcb0fee8dba">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document authentication bug fix in changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/bitbucket-server/CHANGELOG.md

<ul><li>Added new version 0.1.116-beta release notes dated 2026-02-09<br> <li> Documented bug fix for authentication persistence across resource <br>kinds</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2753/files#diff-4087295f4308707050ddfc3032ce41ca71f72c21b2ef3f1e2272660434bf6b83">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Update version to 0.1.116-beta</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

integrations/bitbucket-server/pyproject.toml

- Bumped version from 0.1.115-beta to 0.1.116-beta


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2753/files#diff-50e4940d7c4cc5f1608b023f1319cac8f21899b01256984c6d6f8851fe2ec2a8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

