### PR TITLE
[Integration][Jira] refactor: update token on the client when hit 401

### DIFF
--- a/integrations/jira/CHANGELOG.md
+++ b/integrations/jira/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.6.22 (2026-04-19)
+
+
+### Improvements
+
+- After OAuth token refresh on 401 retry, persist bearer auth on the Jira HTTP client so new requests use the updated access token without repeating failed attempts.
+
+
 ## 0.6.21 (2026-04-17)
 
 

--- a/integrations/jira/jira/client.py
+++ b/integrations/jira/jira/client.py
@@ -110,7 +110,11 @@ class JiraClient(OAuthClient):
             method=request.method,
             url=str(request.url),
         )
-        return next(self._get_bearer().auth_flow(request))
+        bearer_auth = self._get_bearer()
+        # Persist refreshed bearer auth so subsequent new requests use the latest token.
+        self.jira_api_auth = bearer_auth
+        self.client.auth = bearer_auth
+        return next(bearer_auth.auth_flow(request))
 
     async def _send_api_request(
         self,

--- a/integrations/jira/pyproject.toml
+++ b/integrations/jira/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jira"
-version = "0.6.21"
+version = "0.6.22"
 description = "Integration to bring information from Jira into Port"
 authors = ["Mor Paz <mor@getport.io>"]
 

--- a/integrations/jira/tests/test_client.py
+++ b/integrations/jira/tests/test_client.py
@@ -6,7 +6,13 @@ from httpx import BasicAuth, Request, Response
 from port_ocean.context.ocean import initialize_port_ocean_context
 from port_ocean.exceptions.context import PortOceanContextAlreadyInitializedError
 
-from jira.client import PAGE_SIZE, WEBHOOK_EVENTS, OAUTH2_WEBHOOK_EVENTS, JiraClient
+from jira.client import (
+    PAGE_SIZE,
+    WEBHOOK_EVENTS,
+    OAUTH2_WEBHOOK_EVENTS,
+    BearerAuth,
+    JiraClient,
+)
 from jira.overrides import JiraIssueSelector
 
 
@@ -75,6 +81,21 @@ async def test_send_api_request_failure(mock_jira_client: JiraClient) -> None:
         )
         with pytest.raises(Exception):
             await mock_jira_client._send_api_request("GET", "http://example.com")
+
+
+def test_refresh_request_auth_creds_updates_global_auth(
+    mock_jira_client: JiraClient,
+) -> None:
+    """Token refresh updates request header and default client auth for next requests."""
+    request = Request("GET", "https://example.atlassian.net/rest/api/3/myself")
+    refreshed_auth = BearerAuth("newly_refreshed_token")
+
+    with patch.object(mock_jira_client, "_get_bearer", return_value=refreshed_auth):
+        refreshed_request = mock_jira_client.refresh_request_auth_creds(request)
+
+    assert refreshed_request.headers["Authorization"] == "Bearer newly_refreshed_token"
+    assert mock_jira_client.jira_api_auth is refreshed_auth
+    assert mock_jira_client.client.auth is refreshed_auth
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description

What - 
Refactor the Jira client to store the refreshed token for requests to use.

Why -
After a token rotation occurs, we observe multiple 401 Unauthorized responses on the first attempt across concurrent requests. This happens because the refreshed token is only applied within the retry logic, rather than being set as the default authentication token for all subsequent requests.

In contrast, the gitlab-v2 integration handles this more effectively by updating the token at the client level. Once refreshed, the new token is immediately used as the global default, ensuring that all subsequent requests succeed on the first attempt without requiring retries.
How -

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)


<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
