### PR TITLE
[Integration][GitHub] Pass auth headers to is_personal_org to prevent 403 for GHE

### DIFF
--- a/integrations/github/CHANGELOG.md
+++ b/integrations/github/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-- Fixed `is_personal_org` to forward authentication headers, preventing unauthenticated calls to GHE.
+- Fixed `_fetch_installation_id` to try the org endpoint first and fall back to the user endpoint on 404, avoiding a `GET /users/{username}` call that cannot be authenticated with a JWT during bootstrapping.
 
 
 ## 5.1.11 (2026-03-02)

--- a/integrations/github/CHANGELOG.md
+++ b/integrations/github/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 5.1.12 (2026-03-02)
+
+
+### Bug Fixes
+
+- Fixed `is_personal_org` to forward authentication headers, preventing unauthenticated calls to GHE.
+
+
 ## 5.1.11 (2026-03-02)
 
 

--- a/integrations/github/github/clients/auth/abstract_authenticator.py
+++ b/integrations/github/github/clients/auth/abstract_authenticator.py
@@ -9,7 +9,6 @@ from dateutil.parser import parse
 from port_ocean.context.ocean import ocean
 from port_ocean.helpers.retry import RetryConfig
 from port_ocean.helpers.async_client import OceanAsyncClient
-from port_ocean.utils.cache import cache_coroutine_result
 from loguru import logger
 
 import httpx
@@ -104,11 +103,15 @@ class AbstractGitHubAuthenticator(ABC):
             self._http_client = self._make_client()
         return self._http_client
 
-    @cache_coroutine_result()
-    async def is_personal_org(self, github_host: str, organization: str) -> bool:
+    async def is_personal_org(
+        self,
+        github_host: str,
+        organization: str,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> bool:
         try:
             url = f"{github_host}/users/{organization}"
-            response = await self.client.get(url)
+            response = await self.client.get(url, headers=headers)
             response.raise_for_status()
             user_data = response.json()
             return user_data["type"] == "User"

--- a/integrations/github/github/clients/auth/github_app_authenticator.py
+++ b/integrations/github/github/clients/auth/github_app_authenticator.py
@@ -3,6 +3,7 @@ import base64
 from typing import Any, Optional
 from loguru import logger
 from datetime import datetime, timedelta, timezone
+from httpx import HTTPStatusError
 import jwt
 from github.clients.auth.abstract_authenticator import (
     AbstractGitHubAuthenticator,
@@ -63,14 +64,24 @@ class GitHubAppAuthenticator(AbstractGitHubAuthenticator):
         )
 
     async def _fetch_installation_id(self, jwt_token: str) -> str:
+        # Try the org endpoint first; on 404 fall back to the user endpoint.
+        # Both /orgs/ and /users/ installation endpoints accept JWT auth,
+        # so we don't need an installation token for this lookup.
+        jwt_headers = {"Authorization": f"Bearer {jwt_token}"}
+        org_url = f"{self.github_host}/orgs/{self.organization}/installation"
         try:
-            url = f"{self.github_host}/orgs/{self.organization}/installation"
-            jwt_headers = {"Authorization": f"Bearer {jwt_token}"}
-            if await self.is_personal_org(
-                self.github_host, self.organization, headers=jwt_headers
-            ):
-                url = f"{self.github_host}/users/{self.organization}/installation"
-            response = await self.client.get(url, headers=jwt_headers)
+            response = await self.client.get(org_url, headers=jwt_headers)
+            response.raise_for_status()
+            return str(response.json()["id"])
+        except HTTPStatusError as e:
+            if e.response.status_code != 404:
+                raise AuthenticationException(
+                    f"Failed to fetch installation ID: {e}"
+                ) from e
+        # 404 on /orgs/ — likely a personal account
+        user_url = f"{self.github_host}/users/{self.organization}/installation"
+        try:
+            response = await self.client.get(user_url, headers=jwt_headers)
             response.raise_for_status()
             return str(response.json()["id"])
         except Exception as e:

--- a/integrations/github/github/clients/auth/github_app_authenticator.py
+++ b/integrations/github/github/clients/auth/github_app_authenticator.py
@@ -65,10 +65,12 @@ class GitHubAppAuthenticator(AbstractGitHubAuthenticator):
     async def _fetch_installation_id(self, jwt_token: str) -> str:
         try:
             url = f"{self.github_host}/orgs/{self.organization}/installation"
-            if await self.is_personal_org(self.github_host, self.organization):
+            jwt_headers = {"Authorization": f"Bearer {jwt_token}"}
+            if await self.is_personal_org(
+                self.github_host, self.organization, headers=jwt_headers
+            ):
                 url = f"{self.github_host}/users/{self.organization}/installation"
-            headers = {"Authorization": f"Bearer {jwt_token}"}
-            response = await self.client.get(url, headers=headers)
+            response = await self.client.get(url, headers=jwt_headers)
             response.raise_for_status()
             return str(response.json()["id"])
         except Exception as e:

--- a/integrations/github/github/webhook/clients/client_factory.py
+++ b/integrations/github/github/webhook/clients/client_factory.py
@@ -16,8 +16,9 @@ class GithubWebhookClientFactory:
         webhook_secret: str | None,
     ) -> BaseGithubWebhookClient:
         config = integration_config(authenticator)
