### PR TITLE
[Core] hide traceback from error message and move to extra_bind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.37.4 (2026-02-25)
+
+### Bug fixes
+
+- Fixed logger.exception() call in execution manager to properly capture exceptions without interfering with automatic exception capture
 
 ## 0.37.3 (2026-02-24)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.37.3"
+version = "0.37.4"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
### **User description**
- Introduced a patch to the logger.exception method to log only the error message in the main log, while storing the full traceback in the record's extra context. This change aims to reduce clutter in customer logs while retaining detailed error information for debugging purposes.
- Updated the setup_logger function to apply this patch as a hotfix.

This enhancement improves log readability and maintains essential debugging information without overwhelming the logs with tracebacks.

# Description

What -

Why -

How -

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.


___

### **PR Type**
Enhancement


___

### **Description**
- Patch logger.exception to hide traceback from main logs

- Store full traceback in record's extra context for debugging

- Reduce log clutter while maintaining detailed error information

- Apply patch automatically in setup_logger function


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["logger.exception called"] --> B["_patch_exception_logging"]
  B --> C["Extract traceback separately"]
  C --> D["Log message only to main log"]
  D --> E["Store traceback in extra context"]
  E --> F["Cleaner customer logs with debug info available"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>logger_setup.py</strong><dd><code>Patch logger.exception to separate traceback from main log</code></dd></summary>
<hr>

port_ocean/log/logger_setup.py

<ul><li>Added <code>traceback</code> module import for exception formatting<br> <li> Introduced <code>_patch_exception_logging()</code> function that patches <br><code>logger.exception</code> method<br> <li> Extracts full traceback and stores it in record's extra context <br>instead of main log<br> <li> Handles multiple exc_info formats: True, BaseException, and tuple <br>types<br> <li> Filters out NoneType exceptions to avoid unnecessary traceback entries<br> <li> Integrated patch call into <code>setup_logger()</code> function as a hotfix</ul>


</details>


  </td>
  <td><a href="https://github.com/port-labs/ocean/pull/2830/files#diff-114a3b03c16ae42272d8da3104d8409bc8b358734c23db36de4d308835b61bc5">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

