### PR TITLE
[Integration][GitHub] Add closedPrsUpdatedSince Selector for Closed PRs

### DIFF
--- a/integrations/github/CHANGELOG.md
+++ b/integrations/github/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 5.3.13 (2026-04-23)
+
+
+### Improvements
+
+- Added `closedPrsUpdatedSince` selector to fetch closed pull requests from a fixed ISO-8601 timestamp instead of a relative lookback window.
+
+
 ## 5.3.12 (2026-04-21)
 
 

--- a/integrations/github/github/helpers/gql_queries.py
+++ b/integrations/github/github/helpers/gql_queries.py
@@ -327,7 +327,7 @@ query ListPullRequests(
       first: $first,
       after: $after,
       states: $states,
-      orderBy: {{ field: CREATED_AT, direction: DESC }}
+      orderBy: {{ field: UPDATED_AT, direction: DESC }}
     ) {{
       nodes {{
 {generate_pr_fields(options)}

--- a/integrations/github/integration.py
+++ b/integrations/github/integration.py
@@ -312,11 +312,21 @@ class GithubPullRequestSelector(RepoSearchSelector):
         ge=1,
         description="Max number of merged pull requests. Note: large numbers may cause rate limits. Merged PRs are only retrieved when 'closed' is selected in the state selector.",
     )
+    closed_prs_updated_since: Optional[datetime] = Field(
+        title="Closed pull requests updated since",
+        alias="closedPrsUpdatedSince",
+        default=None,
+        description=(
+            "When set (and 'closed' is in states), only closed pull requests with updated_at on or after "
+            "this instant are ingested. Use an ISO 8601 datetime (e.g. 2025-01-01T00:00:00Z). "
+            "Naive values are interpreted as UTC. When omitted, closed PRs use Closed PRs Lookback Days (since) instead."
+        ),
+    )
     since: int = Field(
         title="Closed PRs Lookback Days",
         default=60,
         ge=1,
-        description="Numbers of days back for closed pull requests.",
+        description="Number of days back for closed pull requests, combined with maxResults. Not used when closedPrsUpdatedSince is set.",
     )
     api: Literal["rest", "graphql"] = Field(
         title="API",
@@ -337,7 +347,12 @@ class GithubPullRequestSelector(RepoSearchSelector):
 
     @property
     def updated_after(self) -> datetime:
-        """Convert the since days to a timezone-aware datetime object."""
+        """Lower bound for closed PR updated_at filtering (UTC)."""
+        if self.closed_prs_updated_since is not None:
+            dt = self.closed_prs_updated_since
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt.astimezone(timezone.utc)
         return datetime.now(timezone.utc) - timedelta(days=self.since)
 
 

--- a/integrations/github/pyproject.toml
+++ b/integrations/github/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "github-ocean"
-version = "5.3.12"
+version = "5.3.13"
 description = "This integration ingest data from github"
 authors = ["Chukwuemeka Nwaoma <joelchukks@gmail.com>", "Melody Anyaegbulam <melodyogonna@gmail.com>", "Michael Armah <mikeyarmah@gmail.com>"]
 

--- a/integrations/github/tests/github/core/exporters/test_pull_request_exporter.py
+++ b/integrations/github/tests/github/core/exporters/test_pull_request_exporter.py
@@ -828,7 +828,7 @@ class TestGithubPullRequestSelectorClosedPrs:
         assert sel.updated_after == datetime(2025, 6, 15, 0, 0, 0, tzinfo=UTC)
 
     def test_updated_after_property_accepts_iso8601_string(self) -> None:
-        sel = GithubPullRequestSelector.model_validate(
+        sel = GithubPullRequestSelector.parse_obj(
             {
                 "query": "true",
                 "states": ["closed"],
@@ -847,7 +847,7 @@ class TestGithubPullRequestSelectorClosedPrs:
 
     def test_invalid_datetime_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            GithubPullRequestSelector.model_validate(
+            GithubPullRequestSelector.parse_obj(
                 {
                     "query": "true",
                     "states": ["closed"],

--- a/integrations/github/tests/github/core/exporters/test_pull_request_exporter.py
+++ b/integrations/github/tests/github/core/exporters/test_pull_request_exporter.py
@@ -1,7 +1,10 @@
 from typing import Any, AsyncGenerator, Generator
 import pytest
+from pydantic import ValidationError
 from unittest.mock import patch, AsyncMock
 from datetime import datetime, UTC, timedelta
+
+from integration import GithubPullRequestSelector
 from github.core.exporters.pull_request_exporter import (
     RestPullRequestExporter,
     GraphQLPullRequestExporter,
@@ -736,6 +739,117 @@ class TestGraphQLPullRequestExporter:
             },
         )
         assert mock_normalize.call_count == 2
+
+    async def test_graphql_closed_prs_apply_updated_after_filter(
+        self, graphql_client: GithubGraphQLClient
+    ) -> None:
+        exporter = GraphQLPullRequestExporter(graphql_client)
+
+        pr_nodes = [
+            {
+                "id": 1,
+                "updatedAt": "2025-08-10T15:08:15Z",
+                "state": "CLOSED",
+                "assignees": {"nodes": []},
+                "reviewRequests": {"nodes": []},
+                "comments": {"totalCount": 0},
+                "reviewThreads": {"totalCount": 0},
+                "commits": {"totalCount": 1},
+                "labels": {"nodes": []},
+                "mergeStateStatus": "CLEAN",
+                "mergeable": "UNKNOWN",
+            },
+        ]
+
+        async def mock_closed(
+            *args: Any, **kwargs: Any
+        ) -> AsyncGenerator[list[dict[str, Any]], None]:
+            yield pr_nodes
+
+        anchor = datetime(2025, 1, 1, 0, 0, 0, tzinfo=UTC)
+
+        with (
+            patch.object(
+                graphql_client,
+                "send_paginated_request",
+                side_effect=mock_closed,
+            ) as mock_paginated,
+            patch(
+                "github.core.exporters.pull_request_exporter.core.filter_prs_by_updated_at",
+            ) as mock_filter,
+            patch.object(
+                GraphQLPullRequestExporter,
+                "_normalize_pr_node",
+                side_effect=lambda pr, repo, org, **kwargs: {
+                    **pr,
+                    "__repository": repo,
+                    "__organization": org,
+                },
+            ),
+        ):
+            mock_filter.side_effect = lambda prs, field, updated_after: prs
+            async with event_context("test_event"):
+                options = ListPullRequestOptions(
+                    organization="test-org",
+                    states=["closed"],
+                    repo_name="repo1",
+                    max_results=10,
+                    updated_after=anchor,
+                    repo={"name": "repo1"},
+                )
+                batches = [
+                    batch async for batch in exporter.get_paginated_resources(options)
+                ]
+
+        mock_filter.assert_called_once()
+        assert len(batches) == 1
+        assert len(batches[0]) == 1
+        expected_gql = generate_list_pull_requests_gql(
+            PullRequestGraphQLOptions(enrich_with_first_commit=False)
+        )
+        mock_paginated.assert_called_once_with(
+            expected_gql,
+            {
+                "organization": "test-org",
+                "repo": "repo1",
+                "states": ["CLOSED", "MERGED"],
+                "__path": "repository.pullRequests",
+            },
+        )
+
+
+class TestGithubPullRequestSelectorClosedPrs:
+    def test_updated_after_property_uses_closed_prs_updated_since(self) -> None:
+        sel = GithubPullRequestSelector(
+            query="true",
+            states=["closed"],
+            closedPrsUpdatedSince=datetime(2025, 6, 15, 0, 0, 0, tzinfo=UTC),
+        )
+        assert sel.updated_after == datetime(2025, 6, 15, 0, 0, 0, tzinfo=UTC)
+
+    def test_updated_after_property_accepts_iso8601_string(self) -> None:
+        sel = GithubPullRequestSelector(
+            query="true",
+            states=["closed"],
+            closedPrsUpdatedSince="2025-06-15T00:00:00+00:00",
+        )
+        assert sel.updated_after == datetime(2025, 6, 15, 0, 0, 0, tzinfo=UTC)
+
+    def test_naive_datetime_treated_as_utc(self) -> None:
+        sel = GithubPullRequestSelector(
+            query="true",
+            states=["closed"],
+            closedPrsUpdatedSince=datetime(2025, 6, 15, 12, 0, 0),
+        )
+        assert sel.updated_after == datetime(2025, 6, 15, 12, 0, 0, tzinfo=UTC)
+
+    def test_invalid_datetime_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            GithubPullRequestSelector(
+                query="true",
+                states=["closed"],
+                closedPrsUpdatedSince="not-a-timestamp",
+            )
 
 
 class TestGraphQLPullRequestExporterInternals:


### PR DESCRIPTION
# Description

What -
- Add `closedPrsUpdatedSince` (ISO-8601) selector for the GitHub `pull-request` kind to anchor closed PR ingestion to a fixed timestamp.
- Update GraphQL PR list ordering to `UPDATED_AT` to align pagination with the `updated_at >= updated_after` filtering logic.
- Add tests for selector parsing/normalization and GraphQL closed PR filtering.

Why -
- The existing `since` selector is a rolling “N days ago” window, which drifts over time and can miss PRs outside the window.
- A fixed ISO timestamp supports deterministic “since Jan 1 2025” style ingestion.

How -
- Extend `GithubPullRequestSelector` with `closedPrsUpdatedSince` and make `updated_after` return it (UTC-normalized) when provided, otherwise fall back to `since`.
- Keep the REST/GraphQL exporters filtering logic unchanged (it already uses `updated_after`); ensure GraphQL pagination order matches the filter by ordering by `UPDATED_AT`.
- Add unit tests covering selector behavior and GraphQL closed PR filtering.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [x] Integration able to create all default resources from scratch
- [x] Resync finishes successfully
- [x] Resync able to create entities
- [x] Resync able to update entities
- [x]  Resync able to detect and delete entities
- [x] Scheduled resync able to abort existing resync and start a new one
- [x] Tested with at least 2 integrations from scratch
- [x] Tested with Kafka and Polling event listeners
- [x] Tested deletion of entities that don't pass the selector

### Integration testing checklist

- [x] Integration able to create all default resources from scratch
- [x] Completed a full resync from a freshly installed integration and it completed successfully
- [x] Resync able to create entities
- [x] Resync able to update entities
- [x]  Resync able to detect and delete entities
- [x] Resync finishes successfully
- [x] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [x] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [x] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)