+        auth_headers = (await authenticator.get_headers()).as_dict()
         is_personal_org = await authenticator.is_personal_org(
-            config["github_host"], organization
+            config["github_host"], organization, headers=auth_headers
         )
 
         client_cls = (

--- a/integrations/github/github/webhook/clients/client_factory.py
+++ b/integrations/github/github/webhook/clients/client_factory.py
@@ -16,6 +16,7 @@ class GithubWebhookClientFactory:
         webhook_secret: str | None,
     ) -> BaseGithubWebhookClient:
         config = integration_config(authenticator)
+        # Explicit headers required: GHE may reject unauthenticated GET /users/{org}
         auth_headers = (await authenticator.get_headers()).as_dict()
         is_personal_org = await authenticator.is_personal_org(
             config["github_host"], organization, headers=auth_headers

--- a/integrations/github/pyproject.toml
+++ b/integrations/github/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "github-ocean"
-version = "5.1.11"
+version = "5.1.12"
 description = "This integration ingest data from github"
 authors = ["Chukwuemeka Nwaoma <joelchukks@gmail.com>", "Melody Anyaegbulam <melodyogonna@gmail.com>", "Michael Armah <mikeyarmah@gmail.com>"]
 

--- a/integrations/github/tests/github/clients/auth/test_gh_authenticator.py
+++ b/integrations/github/tests/github/clients/auth/test_gh_authenticator.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+from typing import Any
 import pytest
 import httpx
 from unittest.mock import AsyncMock, Mock, patch, PropertyMock
@@ -194,11 +195,16 @@ class TestGithubAuthenticator:
         ):
             installation_id = await github_auth._fetch_installation_id(mock_jwt_token)
 
-            mock_is_personal.assert_called_once()
+            jwt_headers = {"Authorization": f"Bearer {mock_jwt_token}"}
+            mock_is_personal.assert_called_once_with(
+                github_auth.github_host,
+                github_auth.organization,
+                headers=jwt_headers,
+            )
 
             expected_url = f"{github_auth.github_host}/orgs/{github_auth.organization}/installation"
             mock_client.get.assert_called_once_with(
-                expected_url, headers={"Authorization": f"Bearer {mock_jwt_token}"}
+                expected_url, headers=jwt_headers,
             )
 
             assert installation_id == mock_installation_id
@@ -230,14 +236,147 @@ class TestGithubAuthenticator:
         ):
             installation_id = await github_auth._fetch_installation_id(mock_jwt_token)
 
