### PR TITLE
[Integration][GitHub] Add Affiliation Selector in Collaborator Kind

### DIFF
--- a/integrations/github/CHANGELOG.md
+++ b/integrations/github/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 5.1.32 (2026-03-19)
+
+
+### Bug Fixes
+
+- Respect collaborator `affiliation` selector in live-events (member/membership/team webhooks) and emit deletions when collaborators no longer match the configured affiliation filter.
+- Align webhook collaborator affiliation checks with resync by using the repository collaborators API with the configured `affiliation`, and expand test coverage for `outside` and `direct`.
+
+
 ## 5.1.31 (2026-03-17)
 
 

--- a/integrations/github/CHANGELOG.md
+++ b/integrations/github/CHANGELOG.md
@@ -10,10 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 5.1.32 (2026-03-19)
 
 
-### Bug Fixes
+### Improvements
 
-- Respect collaborator `affiliation` selector in live-events (member/membership/team webhooks) and emit deletions when collaborators no longer match the configured affiliation filter.
-- Align webhook collaborator affiliation checks with resync by using the repository collaborators API with the configured `affiliation`, and expand test coverage for `outside` and `direct`.
+- Add `selector.affiliation` support for the Collaborator kind (`all`/`direct`/`outside`) and apply it consistently across resync and collaborator live-events (member/membership/team).
+- Emit collaborator deletions from live-events when events no longer match the configured affiliation selector, and expand test coverage for `outside` and `direct`.
 
 
 ## 5.1.31 (2026-03-17)

--- a/integrations/github/github/core/exporters/collaborator_exporter.py
+++ b/integrations/github/github/core/exporters/collaborator_exporter.py
@@ -9,6 +9,7 @@ from port_ocean.core.ocean_types import ASYNC_GENERATOR_RESYNC_TYPE, RAW_ITEM
 from loguru import logger
 from github.core.options import ListCollaboratorOptions, SingleCollaboratorOptions
 from github.clients.http.rest_client import GithubRestClient
+from port_ocean.utils.cache import cache_iterator_result
 
 
 class RestCollaboratorExporter(AbstractGithubExporter[GithubRestClient]):
@@ -35,6 +36,7 @@ class RestCollaboratorExporter(AbstractGithubExporter[GithubRestClient]):
             enrich_with_repository(collaborator, cast(str, repo_name)), organization
         )
 
+    @cache_iterator_result()
     async def get_paginated_resources[
         ExporterOptionsT: ListCollaboratorOptions
     ](self, options: ExporterOptionsT) -> ASYNC_GENERATOR_RESYNC_TYPE:

--- a/integrations/github/github/core/options.py
+++ b/integrations/github/github/core/options.py
@@ -251,6 +251,8 @@ class SingleCollaboratorOptions(RepositoryIdentifier):
 class ListCollaboratorOptions(RepositoryIdentifier):
     """Options for listing collaborators."""
 
+    affiliation: Required[str]
+
 
 class BaseSecretScanningAlertOptions(RepositoryIdentifier):
     """Base options for secret scanning alerts."""

--- a/integrations/github/github/webhook/webhook_processors/collaborator_webhook_processor/base_collaborator_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/collaborator_webhook_processor/base_collaborator_webhook_processor.py
@@ -1,0 +1,99 @@
+from typing import Any, Dict, Optional
+
+from github.clients.client_factory import create_github_client
+from github.core.exporters.collaborator_exporter import RestCollaboratorExporter
+from github.core.options import ListCollaboratorOptions
+from github.helpers.utils import (
+    ObjectKind,
+    enrich_with_organization,
+    enrich_with_repository,
+)
+from github.webhook.webhook_processors.base_repository_webhook_processor import (
+    BaseRepositoryWebhookProcessor,
+)
+from port_ocean.core.handlers.webhook.webhook_event import (
+    WebhookEvent,
+    WebhookEventRawResults,
+)
+
+
+class BaseCollaboratorWebhookProcessor(BaseRepositoryWebhookProcessor):
+    async def affiliation_matches(
+        self,
+        *,
+        organization: str,
+        repo_name: str,
+        username: str,
+        affiliation: str,
+        repo_collaborators_cache: Optional[Dict[str, set[str]]] = None,
+    ) -> bool:
+        """
+        Check whether `username` is returned from the repo collaborators endpoint
+        using GitHub's `affiliation` filter.
+        """
+        if affiliation == "all":
+            return True
+
+        cache = repo_collaborators_cache if repo_collaborators_cache is not None else {}
+        cache_key = f"{organization}/{repo_name}:{affiliation}"
+
+        if cache_key not in cache:
+            rest_client = create_github_client()
+            exporter = RestCollaboratorExporter(rest_client)
+            logins: set[str] = set()
+            async for batch in exporter.get_paginated_resources(
+                ListCollaboratorOptions(
+                    organization=organization,
+                    repo_name=repo_name,
+                    affiliation=affiliation,
+                )
+            ):
+                for collaborator in batch:
+                    login = collaborator.get("login")
+                    if login:
+                        logins.add(login)
+            cache[cache_key] = logins
+
+        return username in cache[cache_key]
+
+    def collaborator_delete_payload(
+        self,
+        *,
+        organization: str,
+        repo_name: str,
+        repository: dict[str, Any],
+        username: str,
+        user_id: Any,
+    ) -> dict[str, Any]:
+        return enrich_with_organization(
+            enrich_with_repository(
+                {"login": username, "id": user_id},
+                repo_name,
+                repo=repository,
+            ),
+            organization,
+        )
+
+    def collaborator_delete_result(
+        self,
+        *,
+        organization: str,
+        repo_name: str,
+        repository: dict[str, Any],
+        username: str,
+        user_id: Any,
+    ) -> WebhookEventRawResults:
+        data_to_delete = self.collaborator_delete_payload(
+            organization=organization,
+            repo_name=repo_name,
+            repository=repository,
+            username=username,
+            user_id=user_id,
+        )
+        return WebhookEventRawResults(
+            updated_raw_results=[],
+            deleted_raw_results=[data_to_delete],
+        )
+
+    async def get_matching_kinds(self, event: WebhookEvent) -> list[str]:
+        return [ObjectKind.COLLABORATOR]

