### PR TITLE
[Core] feat: send ocean core version in polling route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.41.6 (2026-04-30)
+
+### Improvements
+
+- When using the polling event listener, requests to Port to fetch the current integration now include `oceanCoreVersion` and `isPolling=true` query parameters. Other callers of the same API are unchanged.
+
 ## 0.41.5 (2026-04-27)
 
 ### Bug fixes

--- a/port_ocean/clients/port/mixins/integrations.py
+++ b/port_ocean/clients/port/mixins/integrations.py
@@ -15,6 +15,7 @@ from port_ocean.core.models import (
 )
 from port_ocean.exceptions.port_defaults import DefaultsProvisionFailed
 from port_ocean.log.sensetive import sensitive_log_filter
+from port_ocean.version import __version__ as ocean_core_version
 
 if TYPE_CHECKING:
     from port_ocean.core.handlers.port_app_config.models import PortAppConfig
@@ -70,11 +71,21 @@ class IntegrationClientMixin:
 
         return response.json().get("integrations", [])
 
-    async def _get_current_integration(self) -> httpx.Response:
+    async def _get_current_integration(
+        self, *, is_polling: bool = False
+    ) -> httpx.Response:
         logger.info(f"Fetching integration with id: {self.integration_identifier}")
+        request_kwargs: dict[str, Any] = {
+            "headers": await self.auth.headers(),
+        }
+        if is_polling:
+            request_kwargs["params"] = {
+                "oceanCoreVersion": ocean_core_version,
+                "isPolling": "true",
+            }
         response = await self.client.get(
             f"{self.auth.api_url}/integration/{self.integration_identifier}",
-            headers=await self.auth.headers(),
+            **request_kwargs,
         )
         return response
 
@@ -82,8 +93,10 @@ class IntegrationClientMixin:
         self,
         should_raise: bool = True,
         should_log: bool = True,
+        *,
+        is_polling: bool = False,
     ) -> dict[str, Any]:
-        response = await self._get_current_integration()
+        response = await self._get_current_integration(is_polling=is_polling)
         handle_port_status_code(response, should_raise, should_log)
         return response.json().get("integration", {})
 

--- a/port_ocean/core/event_listener/polling.py
+++ b/port_ocean/core/event_listener/polling.py
@@ -73,7 +73,9 @@ class PollingEventListener(BaseEventListener):
             logger.info(
                 f"Polling event listener iteration after {self.event_listener_config.interval}. Checking for changes"
             )
-            integration = await ocean.app.port_client.get_current_integration()
+            integration = await ocean.app.port_client.get_current_integration(
+                is_polling=True
+            )
             last_updated_at = integration["updatedAt"]
 
             if self.should_resync(last_updated_at):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.41.5"
+version = "0.41.6"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What -
`oceanCoreVersion` and `isPolling=true` query parameters in the polling route.

Why -
This PR is a preparation for manual resync refactor.

For more details: https://www.notion.so/Manual-resync-refactor-3489be8ff7e38099b6e1cd3cb4672e80?source=copy_link 
How -

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
