### PR TITLE
[Core] Bugfix: send examples before items to parse 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.41.5 (2026-04-27)
+
+### Bug fixes
+
+- Fixed raw examples ingestion for resources using `itemsToParse`: examples are now sent from the original extracted payload before `itemsToParse` expansion/top-level transform, so arrays and parent fields are preserved in Port examples.
+
 ## 0.41.4 (2026-04-23)
 
 ### Bug fixes

--- a/port_ocean/core/handlers/entity_processor/base.py
+++ b/port_ocean/core/handlers/entity_processor/base.py
@@ -25,7 +25,6 @@ class BaseEntityProcessor(BaseHandler):
         mapping: ResourceConfig,
         raw_data: list[RAW_ITEM],
         parse_all: bool = False,
-        send_raw_data_examples_amount: int = 0,
     ) -> CalculationResult:
         pass
 
@@ -34,7 +33,6 @@ class BaseEntityProcessor(BaseHandler):
         mapping: ResourceConfig,
         raw_data: list[RAW_ITEM],
         parse_all: bool = False,
-        send_raw_data_examples_amount: int = 0,
     ) -> CalculationResult:
         """Public method to parse raw entity data and map it to an EntityDiff.
 
@@ -42,7 +40,6 @@ class BaseEntityProcessor(BaseHandler):
             mapping (ResourceConfig): The configuration for entity mapping.
             raw_data (list[RawEntity]): The raw data to be parsed.
             parse_all (bool): Whether to parse all data or just data that passed the selector.
-            send_raw_data_examples_amount (bool): Whether to send example data to the integration service.
 
         Returns:
             EntityDiff: The parsed entity differences.
@@ -50,6 +47,4 @@ class BaseEntityProcessor(BaseHandler):
         with logger.contextualize(kind=mapping.kind, resource_kind=mapping.kind):
             if not raw_data:
                 return CalculationResult(EntitySelectorDiff([], []), [])
-            return await self._parse_items(
-                mapping, raw_data, parse_all, send_raw_data_examples_amount
-            )
+            return await self._parse_items(mapping, raw_data, parse_all)

--- a/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
+++ b/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
@@ -375,19 +375,6 @@ class JQEntityProcessor(BaseEntityProcessor):
             )
             return set()
 
-    @staticmethod
-    async def _send_examples(data: list[dict[str, Any]], kind: str) -> None:
-        try:
-            if data:
-                await ocean.port_client.ingest_integration_kind_examples(
-                    kind, data, should_log=False
-                )
-        except Exception as ex:
-            logger.warning(
-                f"Failed to send raw data example {ex}",
-                exc_info=True,
-            )
-
     async def separate_compileable_and_uncompileable_patterns_and_warmup_cache(
         self, raw_entity_mappings: dict[str, Any], selector_queries: list[str] = []
     ) -> tuple[dict[str, Any], dict[str, Any]]:
@@ -576,16 +563,7 @@ class JQEntityProcessor(BaseEntityProcessor):
         mapping: ResourceConfig,
         raw_results: list[RAW_ITEM],
         parse_all: bool = False,
-        send_raw_data_examples_amount: int = 0,
     ) -> CalculationResult:
-        # Send raw data examples FIRST (before transformation)
-        # This ensures users can see the raw data even if transformation fails
-        if send_raw_data_examples_amount > 0 and raw_results:
-            examples_to_send = [
-                item.copy() for item in raw_results[:send_raw_data_examples_amount]
-            ]
-            await self._send_examples(examples_to_send, mapping.kind)
-
         raw_entity_mappings: dict[str, Any] = mapping.port.entity.mappings.dict(
             exclude_unset=True
         )

--- a/port_ocean/core/integrations/mixins/live_events.py
+++ b/port_ocean/core/integrations/mixins/live_events.py
@@ -60,7 +60,7 @@ class LiveEventsMixin(HandlerMixin):
             for raw_item in webhook_event_raw_result.updated_raw_results:
                 async for batch in self._expand_raw_item(raw_item, resource):
                     calculation_results = await self.entity_processor.parse_items(
-                        resource, batch, parse_all=True, send_raw_data_examples_amount=0
+                        resource, batch, parse_all=True
                     )
                     entities.extend(calculation_results.entity_selector_diff.passed)
                     entities_not_passed.extend(calculation_results.entity_selector_diff.failed)
@@ -68,7 +68,7 @@ class LiveEventsMixin(HandlerMixin):
             for raw_item in webhook_event_raw_result.deleted_raw_results:
                 async for batch in self._expand_raw_item(raw_item, resource):
                     deletion_results = await self.entity_processor.parse_items(
-                        resource, batch, parse_all=True, send_raw_data_examples_amount=0
+                        resource, batch, parse_all=True
                     )
                     entities_to_delete.extend(deletion_results.entity_selector_diff.passed)
 

--- a/port_ocean/core/integrations/mixins/sync_raw.py
+++ b/port_ocean/core/integrations/mixins/sync_raw.py
@@ -121,6 +121,7 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
     ) -> tuple[RESYNC_RESULT, list[RAW_RESULT | Exception]]:
         tasks = []
         results = []
+        shared_examples_budget = {"remaining": max(0, send_raw_data_examples_amount)}
         for task in fns:
             if inspect.isasyncgenfunction(task):
                 logger.info(
@@ -133,7 +134,8 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                         resource_config.port.items_to_parse_name,
                         resource_config.port.items_to_parse,
                         resource_config.port.items_to_parse_top_level_transform,
-                        send_raw_data_examples_amount,
+                        send_raw_data_examples_amount=send_raw_data_examples_amount,
+                        shared_examples_budget=shared_examples_budget,
                     )
                 )
             else:

--- a/port_ocean/core/integrations/mixins/sync_raw.py
+++ b/port_ocean/core/integrations/mixins/sync_raw.py
@@ -121,7 +121,6 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
     ) -> tuple[RESYNC_RESULT, list[RAW_RESULT | Exception]]:
         tasks = []
         results = []
-        shared_examples_budget = {"remaining": max(0, send_raw_data_examples_amount)}
         for task in fns:
             if inspect.isasyncgenfunction(task):
                 logger.info(
@@ -135,7 +134,6 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                         resource_config.port.items_to_parse,
                         resource_config.port.items_to_parse_top_level_transform,
                         send_raw_data_examples_amount=send_raw_data_examples_amount,
-                        shared_examples_budget=shared_examples_budget,
                     )
                 )
             else:

--- a/port_ocean/core/integrations/mixins/sync_raw.py
+++ b/port_ocean/core/integrations/mixins/sync_raw.py
@@ -143,7 +143,9 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                 task = typing.cast(Callable[[str], Awaitable[RAW_RESULT]], task)
                 tasks.append(
                     resync_function_wrapper(
-                        task, resource_config.kind, resource_config.port.items_to_parse
+                        task,
+                        resource_config.kind,
+                        send_raw_data_examples_amount=send_raw_data_examples_amount,
                     )
                 )
 
@@ -168,13 +170,10 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
         self,
         raw_diff: list[tuple[ResourceConfig, list[RAW_ITEM]]],
         parse_all: bool = False,
-        send_raw_data_examples_amount: int = 0,
     ) -> list[CalculationResult]:
         return await asyncio.gather(
             *(
-                self.entity_processor.parse_items(
-                    mapping, results, parse_all, send_raw_data_examples_amount
-                )
+                self.entity_processor.parse_items(mapping, results, parse_all)
                 for mapping, results in raw_diff
             )
         )
@@ -273,7 +272,6 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
         results: list[dict[Any, Any]],
         user_agent_type: UserAgentType,
         parse_all: bool = False,
-        send_raw_data_examples_amount: int = 0,
         batch_index: int = 1,
     ) -> CalculationResult:
         with logger.contextualize(etl_phase=ETLPhase.TRANSFORM):
@@ -282,9 +280,7 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                 batch_index=batch_index,
                 raw_items=len(results),
             )
-            objects_diff = await self._calculate_raw(
-                [(resource, results)], parse_all, send_raw_data_examples_amount
-            )
+            objects_diff = await self._calculate_raw([(resource, results)], parse_all)
             entities_transformed = len(objects_diff[0].entity_selector_diff.passed)
             entities_failed = len(objects_diff[0].entity_selector_diff.failed)
             logger.info(
@@ -413,7 +409,10 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
 
     @TimeMetric(MetricPhase.RESYNC)
     async def _register_in_batches(
-        self, resource_config: ResourceConfig, user_agent_type: UserAgentType, index: int
+        self,
+        resource_config: ResourceConfig,
+        user_agent_type: UserAgentType,
+        index: int,
     ) -> tuple[list[Entity], list[Exception]]:
         send_raw_data_examples_amount = (
             SEND_RAW_DATA_EXAMPLES_AMOUNT if ocean.config.send_raw_data_examples else 0
@@ -462,7 +461,6 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                 resource_config,
                 raw_results,
                 user_agent_type,
-                send_raw_data_examples_amount=send_raw_data_examples_amount,
                 batch_index=batch_index,
             )
             errors.extend(calculation_result.errors)
@@ -488,20 +486,10 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                             event_type=LakehouseEventType.RESYNC,
                         )
                     number_of_raw_results += len(items)
-                    if send_raw_data_examples_amount > 0:
-                        send_raw_data_examples_amount = max(
-                            0, send_raw_data_examples_amount - len(passed_entities)
-                        )
-
                     calculation_result = await self._register_resource_raw(
                         resource_config,
                         items,
                         user_agent_type,
-                        send_raw_data_examples_amount=(
-                            0
-                            if resource_config.port.items_to_parse
-                            else send_raw_data_examples_amount
-                        ),
                         batch_index=batch_index,
                     )
                     passed_entities.extend(
@@ -556,6 +544,7 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
             )
 
         return passed_entities, errors
+
 
 
     async def register_raw(

--- a/port_ocean/core/integrations/mixins/sync_raw.py
+++ b/port_ocean/core/integrations/mixins/sync_raw.py
@@ -78,7 +78,9 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
         raise NotImplementedError("on_resync must be implemented")
 
     async def _get_resource_raw_results(
-        self, resource_config: ResourceConfig
+        self,
+        resource_config: ResourceConfig,
+        send_raw_data_examples_amount: int = 0,
     ) -> tuple[RESYNC_RESULT, list[Exception]]:
         logger.info(f"Fetching {resource_config.kind} resync results")
 
@@ -92,7 +94,9 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
         fns = self._collect_resync_functions(resource_config)
         logger.info(f"Found {len(fns)} resync functions for {resource_config.kind}")
 
-        results, errors = await self._execute_resync_tasks(fns, resource_config)
+        results, errors = await self._execute_resync_tasks(
+            fns, resource_config, send_raw_data_examples_amount
+        )
 
         return results, errors
 
@@ -113,6 +117,7 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
         self,
         fns: list[Callable[[str], Awaitable[RAW_RESULT]]],
         resource_config: ResourceConfig,
+        send_raw_data_examples_amount: int = 0,
     ) -> tuple[RESYNC_RESULT, list[RAW_RESULT | Exception]]:
         tasks = []
         results = []
@@ -128,6 +133,7 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                         resource_config.port.items_to_parse_name,
                         resource_config.port.items_to_parse,
                         resource_config.port.items_to_parse_top_level_transform,
+                        send_raw_data_examples_amount,
                     )
                 )
             else:
@@ -409,9 +415,15 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
     async def _register_in_batches(
         self, resource_config: ResourceConfig, user_agent_type: UserAgentType, index: int
     ) -> tuple[list[Entity], list[Exception]]:
+        send_raw_data_examples_amount = (
+            SEND_RAW_DATA_EXAMPLES_AMOUNT if ocean.config.send_raw_data_examples else 0
+        )
+
         with logger.contextualize(etl_phase=ETLPhase.EXTRACT):
             logger.info("Starting extract phase")
-            results, errors = await self._get_resource_raw_results(resource_config)
+            results, errors = await self._get_resource_raw_results(
+                resource_config, send_raw_data_examples_amount
+            )
             async_generators: list[ASYNC_GENERATOR_RESYNC_TYPE] = []
             raw_results: RAW_RESULT = []
             lakehouse_data_enabled = await is_lakehouse_data_enabled()
@@ -437,10 +449,6 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                 raw_items=len(raw_results),
                 async_generators=len(async_generators),
             )
-
-        send_raw_data_examples_amount = (
-            SEND_RAW_DATA_EXAMPLES_AMOUNT if ocean.config.send_raw_data_examples else 0
-        )
 
         passed_entities = []
         number_of_raw_results = 0
@@ -489,7 +497,11 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                         resource_config,
                         items,
                         user_agent_type,
-                        send_raw_data_examples_amount=send_raw_data_examples_amount,
+                        send_raw_data_examples_amount=(
+                            0
+                            if resource_config.port.items_to_parse
+                            else send_raw_data_examples_amount
+                        ),
                         batch_index=batch_index,
                     )
                     passed_entities.extend(

--- a/port_ocean/core/integrations/mixins/utils.py
+++ b/port_ocean/core/integrations/mixins/utils.py
@@ -192,7 +192,6 @@ async def resync_generator_wrapper(
     items_to_parse: str | None = None,
     items_to_parse_top_level_transform: bool = True,
     send_raw_data_examples_amount: int = 0,
-    shared_examples_budget: dict[str, int] | None = None,
 ) -> ASYNC_GENERATOR_RESYNC_TYPE:
     generator = fn(kind)
     errors = []
@@ -204,22 +203,12 @@ async def resync_generator_wrapper(
                     result = validate_result(await anext(generator))
 
                     if items_to_parse:
-                        current_remaining_examples = (
-                            max(0, shared_examples_budget.get("remaining", 0))
-                            if shared_examples_budget is not None
-                            else remaining_examples_to_send
-                        )
                         sent_examples = await send_raw_data_examples_before_transform(
-                            result, kind, current_remaining_examples
+                            result, kind, remaining_examples_to_send
                         )
-                        if shared_examples_budget is not None:
-                            shared_examples_budget["remaining"] = max(
-                                0, current_remaining_examples - sent_examples
-                            )
-                        else:
-                            remaining_examples_to_send = max(
-                                0, remaining_examples_to_send - sent_examples
-                            )
+                        remaining_examples_to_send = max(
+                            0, remaining_examples_to_send - sent_examples
+                        )
                         items_to_parse_generator = handle_items_to_parse(result, items_to_parse_name, items_to_parse, items_to_parse_top_level_transform)
                         del result
                         async for batch in items_to_parse_generator:

--- a/port_ocean/core/integrations/mixins/utils.py
+++ b/port_ocean/core/integrations/mixins/utils.py
@@ -132,7 +132,7 @@ async def resync_function_wrapper(
 ) -> RAW_RESULT:
     with resync_error_handling():
         results = validate_result(await fn(kind))
-        await send_raw_data_examples_before_transform(
+        await send_raw_data_examples(
             results, kind, send_raw_data_examples_amount
         )
         return results
@@ -171,7 +171,7 @@ async def handle_items_to_parse(result: RAW_RESULT, items_to_parse_name: str, it
         if batch:
             yield batch
 
-async def send_raw_data_examples_before_transform(
+async def send_raw_data_examples(
     result: RAW_RESULT, kind: str, amount: int
 ) -> int:
     if amount <= 0 or not result:
@@ -206,7 +206,7 @@ async def resync_generator_wrapper(
             try:
                 with resync_error_handling():
                     result = validate_result(await anext(generator))
-                    sent_examples = await send_raw_data_examples_before_transform(
+                    sent_examples = await send_raw_data_examples(
                         result, kind, remaining_examples_to_send
                     )
                     remaining_examples_to_send = max(

--- a/port_ocean/core/integrations/mixins/utils.py
+++ b/port_ocean/core/integrations/mixins/utils.py
@@ -166,11 +166,30 @@ async def handle_items_to_parse(result: RAW_RESULT, items_to_parse_name: str, it
         if batch:
             yield batch
 
+async def send_raw_data_examples_before_transform(
+    result: RAW_RESULT, kind: str, amount: int
+) -> int:
+    if amount <= 0 or not result:
+        return 0
+
+    examples_to_send = [item.copy() for item in result[:amount]]
+    try:
+        await ocean.port_client.ingest_integration_kind_examples(
+            kind, examples_to_send, should_log=False
+        )
+    except Exception as ex:
+        logger.warning(
+            f"Failed to send raw data example {ex}",
+            exc_info=True,
+        )
+    return len(examples_to_send)
+
 async def resync_generator_wrapper(
-    fn: Callable[[str], ASYNC_GENERATOR_RESYNC_TYPE], kind: str, items_to_parse_name: str, items_to_parse: str | None = None, items_to_parse_top_level_transform: bool = True
+    fn: Callable[[str], ASYNC_GENERATOR_RESYNC_TYPE], kind: str, items_to_parse_name: str, items_to_parse: str | None = None, items_to_parse_top_level_transform: bool = True, send_raw_data_examples_amount: int = 0
 ) -> ASYNC_GENERATOR_RESYNC_TYPE:
     generator = fn(kind)
     errors = []
+    remaining_examples_to_send = send_raw_data_examples_amount
     try:
         while True:
             try:
@@ -178,6 +197,12 @@ async def resync_generator_wrapper(
                     result = validate_result(await anext(generator))
 
                     if items_to_parse:
+                        sent_examples = await send_raw_data_examples_before_transform(
+                            result, kind, remaining_examples_to_send
+                        )
+                        remaining_examples_to_send = max(
+                            0, remaining_examples_to_send - sent_examples
+                        )
                         items_to_parse_generator = handle_items_to_parse(result, items_to_parse_name, items_to_parse, items_to_parse_top_level_transform)
                         del result
                         async for batch in items_to_parse_generator:

--- a/port_ocean/core/integrations/mixins/utils.py
+++ b/port_ocean/core/integrations/mixins/utils.py
@@ -126,11 +126,16 @@ def resync_error_handling() -> Generator[None, None, None]:
 
 
 async def resync_function_wrapper(
-    fn: Callable[[str], Awaitable[RAW_RESULT]], kind: str, items_to_parse: str | None = None
+    fn: Callable[[str], Awaitable[RAW_RESULT]],
+    kind: str,
+    send_raw_data_examples_amount: int = 0,
 ) -> RAW_RESULT:
     with resync_error_handling():
-        results = await fn(kind)
-        return validate_result(results)
+        results = validate_result(await fn(kind))
+        await send_raw_data_examples_before_transform(
+            results, kind, send_raw_data_examples_amount
+        )
+        return results
 
 async def handle_items_to_parse(result: RAW_RESULT, items_to_parse_name: str, items_to_parse: str | None = None, items_to_parse_top_level_transform: bool = True) -> AsyncGenerator[list[dict[str, Any]], None]:
     delete_target = extract_jq_deletion_path_revised(items_to_parse) or '.'
@@ -201,14 +206,14 @@ async def resync_generator_wrapper(
             try:
                 with resync_error_handling():
                     result = validate_result(await anext(generator))
+                    sent_examples = await send_raw_data_examples_before_transform(
+                        result, kind, remaining_examples_to_send
+                    )
+                    remaining_examples_to_send = max(
+                        0, remaining_examples_to_send - sent_examples
+                    )
 
                     if items_to_parse:
-                        sent_examples = await send_raw_data_examples_before_transform(
-                            result, kind, remaining_examples_to_send
-                        )
-                        remaining_examples_to_send = max(
-                            0, remaining_examples_to_send - sent_examples
-                        )
                         items_to_parse_generator = handle_items_to_parse(result, items_to_parse_name, items_to_parse, items_to_parse_top_level_transform)
                         del result
                         async for batch in items_to_parse_generator:

--- a/port_ocean/core/integrations/mixins/utils.py
+++ b/port_ocean/core/integrations/mixins/utils.py
@@ -177,15 +177,22 @@ async def send_raw_data_examples_before_transform(
         await ocean.port_client.ingest_integration_kind_examples(
             kind, examples_to_send, should_log=False
         )
+        return len(examples_to_send)
     except Exception as ex:
         logger.warning(
             f"Failed to send raw data example {ex}",
             exc_info=True,
         )
-    return len(examples_to_send)
+        return 0
 
 async def resync_generator_wrapper(
-    fn: Callable[[str], ASYNC_GENERATOR_RESYNC_TYPE], kind: str, items_to_parse_name: str, items_to_parse: str | None = None, items_to_parse_top_level_transform: bool = True, send_raw_data_examples_amount: int = 0
+    fn: Callable[[str], ASYNC_GENERATOR_RESYNC_TYPE],
+    kind: str,
+    items_to_parse_name: str,
+    items_to_parse: str | None = None,
+    items_to_parse_top_level_transform: bool = True,
+    send_raw_data_examples_amount: int = 0,
+    shared_examples_budget: dict[str, int] | None = None,
 ) -> ASYNC_GENERATOR_RESYNC_TYPE:
     generator = fn(kind)
     errors = []
@@ -197,12 +204,22 @@ async def resync_generator_wrapper(
                     result = validate_result(await anext(generator))
 
                     if items_to_parse:
+                        current_remaining_examples = (
+                            max(0, shared_examples_budget.get("remaining", 0))
+                            if shared_examples_budget is not None
+                            else remaining_examples_to_send
+                        )
                         sent_examples = await send_raw_data_examples_before_transform(
-                            result, kind, remaining_examples_to_send
+                            result, kind, current_remaining_examples
                         )
-                        remaining_examples_to_send = max(
-                            0, remaining_examples_to_send - sent_examples
-                        )
+                        if shared_examples_budget is not None:
+                            shared_examples_budget["remaining"] = max(
+                                0, current_remaining_examples - sent_examples
+                            )
+                        else:
+                            remaining_examples_to_send = max(
+                                0, remaining_examples_to_send - sent_examples
+                            )
                         items_to_parse_generator = handle_items_to_parse(result, items_to_parse_name, items_to_parse, items_to_parse_top_level_transform)
                         del result
                         async for batch in items_to_parse_generator:

--- a/port_ocean/tests/core/handlers/entity_processor/test_jq_entity_processor.py
+++ b/port_ocean/tests/core/handlers/entity_processor/test_jq_entity_processor.py
@@ -1,5 +1,5 @@
 from io import StringIO
-from typing import Any, cast
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
@@ -368,23 +368,15 @@ class TestJQEntityProcessor:
             },
             {"foo": "bar", "baz": "bazbar", "bar": {"foobar": "foobar"}},
         ]
-        with patch(
-            "port_ocean.core.handlers.entity_processor.jq_entity_processor.JQEntityProcessor._send_examples"
-        ) as mock_send_examples:
-            result = await mocked_processor._parse_items(
-                mapping, raw_results, send_raw_data_examples_amount=1
-            )
-            assert len(result.misconfigured_entity_keys) > 0
-            assert len(result.misconfigured_entity_keys) == 4
-            assert result.misconfigured_entity_keys == {
-                "identifier": ".ark",
-                "properties.description": ".bazbar",
-                "properties.url": ".foobar",
-                "properties.defaultBranch": ".bar.baz",
-            }
-            assert mock_send_examples.await_args is not None, "mock was not awaited"
-            args, _ = mock_send_examples.await_args
-            assert len(cast(list[Any], args[0])) > 0
+        result = await mocked_processor._parse_items(mapping, raw_results)
+        assert len(result.misconfigured_entity_keys) > 0
+        assert len(result.misconfigured_entity_keys) == 4
+        assert result.misconfigured_entity_keys == {
+            "identifier": ".ark",
+            "properties.description": ".bazbar",
+            "properties.url": ".foobar",
+            "properties.defaultBranch": ".bar.baz",
+        }
 
     async def test_parse_items_empty_required(
         self, mocked_processor: JQEntityProcessor
@@ -545,16 +537,13 @@ class TestJQEntityProcessor:
             assert "WARNING" in line
             assert "ERROR" not in line
 
-    async def test_examples_sent_even_when_transformation_fails(
+    async def test_parse_items_reports_misconfiguration_when_transformation_fails(
         self, mocked_processor: JQEntityProcessor
     ) -> None:
         """