--- a/integrations/github/github/webhook/webhook_processors/collaborator_webhook_processor/member_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/collaborator_webhook_processor/member_webhook_processor.py
@@ -4,7 +4,6 @@ from github.clients.client_factory import create_github_client
 from github.core.exporters.collaborator_exporter import RestCollaboratorExporter
 from github.core.options import SingleCollaboratorOptions
 from github.helpers.utils import (
-    ObjectKind,
     enrich_with_organization,
     enrich_with_repository,
 )
@@ -12,18 +11,20 @@ from github.webhook.events import (
     COLLABORATOR_DELETE_EVENTS,
     COLLABORATOR_EVENTS,
 )
-from github.webhook.webhook_processors.base_repository_webhook_processor import (
-    BaseRepositoryWebhookProcessor,
+from github.webhook.webhook_processors.collaborator_webhook_processor.base_collaborator_webhook_processor import (
+    BaseCollaboratorWebhookProcessor,
 )
+from integration import GithubCollaboratorConfig
 from port_ocean.core.handlers.port_app_config.models import ResourceConfig
 from port_ocean.core.handlers.webhook.webhook_event import (
     EventPayload,
     WebhookEvent,
     WebhookEventRawResults,
 )
+from typing import cast
 
 
-class CollaboratorMemberWebhookProcessor(BaseRepositoryWebhookProcessor):
+class CollaboratorMemberWebhookProcessor(BaseCollaboratorWebhookProcessor):
 
     async def _validate_payload(self, payload: EventPayload) -> bool:
         has_required_fields = not ({"action", "repository", "member"} - payload.keys())
@@ -36,9 +37,6 @@ class CollaboratorMemberWebhookProcessor(BaseRepositoryWebhookProcessor):
             and event.payload.get("action") in COLLABORATOR_EVENTS
         )
 
-    async def get_matching_kinds(self, event: WebhookEvent) -> list[str]:
-        return [ObjectKind.COLLABORATOR]
-
     async def handle_event(
         self, payload: EventPayload, resource_config: ResourceConfig
     ) -> WebhookEventRawResults:
@@ -48,6 +46,7 @@ class CollaboratorMemberWebhookProcessor(BaseRepositoryWebhookProcessor):
         repo_name = repository["name"]
         username = payload["member"]["login"]
         organization = self.get_webhook_payload_organization(payload)["login"]
+        config = cast(GithubCollaboratorConfig, resource_config)
 
         logger.info(
             f"Processing member event: {action} for {username} in {repo_name} of organization: {organization}"
@@ -70,6 +69,26 @@ class CollaboratorMemberWebhookProcessor(BaseRepositoryWebhookProcessor):
                 updated_raw_results=[], deleted_raw_results=[data_to_delete]
             )
 
+        repo_cache: dict[str, set[str]] = {}
+        if not await self.affiliation_matches(
+            organization=organization,
+            repo_name=repo_name,
+            username=username,
+            affiliation=config.selector.affiliation,
+            repo_collaborators_cache=repo_cache,
+        ):
+            logger.info(
+                f"Collaborator {username} in {repo_name} does not match affiliation "
+                f"selector '{config.selector.affiliation}', emitting deletion"
+            )
+            return self.collaborator_delete_result(
+                organization=organization,
+                repo_name=repo_name,
+                repository=repository,
+                username=username,
+                user_id=payload["member"]["id"],
+            )
+
         logger.info(
             f"Creating REST client and exporter for collaborator {username} of organization: {organization}"
         )
@@ -82,6 +101,9 @@ class CollaboratorMemberWebhookProcessor(BaseRepositoryWebhookProcessor):
             )
         )
         if not data_to_upsert:
+            logger.info(
+                f"Collaborator {username} in {repo_name} does not exist, skipping upsert"
+            )
             return WebhookEventRawResults(
                 updated_raw_results=[], deleted_raw_results=[]
             )

--- a/integrations/github/github/webhook/webhook_processors/collaborator_webhook_processor/membership_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/collaborator_webhook_processor/membership_webhook_processor.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, cast
 
 from loguru import logger
 
@@ -8,7 +8,6 @@ from github.core.exporters.team_exporter import (
 )
 from github.core.options import SingleTeamOptions
 from github.helpers.utils import (
-    ObjectKind,
     enrich_with_repository,
     enrich_with_organization,
 )
@@ -16,9 +15,10 @@ from github.webhook.events import (
     COLLABORATOR_EVENTS,
     COLLABORATOR_UPSERT_EVENTS,
 )