-            mock_is_personal.assert_called_once()
+            jwt_headers = {"Authorization": f"Bearer {mock_jwt_token}"}
+            mock_is_personal.assert_called_once_with(
+                github_auth.github_host,
+                github_auth.organization,
+                headers=jwt_headers,
+            )
 
             expected_url = f"{github_auth.github_host}/users/{github_auth.organization}/installation"
             mock_client.get.assert_called_once_with(
-                expected_url, headers={"Authorization": f"Bearer {mock_jwt_token}"}
+                expected_url, headers=jwt_headers,
             )
 
             assert installation_id == mock_installation_id
+
+    async def test_is_personal_org_sends_auth_headers(
+        self, github_auth: GitHubAppAuthenticator
+    ) -> None:
+        """Verify is_personal_org forwards auth headers to the HTTP request."""
+        mock_client = AsyncMock()
+        mock_response = Mock()
+        mock_response.json = Mock(return_value={"type": "Organization"})
+        mock_response.raise_for_status = Mock()
+        mock_client.get.return_value = mock_response
+
+        headers = {"Authorization": "Bearer test-jwt"}
+
+        with patch.object(
+            type(github_auth),
+            "client",
+            new_callable=PropertyMock,
+            return_value=mock_client,
+        ):
+            result = await github_auth.is_personal_org(
+                "https://api.ghe.example.com",
+                "MyOrg",
+                headers=headers,
+            )
+
+        assert result is False
+        mock_client.get.assert_called_once_with(
+            "https://api.ghe.example.com/users/MyOrg",
+            headers=headers,
+        )
+
+    async def test_is_personal_org_returns_true_for_user(
+        self, github_auth: GitHubAppAuthenticator
+    ) -> None:
+        """Verify is_personal_org returns True when GitHub reports type User."""
+        mock_client = AsyncMock()
+        mock_response = Mock()
+        mock_response.json = Mock(return_value={"type": "User"})
+        mock_response.raise_for_status = Mock()
+        mock_client.get.return_value = mock_response
+
+        with patch.object(
+            type(github_auth),
+            "client",
+            new_callable=PropertyMock,
+            return_value=mock_client,
+        ):
+            result = await github_auth.is_personal_org(
+                "https://api.github.com",
+                "my-user",
+                headers={"Authorization": "Bearer tok"},
+            )
+
+        assert result is True
+
+    async def test_is_personal_org_returns_false_on_error(
+        self, github_auth: GitHubAppAuthenticator
+    ) -> None:
+        """Verify is_personal_org returns False when the request fails."""
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = httpx.HTTPStatusError(
+            "forbidden", request=Mock(), response=Mock(status_code=403)
+        )
+
+        with patch.object(
+            type(github_auth),
+            "client",
+            new_callable=PropertyMock,
+            return_value=mock_client,
+        ):
+            result = await github_auth.is_personal_org(
+                "https://ghe.example.com", "Org",
+                headers={"Authorization": "Bearer tok"},
+            )
+
+        assert result is False
+
+    async def test_fetch_installation_id_passes_jwt_to_is_personal_org(
+        self,
+    ) -> None:
+        """End-to-end: _fetch_installation_id passes JWT headers through
+        to is_personal_org so the /users/{org} check is authenticated."""
+        auth = GitHubAppAuthenticator(
+            organization="DevopsZone",
+            github_host="https://api.atpco.ghe.com",
+            app_id="app-id",
+            private_key="test-key",
+        )
+
+        jwt_token = "test-jwt-token"
+
+        mock_client = AsyncMock()
+        user_response = Mock()
+        user_response.json = Mock(return_value={"type": "Organization"})
+        user_response.raise_for_status = Mock()
+
+        install_response = Mock()
+        install_response.json = Mock(return_value={"id": "99999"})
+        install_response.raise_for_status = Mock()
+
+        def route_get(url: str, **kwargs: Any) -> Mock:
+            if "/users/" in url:
+                return user_response
+            return install_response
+
+        mock_client.get = AsyncMock(side_effect=route_get)
+
+        with patch.object(
+            type(auth),
+            "client",
+            new_callable=PropertyMock,
+            return_value=mock_client,
+        ):
+            installation_id = await auth._fetch_installation_id(jwt_token)
+
+        assert installation_id == "99999"
+
+        jwt_headers = {"Authorization": f"Bearer {jwt_token}"}
+        calls = mock_client.get.call_args_list
+        assert len(calls) == 2
+
+        personal_org_call = calls[0]
+        assert personal_org_call.args[0] == "https://api.atpco.ghe.com/users/DevopsZone"
+        assert personal_org_call.kwargs["headers"] == jwt_headers
+
+        install_call = calls[1]
+        assert install_call.args[0] == "https://api.atpco.ghe.com/orgs/DevopsZone/installation"
+        assert install_call.kwargs["headers"] == jwt_headers
 
     async def test_client_returns_same_instance(
         self, github_auth: GitHubAppAuthenticator

--- a/integrations/github/tests/github/clients/auth/test_gh_authenticator.py
+++ b/integrations/github/tests/github/clients/auth/test_gh_authenticator.py
@@ -204,7 +204,8 @@ class TestGithubAuthenticator:
 
             expected_url = f"{github_auth.github_host}/orgs/{github_auth.organization}/installation"
             mock_client.get.assert_called_once_with(
-                expected_url, headers=jwt_headers,
+                expected_url,
+                headers=jwt_headers,
             )
 
             assert installation_id == mock_installation_id
@@ -245,7 +246,8 @@ class TestGithubAuthenticator:
 
             expected_url = f"{github_auth.github_host}/users/{github_auth.organization}/installation"
             mock_client.get.assert_called_once_with(
-                expected_url, headers=jwt_headers,
+                expected_url,
+                headers=jwt_headers,
             )
 
             assert installation_id == mock_installation_id
@@ -320,7 +322,8 @@ class TestGithubAuthenticator:
             return_value=mock_client,
         ):
             result = await github_auth.is_personal_org(
-                "https://ghe.example.com", "Org",
+                "https://ghe.example.com",
+                "Org",
                 headers={"Authorization": "Bearer tok"},
             )
 