-        Test that kind examples are sent BEFORE transformation, so users can see
-        raw data even when the mapping fails completely.
-
         Scenario: Raw data has user objects with 'name' and 'email', but the mapping
         tries to use '.test' as identifier (which doesn't exist). Transformation
-        should fail, but examples should still be sent.
+        should fail and report the misconfiguration.
         """
         mapping = Mock()
         mapping.kind = "users"
@@ -577,43 +566,17 @@ class TestJQEntityProcessor:
             {"name": "Bob Wilson", "email": "bob@example.com"},
         ]
 
-        with patch(
-            "port_ocean.core.handlers.entity_processor.jq_entity_processor.JQEntityProcessor._send_examples"
-        ) as mock_send_examples:
-            result = await mocked_processor._parse_items(
-                mapping, raw_results, send_raw_data_examples_amount=2
-            )
+        result = await mocked_processor._parse_items(mapping, raw_results)
 
-            # Verify examples were sent (this is the key assertion)
-            assert (
-                mock_send_examples.await_args is not None
-            ), "Examples should be sent even when transformation fails"
+        # Verify transformation failed (no entities created because .color doesn't exist)
+        assert (
+            len(result.entity_selector_diff.passed) == 0
+        ), "No entities should pass because identifier mapping failed"
 
-            # Verify the raw data was sent as examples
-            args, _ = mock_send_examples.await_args
-            examples_sent = cast(list[Any], args[0])
-            assert len(examples_sent) == 2, "Should send requested number of examples"
-
-            # Verify examples contain the raw data
-            assert examples_sent[0] == {"name": "John Doe", "email": "john@example.com"}
-            assert examples_sent[1] == {
-                "name": "Jane Smith",
-                "email": "jane@example.com",
-            }
-
-            # Verify the kind was passed correctly
-            kind_arg = args[1]
-            assert kind_arg == "users"
-
-            # Verify transformation failed (no entities created because .color doesn't exist)
-            assert (
-                len(result.entity_selector_diff.passed) == 0
-            ), "No entities should pass because identifier mapping failed"
-
-            # Verify misconfigurations were detected
-            assert (
-                "identifier" in result.misconfigured_entity_keys
-            ), "Should report identifier as misconfigured"
+        # Verify misconfigurations were detected
+        assert (
+            "identifier" in result.misconfigured_entity_keys
+        ), "Should report identifier as misconfigured"
 
     async def test_separate_compileable_and_uncompileable_patterns_simple(
         self, mocked_processor: JQEntityProcessor
@@ -1181,7 +1144,7 @@ class TestJQEntityProcessor:
 
         This test directly exercises the buggy code path:
         - Creates data with nested objects containing sensitive patterns
-        - Makes a shallow copy (as _parse_items does)
+        - Makes a shallow copy (as send_raw_data_examples_before_transform does)
         - Calls mask_object on the copy
         - Verifies the original is NOT mutated
         """
@@ -1218,7 +1181,7 @@ class TestJQEntityProcessor:
             # Store original values for comparison
             raw_results_before: list[dict[str, Any]] = deepcopy(raw_results)
 
-            # Simulate what JQEntityProcessor._parse_items does: shallow copy for examples
+            # Simulate what send_raw_data_examples_before_transform does: shallow copy for examples
             examples_to_send = [item.copy() for item in raw_results[:1]]
 
             # Call mask_object on the examples (as ingest_integration_kind_examples does)

--- a/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
+++ b/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
@@ -1489,3 +1489,36 @@ async def test_parse_items_sets_both_kind_and_resource_kind_in_logger_context(
     assert any(
         r.get("resource_kind") == mock_resource_config.kind for r in records
     ), "Expected 'resource_kind' to be set in logger context"
+
+
+@pytest.mark.asyncio
+async def test_execute_resync_tasks_shares_examples_budget_across_async_generators(
+    mock_sync_raw_mixin: SyncRawMixin,
+    mock_resource_config: ResourceConfig,
+) -> None:
+    async def generator_one(kind: str) -> AsyncGenerator[list[dict[str, Any]], None]:
+        if False:
+            yield [{"kind": kind}]
+
+    async def generator_two(kind: str) -> AsyncGenerator[list[dict[str, Any]], None]:
+        if False:
+            yield [{"kind": kind}]
+
+    wrapped_generator_one = generator_one("test-kind")
+    wrapped_generator_two = generator_two("test-kind")
+
+    with patch(
+        "port_ocean.core.integrations.mixins.sync_raw.resync_generator_wrapper",
+        side_effect=[wrapped_generator_one, wrapped_generator_two],
+    ) as mock_wrapper:
+        await mock_sync_raw_mixin._execute_resync_tasks(
+            [generator_one, generator_two],
+            mock_resource_config,
+            send_raw_data_examples_amount=5,
+        )
+
+    assert mock_wrapper.call_count == 2
+    first_budget = mock_wrapper.call_args_list[0].kwargs["shared_examples_budget"]
+    second_budget = mock_wrapper.call_args_list[1].kwargs["shared_examples_budget"]
+    assert first_budget is second_budget
+    assert first_budget["remaining"] == 5

--- a/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
+++ b/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
@@ -1492,7 +1492,7 @@ async def test_parse_items_sets_both_kind_and_resource_kind_in_logger_context(
 
 
 @pytest.mark.asyncio
-async def test_execute_resync_tasks_shares_examples_budget_across_async_generators(
+async def test_execute_resync_tasks_passes_examples_amount_to_each_async_generator(
     mock_sync_raw_mixin: SyncRawMixin,
     mock_resource_config: ResourceConfig,
 ) -> None:
@@ -1522,7 +1522,5 @@ async def test_execute_resync_tasks_shares_examples_budget_across_async_generato
         )
 
     assert mock_wrapper.call_count == 2
-    first_budget = mock_wrapper.call_args_list[0].kwargs["shared_examples_budget"]
-    second_budget = mock_wrapper.call_args_list[1].kwargs["shared_examples_budget"]
-    assert first_budget is second_budget
-    assert first_budget["remaining"] == 5
+    assert mock_wrapper.call_args_list[0].kwargs == {"send_raw_data_examples_amount": 5}
+    assert mock_wrapper.call_args_list[1].kwargs == {"send_raw_data_examples_amount": 5}

--- a/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
+++ b/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
@@ -1108,7 +1108,7 @@ async def test_kind_examples_sent_before_transformation_even_when_mapping_fails(
     - Raw data has users with 'name' and 'email' fields
     - Mapping tries to use '.nonexistent_field' as identifier (doesn't exist)
     - Transformation should fail (no valid entities created)
-    - BUT examples should still be sent to Port
+    - BUT examples should already be sent to Port by the extraction wrapper
     """
     # Create a resource config with a broken mapping (identifier field doesn't exist)
     broken_resource_config = ResourceConfig(
@@ -1147,6 +1147,9 @@ async def test_kind_examples_sent_before_transformation_even_when_mapping_fails(
     # Enable sending raw data examples
     mock_ocean.config.send_raw_data_examples = True
 
+    async def resync_handler(kind: str) -> list[dict[str, Any]]:
+        return raw_results
+
     async with event_context(
         EventType.RESYNC,
         trigger_type="machine",
@@ -1154,12 +1157,20 @@ async def test_kind_examples_sent_before_transformation_even_when_mapping_fails(
     ) as event:
         event.port_app_config = broken_app_config
 
-        # Call _register_resource_raw which will process the data
+        extracted_results, errors = (
+            await mock_sync_raw_mixin_with_jq_processor._execute_resync_tasks(
+                [resync_handler],
+                broken_resource_config,
+                send_raw_data_examples_amount=2,
+            )
+        )
+        assert errors == []
+
+        # Call _register_resource_raw which will process the data after examples were sent
         result = await mock_sync_raw_mixin_with_jq_processor._register_resource_raw(
             broken_resource_config,
-            raw_results,
+            cast(list[dict[Any, Any]], extracted_results),
             UserAgentType.exporter,
-            send_raw_data_examples_amount=2,  # Request 2 examples
         )
 
         # KEY ASSERTION: Examples should be sent even though transformation failed

--- a/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
+++ b/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
@@ -1,5 +1,5 @@
 from graphlib import CycleError
-from typing import Any, AsyncGenerator
+from typing import Any, AsyncGenerator, Awaitable, Callable, cast
 
 from loguru import logger
 from port_ocean.core.utils.entity_topological_sorter import EntityTopologicalSorter
@@ -1511,8 +1511,12 @@ async def test_execute_resync_tasks_shares_examples_budget_across_async_generato
         "port_ocean.core.integrations.mixins.sync_raw.resync_generator_wrapper",
         side_effect=[wrapped_generator_one, wrapped_generator_two],
     ) as mock_wrapper:
+        resync_handlers = [
+            cast(Callable[[str], Awaitable[list[dict[Any, Any]]]], generator_one),
+            cast(Callable[[str], Awaitable[list[dict[Any, Any]]]], generator_two),
+        ]
         await mock_sync_raw_mixin._execute_resync_tasks(
-            [generator_one, generator_two],
+            resync_handlers,
             mock_resource_config,
             send_raw_data_examples_amount=5,
         )

--- a/port_ocean/tests/core/integrations/mixins/test_integration_utils.py
+++ b/port_ocean/tests/core/integrations/mixins/test_integration_utils.py
@@ -1,5 +1,5 @@
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -570,3 +570,57 @@ class TestResyncGeneratorWrapperDoesNotMutateYieldedBatches:
 
             # The original list must NOT have been mutated
             assert len(original_batch) == original_length
+
+    @pytest.mark.asyncio
+    async def test_items_to_parse_sends_examples_before_expansion(
+        self,
+        mock_context: PortOceanContext,
+        mock_entity_processor: JQEntityProcessor,
+    ) -> None:
+        original_batch = [
+            {
+                "id": "1",
+                "keep_this": "should stay",
+                "items": [{"sub_id": "a"}, {"sub_id": "b"}],
+            }
+        ]
+
+        async def fake_generator(kind: str) -> Any:
+            yield original_batch
+
+        with patch(
+            "port_ocean.core.integrations.mixins.utils.ocean"
+        ) as mock_ocean_context:
+            mock_ocean_context.config.yield_items_to_parse_batch_size = 100
+            mock_ocean_context.app.integration.entity_processor = mock_entity_processor
+            mock_ocean_context.metrics = mock_context.app.metrics
+            mock_ocean_context.port_client.ingest_integration_kind_examples = AsyncMock()
+
+            expanded_batches = [
+                batch
+                async for batch in resync_generator_wrapper(
+                    fake_generator,
+                    "test-kind",
+                    items_to_parse_name="item",
+                    items_to_parse=".items",
+                    send_raw_data_examples_amount=1,
+                )
+            ]
+
+            mock_ocean_context.port_client.ingest_integration_kind_examples.assert_awaited_once_with(
+                "test-kind",
+                [
+                    {
+                        "id": "1",
+                        "keep_this": "should stay",
+                        "items": [{"sub_id": "a"}, {"sub_id": "b"}],
+                    }
+                ],
+                should_log=False,
+            )
+            assert expanded_batches == [
+                [
+                    {"id": "1", "keep_this": "should stay", "item": {"sub_id": "a"}},
+                    {"id": "1", "keep_this": "should stay", "item": {"sub_id": "b"}},
+                ]
+            ]

--- a/port_ocean/tests/core/integrations/mixins/test_integration_utils.py
+++ b/port_ocean/tests/core/integrations/mixins/test_integration_utils.py
@@ -17,6 +17,7 @@ from port_ocean.core.handlers.port_app_config.models import (
 from port_ocean.core.integrations.mixins.utils import (
     extract_jq_deletion_path_revised,
     handle_items_to_parse,
+    resync_function_wrapper,
     resync_generator_wrapper,
 )
 
@@ -624,6 +625,60 @@ class TestResyncGeneratorWrapperDoesNotMutateYieldedBatches:
                     {"id": "1", "keep_this": "should stay", "item": {"sub_id": "b"}},
                 ]
             ]
+
+    @pytest.mark.asyncio
+    async def test_resync_function_wrapper_sends_examples_before_parsing(
+        self,
+    ) -> None:
+        raw_results = [{"id": "1"}, {"id": "2"}]
+
+        async def fake_resync(kind: str) -> list[dict[str, Any]]:
+            return raw_results
+
+        with patch(
+            "port_ocean.core.integrations.mixins.utils.ocean"
+        ) as mock_ocean_context:
+            mock_ocean_context.port_client.ingest_integration_kind_examples = AsyncMock()
+
+            result = await resync_function_wrapper(
+                fake_resync,
+                "test-kind",
+                send_raw_data_examples_amount=1,
+            )
+
+            assert result == raw_results
+            mock_ocean_context.port_client.ingest_integration_kind_examples.assert_awaited_once_with(
+                "test-kind", [{"id": "1"}], should_log=False
+            )
+
+    @pytest.mark.asyncio
+    async def test_resync_generator_wrapper_sends_examples_without_items_to_parse(
+        self,
+    ) -> None:
+        raw_results = [{"id": "1"}, {"id": "2"}]
+
+        async def fake_generator(kind: str) -> Any:
+            yield raw_results
+
+        with patch(
+            "port_ocean.core.integrations.mixins.utils.ocean"
+        ) as mock_ocean_context:
+            mock_ocean_context.port_client.ingest_integration_kind_examples = AsyncMock()
+
+            batches = [
+                batch
+                async for batch in resync_generator_wrapper(
+                    fake_generator,
+                    "test-kind",
+                    items_to_parse_name="item",
+                    send_raw_data_examples_amount=1,
+                )
+            ]
+
+            assert batches == [raw_results]
+            mock_ocean_context.port_client.ingest_integration_kind_examples.assert_awaited_once_with(
+                "test-kind", [{"id": "1"}], should_log=False
+            )
 
     @pytest.mark.asyncio
     async def test_items_to_parse_retries_examples_on_later_batch_after_failure(

--- a/port_ocean/tests/core/integrations/mixins/test_integration_utils.py
+++ b/port_ocean/tests/core/integrations/mixins/test_integration_utils.py
@@ -624,3 +624,55 @@ class TestResyncGeneratorWrapperDoesNotMutateYieldedBatches:
                     {"id": "1", "keep_this": "should stay", "item": {"sub_id": "b"}},
                 ]
             ]
+
+    @pytest.mark.asyncio
+    async def test_items_to_parse_retries_examples_on_later_batch_after_failure(
+        self,
+        mock_context: PortOceanContext,
+        mock_entity_processor: JQEntityProcessor,
+    ) -> None:
+        first_batch = [{"id": "1", "items": [{"sub_id": "a"}]}]
+        second_batch = [{"id": "2", "items": [{"sub_id": "b"}]}]
+
+        async def fake_generator(kind: str) -> Any:
+            yield first_batch
+            yield second_batch
+
+        with patch(
+            "port_ocean.core.integrations.mixins.utils.ocean"
+        ) as mock_ocean_context:
+            mock_ocean_context.config.yield_items_to_parse_batch_size = 100
+            mock_ocean_context.app.integration.entity_processor = mock_entity_processor
+            mock_ocean_context.metrics = mock_context.app.metrics
+            mock_ocean_context.port_client.ingest_integration_kind_examples = AsyncMock(
+                side_effect=[Exception("temporary failure"), None]
+            )
+
+            _expanded_batches = [
+                batch
+                async for batch in resync_generator_wrapper(
+                    fake_generator,
+                    "test-kind",
+                    items_to_parse_name="item",
+                    items_to_parse=".items",
+                    send_raw_data_examples_amount=1,
+                )
+            ]
+
+            assert (
+                mock_ocean_context.port_client.ingest_integration_kind_examples.await_count
+                == 2
+            )
+            calls = (
+                mock_ocean_context.port_client.ingest_integration_kind_examples.await_args_list
+            )
+            assert calls[0].args == (
+                "test-kind",
+                [{"id": "1", "items": [{"sub_id": "a"}]}],
+            )
+            assert calls[0].kwargs == {"should_log": False}
+            assert calls[1].args == (
+                "test-kind",
+                [{"id": "2", "items": [{"sub_id": "b"}]}],
+            )
+            assert calls[1].kwargs == {"should_log": False}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.41.4"
+version = "0.41.5"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What -
Fix to this bug: https://getport.atlassian.net/browse/PORT-17568

Why -
Examples are ingested to port after the `items to parse` transformation, causing to missing data in the examples.

In this PR: Examples are now sent only in the resync extraction wrappers in utils.py:
resync_function_wrapper() sends after validating the returned raw result.
resync_generator_wrapper() sends after validating each yielded raw batch, before items_to_parse.
I removed example sending from JQEntityProcessor._parse_items() and removed send_raw_data_examples_amount from the entity processor path.

How -

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
