### PR TITLE
[Core] Fix Resync Mappings Logging to be JSON Safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.41.7 (2026-05-07)
+
+## Improvements
+
+- Serialize Port app config mappings to JSON-safe types in resync logs.
+
+## 0.41.6 (2026-04-30)
+
+### Improvements
+
+- When using the polling event listener, requests to Port to fetch the current integration now include `oceanCoreVersion` and `isPolling=true` query parameters. Other callers of the same API are unchanged.
+
 ## 0.41.6 (2026-04-30)
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,6 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - When using the polling event listener, requests to Port to fetch the current integration now include `oceanCoreVersion` and `isPolling=true` query parameters. Other callers of the same API are unchanged.
 
-## 0.41.6 (2026-04-30)
-
-### Improvements
-
-- When using the polling event listener, requests to Port to fetch the current integration now include `oceanCoreVersion` and `isPolling=true` query parameters. Other callers of the same API are unchanged.
-
 ## 0.41.5 (2026-04-27)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 <!-- towncrier release notes start -->
 ## 0.41.7 (2026-05-07)
 
-## Improvements
+### Improvements
 
 - Serialize Port app config mappings to JSON-safe types in resync logs.
 

--- a/port_ocean/core/integrations/mixins/sync_raw.py
+++ b/port_ocean/core/integrations/mixins/sync_raw.py
@@ -8,6 +8,7 @@ import typing
 from typing import AsyncGenerator, Callable, Awaitable, Any
 import multiprocessing
 import httpx
+import json
 from loguru import logger
 from port_ocean.clients.port.types import UserAgentType
 from port_ocean.context.event import TriggerType, event_context, EventType, event
@@ -1131,7 +1132,7 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
             app_config = await self.port_app_config_handler.get_port_app_config(
                 use_cache=False
             )
-            logger.info(f"Resync will use the following mappings: {app_config.dict()}")
+            logger.info(f"Resync will use the following mappings: {json.loads(app_config.json())}")
 
             kinds = [
                 f"{resource.kind}-{index}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.41.6"
+version = "0.41.7"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What -
- Updated resync mappings logging to use JSON-safe serialization (`json.loads(app_config.json())`) instead of `app_config.dict()`.
- Added `port_ocean/core/integrations/mixins/changelog.MD` entry for the change.

Why -
- Prevent issues with non-JSON-serializable values/types in logged mappings and keep logs consistently JSON-compatible.

How -
- Convert the Port app config model to JSON (`.json()`), then back to plain Python types (`json.loads`) for logging.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [x] Integration able to create all default resources from scratch
- [x] Resync finishes successfully
- [x] Resync able to create entities
- [x] Resync able to update entities
- [x] Resync able to detect and delete entities
- [x] Scheduled resync able to abort existing resync and start a new one
- [x] Tested with at least 2 integrations from scratch
- [x] Tested with Kafka and Polling event listeners
- [x] Tested deletion of entities that don't pass the selector

### Integration testing checklist

- [x] Integration able to create all default resources from scratch
- [x] Completed a full resync from a freshly installed integration and it completed successfully
- [x] Resync able to create entities
- [x] Resync able to update entities
- [x] Resync able to detect and delete entities
- [x] Resync finishes successfully
- [x] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [x] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [x] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)