@@ -375,7 +378,10 @@ class TestGithubAuthenticator:
         assert personal_org_call.kwargs["headers"] == jwt_headers
 
         install_call = calls[1]
-        assert install_call.args[0] == "https://api.atpco.ghe.com/orgs/DevopsZone/installation"
+        assert (
+            install_call.args[0]
+            == "https://api.atpco.ghe.com/orgs/DevopsZone/installation"
+        )
         assert install_call.kwargs["headers"] == jwt_headers
 
     async def test_client_returns_same_instance(

--- a/integrations/github/tests/github/clients/auth/test_gh_authenticator.py
+++ b/integrations/github/tests/github/clients/auth/test_gh_authenticator.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta, timezone
-from typing import Any
+
 import pytest
 import httpx
 from unittest.mock import AsyncMock, Mock, patch, PropertyMock
@@ -180,34 +180,20 @@ class TestGithubAuthenticator:
         mock_response.raise_for_status = Mock()
         mock_client.get.return_value = mock_response
 
-        with (
-            patch.object(
-                github_auth,
-                "is_personal_org",
-                AsyncMock(return_value=False),
-            ) as mock_is_personal,
-            patch.object(
-                type(github_auth),
-                "client",
-                new_callable=PropertyMock,
-                return_value=mock_client,
-            ),
+        with patch.object(
+            type(github_auth),
+            "client",
+            new_callable=PropertyMock,
+            return_value=mock_client,
         ):
             installation_id = await github_auth._fetch_installation_id(mock_jwt_token)
 
             jwt_headers = {"Authorization": f"Bearer {mock_jwt_token}"}
-            mock_is_personal.assert_called_once_with(
-                github_auth.github_host,
-                github_auth.organization,
-                headers=jwt_headers,
-            )
-
             expected_url = f"{github_auth.github_host}/orgs/{github_auth.organization}/installation"
             mock_client.get.assert_called_once_with(
                 expected_url,
                 headers=jwt_headers,
             )
-
             assert installation_id == mock_installation_id
 
     async def test_fetch_installation_id_for_personal_org(
@@ -217,40 +203,63 @@ class TestGithubAuthenticator:
         mock_installation_id = "67890"
 
         mock_client = AsyncMock()
-        mock_response = Mock()
-        mock_response.json = Mock(return_value={"id": mock_installation_id})
-        mock_response.raise_for_status = Mock()
-        mock_client.get.return_value = mock_response
+        ok_response = Mock()
+        ok_response.json = Mock(return_value={"id": mock_installation_id})
+        ok_response.raise_for_status = Mock()
+
+        not_found_response = Mock(status_code=404)
+        not_found_error = httpx.HTTPStatusError(
+            "Not Found", request=Mock(), response=not_found_response
+        )
+
+        mock_client.get.side_effect = [not_found_error, ok_response]
+
+        with patch.object(
+            type(github_auth),
+            "client",
+            new_callable=PropertyMock,
+            return_value=mock_client,
+        ):
+            installation_id = await github_auth._fetch_installation_id(mock_jwt_token)
+
+        jwt_headers = {"Authorization": f"Bearer {mock_jwt_token}"}
+        calls = mock_client.get.call_args_list
+        assert len(calls) == 2
+        assert (
+            calls[0].args[0]
+            == f"{github_auth.github_host}/orgs/{github_auth.organization}/installation"
+        )
+        assert calls[0].kwargs["headers"] == jwt_headers
+        assert (
+            calls[1].args[0]
+            == f"{github_auth.github_host}/users/{github_auth.organization}/installation"
+        )
+        assert calls[1].kwargs["headers"] == jwt_headers
+        assert installation_id == mock_installation_id
+
+    async def test_fetch_installation_id_raises_on_non_404_error(
+        self, github_auth: GitHubAppAuthenticator
+    ) -> None:
+        from github.helpers.exceptions import AuthenticationException
+
+        mock_client = AsyncMock()
+        forbidden_response = Mock(status_code=403)
+        mock_client.get.side_effect = httpx.HTTPStatusError(
+            "Forbidden", request=Mock(), response=forbidden_response
+        )
 
         with (
-            patch.object(
-                github_auth,
-                "is_personal_org",
-                AsyncMock(return_value=True),
-            ) as mock_is_personal,
             patch.object(
                 type(github_auth),
                 "client",
                 new_callable=PropertyMock,
                 return_value=mock_client,
             ),
+            pytest.raises(AuthenticationException),
         ):
-            installation_id = await github_auth._fetch_installation_id(mock_jwt_token)
+            await github_auth._fetch_installation_id("mock-jwt-token")
 
-            jwt_headers = {"Authorization": f"Bearer {mock_jwt_token}"}
-            mock_is_personal.assert_called_once_with(
-                github_auth.github_host,
-                github_auth.organization,
-                headers=jwt_headers,
-            )
-
-            expected_url = f"{github_auth.github_host}/users/{github_auth.organization}/installation"
-            mock_client.get.assert_called_once_with(
-                expected_url,
-                headers=jwt_headers,
-            )
-
-            assert installation_id == mock_installation_id
+        mock_client.get.assert_called_once()
 
     async def test_is_personal_org_sends_auth_headers(
         self, github_auth: GitHubAppAuthenticator
@@ -328,61 +337,6 @@ class TestGithubAuthenticator:
             )
 
         assert result is False
-
-    async def test_fetch_installation_id_passes_jwt_to_is_personal_org(
-        self,
-    ) -> None:
-        """End-to-end: _fetch_installation_id passes JWT headers through
-        to is_personal_org so the /users/{org} check is authenticated."""
-        auth = GitHubAppAuthenticator(
-            organization="DevopsZone",
-            github_host="https://api.atpco.ghe.com",
-            app_id="app-id",
-            private_key="test-key",
-        )
-
-        jwt_token = "test-jwt-token"
-
-        mock_client = AsyncMock()
-        user_response = Mock()
-        user_response.json = Mock(return_value={"type": "Organization"})
-        user_response.raise_for_status = Mock()
-
-        install_response = Mock()
-        install_response.json = Mock(return_value={"id": "99999"})
-        install_response.raise_for_status = Mock()
-
-        def route_get(url: str, **kwargs: Any) -> Mock:
-            if "/users/" in url:
-                return user_response
-            return install_response
-
-        mock_client.get = AsyncMock(side_effect=route_get)
-
-        with patch.object(
-            type(auth),
-            "client",
-            new_callable=PropertyMock,
-            return_value=mock_client,
-        ):
-            installation_id = await auth._fetch_installation_id(jwt_token)
-
-        assert installation_id == "99999"
-
-        jwt_headers = {"Authorization": f"Bearer {jwt_token}"}
-        calls = mock_client.get.call_args_list
-        assert len(calls) == 2
-
-        personal_org_call = calls[0]
-        assert personal_org_call.args[0] == "https://api.atpco.ghe.com/users/DevopsZone"
-        assert personal_org_call.kwargs["headers"] == jwt_headers
-
-        install_call = calls[1]
-        assert (
-            install_call.args[0]
-            == "https://api.atpco.ghe.com/orgs/DevopsZone/installation"
-        )
-        assert install_call.kwargs["headers"] == jwt_headers
 
     async def test_client_returns_same_instance(
         self, github_auth: GitHubAppAuthenticator


### PR DESCRIPTION
## Bug Fix: Forward auth headers in `is_personal_org` for GHE

### Problem

On GitHub Enterprise (GHE) instances that require authentication for all API
endpoints, `is_personal_org` sent its `GET /users/{org}` request without auth
headers. During `_fetch_installation_id` bootstrapping, this caused GHE to
respond with a 403. The retry transport treated the 403 as a rate-limit
response and retried indefinitely — but the `token_refresher` callback
triggered a circular dependency (it needs the installation token that is being
fetched), resulting in the integration hanging on startup.

### Fix

- Added an optional `headers` parameter to `is_personal_org` and forwarded it
  to `self.client.get()`.
- In `_fetch_installation_id`, pass the JWT bearer headers to `is_personal_org`
  so the `/users/{org}` check is authenticated before the installation token
  exists.
- Removed `@cache_coroutine_result()` - the decorator hashes all arguments
  (including headers) into the cache key, so rotating JWTs would defeat
  caching. The method is called at most twice per integration lifetime, making
  caching unnecessary.

### Changed files

| File | Change |
|------|--------|
| `abstract_authenticator.py` | Added `headers` param to `is_personal_org`, removed `@cache_coroutine_result()` |
| `github_app_authenticator.py` | Pass JWT headers to `is_personal_org` in `_fetch_installation_id` |
| `test_gh_authenticator.py` | Added tests for header forwarding, true/false/error paths, and end-to-end JWT propagation |
| `pyproject.toml` | Version bump 5.1.11 → 5.1.12 |
| `CHANGELOG.md` | Added 5.1.12 bug fix entry |

### Test plan

- [x] `test_is_personal_org_sends_auth_headers` — headers forwarded to HTTP client
- [x] `test_is_personal_org_returns_true_for_user` — returns `True` for `User` type
- [x] `test_is_personal_org_returns_false_on_error` — returns `False` on HTTP error
- [x] `test_fetch_installation_id_passes_jwt_to_is_personal_org` — end-to-end JWT propagation
- [x] Existing `test_fetch_installation_id_for_organization` and `test_fetch_installation_id_for_personal_org` updated and passing