### PR TITLE
[Integration][SonarQube] Add qualityGateName to SonarQube project blueprint

### DIFF
--- a/integrations/sonarqube/.port/resources/blueprints.json
+++ b/integrations/sonarqube/.port/resources/blueprints.json
@@ -78,6 +78,10 @@
         "managed": {
           "type": "boolean",
           "title": "Managed"
+        },
+        "qualityGateName": {
+          "type": "string",
+          "title": "Quality Gate Name"
         }
       },
       "required": []

--- a/integrations/sonarqube/.port/resources/port-app-config.yaml
+++ b/integrations/sonarqube/.port/resources/port-app-config.yaml
@@ -38,6 +38,7 @@ resources:
             mainBranchLastAnalysisDate: (.__branch.analysisDate // null) | if . then sub("(?<h>[+-]\\d{2})(?<m>\\d{2})$"; "\(.h):\(.m)") else null end
             revision: .revision
             managed: .managed
+            qualityGateName: .__qualityGateName
   - kind: analysis
     selector:
       query: 'true'

--- a/integrations/sonarqube/client.py
+++ b/integrations/sonarqube/client.py
@@ -298,7 +298,7 @@ class SonarQubeClient:
         :param project_key: A string containing the project key.
         :return: The name of the quality gate assigned to the project, or None.
         """
-        logger.info(f"Fetching quality gate for project: {project_key}")
+        logger.debug(f"Fetching quality gate for project: {project_key}")
         try:
             response = await self._send_api_request(
                 endpoint=Endpoints.QUALITY_GATE_PROJECT,

--- a/integrations/sonarqube/client.py
+++ b/integrations/sonarqube/client.py
@@ -299,11 +299,23 @@ class SonarQubeClient:
         :return: The name of the quality gate assigned to the project, or None.
         """
         logger.info(f"Fetching quality gate for project: {project_key}")
-        response = await self._send_api_request(
-            endpoint=Endpoints.QUALITY_GATE_PROJECT,
-            query_params={"project": project_key},
-        )
-        return response.get("qualityGate", {}).get("name")
+        try:
+            response = await self._send_api_request(
+                endpoint=Endpoints.QUALITY_GATE_PROJECT,
+                query_params={"project": project_key},
+            )
+            return response.get("qualityGate", {}).get("name")
+        except httpx.HTTPStatusError as e:
+            logger.warning(
+                f"Failed to fetch quality gate for project {project_key}: "
+                f"HTTP {e.response.status_code}. Skipping."
+            )
+            return None
+        except httpx.HTTPError as e:
+            logger.warning(
+                f"Failed to fetch quality gate for project {project_key}: {e}. Skipping."
+            )
+            return None
 
     async def get_single_project(self, project: dict[str, Any]) -> dict[str, Any]:
         """

--- a/integrations/sonarqube/examples/blueprints.json
+++ b/integrations/sonarqube/examples/blueprints.json
@@ -78,6 +78,10 @@
         "managed": {
           "type": "boolean",
           "title": "Managed"
+        },
+        "qualityGateName": {
+          "type": "string",
+          "title": "Quality Gate Name"
         }
       },
       "required": []
@@ -203,6 +207,10 @@
         "tags": {
           "type": "array",
           "title": "Tags"
+        },
+        "qualityGateName": {
+          "type": "string",
+          "title": "Quality Gate Name"
         }
       },
       "required": []

--- a/integrations/sonarqube/examples/mappings.yaml
+++ b/integrations/sonarqube/examples/mappings.yaml
@@ -35,6 +35,7 @@ resources:
             mainBranchLastAnalysisDate: .__branch.analysisDate
             revision: .revision
             managed: .managed
+            qualityGateName: .__qualityGateName
   - kind: projects
     selector:
       query: 'true'
@@ -70,6 +71,7 @@ resources:
             coverage: .__measures[]? | select(.metric == "coverage") | .value
             mainBranch: .__branch.name
             tags: .tags
+            qualityGateName: .__qualityGateName
   - kind: analysis
     selector:
       query: 'true'

--- a/integrations/sonarqube/examples/project.entity.json
+++ b/integrations/sonarqube/examples/project.entity.json
@@ -12,7 +12,8 @@
         "numberOfHotSpots": 3,
         "numberOfDuplications": 18,
         "coverage": 0,
-        "mainBranch": "main"
+        "mainBranch": "main",
+        "qualityGateName": "Sonar way"
     },
     "relations": {},
     "icon": "sonarqube"

--- a/integrations/sonarqube/tests/test_client.py
+++ b/integrations/sonarqube/tests/test_client.py
@@ -451,6 +451,32 @@ async def test_get_branches_is_called_with_correct_params(
     )
 
 
+async def test_get_quality_gate_for_project_is_called_with_correct_params(
+    mock_ocean_context: Any,
+    monkeypatch: Any,
+) -> None:
+    sonarqube_client = SonarQubeClient(
+        "https://sonarqube.com",
+        "token",
+        "organization_id",
+        "app_host",
+        False,
+    )
+    mock_send_api_request = AsyncMock()
+    mock_send_api_request.return_value = {
+        "qualityGate": {"name": "Sonar way", "id": "1", "default": True}
+    }
+    monkeypatch.setattr(sonarqube_client, "_send_api_request", mock_send_api_request)
+
+    result = await sonarqube_client.get_quality_gate_for_project(PURE_PROJECTS[0]["key"])
+
+    mock_send_api_request.assert_awaited_once_with(
+        endpoint="qualitygates/get_by_project",
+        query_params={"project": PURE_PROJECTS[0]["key"]},
+    )
+    assert result == "Sonar way"
+
+
 async def test_get_single_project_is_called_with_correct_params(
     mock_ocean_context: Any,
     monkeypatch: Any,
@@ -467,16 +493,21 @@ async def test_get_single_project_is_called_with_correct_params(
     mock_get_measures.return_value = {}
     mock_get_branches = AsyncMock()
     mock_get_branches.return_value = [{"isMain": True}]
+    mock_get_quality_gate = AsyncMock()
+    mock_get_quality_gate.return_value = "Sonar way"
 
     sonarqube_client.http_client = MockHttpxClient([])  # type: ignore
     monkeypatch.setattr(sonarqube_client, "get_measures", mock_get_measures)
     monkeypatch.setattr(sonarqube_client, "get_branches", mock_get_branches)
+    monkeypatch.setattr(
+        sonarqube_client, "get_quality_gate_for_project", mock_get_quality_gate
+    )
 
     await sonarqube_client.get_single_project(PURE_PROJECTS[0])
 
     mock_get_measures.assert_any_call(PURE_PROJECTS[0]["key"])
-
     mock_get_branches.assert_any_call(PURE_PROJECTS[0]["key"])
+    mock_get_quality_gate.assert_any_call(PURE_PROJECTS[0]["key"])
 
 
 async def test_projects_will_return_correct_data(

--- a/integrations/sonarqube/tests/test_client.py
+++ b/integrations/sonarqube/tests/test_client.py
@@ -477,6 +477,38 @@ async def test_get_quality_gate_for_project_is_called_with_correct_params(
     assert result == "Sonar way"
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "side_effect",
+    [
+        httpx.HTTPStatusError(
+            "Server error",
+            request=httpx.Request("GET", "https://sonarqube.com"),
+            response=httpx.Response(500, request=httpx.Request("GET", "https://sonarqube.com")),
+        ),
+        httpx.TimeoutException("Request timed out"),
+    ],
+)
+async def test_get_quality_gate_for_project_returns_none_on_error(
+    mock_ocean_context: Any,
+    monkeypatch: Any,
+    side_effect: Exception,
+) -> None:
+    sonarqube_client = SonarQubeClient(
+        "https://sonarqube.com",
+        "token",
+        "organization_id",
+        "app_host",
+        False,
+    )
+    mock_send_api_request = AsyncMock(side_effect=side_effect)
+    monkeypatch.setattr(sonarqube_client, "_send_api_request", mock_send_api_request)
+
+    result = await sonarqube_client.get_quality_gate_for_project(PURE_PROJECTS[0]["key"])
+
+    assert result is None
+
+
 async def test_get_single_project_is_called_with_correct_params(
     mock_ocean_context: Any,
     monkeypatch: Any,


### PR DESCRIPTION
# Description

**What**
Add qualityGateName to SonarQube project blueprint

**Why**
Closes  https://github.com/port-labs/ocean/issues/2843

**How**
Fetch the quality gate name assigned to each project via the qualitygates/get_by_project endpoint and expose it as the qualityGateName property on the sonarQubeProject blueprint.

Allows users to filter and group Port entities by which quality gate policy governs each project.

## Type of change

Please leave one option from the following and delete the rest:

- [X] Non-breaking change (fix of existing functionality that will not change current behavior)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

Tested locally from CLI using user token generated from on-premise SonarQube instance and using same API calls tools will be making
<img width="791" height="133" alt="image (2)" src="https://github.com/user-attachments/assets/314047ec-33ba-4aec-982d-947e88b8157f" />

## API Documentation

Provide links to the API documentation used for this integration.

⚠️ not sure who and when needs to update https://docs.port.io/build-your-software-catalog/sync-data-to-catalog/code-quality-security/sonarqube/ docs to include new parameter
