### PR TITLE
[Integration][Gitlab-v2] Gitlab-v2 integration silently under ingests projects

### DIFF
--- a/integrations/gitlab-v2/CHANGELOG.md
+++ b/integrations/gitlab-v2/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.6.12 (2026-04-09)
+
+
+### Bug Fixes
+
+- Fix silent under-ingestion of projects and groups by reverting `includeOnlyActiveProjects` and `includeOnlyActiveGroups` selectors to default to unset (`None`) instead of `false`, which was causing unintended active-status filtering on GitLab API requests
+
+
 ## 0.6.11 (2026-04-09)
 
 

--- a/integrations/gitlab-v2/integration.py
+++ b/integrations/gitlab-v2/integration.py
@@ -41,8 +41,8 @@ class SearchQuery(BaseModel):
 
 
 class GroupSelector(Selector):
-    include_only_active_groups: bool = Field(
-        default=False,
+    include_only_active_groups: Optional[bool] = Field(
+        default=None,
         alias="includeOnlyActiveGroups",
         title="Include Only Active Groups",
         description="Filter groups by active status",
@@ -56,8 +56,8 @@ class ProjectSelector(Selector):
         default=False,
         description="Whether to include the languages of the project, defaults to false",
     )
-    include_only_active_projects: bool = Field(
-        default=False,
+    include_only_active_projects: Optional[bool] = Field(
+        default=None,
         alias="includeOnlyActiveProjects",
         title="Include Only Active Projects",
         description="Filter projects by active status",
@@ -411,8 +411,8 @@ class GitManipulationHandler(JQEntityProcessor):
                 f"DEPRECATION: Using 'file://' prefix in mappings is deprecated and will be removed in a future version. "
                 f"Pattern: '{pattern}'. "
                 f"Use the 'includedFiles' selector instead. Example: "
-                f"selector.includedFiles: ['{pattern[len(FILE_PROPERTY_PREFIX):]}'] "
-                f'and mapping: .__includedFiles["{pattern[len(FILE_PROPERTY_PREFIX):]}"]'
+                f"selector.includedFiles: ['{pattern[len(FILE_PROPERTY_PREFIX) :]}'] "
+                f'and mapping: .__includedFiles["{pattern[len(FILE_PROPERTY_PREFIX) :]}"]'
             )
             entity_processor = FileEntityProcessor
         elif pattern.startswith(SEARCH_PROPERTY_PREFIX):

--- a/integrations/gitlab-v2/pyproject.toml
+++ b/integrations/gitlab-v2/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gitlab-v2"
-version = "0.6.11"
+version = "0.6.12"
 description = "Gitlab"
 authors = ["Shariff <mohammed.s@getport.io>"]
 


### PR DESCRIPTION
# Description

What - revert change to `include_active_only_projects` and `include_only_active_groups` fields.

Why - Is causing data loss

How - 

## Type of change

Please leave one option from the following and delete the rest:

- [ x ] Bug fix (non-breaking change which fixes an issue)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
