### PR TITLE
[Integration][PagerDuty] Handled daily rate limits for `analytics` endpoints

### DIFF
--- a/integrations/pagerduty/CHANGELOG.md
+++ b/integrations/pagerduty/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.5.50 (2026-05-03)
+
+
+### Bug Fixes
+
+- Respect PagerDuty `daily-ratelimit-*` headers on analytics endpoints to halt resync analytics calls once the daily quota is reached, avoiding repeated 429s and dropped enrichment.
+
+
 ## 0.5.49 (2026-04-30)
 
 

--- a/integrations/pagerduty/CHANGELOG.md
+++ b/integrations/pagerduty/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
-## 0.5.50 (2026-05-03)
+## 0.5.50 (2026-05-05)
 
 
 ### Bug Fixes

--- a/integrations/pagerduty/clients/pagerduty.py
+++ b/integrations/pagerduty/clients/pagerduty.py
@@ -337,6 +337,7 @@ class PagerDutyClient(OAuthClient):
 
                 if (
                     status_code == HTTPStatus.TOO_MANY_REQUESTS
+                    and endpoint.startswith("analytics/")
                     and daily_quota_exhausted(e.response.headers)
                 ):
                     raise PagerDutyDailyRateLimitExceededError(

--- a/integrations/pagerduty/clients/pagerduty.py
+++ b/integrations/pagerduty/clients/pagerduty.py
@@ -12,7 +12,12 @@ from port_ocean.helpers.async_client import OceanAsyncClient
 from port_ocean.helpers.retry import RetryConfig
 
 from clients.utils import get_date_range_for_last_n_months
-from clients.rate_limiter import PagerDutyRateLimiter
+from clients.rate_limiter import (
+    PagerDutyDailyRateLimitExceededError,
+    PagerDutyRateLimiter,
+    daily_quota_exhausted,
+)
+from clients.retry_transport import PagerDutyRetryTransport
 
 USER_KEY = "users"
 
@@ -29,7 +34,12 @@ class PagerDutyClient(OAuthClient):
         self.token = token
         self.api_url = api_url
         self.app_host = app_host
+        self._rate_limiter = PagerDutyRateLimiter(
+            max_concurrent=MAX_CONCURRENT_REQUESTS,
+        )
         self.http_client = OceanAsyncClient(
+            transport_class=PagerDutyRetryTransport,
+            transport_kwargs={"rate_limiter": self._rate_limiter},
             retry_config=RetryConfig(
                 additional_retry_status_codes=[HTTPStatus.INTERNAL_SERVER_ERROR],
                 retry_after_headers=[
@@ -39,9 +49,6 @@ class PagerDutyClient(OAuthClient):
             timeout=ocean.config.client_timeout,
         )
         self.http_client.headers.update(self.headers)
-        self._rate_limiter = PagerDutyRateLimiter(
-            max_concurrent=MAX_CONCURRENT_REQUESTS,
-        )
 
     @classmethod
     def from_ocean_configuration(cls) -> "PagerDutyClient":
@@ -307,6 +314,8 @@ class PagerDutyClient(OAuthClient):
             f"Sending API request to {method} {endpoint} with query params: {query_params}"
         )
 
+        self._rate_limiter.check_daily_budget(endpoint)
+
         async with self._rate_limiter:
             try:
                 response = await self.http_client.request(
@@ -320,11 +329,19 @@ class PagerDutyClient(OAuthClient):
                 return response.json()
             except httpx.HTTPStatusError as e:
                 status_code = e.response.status_code
-                if status_code == 404:
+                if status_code == HTTPStatus.NOT_FOUND:
                     logger.debug(
                         f"Resource not found at endpoint '{endpoint}' with params: {query_params}, method: {method}"
                     )
                     return {}
+
+                if (
+                    status_code == HTTPStatus.TOO_MANY_REQUESTS
+                    and daily_quota_exhausted(e.response.headers)
+                ):
+                    raise PagerDutyDailyRateLimitExceededError(
+                        f"PagerDuty analytics daily quota exhausted on {endpoint}."
+                    ) from e
 
                 logger.error(
                     f"HTTP error for endpoint '{endpoint}': Status code {status_code}, Method: {method}, Query params: {query_params}, Response text: {e.response.text}"

--- a/integrations/pagerduty/clients/rate_limiter.py
+++ b/integrations/pagerduty/clients/rate_limiter.py
@@ -130,12 +130,12 @@ class PagerDutyRateLimiter:
                 f"(resets in {info.seconds_until_reset}s)"
             )
 
-        daily_info = self._parse_daily_headers(parsed)
-        if daily_info:
-            self.daily_rate_limit_info = daily_info
+        daily_rate_limit_info = self._parse_daily_headers(parsed)
+        if daily_rate_limit_info:
+            self.daily_rate_limit_info = daily_rate_limit_info
             logger.debug(
-                f"Daily rate limit on {resource}: {daily_info.remaining}/{daily_info.limit} "
-                f"remaining (resets in {daily_info.seconds_until_reset}s)"
+                f"Daily rate limit on {resource}: {daily_rate_limit_info.remaining}/{daily_rate_limit_info.limit} "
+                f"remaining (resets in {daily_rate_limit_info.seconds_until_reset}s)"
             )
 
         return info

--- a/integrations/pagerduty/clients/rate_limiter.py
+++ b/integrations/pagerduty/clients/rate_limiter.py
@@ -21,32 +21,44 @@ class RateLimitInfo:
         return max(0.0, min(100.0, (used / self.limit) * 100.0))
 
 
+class PagerDutyDailyRateLimitExceededError(Exception):
+    """Raised when an analytics request would exceed PagerDuty's daily quota."""
+
+
+def daily_quota_exhausted(headers: httpx.Headers) -> bool:
+    raw = headers.get("daily-ratelimit-remaining")
+    try:
+        return raw is not None and int(raw) <= 0
+    except ValueError:
+        return False
+
+
 class RateLimiterRequiredHeaders(BaseModel):
-    """
-    Headers required for the GitHubRateLimiter.
-    """
+    """Per-minute `ratelimit-*` headers and the analytics-only `daily-ratelimit-*` headers."""
 
     ratelimit_limit: Optional[str] = Field(alias="ratelimit-limit")
     ratelimit_remaining: Optional[str] = Field(alias="ratelimit-remaining")
     ratelimit_reset: Optional[str] = Field(alias="ratelimit-reset")
+    daily_ratelimit_limit: Optional[str] = Field(alias="daily-ratelimit-limit")
+    daily_ratelimit_remaining: Optional[str] = Field(alias="daily-ratelimit-remaining")
+    daily_ratelimit_reset: Optional[str] = Field(alias="daily-ratelimit-reset")
 
     def as_dict(self) -> Dict[str, str]:
         return self.dict(by_alias=True)
 
 
 class PagerDutyRateLimiter:
-    """
-    Async rate limiter for PagerDuty APIs (REST and Analytics).
-    - Controls concurrency via semaphore.
-    - Tracks rate-limit headers and proactively sleeps when budget is depleted.
-    - Computes retry delays on 429 using ratelimit-reset headers.
+    """Concurrency + per-minute sleep + analytics daily-quota short-circuit.
+
+    REST endpoints only emit `ratelimit-*`; analytics endpoints additionally emit
+    `daily-ratelimit-*` for a separate, much smaller daily budget.
     """
 
     def __init__(self, max_concurrent: int = 10) -> None:
         self._semaphore = asyncio.BoundedSemaphore(max_concurrent)
         self._lock = asyncio.Lock()
-
         self.rate_limit_info: Optional[RateLimitInfo] = None
+        self.daily_rate_limit_info: Optional[RateLimitInfo] = None
 
     async def __aenter__(self) -> "PagerDutyRateLimiter":
         await self._semaphore.acquire()
@@ -74,7 +86,7 @@ class PagerDutyRateLimiter:
     ) -> None:
         self._semaphore.release()
 
-    def _parse_rate_limit_headers(
+    def _parse_per_minute_headers(
         self, headers: RateLimiterRequiredHeaders
     ) -> Optional[RateLimitInfo]:
         if not (
@@ -84,22 +96,60 @@ class PagerDutyRateLimiter:
         ):
             logger.warning(f"Rate limit headers not found: {headers}")
             return None
-
         return RateLimitInfo(
             limit=int(headers.ratelimit_limit),
             remaining=int(headers.ratelimit_remaining),
             seconds_until_reset=int(headers.ratelimit_reset),
         )
 
+    def _parse_daily_headers(
+        self, headers: RateLimiterRequiredHeaders
+    ) -> Optional[RateLimitInfo]:
+        if not (
+            headers.daily_ratelimit_limit
+            and headers.daily_ratelimit_remaining
+            and headers.daily_ratelimit_reset
+        ):
+            return None
+        return RateLimitInfo(
+            limit=int(headers.daily_ratelimit_limit),
+            remaining=int(headers.daily_ratelimit_remaining),
+            seconds_until_reset=int(headers.daily_ratelimit_reset),
+        )
+
     def update_rate_limits(
         self, headers: httpx.Headers, resource: str
     ) -> Optional[RateLimitInfo]:
-        rate_limit_headers = RateLimiterRequiredHeaders(**headers)
-        info = self._parse_rate_limit_headers(rate_limit_headers)
+        parsed = RateLimiterRequiredHeaders(**headers)
+
+        info = self._parse_per_minute_headers(parsed)
         if info:
             self.rate_limit_info = info
             logger.debug(
-                f"Rate limit hit on {resource}: {info.remaining}/{info.limit} remaining "
+                f"Rate limit on {resource}: {info.remaining}/{info.limit} remaining "
                 f"(resets in {info.seconds_until_reset}s)"
             )
+
+        daily_info = self._parse_daily_headers(parsed)
+        if daily_info:
+            self.daily_rate_limit_info = daily_info
+            logger.debug(
+                f"Daily rate limit on {resource}: {daily_info.remaining}/{daily_info.limit} "
+                f"remaining (resets in {daily_info.seconds_until_reset}s)"
+            )
+
         return info
+
+    def check_daily_budget(self, endpoint: str) -> None:
+        """Raise if a known-exhausted analytics daily quota would be hit. No-op for REST endpoints."""
+        info = self.daily_rate_limit_info
+        if not endpoint.startswith("analytics/") or info is None or info.remaining > 0:
+            return
+
+        logger.warning(
+            f"PagerDuty analytics daily quota exhausted ({info.remaining}/{info.limit}); "
+            f"skipping {endpoint} until reset in {info.seconds_until_reset}s."
+        )
+        raise PagerDutyDailyRateLimitExceededError(
+            f"PagerDuty analytics daily quota exhausted; resets in {info.seconds_until_reset}s."
+        )

--- a/integrations/pagerduty/clients/rate_limiter.py
+++ b/integrations/pagerduty/clients/rate_limiter.py
@@ -48,10 +48,11 @@ class RateLimiterRequiredHeaders(BaseModel):
 
 
 class PagerDutyRateLimiter:
-    """Concurrency + per-minute sleep + analytics daily-quota short-circuit.
-
-    REST endpoints only emit `ratelimit-*`; analytics endpoints additionally emit
-    `daily-ratelimit-*` for a separate, much smaller daily budget.
+    """
+    Async rate limiter for PagerDuty APIs (REST and Analytics).
+    - Controls concurrency via semaphore.
+    - Tracks rate-limit headers and proactively sleeps when budget is depleted.
+    - Computes retry delays on 429 using ratelimit-reset headers.
     """
 
     def __init__(self, max_concurrent: int = 10) -> None:

--- a/integrations/pagerduty/clients/retry_transport.py
+++ b/integrations/pagerduty/clients/retry_transport.py
@@ -1,0 +1,30 @@
+from http import HTTPStatus
+from typing import Any
+
+import httpx
+from port_ocean.helpers.retry import RetryTransport
+
+from clients.rate_limiter import PagerDutyRateLimiter, daily_quota_exhausted
+
+
+class PagerDutyRetryTransport(RetryTransport):
+    """Feeds the rate limiter from every response and stops retrying 429s once
+    the analytics daily quota is exhausted (since `ratelimit-reset` is irrelevant
+    when `daily-ratelimit-reset` is hours away)."""
+
+    def __init__(self, *, rate_limiter: PagerDutyRateLimiter, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._rate_limiter = rate_limiter
+
+    async def after_retry_async(
+        self, request: httpx.Request, response: httpx.Response, attempt: int
+    ) -> None:
+        self._rate_limiter.update_rate_limits(response.headers, str(request.url))
+
+    async def _should_retry_async(self, response: httpx.Response) -> bool:
+        if (
+            response.status_code == HTTPStatus.TOO_MANY_REQUESTS
+            and daily_quota_exhausted(response.headers)
+        ):
+            return False
+        return await super()._should_retry_async(response)

--- a/integrations/pagerduty/clients/retry_transport.py
+++ b/integrations/pagerduty/clients/retry_transport.py
@@ -8,8 +8,10 @@ from clients.rate_limiter import PagerDutyRateLimiter, daily_quota_exhausted
 
 
 class PagerDutyRetryTransport(RetryTransport):
-    """Feeds the rate limiter from intermediate retry responses and stops
-    retrying 429s once the analytics daily quota is exhausted.
+    """Updates rate limits from each retry response and stops retrying 429s
+    when the analytics daily quota is exhausted.
+
+    Per-attempt updates help concurrent in-flight requests adapt early.
     """
 
     def __init__(self, *, rate_limiter: PagerDutyRateLimiter, **kwargs: Any) -> None:
@@ -19,8 +21,7 @@ class PagerDutyRetryTransport(RetryTransport):
     async def after_retry_async(
         self, request: httpx.Request, response: httpx.Response, attempt: int
     ) -> None:
-        if await self._should_retry_async(response):
-            self._rate_limiter.update_rate_limits(response.headers, str(request.url))
+        self._rate_limiter.update_rate_limits(response.headers, str(request.url))
 
     async def _should_retry_async(self, response: httpx.Response) -> bool:
         if (

--- a/integrations/pagerduty/clients/retry_transport.py
+++ b/integrations/pagerduty/clients/retry_transport.py
@@ -8,9 +8,9 @@ from clients.rate_limiter import PagerDutyRateLimiter, daily_quota_exhausted
 
 
 class PagerDutyRetryTransport(RetryTransport):
-    """Feeds the rate limiter from every response and stops retrying 429s once
-    the analytics daily quota is exhausted (since `ratelimit-reset` is irrelevant
-    when `daily-ratelimit-reset` is hours away)."""
+    """Feeds the rate limiter from intermediate retry responses and stops
+    retrying 429s once the analytics daily quota is exhausted.
+    """
 
     def __init__(self, *, rate_limiter: PagerDutyRateLimiter, **kwargs: Any) -> None:
         super().__init__(**kwargs)
@@ -19,7 +19,8 @@ class PagerDutyRetryTransport(RetryTransport):
     async def after_retry_async(
         self, request: httpx.Request, response: httpx.Response, attempt: int
     ) -> None:
-        self._rate_limiter.update_rate_limits(response.headers, str(request.url))
+        if await self._should_retry_async(response):
+            self._rate_limiter.update_rate_limits(response.headers, str(request.url))
 
     async def _should_retry_async(self, response: httpx.Response) -> bool:
         if (

--- a/integrations/pagerduty/main.py
+++ b/integrations/pagerduty/main.py
@@ -9,6 +9,7 @@ from port_ocean.context.ocean import ocean
 from port_ocean.core.ocean_types import ASYNC_GENERATOR_RESYNC_TYPE
 
 from clients.pagerduty import PagerDutyClient
+from clients.rate_limiter import PagerDutyDailyRateLimitExceededError
 from integration import (
     OBJECTS_WITH_SPECIAL_HANDLING,
     PagerdutyEscalationPolicyResourceConfig,
@@ -43,6 +44,11 @@ async def enrich_service_with_analytics_data(
                 for service in services
             ]
             return enriched_services
+        except PagerDutyDailyRateLimitExceededError as e:
+            logger.warning(
+                f"Skipping service analytics enrichment for {len(service_ids)} services: {e}"
+            )
+            return [{**service, "__analytics": None} for service in services]
         except Exception as e:
             logger.error(f"Failed to fetch analytics for service {service_ids}: {e}")
             return [{**service, "__analytics": None} for service in services]
@@ -68,9 +74,19 @@ async def on_incidents_resync(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
         logger.info(f"Received batch with {len(incidents)} incidents")
 
         if selector.incident_analytics:
-            incidents = await pager_duty_client.enrich_incidents_with_analytics_data(
-                incidents
-            )
+            try:
+                incidents = (
+                    await pager_duty_client.enrich_incidents_with_analytics_data(
+                        incidents
+                    )
+                )
+            except PagerDutyDailyRateLimitExceededError as e:
+                logger.warning(
+                    f"Skipping incident analytics enrichment for {len(incidents)} incidents: {e}"
+                )
+                incidents = [
+                    {**incident, "__analytics": None} for incident in incidents
+                ]
 
         if selector.include_custom_fields:
             incidents = await pager_duty_client.enrich_entities_with_custom_fields(

--- a/integrations/pagerduty/main.py
+++ b/integrations/pagerduty/main.py
@@ -1,5 +1,4 @@
 import typing
-from typing import Any
 
 from loguru import logger
 from webhook_processors.incidents import IncidentWebhookProcessor
@@ -19,41 +18,7 @@ from integration import (
     PagerdutyServiceResourceConfig,
 )
 from kinds import Kinds
-
-
-async def enrich_service_with_analytics_data(
-    client: PagerDutyClient, services: list[dict[str, Any]], months_period: int
-) -> list[dict[str, Any]]:
-    async def fetch_service_analytics(
-        services: list[dict[str, Any]]
-    ) -> list[dict[str, Any]]:
-        service_ids = [service["id"] for service in services]
-        try:
-            services_analytics = await client.get_service_analytics(
-                service_ids, months_period
-            )
-            # Map analytics to corresponding services
-            service_analytics_map = {
-                analytics["service_id"]: analytics for analytics in services_analytics
-            }
-            enriched_services = [
-                {
-                    **service,
-                    "__analytics": service_analytics_map.get(service["id"], None),
-                }
-                for service in services
-            ]
-            return enriched_services
-        except PagerDutyDailyRateLimitExceededError as e:
-            logger.warning(
-                f"Skipping service analytics enrichment for {len(service_ids)} services: {e}"
-            )
-            return [{**service, "__analytics": None} for service in services]
-        except Exception as e:
-            logger.error(f"Failed to fetch analytics for service {service_ids}: {e}")
-            return [{**service, "__analytics": None} for service in services]
-
-    return await fetch_service_analytics(services)
+from utils import enrich_service_with_analytics_data
 
 
 @ocean.on_resync(Kinds.INCIDENTS)

--- a/integrations/pagerduty/pyproject.toml
+++ b/integrations/pagerduty/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pagerduty"
-version = "0.5.49"
+version = "0.5.50"
 description = "PagerDuty Integration"
 authors = ["Port Team <support@getport.io>"]
 

--- a/integrations/pagerduty/tests/test_client.py
+++ b/integrations/pagerduty/tests/test_client.py
@@ -5,6 +5,7 @@ import httpx
 from port_ocean.context.ocean import initialize_port_ocean_context
 from port_ocean.exceptions.context import PortOceanContextAlreadyInitializedError
 from clients.pagerduty import PagerDutyClient
+from clients.rate_limiter import PagerDutyDailyRateLimitExceededError
 
 
 TEST_INTEGRATION_CONFIG: dict[str, str] = {
@@ -266,6 +267,69 @@ class TestPagerDutyClient:
         ):
             result = await client.send_api_request("nonexistent/endpoint")
             assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_send_api_request_short_circuits_after_daily_quota_429(
+        self, client: PagerDutyClient
+    ) -> None:
+        """First analytics 429 with daily quota exhausted should arm the limiter
+        so that subsequent analytics calls short-circuit without hitting HTTP."""
+        rate_limit_429 = MagicMock()
+        rate_limit_429.status_code = 429
+        rate_limit_429.headers = httpx.Headers(
+            {
+                "ratelimit-limit": "960",
+                "ratelimit-remaining": "959",
+                "ratelimit-reset": "56",
+                "daily-ratelimit-limit": "10",
+                "daily-ratelimit-remaining": "-273",
+                "daily-ratelimit-reset": "49015",
+            }
+        )
+        rate_limit_429.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Too Many Requests", request=MagicMock(), response=rate_limit_429
+        )
+
+        request_mock = AsyncMock(return_value=rate_limit_429)
+        with patch.object(client.http_client, "request", request_mock):
+            with pytest.raises(PagerDutyDailyRateLimitExceededError):
+                await client.send_api_request(
+                    "analytics/metrics/incidents/services", method="POST"
+                )
+
+            with pytest.raises(PagerDutyDailyRateLimitExceededError):
+                await client.send_api_request(
+                    "analytics/metrics/incidents/services", method="POST"
+                )
+
+        # Only the first call hits the network; the second short-circuits via check_daily_budget
+        assert request_mock.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_send_api_request_daily_quota_does_not_block_rest_endpoints(
+        self, client: PagerDutyClient
+    ) -> None:
+        """Daily-quota state from a prior analytics 429 must not block REST calls."""
+        from clients.rate_limiter import RateLimitInfo
+
+        client._rate_limiter.daily_rate_limit_info = RateLimitInfo(
+            limit=10, remaining=-1, seconds_until_reset=49015
+        )
+
+        rest_response = MagicMock()
+        rest_response.json.return_value = {"result": "ok"}
+        rest_response.raise_for_status.return_value = None
+        rest_response.headers = httpx.Headers(
+            {
+                "ratelimit-limit": "960",
+                "ratelimit-remaining": "900",
+                "ratelimit-reset": "30",
+            }
+        )
+
+        with patch.object(client.http_client, "request", return_value=rest_response):
+            result = await client.send_api_request("services")
+            assert result == {"result": "ok"}
 
     @pytest.mark.asyncio
     async def test_transform_user_ids_to_emails(self, client: PagerDutyClient) -> None:

--- a/integrations/pagerduty/tests/test_client.py
+++ b/integrations/pagerduty/tests/test_client.py
@@ -269,19 +269,17 @@ class TestPagerDutyClient:
             assert result == {}
 
     @pytest.mark.asyncio
-    async def test_send_api_request_short_circuits_after_daily_quota_429(
+    async def test_send_api_request_converts_daily_exhausted_429(
         self, client: PagerDutyClient
     ) -> None:
-        """First analytics 429 with daily quota exhausted should arm the limiter
-        so that subsequent analytics calls short-circuit without hitting HTTP."""
+        """A 429 carrying daily-quota-exhausted headers must surface as
+        PagerDutyDailyRateLimitExceededError so callers can distinguish it from
+        transient 429s and other errors."""
         rate_limit_429 = MagicMock()
         rate_limit_429.status_code = 429
         rate_limit_429.headers = httpx.Headers(
             {
-                "ratelimit-limit": "960",
                 "ratelimit-remaining": "959",
-                "ratelimit-reset": "56",
-                "daily-ratelimit-limit": "10",
                 "daily-ratelimit-remaining": "-273",
                 "daily-ratelimit-reset": "49015",
             }
@@ -290,20 +288,34 @@ class TestPagerDutyClient:
             "Too Many Requests", request=MagicMock(), response=rate_limit_429
         )
 
-        request_mock = AsyncMock(return_value=rate_limit_429)
+        with patch.object(
+            client.http_client, "request", AsyncMock(return_value=rate_limit_429)
+        ):
+            with pytest.raises(PagerDutyDailyRateLimitExceededError):
+                await client.send_api_request(
+                    "analytics/metrics/incidents/services", method="POST"
+                )
+
+    @pytest.mark.asyncio
+    async def test_send_api_request_short_circuits_when_daily_budget_known_exhausted(
+        self, client: PagerDutyClient
+    ) -> None:
+        """Once the rate limiter knows daily quota is gone, analytics calls must
+        not even reach the HTTP layer."""
+        from clients.rate_limiter import RateLimitInfo
+
+        client._rate_limiter.daily_rate_limit_info = RateLimitInfo(
+            limit=10, remaining=-1, seconds_until_reset=49015
+        )
+
+        request_mock = AsyncMock()
         with patch.object(client.http_client, "request", request_mock):
             with pytest.raises(PagerDutyDailyRateLimitExceededError):
                 await client.send_api_request(
                     "analytics/metrics/incidents/services", method="POST"
                 )
 
-            with pytest.raises(PagerDutyDailyRateLimitExceededError):
-                await client.send_api_request(
-                    "analytics/metrics/incidents/services", method="POST"
-                )
-
-        # Only the first call hits the network; the second short-circuits via check_daily_budget
-        assert request_mock.await_count == 1
+        assert request_mock.await_count == 0
 
     @pytest.mark.asyncio
     async def test_send_api_request_daily_quota_does_not_block_rest_endpoints(

--- a/integrations/pagerduty/tests/test_rate_limiter.py
+++ b/integrations/pagerduty/tests/test_rate_limiter.py
@@ -5,7 +5,11 @@ from unittest.mock import Mock, patch
 import httpx
 import pytest
 
-from clients.rate_limiter import PagerDutyRateLimiter, RateLimitInfo
+from clients.rate_limiter import (
+    PagerDutyDailyRateLimitExceededError,
+    PagerDutyRateLimiter,
+    RateLimitInfo,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -79,6 +83,86 @@ class TestPagerDutyRateLimiter:
 
         # Should not sleep when remaining is above threshold
         mock_sleep.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_daily_headers_are_parsed_and_stored(self, mock_sleep: Mock) -> None:
+        limiter = PagerDutyRateLimiter(max_concurrent=5)
+        headers = httpx.Headers(
+            {
+                "ratelimit-limit": "960",
+                "ratelimit-remaining": "959",
+                "ratelimit-reset": "56",
+                "daily-ratelimit-limit": "10",
+                "daily-ratelimit-remaining": "5",
+                "daily-ratelimit-reset": "49015",
+            }
+        )
+
+        limiter.update_rate_limits(headers, "analytics/metrics/incidents/services")
+
+        assert limiter.daily_rate_limit_info is not None
+        assert limiter.daily_rate_limit_info.limit == 10
+        assert limiter.daily_rate_limit_info.remaining == 5
+        assert limiter.daily_rate_limit_info.seconds_until_reset == 49015
+        mock_sleep.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_daily_state_not_clobbered_by_rest_response(
+        self, mock_sleep: Mock
+    ) -> None:
+        limiter = PagerDutyRateLimiter(max_concurrent=5)
+        limiter.daily_rate_limit_info = RateLimitInfo(
+            limit=10, remaining=2, seconds_until_reset=49000
+        )
+        headers = httpx.Headers(
+            {
+                "ratelimit-limit": "960",
+                "ratelimit-remaining": "900",
+                "ratelimit-reset": "30",
+            }
+        )
+
+        limiter.update_rate_limits(headers, "services")
+
+        assert limiter.daily_rate_limit_info.limit == 10
+        assert limiter.daily_rate_limit_info.remaining == 2
+        assert limiter.daily_rate_limit_info.seconds_until_reset == 49000
+        assert limiter.rate_limit_info is not None
+        assert limiter.rate_limit_info.remaining == 900
+        mock_sleep.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_check_daily_budget_raises_for_analytics_when_exhausted(
+        self, mock_sleep: Mock
+    ) -> None:
+        limiter = PagerDutyRateLimiter(max_concurrent=5)
+        limiter.daily_rate_limit_info = RateLimitInfo(
+            limit=10, remaining=-1, seconds_until_reset=49015
+        )
+
+        with pytest.raises(PagerDutyDailyRateLimitExceededError):
+            limiter.check_daily_budget("analytics/metrics/incidents/services")
+
+    @pytest.mark.asyncio
+    async def test_check_daily_budget_no_op_for_rest_endpoint(
+        self, mock_sleep: Mock
+    ) -> None:
+        limiter = PagerDutyRateLimiter(max_concurrent=5)
+        limiter.daily_rate_limit_info = RateLimitInfo(
+            limit=10, remaining=-1, seconds_until_reset=49015
+        )
+
+        # Must not raise — REST endpoints are not subject to the analytics daily quota
+        limiter.check_daily_budget("services")
+
+    @pytest.mark.asyncio
+    async def test_check_daily_budget_no_op_when_daily_state_unknown(
+        self, mock_sleep: Mock
+    ) -> None:
+        limiter = PagerDutyRateLimiter(max_concurrent=5)
+
+        # Fresh limiter — no daily info observed yet, must not raise
+        limiter.check_daily_budget("analytics/metrics/incidents/services")
 
     @pytest.mark.asyncio
     async def test_concurrent_requests_respect_semaphore(

--- a/integrations/pagerduty/tests/test_retry_transport.py
+++ b/integrations/pagerduty/tests/test_retry_transport.py
@@ -16,10 +16,9 @@ def _build_transport(rate_limiter: PagerDutyRateLimiter) -> PagerDutyRetryTransp
 
 class TestPagerDutyRetryTransport:
     @pytest.mark.asyncio
-    async def test_after_retry_async_feeds_limiter_for_retryable_response(self) -> None:
-        """Intermediate retry responses (e.g. per-minute 429s) feed the limiter
-        early so concurrent in-flight calls can react before they exhaust their
-        own retry budgets."""
+    async def test_after_retry_async_feeds_limiter(self) -> None:
+        """Every retry-loop response (intermediate or final) feeds the limiter
+        from this single layer so concurrent in-flight calls react early."""
         limiter = PagerDutyRateLimiter(max_concurrent=5)
         transport = _build_transport(limiter)
 
@@ -40,29 +39,6 @@ class TestPagerDutyRetryTransport:
 
         assert limiter.rate_limit_info is not None
         assert limiter.rate_limit_info.remaining == 0
-
-    @pytest.mark.asyncio
-    async def test_after_retry_async_skips_final_response(self) -> None:
-        """Final responses (2xx, daily-exhausted 429) are not retried, so the
-        transport leaves the limiter update to `send_api_request`'s finally."""
-        limiter = PagerDutyRateLimiter(max_concurrent=5)
-        transport = _build_transport(limiter)
-
-        request = httpx.Request("GET", "https://api.pagerduty.com/services")
-        ok_response = MagicMock(spec=httpx.Response)
-        ok_response.status_code = 200
-        ok_response.headers = httpx.Headers(
-            {
-                "ratelimit-limit": "960",
-                "ratelimit-remaining": "959",
-                "ratelimit-reset": "56",
-            }
-        )
-
-        await transport.after_retry_async(request, ok_response, attempt=1)
-
-        assert limiter.rate_limit_info is None
-        assert limiter.daily_rate_limit_info is None
 
     @pytest.mark.asyncio
     async def test_should_retry_async_false_for_429_with_daily_exhausted(self) -> None:

--- a/integrations/pagerduty/tests/test_retry_transport.py
+++ b/integrations/pagerduty/tests/test_retry_transport.py
@@ -16,32 +16,53 @@ def _build_transport(rate_limiter: PagerDutyRateLimiter) -> PagerDutyRetryTransp
 
 class TestPagerDutyRetryTransport:
     @pytest.mark.asyncio
-    async def test_after_retry_async_feeds_rate_limiter(self) -> None:
+    async def test_after_retry_async_feeds_limiter_for_retryable_response(self) -> None:
+        """Intermediate retry responses (e.g. per-minute 429s) feed the limiter
+        early so concurrent in-flight calls can react before they exhaust their
+        own retry budgets."""
         limiter = PagerDutyRateLimiter(max_concurrent=5)
         transport = _build_transport(limiter)
 
         request = httpx.Request(
-            "POST",
-            "https://api.pagerduty.com/analytics/metrics/incidents/services",
+            "GET", "https://api.pagerduty.com/analytics/raw/incidents/X"
         )
         response = MagicMock(spec=httpx.Response)
+        response.status_code = 429
         response.headers = httpx.Headers(
             {
                 "ratelimit-limit": "960",
-                "ratelimit-remaining": "959",
+                "ratelimit-remaining": "0",
                 "ratelimit-reset": "56",
-                "daily-ratelimit-limit": "10",
-                "daily-ratelimit-remaining": "-273",
-                "daily-ratelimit-reset": "49015",
             }
         )
 
         await transport.after_retry_async(request, response, attempt=1)
 
-        assert limiter.daily_rate_limit_info is not None
-        assert limiter.daily_rate_limit_info.remaining == -273
         assert limiter.rate_limit_info is not None
-        assert limiter.rate_limit_info.remaining == 959
+        assert limiter.rate_limit_info.remaining == 0
+
+    @pytest.mark.asyncio
+    async def test_after_retry_async_skips_final_response(self) -> None:
+        """Final responses (2xx, daily-exhausted 429) are not retried, so the
+        transport leaves the limiter update to `send_api_request`'s finally."""
+        limiter = PagerDutyRateLimiter(max_concurrent=5)
+        transport = _build_transport(limiter)
+
+        request = httpx.Request("GET", "https://api.pagerduty.com/services")
+        ok_response = MagicMock(spec=httpx.Response)
+        ok_response.status_code = 200
+        ok_response.headers = httpx.Headers(
+            {
+                "ratelimit-limit": "960",
+                "ratelimit-remaining": "959",
+                "ratelimit-reset": "56",
+            }
+        )
+
+        await transport.after_retry_async(request, ok_response, attempt=1)
+
+        assert limiter.rate_limit_info is None
+        assert limiter.daily_rate_limit_info is None
 
     @pytest.mark.asyncio
     async def test_should_retry_async_false_for_429_with_daily_exhausted(self) -> None:
@@ -107,9 +128,9 @@ class TestPagerDutyRetryTransport:
         assert await transport._should_retry_async(response) is False
 
     @pytest.mark.asyncio
-    async def test_after_retry_async_is_called_during_retry_loop(self) -> None:
-        """End-to-end-ish: drive `_retry_operation_async` and confirm the limiter
-        is fed from the very first 429 response — not just the final one."""
+    async def test_daily_exhausted_429_does_not_loop(self) -> None:
+        """End-to-end-ish: a 429 with daily quota gone must return on the first
+        attempt rather than burning ~10 retries × ~60s."""
         limiter = PagerDutyRateLimiter(max_concurrent=5)
         transport = _build_transport(limiter)
 
@@ -121,10 +142,7 @@ class TestPagerDutyRetryTransport:
         first_429.status_code = 429
         first_429.headers = httpx.Headers(
             {
-                "ratelimit-limit": "960",
                 "ratelimit-remaining": "959",
-                "ratelimit-reset": "56",
-                "daily-ratelimit-limit": "10",
                 "daily-ratelimit-remaining": "-1",
                 "daily-ratelimit-reset": "49015",
             }
@@ -136,9 +154,5 @@ class TestPagerDutyRetryTransport:
 
         result = await transport._retry_operation_async(request, send_method)
 
-        # Single attempt — `_should_retry_async` returned False on first 429,
-        # so retries did not loop, and the rate limiter was fed once.
         assert send_method.await_count == 1
         assert result is first_429
-        assert limiter.daily_rate_limit_info is not None
-        assert limiter.daily_rate_limit_info.remaining == -1

--- a/integrations/pagerduty/tests/test_retry_transport.py
+++ b/integrations/pagerduty/tests/test_retry_transport.py
@@ -1,0 +1,144 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from clients.rate_limiter import PagerDutyRateLimiter
+from clients.retry_transport import PagerDutyRetryTransport
+
+
+def _build_transport(rate_limiter: PagerDutyRateLimiter) -> PagerDutyRetryTransport:
+    return PagerDutyRetryTransport(
+        rate_limiter=rate_limiter,
+        wrapped_transport=MagicMock(spec=httpx.AsyncBaseTransport),
+    )
+
+
+class TestPagerDutyRetryTransport:
+    @pytest.mark.asyncio
+    async def test_after_retry_async_feeds_rate_limiter(self) -> None:
+        limiter = PagerDutyRateLimiter(max_concurrent=5)
+        transport = _build_transport(limiter)
+
+        request = httpx.Request(
+            "POST",
+            "https://api.pagerduty.com/analytics/metrics/incidents/services",
+        )
+        response = MagicMock(spec=httpx.Response)
+        response.headers = httpx.Headers(
+            {
+                "ratelimit-limit": "960",
+                "ratelimit-remaining": "959",
+                "ratelimit-reset": "56",
+                "daily-ratelimit-limit": "10",
+                "daily-ratelimit-remaining": "-273",
+                "daily-ratelimit-reset": "49015",
+            }
+        )
+
+        await transport.after_retry_async(request, response, attempt=1)
+
+        assert limiter.daily_rate_limit_info is not None
+        assert limiter.daily_rate_limit_info.remaining == -273
+        assert limiter.rate_limit_info is not None
+        assert limiter.rate_limit_info.remaining == 959
+
+    @pytest.mark.asyncio
+    async def test_should_retry_async_false_for_429_with_daily_exhausted(self) -> None:
+        limiter = PagerDutyRateLimiter(max_concurrent=5)
+        transport = _build_transport(limiter)
+
+        response = MagicMock(spec=httpx.Response)
+        response.status_code = 429
+        response.headers = httpx.Headers(
+            {
+                "ratelimit-remaining": "959",
+                "daily-ratelimit-remaining": "-1",
+                "daily-ratelimit-reset": "49015",
+            }
+        )
+
+        assert await transport._should_retry_async(response) is False
+
+    @pytest.mark.asyncio
+    async def test_should_retry_async_true_for_regular_429(self) -> None:
+        """A 429 without `daily-ratelimit-*` headers must still be retried by the parent."""
+        limiter = PagerDutyRateLimiter(max_concurrent=5)
+        transport = _build_transport(limiter)
+
+        response = MagicMock(spec=httpx.Response)
+        response.status_code = 429
+        response.headers = httpx.Headers(
+            {
+                "ratelimit-limit": "960",
+                "ratelimit-remaining": "0",
+                "ratelimit-reset": "56",
+            }
+        )
+
+        assert await transport._should_retry_async(response) is True
+
+    @pytest.mark.asyncio
+    async def test_should_retry_async_true_for_429_with_daily_remaining(self) -> None:
+        limiter = PagerDutyRateLimiter(max_concurrent=5)
+        transport = _build_transport(limiter)
+
+        response = MagicMock(spec=httpx.Response)
+        response.status_code = 429
+        response.headers = httpx.Headers(
+            {
+                "ratelimit-remaining": "0",
+                "daily-ratelimit-remaining": "5",
+                "daily-ratelimit-reset": "49015",
+            }
+        )
+
+        assert await transport._should_retry_async(response) is True
+
+    @pytest.mark.asyncio
+    async def test_should_retry_async_false_for_2xx(self) -> None:
+        limiter = PagerDutyRateLimiter(max_concurrent=5)
+        transport = _build_transport(limiter)
+
+        response = MagicMock(spec=httpx.Response)
+        response.status_code = 200
+        response.headers = httpx.Headers({})
+
+        assert await transport._should_retry_async(response) is False
+
+    @pytest.mark.asyncio
+    async def test_after_retry_async_is_called_during_retry_loop(self) -> None:
+        """End-to-end-ish: drive `_retry_operation_async` and confirm the limiter
+        is fed from the very first 429 response — not just the final one."""
+        limiter = PagerDutyRateLimiter(max_concurrent=5)
+        transport = _build_transport(limiter)
+
+        request = httpx.Request(
+            "GET", "https://api.pagerduty.com/analytics/raw/incidents/X"
+        )
+
+        first_429 = MagicMock(spec=httpx.Response)
+        first_429.status_code = 429
+        first_429.headers = httpx.Headers(
+            {
+                "ratelimit-limit": "960",
+                "ratelimit-remaining": "959",
+                "ratelimit-reset": "56",
+                "daily-ratelimit-limit": "10",
+                "daily-ratelimit-remaining": "-1",
+                "daily-ratelimit-reset": "49015",
+            }
+        )
+        first_429.aclose = AsyncMock()
+        first_429.aread = AsyncMock()
+
+        send_method = AsyncMock(return_value=first_429)
+
+        result = await transport._retry_operation_async(request, send_method)
+
+        # Single attempt — `_should_retry_async` returned False on first 429,
+        # so retries did not loop, and the rate limiter was fed once.
+        assert send_method.await_count == 1
+        assert result is first_429
+        assert limiter.daily_rate_limit_info is not None
+        assert limiter.daily_rate_limit_info.remaining == -1

--- a/integrations/pagerduty/tests/test_utils.py
+++ b/integrations/pagerduty/tests/test_utils.py
@@ -1,0 +1,85 @@
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from clients.pagerduty import PagerDutyClient
+from clients.rate_limiter import PagerDutyDailyRateLimitExceededError
+from utils import enrich_service_with_analytics_data
+
+
+def _service(service_id: str) -> dict[str, Any]:
+    return {"id": service_id, "name": f"svc-{service_id}"}
+
+
+class TestEnrichServiceWithAnalyticsData:
+    @pytest.mark.asyncio
+    async def test_returns_services_enriched_with_matched_analytics(self) -> None:
+        services = [_service("S1"), _service("S2")]
+        analytics = [
+            {"service_id": "S1", "mean_seconds_to_resolve": 100},
+            {"service_id": "S2", "mean_seconds_to_resolve": 200},
+        ]
+        client = MagicMock(spec=PagerDutyClient)
+        client.get_service_analytics = AsyncMock(return_value=analytics)
+
+        result = await enrich_service_with_analytics_data(client, services, 3)
+
+        assert result == [
+            {**services[0], "__analytics": analytics[0]},
+            {**services[1], "__analytics": analytics[1]},
+        ]
+        client.get_service_analytics.assert_awaited_once_with(["S1", "S2"], 3)
+
+    @pytest.mark.asyncio
+    async def test_unmatched_service_gets_none(self) -> None:
+        services = [_service("S1"), _service("S2")]
+        client = MagicMock(spec=PagerDutyClient)
+        client.get_service_analytics = AsyncMock(
+            return_value=[{"service_id": "S1", "mean_seconds_to_resolve": 100}]
+        )
+
+        result = await enrich_service_with_analytics_data(client, services, 3)
+
+        assert result[0]["__analytics"] == {
+            "service_id": "S1",
+            "mean_seconds_to_resolve": 100,
+        }
+        assert result[1]["__analytics"] is None
+
+    @pytest.mark.asyncio
+    async def test_daily_rate_limit_returns_unenriched_without_raising(self) -> None:
+        services = [_service("S1"), _service("S2")]
+        client = MagicMock(spec=PagerDutyClient)
+        client.get_service_analytics = AsyncMock(
+            side_effect=PagerDutyDailyRateLimitExceededError(
+                "PagerDuty analytics daily quota exhausted; resets in 49000s."
+            )
+        )
+
+        result = await enrich_service_with_analytics_data(client, services, 3)
+
+        assert result == [
+            {**services[0], "__analytics": None},
+            {**services[1], "__analytics": None},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_generic_exception_returns_unenriched_without_raising(self) -> None:
+        services = [_service("S1")]
+        client = MagicMock(spec=PagerDutyClient)
+        client.get_service_analytics = AsyncMock(side_effect=RuntimeError("boom"))
+
+        result = await enrich_service_with_analytics_data(client, services, 3)
+
+        assert result == [{**services[0], "__analytics": None}]
+
+    @pytest.mark.asyncio
+    async def test_empty_services_yields_empty(self) -> None:
+        client = MagicMock(spec=PagerDutyClient)
+        client.get_service_analytics = AsyncMock(return_value=[])
+
+        result = await enrich_service_with_analytics_data(client, [], 3)
+
+        assert result == []
+        client.get_service_analytics.assert_awaited_once_with([], 3)

--- a/integrations/pagerduty/utils.py
+++ b/integrations/pagerduty/utils.py
@@ -1,0 +1,41 @@
+from typing import Any
+
+from loguru import logger
+
+from clients.pagerduty import PagerDutyClient
+from clients.rate_limiter import PagerDutyDailyRateLimitExceededError
+
+
+def _services_without_analytics(
+    services: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    return [{**service, "__analytics": None} for service in services]
+
+
+async def enrich_service_with_analytics_data(
+    client: PagerDutyClient, services: list[dict[str, Any]], months_period: int
+) -> list[dict[str, Any]]:
+    """Attach `__analytics` to each service. Returns services with `__analytics: None`
+    when the daily quota is exhausted (logged at WARNING) or any other error occurs
+    (logged at ERROR), so resyncs degrade gracefully instead of failing.
+    """
+    service_ids = [service["id"] for service in services]
+    try:
+        services_analytics = await client.get_service_analytics(
+            service_ids, months_period
+        )
+        analytics_by_service = {
+            analytics["service_id"]: analytics for analytics in services_analytics
+        }
+        return [
+            {**service, "__analytics": analytics_by_service.get(service["id"])}
+            for service in services
+        ]
+    except PagerDutyDailyRateLimitExceededError as e:
+        logger.warning(
+            f"Skipping service analytics enrichment for {len(service_ids)} services: {e}"
+        )
+        return _services_without_analytics(services)
+    except Exception as e:
+        logger.error(f"Failed to fetch analytics for service {service_ids}: {e}")
+        return _services_without_analytics(services)

--- a/integrations/pagerduty/utils.py
+++ b/integrations/pagerduty/utils.py
@@ -15,10 +15,6 @@ def _services_without_analytics(
 async def enrich_service_with_analytics_data(
     client: PagerDutyClient, services: list[dict[str, Any]], months_period: int
 ) -> list[dict[str, Any]]:
-    """Attach `__analytics` to each service. Returns services with `__analytics: None`
-    when the daily quota is exhausted (logged at WARNING) or any other error occurs
-    (logged at ERROR), so resyncs degrade gracefully instead of failing.
-    """
     service_ids = [service["id"] for service in services]
     try:
         services_analytics = await client.get_service_analytics(


### PR DESCRIPTION
- Added support for respecting PagerDuty's `daily-ratelimit-*` headers on analytics endpoints, preventing excessive 429 errors and dropped enrichment.
- Introduced `PagerDutyDailyRateLimitExceededError` to manage daily quota exhaustion.
- Enhanced logging for skipped analytics enrichment due to rate limit issues.
- Updated version to 0.5.50 in `pyproject.toml` and documented changes in `CHANGELOG.md`.
- Added tests to ensure correct behavior under rate limit conditions.

# Description

What - Teach the PagerDuty integration to honor the analytics-only daily-ratelimit-* headers so resyncs stop hammering 429s once the daily quota is exhausted.

Why - Analytics endpoints (/analytics/metrics/..., /analytics/raw/...) enforce a separate, much smaller daily quota (e.g. 10/day) than the per-minute one (~960/min). The current rate limiter only parses ratelimit-* headers, so it never noticed daily exhaustion. Worse, OceanAsyncClient's default retry transport silently retries 429s using ratelimit-reset (~56s), burning ~10 attempts × ~56s ≈ 9 minutes per call before our code even sees the failure — and every concurrent in-flight analytics call enters the same doomed loop. Net effect: long resyncs, dropped analytics enrichment, no clear signal in logs.

How  
- Extended `RateLimiterRequiredHeaders` with the three `daily-ratelimit-*` aliases and added `daily_rate_limit_info` tracking on `PagerDutyRateLimiter`. Daily state is updated only when those headers are present so REST responses don't clobber it.
- Added PagerDutyRateLimiter.check_daily_budget(endpoint) and a PagerDutyDailyRateLimitExceededError. send_api_request calls it before acquiring the semaphore so subsequent analytics calls short-circuit without HTTP.
- Introduced PagerDutyRetryTransport(RetryTransport) (wired via OceanAsyncClient(transport_class=...)). It feeds the limiter from every response (including intermediate 429s) via after_retry_async, and overrides _should_retry_async to return False for any 429 with daily-ratelimit-remaining ≤ 0 — so the very first daily-quota 429 surfaces in seconds and concurrent retry loops also bail out on their next iteration.
- main.py catches PagerDutyDailyRateLimitExceededError narrowly in service and incident analytics enrichment paths, logs at WARNING, and returns un-enriched entities with __analytics: None instead of erroring.
- Added unit tests for the new headers, check_daily_budget, the transport hooks, and the end-to-end retry loop short-circuit.

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [x] Integration able to create all default resources from scratch
- [x] Resync finishes successfully
- [x] Resync able to create entities
- [x] Resync able to update entities
- [x] Resync able to detect and delete entities
- [x] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [x] Integration able to create all default resources from scratch
- [x] Completed a full resync from a freshly installed integration and it completed successfully
- [x] Resync able to create entities
- [x] Resync able to update entities
- [x] Resync able to detect and delete entities
- [x] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [x] Handled rate limiting
- [x] Handled pagination
- [x] Implemented the code in async

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

<img width="1420" height="987" alt="Screenshot 2026-05-03 at 11 15 42 AM" src="https://github.com/user-attachments/assets/1088ec8a-6a37-47f8-b8fc-376014ff71fd" />
<img width="2432" height="1299" alt="image" src="https://github.com/user-attachments/assets/f002ef66-ecda-4d7e-acf8-5e9f8e8b1a56" />
<img width="1266" height="185" alt="Screenshot 2026-05-03 at 12 23 34 PM" src="https://github.com/user-attachments/assets/640dc581-1b92-40ee-baea-8503bc41a0f4" />


## API Documentation

Provide links to the API documentation used for this integration.