-from github.webhook.webhook_processors.base_repository_webhook_processor import (
-    BaseRepositoryWebhookProcessor,
+from github.webhook.webhook_processors.collaborator_webhook_processor.base_collaborator_webhook_processor import (
+    BaseCollaboratorWebhookProcessor,
 )
+from integration import GithubCollaboratorConfig
 from port_ocean.core.handlers.port_app_config.models import ResourceConfig
 from port_ocean.core.handlers.webhook.webhook_event import (
     EventPayload,
@@ -27,7 +27,7 @@ from port_ocean.core.handlers.webhook.webhook_event import (
 )
 
 
-class CollaboratorMembershipWebhookProcessor(BaseRepositoryWebhookProcessor):
+class CollaboratorMembershipWebhookProcessor(BaseCollaboratorWebhookProcessor):
 
     async def validate_payload(self, payload: EventPayload) -> bool:
         return await self._validate_payload(payload)
@@ -52,9 +52,6 @@ class CollaboratorMembershipWebhookProcessor(BaseRepositoryWebhookProcessor):
             and event.payload.get("action") in COLLABORATOR_EVENTS
         )
 
-    async def get_matching_kinds(self, event: WebhookEvent) -> list[str]:
-        return [ObjectKind.COLLABORATOR]
-
     async def handle_event(
         self, payload: EventPayload, resource_config: ResourceConfig
     ) -> WebhookEventRawResults:
@@ -65,6 +62,7 @@ class CollaboratorMembershipWebhookProcessor(BaseRepositoryWebhookProcessor):
         team_slug = payload["team"]["slug"]
         member_login = member["login"]
         organization = self.get_webhook_payload_organization(payload)["login"]
+        config = cast(GithubCollaboratorConfig, resource_config)
 
         logger.info(
             f"Handling membership event: {action} for {member_login} in team {team_slug}"
@@ -94,34 +92,43 @@ class CollaboratorMembershipWebhookProcessor(BaseRepositoryWebhookProcessor):
                     continue
                 repositories.append(repo)
 
-        list_data_to_upsert = self._enrich_collaborators_with_repositories(
-            member, repositories, organization
-        )
+        affiliation = config.selector.affiliation
+        updated_raw_results: List[Dict[str, Any]] = []
+        deleted_raw_results: List[Dict[str, Any]] = []
+        repo_cache: Dict[str, set[str]] = {}
+
+        for repo in repositories:
+            repo_name = repo["name"]
+            if await self.affiliation_matches(
+                organization=organization,
+                repo_name=repo_name,
+                username=member_login,
+                affiliation=affiliation,
+                repo_collaborators_cache=repo_cache,
+            ):
+                updated_raw_results.append(
+                    enrich_with_organization(
+                        enrich_with_repository(member.copy(), repo_name, repo=repo),
+                        organization,
+                    )
+                )
+            else:
+                deleted_raw_results.append(
+                    self.collaborator_delete_payload(
+                        organization=organization,
+                        repo_name=repo_name,
+                        repository=repo,
+                        username=member_login,
+                        user_id=member["id"],
+                    )
+                )
 
         logger.info(
-            f"Upserting {len(list_data_to_upsert)} collaborators for member {member_login} in team {team_slug} of organization: {organization}"
+            f"Affiliation selector='{affiliation}' for {member_login} in team {team_slug} of {organization}: "
+            f"upserts={len(updated_raw_results)}, deletions={len(deleted_raw_results)}"
         )
 
         return WebhookEventRawResults(
-            updated_raw_results=list_data_to_upsert, deleted_raw_results=[]
+            updated_raw_results=updated_raw_results,
+            deleted_raw_results=deleted_raw_results,
         )
-
-    def _enrich_collaborators_with_repositories(
-        self,
-        response: Dict[str, Any],
-        repositories: List[Dict[str, Any]],
-        organization: str,
-    ) -> List[Dict[str, Any]]:
-        """Helper function to enrich response with repository information."""
-        list_of_collaborators = []
-        for repository in repositories:
-            collaborator_copy = response.copy()
-            list_of_collaborators.append(
-                enrich_with_organization(
-                    enrich_with_repository(
-                        collaborator_copy, repository["name"], repo=repository
-                    ),
-                    organization,
-                )
-            )
-        return list_of_collaborators

--- a/integrations/github/github/webhook/webhook_processors/collaborator_webhook_processor/team_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/collaborator_webhook_processor/team_webhook_processor.py
@@ -4,13 +4,19 @@ from github.clients.client_factory import create_github_client
 from github.core.exporters.team_exporter import (
     GraphQLTeamMembersAndReposExporter,
 )
-from github.helpers.utils import GithubClientType, ObjectKind
+from github.helpers.utils import (
+    GithubClientType,
+    ObjectKind,
+    enrich_with_organization,
+    enrich_with_repository,
+)
 from github.webhook.events import (
     TEAM_COLLABORATOR_EVENTS,
 )
-from github.webhook.webhook_processors.base_repository_webhook_processor import (
-    BaseRepositoryWebhookProcessor,
+from github.webhook.webhook_processors.collaborator_webhook_processor.base_collaborator_webhook_processor import (
+    BaseCollaboratorWebhookProcessor,
 )
+from integration import GithubCollaboratorConfig
 from port_ocean.core.handlers.port_app_config.models import ResourceConfig
 from port_ocean.core.handlers.webhook.webhook_event import (
     EventPayload,
@@ -18,10 +24,10 @@ from port_ocean.core.handlers.webhook.webhook_event import (
     WebhookEventRawResults,
 )
 from github.core.options import SingleTeamOptions
+from typing import Any, Dict, List, Optional, cast
 
 
-class CollaboratorTeamWebhookProcessor(BaseRepositoryWebhookProcessor):
-
+class CollaboratorTeamWebhookProcessor(BaseCollaboratorWebhookProcessor):
     async def _validate_payload(self, payload: EventPayload) -> bool:
 
         has_required_fields = not (
@@ -50,6 +56,8 @@ class CollaboratorTeamWebhookProcessor(BaseRepositoryWebhookProcessor):
         action = payload["action"]
         team_slug = payload["team"]["slug"]
         organization = self.get_webhook_payload_organization(payload)["login"]
+        config = cast(GithubCollaboratorConfig, resource_config)
+        affiliation = config.selector.affiliation
 
         logger.info(
             f"Handling team event: {action} for team {team_slug} of organization: {organization}"
@@ -77,22 +85,112 @@ class CollaboratorTeamWebhookProcessor(BaseRepositoryWebhookProcessor):
                 updated_raw_results=[], deleted_raw_results=[]
             )
 
-        data_to_upsert = [
-            {
-                "id": member["id"],
-                "login": member["login"],
-                "name": member["name"],
-                "site_admin": member["isSiteAdmin"],
-                "__repository": repo["name"],
-            }
-            for member in team_data["members"]["nodes"]
-            for repo in team_data["repositories"]["nodes"]
-        ]
+        members: List[Dict[str, Any]] = team_data.get("members", {}).get("nodes", [])
+        repos: List[Dict[str, Any]] = team_data.get("repositories", {}).get("nodes", [])
+        repo_cache: Dict[str, set[str]] = {}
+
+        filtered_repos: List[Dict[str, Any]] = []
+        for repo in repos:
+            visibility = repo.get("visibility")
+            if visibility and not await self.validate_repository_visibility(visibility):
+                logger.info(
+                    f"Skipping repository {repo.get('name')} due to visibility validation of organization: {organization}"
+                )
+                continue
+            filtered_repos.append(repo)
+
+        if affiliation == "all":
+            updated_raw_results, deleted_raw_results = (
+                self._build_enriched_collaborator_data(
+                    repos=filtered_repos,
+                    members=members,
+                    organization=organization,
+                )
+            )
+        else:
+            updated_raw_results: list[dict[str, Any]] = []
+            deleted_raw_results: list[dict[str, Any]] = []
+
+            for repo in filtered_repos:
+                repo_name = repo["name"]
+                matching_members: list[dict[str, Any]] = []
+                non_matching_members: list[dict[str, Any]] = []
+
+                for member in members:
+                    member_login = member.get("login")
+                    if not member_login:
+                        continue
+
+                    if await self.affiliation_matches(
+                        organization=organization,
+                        repo_name=repo_name,
+                        username=member_login,
+                        affiliation=affiliation,
+                        repo_collaborators_cache=repo_cache,
+                    ):
+                        matching_members.append(member)
+                    else:
+                        non_matching_members.append(member)
+
+                u, d = self._build_enriched_collaborator_data(
+                    repos=[repo],
+                    members=matching_members,
+                    organization=organization,
+                    non_matching_members=non_matching_members,
+                )
+                updated_raw_results.extend(u)
+                deleted_raw_results.extend(d)
 
         logger.info(
-            f"Upserting {len(data_to_upsert)} collaborators for team {team_slug} of organization: {organization}"
+            f"Affiliation selector='{affiliation}' for team {team_slug} of {organization}: "
+            f"upserts={len(updated_raw_results)}, deletions={len(deleted_raw_results)}"
         )
 
         return WebhookEventRawResults(
-            updated_raw_results=data_to_upsert, deleted_raw_results=[]
+            updated_raw_results=updated_raw_results,
+            deleted_raw_results=deleted_raw_results,
         )
+
+    def _build_enriched_collaborator_data(
+        self,
+        repos: List[Dict[str, Any]],
+        members: List[Dict[str, Any]],
+        organization: str,
+        non_matching_members: Optional[List[Dict[str, Any]]] = None,
+    ) -> tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+        if non_matching_members is None:
+            non_matching_members = []
+
+        updated_raw_results: List[Dict[str, Any]] = []
+        deleted_raw_results: List[Dict[str, Any]] = []
+
+        for repo in repos:
+            repo_name = repo["name"]
+
+            for member in members:
+                collaborator = {
+                    "id": member["id"],
+                    "login": member["login"],
+                    "name": member.get("name"),
+                    "site_admin": member.get("isSiteAdmin"),
+                }
+
+                updated_raw_results.append(
+                    enrich_with_organization(
+                        enrich_with_repository(collaborator, repo_name, repo=repo),
+                        organization,
+                    )
+                )
+
+            for member in non_matching_members:
+                deleted_raw_results.append(
+                    self.collaborator_delete_payload(
+                        organization=organization,
+                        repo_name=repo_name,
+                        repository=repo,
+                        username=member["login"],
+                        user_id=member["id"],
+                    )
+                )
+
+        return updated_raw_results, deleted_raw_results

--- a/integrations/github/github/webhook/webhook_processors/collaborator_webhook_processor/team_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/collaborator_webhook_processor/team_webhook_processor.py
@@ -99,28 +99,26 @@ class CollaboratorTeamWebhookProcessor(BaseCollaboratorWebhookProcessor):
                 continue
             filtered_repos.append(repo)
 
+        updated_raw_results: list[dict[str, Any]] = []
+        deleted_raw_results: list[dict[str, Any]] = []
+
         if affiliation == "all":
-            updated_raw_results, deleted_raw_results = (
-                self._build_enriched_collaborator_data(
-                    repos=filtered_repos,
-                    members=members,
-                    organization=organization,
-                )
+            (
+                updated_raw_results,
+                deleted_raw_results,
+            ) = self._build_enriched_collaborator_data(
+                repos=filtered_repos,
+                members=members,
+                organization=organization,
             )
         else:
-            updated_raw_results: list[dict[str, Any]] = []
-            deleted_raw_results: list[dict[str, Any]] = []
-
             for repo in filtered_repos:
                 repo_name = repo["name"]
                 matching_members: list[dict[str, Any]] = []
                 non_matching_members: list[dict[str, Any]] = []
 
                 for member in members:
-                    member_login = member.get("login")
-                    if not member_login:
-                        continue
-
+                    member_login = member["login"]
                     if await self.affiliation_matches(
                         organization=organization,
                         repo_name=repo_name,

--- a/integrations/github/integration.py
+++ b/integrations/github/integration.py
@@ -459,6 +459,14 @@ class GithubBranchSelector(RepoSearchSelector):
     )
 
 
+class GithubCollaboratorSelector(RepoSearchSelector):
+    affiliation: Literal["all", "direct"] = Field(
+        title="Affiliation",
+        default="all",
+        description="Filter collaborators by affiliation (all, direct, outside).",
+    )
+
+
 class GithubBranchConfig(ResourceConfig):
     kind: Literal[ObjectKind.BRANCH] = Field(
         title="Github Branch",
@@ -541,7 +549,7 @@ class GithubCollaboratorConfig(ResourceConfig):
         title="Github Collaborator",
         description="Github collaborator resource kind.",
     )
-    selector: RepoSearchSelector = Field(
+    selector: GithubCollaboratorSelector = Field(
         title="Collaborator selector",
         description="Selector for the collaborator resource.",
     )

--- a/integrations/github/integration.py
+++ b/integrations/github/integration.py
@@ -460,7 +460,7 @@ class GithubBranchSelector(RepoSearchSelector):
 
 
 class GithubCollaboratorSelector(RepoSearchSelector):
-    affiliation: Literal["all", "direct"] = Field(
+    affiliation: Literal["all", "direct", "outside"] = Field(
         title="Affiliation",
         default="all",
         description="Filter collaborators by affiliation (all, direct, outside).",

--- a/integrations/github/main.py
+++ b/integrations/github/main.py
@@ -994,7 +994,9 @@ async def resync_collaborators(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
                     tasks.append(
                         collaborator_exporter.get_paginated_resources(
                             ListCollaboratorOptions(
-                                organization=org_name, repo_name=repo["name"]
+                                organization=org_name,
+                                repo_name=repo["name"],
+                                affiliation=config.selector.affiliation,
                             )
                         )
                     )

--- a/integrations/github/pyproject.toml
+++ b/integrations/github/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "github-ocean"
-version = "5.1.31"
+version = "5.1.32"
 description = "This integration ingest data from github"
 authors = ["Chukwuemeka Nwaoma <joelchukks@gmail.com>", "Melody Anyaegbulam <melodyogonna@gmail.com>", "Michael Armah <mikeyarmah@gmail.com>"]
 

--- a/integrations/github/tests/github/core/exporters/test_collaborator_exporter.py
+++ b/integrations/github/tests/github/core/exporters/test_collaborator_exporter.py
@@ -102,7 +102,7 @@ class TestRestCollaboratorExporter:
         ) as mock_request:
             async with event_context("test_event"):
                 options = ListCollaboratorOptions(
-                    organization="test-org", repo_name="test-repo"
+                    organization="test-org", repo_name="test-repo", affiliation="all"
                 )
                 exporter = RestCollaboratorExporter(rest_client)
 
@@ -126,5 +126,5 @@ class TestRestCollaboratorExporter:
 
                 mock_request.assert_called_once_with(
                     f"{rest_client.base_url}/repos/test-org/test-repo/collaborators",
-                    {},
+                    {"affiliation": "all"},
                 )

--- a/integrations/github/tests/github/webhook/webhook_processors/test_collaborator_webhook_processor/test_member_webhook_processor.py
+++ b/integrations/github/tests/github/webhook/webhook_processors/test_collaborator_webhook_processor/test_member_webhook_processor.py
@@ -20,7 +20,7 @@ from port_ocean.core.handlers.webhook.webhook_event import (
     WebhookEventRawResults,
 )
 from github.core.options import SingleCollaboratorOptions
-from typing import Any
+from typing import Any, Literal
 from port_ocean.context.event import event_context
 
 
@@ -221,13 +221,13 @@ class TestCollaboratorMemberWebhookProcessor:
         self,
         member_webhook_processor: CollaboratorMemberWebhookProcessor,
         resource_config: GithubCollaboratorConfig,
-        affiliation: str,
+        affiliation: Literal["outside", "direct"],
         is_outside: bool,
         expected_updated: bool,
         expected_deleted: bool,
     ) -> None:
         cfg = resource_config.copy(deep=True)
-        cfg.selector.affiliation = affiliation  # type: ignore[attr-defined]
+        cfg.selector.affiliation = affiliation
 
         payload = VALID_MEMBER_COLLABORATOR_PAYLOADS.copy()
         payload["action"] = "added"
@@ -236,7 +236,7 @@ class TestCollaboratorMemberWebhookProcessor:
             "owner": {"type": "Organization"},
         }
 
-        member_webhook_processor.affiliation_matches = AsyncMock(
+        affiliation_matches_mock = AsyncMock(
             return_value=(
                 (affiliation == "outside" and is_outside)
                 or (affiliation == "direct" and not is_outside)
@@ -264,7 +264,12 @@ class TestCollaboratorMemberWebhookProcessor:
                     return_value=mock_collaborator_data
                 )
 
-                result = await member_webhook_processor.handle_event(payload, cfg)
+                with patch.object(
+                    member_webhook_processor,
+                    "affiliation_matches",
+                    new=affiliation_matches_mock,
+                ):
+                    result = await member_webhook_processor.handle_event(payload, cfg)
 
         assert bool(result.updated_raw_results) is expected_updated
         assert bool(result.deleted_raw_results) is expected_deleted

--- a/integrations/github/tests/github/webhook/webhook_processors/test_collaborator_webhook_processor/test_member_webhook_processor.py
+++ b/integrations/github/tests/github/webhook/webhook_processors/test_collaborator_webhook_processor/test_member_webhook_processor.py
@@ -1,10 +1,13 @@
-from integration import GithubPortAppConfig
+from integration import (
+    GithubCollaboratorConfig,
+    GithubCollaboratorSelector,
+    GithubPortAppConfig,
+)
 from port_ocean.core.handlers.port_app_config.models import (
     EntityMapping,
     MappingsConfig,
     PortResourceConfig,
     ResourceConfig,
-    Selector,
 )
 import pytest
 from unittest.mock import MagicMock, patch, AsyncMock
@@ -45,10 +48,10 @@ INVALID_MEMBER_COLLABORATOR_PAYLOADS: dict[str, Any] = {
 
 
 @pytest.fixture
-def resource_config() -> ResourceConfig:
-    return ResourceConfig(
+def resource_config() -> GithubCollaboratorConfig:
+    return GithubCollaboratorConfig(
         kind=ObjectKind.COLLABORATOR,
-        selector=Selector(query="true"),
+        selector=GithubCollaboratorSelector(query="true", affiliation="all"),
         port=PortResourceConfig(
             entity=MappingsConfig(
                 mappings=EntityMapping(
@@ -204,3 +207,80 @@ class TestCollaboratorMemberWebhookProcessor:
                     }
                     assert result.deleted_raw_results == [expected_deleted_data]
                     mock_exporter.get_resource.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "affiliation,is_outside,expected_updated,expected_deleted",
+        [
+            ("outside", True, True, False),
+            ("outside", False, False, True),
+            ("direct", True, False, True),
+            ("direct", False, True, False),
+        ],
+    )
+    async def test_handle_event_member_events_affiliation_filter(
+        self,
+        member_webhook_processor: CollaboratorMemberWebhookProcessor,
+        resource_config: GithubCollaboratorConfig,
+        affiliation: str,
+        is_outside: bool,
+        expected_updated: bool,
+        expected_deleted: bool,
+    ) -> None:
+        cfg = resource_config.copy(deep=True)
+        cfg.selector.affiliation = affiliation  # type: ignore[attr-defined]
+
+        payload = VALID_MEMBER_COLLABORATOR_PAYLOADS.copy()
+        payload["action"] = "added"
+        payload["repository"] = {
+            "name": "test-repo",
+            "owner": {"type": "Organization"},
+        }
+
+        member_webhook_processor.affiliation_matches = AsyncMock(
+            return_value=(
+                (affiliation == "outside" and is_outside)
+                or (affiliation == "direct" and not is_outside)
+            )
+        )
+
+        mock_collaborator_data = {
+            "login": "test-user",
+            "name": "Test User",
+            "email": "test@example.com",
+        }
+
+        with patch(
+            "github.webhook.webhook_processors.collaborator_webhook_processor.member_webhook_processor.create_github_client"
+        ) as mock_create_client:
+            mock_client = MagicMock()
+            mock_create_client.return_value = mock_client
+
+            with patch(
+                "github.webhook.webhook_processors.collaborator_webhook_processor.member_webhook_processor.RestCollaboratorExporter"
+            ) as mock_exporter_class:
+                mock_exporter = MagicMock()
+                mock_exporter_class.return_value = mock_exporter
+                mock_exporter.get_resource = AsyncMock(
+                    return_value=mock_collaborator_data
+                )
+
+                result = await member_webhook_processor.handle_event(payload, cfg)
+
+        assert bool(result.updated_raw_results) is expected_updated
+        assert bool(result.deleted_raw_results) is expected_deleted
+
+        if expected_updated:
+            assert result.updated_raw_results == [mock_collaborator_data]
+        if expected_deleted:
+            assert result.deleted_raw_results == [
+                {
+                    "login": "test-user",
+                    "id": 1,
+                    "__repository": "test-repo",
+                    "__repository_object": {
+                        "name": "test-repo",
+                        "owner": {"type": "Organization"},
+                    },
+                    "__organization": "test-org",
+                }
+            ]

--- a/integrations/github/tests/github/webhook/webhook_processors/test_collaborator_webhook_processor/test_membership_webhook_processor.py
+++ b/integrations/github/tests/github/webhook/webhook_processors/test_collaborator_webhook_processor/test_membership_webhook_processor.py
@@ -1,13 +1,16 @@
-from integration import GithubPortAppConfig
+from integration import (
+    GithubCollaboratorConfig,
+    GithubCollaboratorSelector,
+    GithubPortAppConfig,
+)
 from port_ocean.core.handlers.port_app_config.models import (
     EntityMapping,
     MappingsConfig,
     PortResourceConfig,
     ResourceConfig,
-    Selector,
 )
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, AsyncMock
 from github.webhook.webhook_processors.collaborator_webhook_processor.membership_webhook_processor import (
     CollaboratorMembershipWebhookProcessor,
 )
@@ -26,7 +29,7 @@ VALID_MEMBERSHIP_COLLABORATOR_PAYLOADS: dict[str, Any] = {
     "repository": {"name": "test-repo"},
     "organization": {"login": "test-org"},
     "team": {"name": "test-team", "slug": "test-team"},
-    "member": {"login": "test-user"},
+    "member": {"login": "test-user", "id": 123},
 }
 
 INVALID_MEMBERSHIP_COLLABORATOR_PAYLOADS: dict[str, Any] = {
@@ -70,10 +73,10 @@ INVALID_MEMBERSHIP_COLLABORATOR_PAYLOADS: dict[str, Any] = {
 
 
 @pytest.fixture
-def resource_config() -> ResourceConfig:
-    return ResourceConfig(
+def resource_config() -> GithubCollaboratorConfig:
+    return GithubCollaboratorConfig(
         kind=ObjectKind.COLLABORATOR,
-        selector=Selector(query="true"),
+        selector=GithubCollaboratorSelector(query="true", affiliation="all"),
         port=PortResourceConfig(
             entity=MappingsConfig(
                 mappings=EntityMapping(
@@ -241,23 +244,92 @@ class TestCollaboratorMembershipWebhookProcessor:
                     # For non-upsert events, no repositories should be fetched
                     mock_team_exporter.get_team_repositories_by_slug.assert_not_called()
 
-    async def test_enrich_collaborators_with_repositories(
-        self, membership_webhook_processor: CollaboratorMembershipWebhookProcessor
+    @pytest.mark.parametrize(
+        "affiliation,is_outside,expected_updated,expected_deleted",
+        [
+            ("outside", True, True, False),
+            ("outside", False, False, True),
+            ("direct", True, False, True),
+            ("direct", False, True, False),
+        ],
+    )
+    async def test_handle_event_membership_events_affiliation_filter(
+        self,
+        membership_webhook_processor: CollaboratorMembershipWebhookProcessor,
+        resource_config: GithubCollaboratorConfig,
+        mock_port_app_config: GithubPortAppConfig,
+        affiliation: str,
+        is_outside: bool,
+        expected_updated: bool,
+        expected_deleted: bool,
     ) -> None:
-        """Test the helper method that enriches collaborators with repository information."""
-        member_data = {"login": "test-user", "name": "Test User"}
-        repositories = [
-            {"name": "repo1", "full_name": "org/repo1"},
-            {"name": "repo2", "full_name": "org/repo2"},
+        cfg = resource_config.copy(deep=True)
+        cfg.selector.affiliation = affiliation  # type: ignore[attr-defined]
+
+        payload = VALID_MEMBERSHIP_COLLABORATOR_PAYLOADS.copy()
+        payload["action"] = "added"
+
+        mock_repositories = [
+            {
+                "name": "repo1",
+                "full_name": "org/repo1",
+                "visibility": "public",
+                "owner": {"type": "Organization"},
+            },
+            {
+                "name": "repo2",
+                "full_name": "org/repo2",
+                "visibility": "public",
+                "owner": {"type": "Organization"},
+            },
         ]
 
-        result = membership_webhook_processor._enrich_collaborators_with_repositories(
-            member_data, repositories, "test-org"
+        membership_webhook_processor.affiliation_matches = AsyncMock(
+            return_value=(
+                (affiliation == "outside" and is_outside)
+                or (affiliation == "direct" and not is_outside)
+            )
         )
 
-        assert len(result) == 2
-        assert result[0]["login"] == "test-user"
-        assert result[0]["__repository"] == "repo1"
-        assert result[1]["login"] == "test-user"
-        assert result[1]["__repository"] == "repo2"
-        assert all(item["__organization"] == "test-org" for item in result)
+        with patch(
+            "github.webhook.webhook_processors.collaborator_webhook_processor.membership_webhook_processor.create_github_client"
+        ) as mock_create_client:
+            mock_client = MagicMock()
+            mock_create_client.return_value = mock_client
+
+            with patch(
+                "github.webhook.webhook_processors.collaborator_webhook_processor.membership_webhook_processor.RestTeamExporter"
+            ) as mock_team_exporter_class:
+                mock_team_exporter = MagicMock()
+                mock_team_exporter_class.return_value = mock_team_exporter
+
+                async def mock_get_team_repositories() -> (
+                    AsyncGenerator[list[dict[str, Any]], None]
+                ):
+                    yield mock_repositories
+
+                mock_team_exporter.get_team_repositories_by_slug.return_value = (
+                    mock_get_team_repositories()
+                )
+
+                async with event_context("test_event") as event_context_obj:
+                    event_context_obj.port_app_config = mock_port_app_config
+                    result = await membership_webhook_processor.handle_event(
+                        payload, cfg
+                    )
+
+        assert bool(result.updated_raw_results) is expected_updated
+        assert bool(result.deleted_raw_results) is expected_deleted
+
+        if expected_updated:
+            assert {r["__repository"] for r in result.updated_raw_results} == {
+                "repo1",
+                "repo2",
+            }
+        if expected_deleted:
+            assert {r["__repository"] for r in result.deleted_raw_results} == {
+                "repo1",
+                "repo2",
+            }
+
+        assert membership_webhook_processor.affiliation_matches.await_count == 2

--- a/integrations/github/tests/github/webhook/webhook_processors/test_collaborator_webhook_processor/test_membership_webhook_processor.py
+++ b/integrations/github/tests/github/webhook/webhook_processors/test_collaborator_webhook_processor/test_membership_webhook_processor.py
@@ -20,7 +20,7 @@ from port_ocean.core.handlers.webhook.webhook_event import (
     WebhookEventRawResults,
 )
 from github.core.options import SingleTeamOptions
-from typing import Any, AsyncGenerator
+from typing import Any, AsyncGenerator, Literal
 from port_ocean.context.event import event_context
 
 
@@ -258,13 +258,13 @@ class TestCollaboratorMembershipWebhookProcessor:
         membership_webhook_processor: CollaboratorMembershipWebhookProcessor,
         resource_config: GithubCollaboratorConfig,
         mock_port_app_config: GithubPortAppConfig,
-        affiliation: str,
+        affiliation: Literal["outside", "direct"],
         is_outside: bool,
         expected_updated: bool,
         expected_deleted: bool,
     ) -> None:
         cfg = resource_config.copy(deep=True)
-        cfg.selector.affiliation = affiliation  # type: ignore[attr-defined]
+        cfg.selector.affiliation = affiliation
 
         payload = VALID_MEMBERSHIP_COLLABORATOR_PAYLOADS.copy()
         payload["action"] = "added"
@@ -284,7 +284,7 @@ class TestCollaboratorMembershipWebhookProcessor:
             },
         ]
 
-        membership_webhook_processor.affiliation_matches = AsyncMock(
+        affiliation_matches_mock = AsyncMock(
             return_value=(
                 (affiliation == "outside" and is_outside)
                 or (affiliation == "direct" and not is_outside)
@@ -312,11 +312,16 @@ class TestCollaboratorMembershipWebhookProcessor:
                     mock_get_team_repositories()
                 )
 
-                async with event_context("test_event") as event_context_obj:
-                    event_context_obj.port_app_config = mock_port_app_config
-                    result = await membership_webhook_processor.handle_event(
-                        payload, cfg
-                    )
+                with patch.object(
+                    membership_webhook_processor,
+                    "affiliation_matches",
+                    new=affiliation_matches_mock,
+                ):
+                    async with event_context("test_event") as event_context_obj:
+                        event_context_obj.port_app_config = mock_port_app_config
+                        result = await membership_webhook_processor.handle_event(
+                            payload, cfg
+                        )
 
         assert bool(result.updated_raw_results) is expected_updated
         assert bool(result.deleted_raw_results) is expected_deleted
@@ -332,4 +337,4 @@ class TestCollaboratorMembershipWebhookProcessor:
                 "repo2",
             }
 
-        assert membership_webhook_processor.affiliation_matches.await_count == 2
+        assert affiliation_matches_mock.await_count == 2

--- a/integrations/github/tests/github/webhook/webhook_processors/test_collaborator_webhook_processor/test_team_webhook_processor.py
+++ b/integrations/github/tests/github/webhook/webhook_processors/test_collaborator_webhook_processor/test_team_webhook_processor.py
@@ -19,7 +19,7 @@ from port_ocean.core.handlers.webhook.webhook_event import (
     WebhookEvent,
     WebhookEventRawResults,
 )
-from typing import Any
+from typing import Any, Literal
 from port_ocean.context.event import event_context
 
 
@@ -280,14 +280,14 @@ class TestCollaboratorTeamWebhookProcessor:
         self,
         team_webhook_processor: CollaboratorTeamWebhookProcessor,
         resource_config: GithubCollaboratorConfig,
-        affiliation: str,
+        affiliation: Literal["outside", "direct"],
         is_outside: bool,
         expected_updated: bool,
         expected_deleted: bool,
     ) -> None:
         cfg = resource_config.copy(deep=True)
-        cfg.selector.affiliation = affiliation  # type: ignore[attr-defined]
-        team_webhook_processor.affiliation_matches = AsyncMock(
+        cfg.selector.affiliation = affiliation
+        affiliation_matches_mock = AsyncMock(
             return_value=(
                 (affiliation == "outside" and is_outside)
                 or (affiliation == "direct" and not is_outside)
@@ -333,7 +333,12 @@ class TestCollaboratorTeamWebhookProcessor:
                     return_value=mock_team_data
                 )
 
-                result = await team_webhook_processor.handle_event(payload, cfg)
+                with patch.object(
+                    team_webhook_processor,
+                    "affiliation_matches",
+                    new=affiliation_matches_mock,
+                ):
+                    result = await team_webhook_processor.handle_event(payload, cfg)
 
         assert bool(result.updated_raw_results) is expected_updated
         assert bool(result.deleted_raw_results) is expected_deleted
@@ -349,7 +354,7 @@ class TestCollaboratorTeamWebhookProcessor:
                 "repo2",
             }
 
-        assert team_webhook_processor.affiliation_matches.await_count == 2
+        assert affiliation_matches_mock.await_count == 2
 
     async def test_handle_event_no_team_data(
         self,

--- a/integrations/github/tests/github/webhook/webhook_processors/test_collaborator_webhook_processor/test_team_webhook_processor.py
+++ b/integrations/github/tests/github/webhook/webhook_processors/test_collaborator_webhook_processor/test_team_webhook_processor.py
@@ -1,10 +1,13 @@
-from integration import GithubPortAppConfig
+from integration import (
+    GithubCollaboratorConfig,
+    GithubCollaboratorSelector,
+    GithubPortAppConfig,
+)
 from port_ocean.core.handlers.port_app_config.models import (
     EntityMapping,
     MappingsConfig,
     PortResourceConfig,
     ResourceConfig,
-    Selector,
 )
 import pytest
 from unittest.mock import MagicMock, patch, AsyncMock
@@ -62,10 +65,10 @@ INVALID_TEAM_COLLABORATOR_PAYLOADS: dict[str, Any] = {
 
 
 @pytest.fixture
-def resource_config() -> ResourceConfig:
-    return ResourceConfig(
+def resource_config() -> GithubCollaboratorConfig:
+    return GithubCollaboratorConfig(
         kind=ObjectKind.COLLABORATOR,
-        selector=Selector(query="true"),
+        selector=GithubCollaboratorSelector(query="true", affiliation="all"),
         port=PortResourceConfig(
             entity=MappingsConfig(
                 mappings=EntityMapping(
@@ -235,6 +238,8 @@ class TestCollaboratorTeamWebhookProcessor:
                             "name": "Test User",
                             "site_admin": False,
                             "__repository": "repo1",
+                            "__repository_object": {"name": "repo1"},
+                            "__organization": "test-org",
                         },
                         {
                             "id": "user1",
@@ -242,6 +247,8 @@ class TestCollaboratorTeamWebhookProcessor:
                             "name": "Test User",
                             "site_admin": False,
                             "__repository": "repo2",
+                            "__repository_object": {"name": "repo2"},
+                            "__organization": "test-org",
                         },
                     ]
                     assert result.updated_raw_results == expected_team_data
@@ -259,6 +266,90 @@ class TestCollaboratorTeamWebhookProcessor:
                     # For unsupported events, no exporters should be called
                     mock_create_client.assert_not_called()
                     mock_graphql_team_exporter.get_resource.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "affiliation,is_outside,expected_updated,expected_deleted",
+        [
+            ("outside", True, True, False),
+            ("outside", False, False, True),
+            ("direct", True, False, True),
+            ("direct", False, True, False),
+        ],
+    )
+    async def test_handle_event_team_events_affiliation_filter(
+        self,
+        team_webhook_processor: CollaboratorTeamWebhookProcessor,
+        resource_config: GithubCollaboratorConfig,
+        affiliation: str,
+        is_outside: bool,
+        expected_updated: bool,
+        expected_deleted: bool,
+    ) -> None:
+        cfg = resource_config.copy(deep=True)
+        cfg.selector.affiliation = affiliation  # type: ignore[attr-defined]
+        team_webhook_processor.affiliation_matches = AsyncMock(
+            return_value=(
+                (affiliation == "outside" and is_outside)
+                or (affiliation == "direct" and not is_outside)
+            )
+        )
+
+        payload = VALID_TEAM_COLLABORATOR_PAYLOADS.copy()
+        payload["action"] = "added_to_repository"
+
+        mock_team_data = {
+            "members": {
+                "nodes": [
+                    {
+                        "id": "user1",
+                        "login": "test-user",
+                        "name": "Test User",
+                        "isSiteAdmin": False,
+                    }
+                ]
+            },
+            "repositories": {
+                "nodes": [
+                    {"name": "repo1"},
+                    {"name": "repo2"},
+                ]
+            },
+        }
+
+        with patch(
+            "github.webhook.webhook_processors.collaborator_webhook_processor.team_webhook_processor.create_github_client"
+        ) as mock_create_client:
+            mock_client = MagicMock()
+            mock_create_client.return_value = mock_client
+
+            with patch(
+                "github.webhook.webhook_processors.collaborator_webhook_processor.team_webhook_processor.GraphQLTeamMembersAndReposExporter"
+            ) as mock_graphql_team_exporter_class:
+                mock_graphql_team_exporter = MagicMock()
+                mock_graphql_team_exporter_class.return_value = (
+                    mock_graphql_team_exporter
+                )
+                mock_graphql_team_exporter.get_resource = AsyncMock(
+                    return_value=mock_team_data
+                )
+
+                result = await team_webhook_processor.handle_event(payload, cfg)
+
+        assert bool(result.updated_raw_results) is expected_updated
+        assert bool(result.deleted_raw_results) is expected_deleted
+
+        if expected_updated:
+            assert {r["__repository"] for r in result.updated_raw_results} == {
+                "repo1",
+                "repo2",
+            }
+        if expected_deleted:
+            assert {r["__repository"] for r in result.deleted_raw_results} == {
+                "repo1",
+                "repo2",
+            }
+
+        assert team_webhook_processor.affiliation_matches.await_count == 2
 
     async def test_handle_event_no_team_data(
         self,


### PR DESCRIPTION
# Description

What -
- Add selector.affiliation to the GitHub Collaborator kind configuration (all/direct/outside).
- Apply the configured affiliation filter to collaborator live-events (member/membership/team) and emit deletions when an event no longer matches the selector.
- Expand collaborator webhook test coverage for affiliation=outside and affiliation=direct.

Why -
- Allow users to control which collaborators are synced (and kept) by affiliation, and keep live-events consistent with the configured selector to avoid drift.

How -
- Implement repo-scoped collaborator filtering via the repository collaborators API using the configured affiliation.
- Share the affiliation matching logic across collaborator webhook processors and use it to decide upserts vs deletions.
- Update/add tests for the new affiliation cases.

## Type of change

Please leave one option from the following and delete the rest:

- [x] New feature (non-breaking change which adds functionality)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [x] Integration able to create all default resources from scratch
- [x] Resync finishes successfully
- [x] Resync able to create entities
- [x] Resync able to update entities
- [x] Resync able to detect and delete entities
- [x] Scheduled resync able to abort existing resync and start a new one
- [x] Tested with at least 2 integrations from scratch
- [x] Tested with Kafka and Polling event listeners
- [x]  Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [x] Integration able to create all default resources from scratch
- [x] Completed a full resync from a freshly installed integration and it completed successfully
- [x] Resync able to create entities
- [x] Resync able to update entities
- [x]  Resync able to detect and delete entities
- [x] Resync finishes successfully
- [x] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [x] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [x] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
