### PR TITLE
[Integration][Claude] Add timeFrame selector to claude-code-analytics for per-day backfill

### DIFF
--- a/.cursor/rules/integration-development.mdc
+++ b/.cursor/rules/integration-development.mdc
@@ -85,6 +85,7 @@ Integration Development Guidelines
     - Include version numbers
     - Describe new features and fixes
     - Note breaking changes
+    - Every PR that modifies an integration MUST add an entry to `integrations/<name>/CHANGELOG.md` under a new version heading immediately after the `<!-- towncrier release notes start -->` comment, using Keep a Changelog format (`### Features`, `### Improvements`, or `### Bug Fixes`)
 
 12. Testing Requirements
     - Write unit tests for new code
@@ -93,9 +94,11 @@ Integration Development Guidelines
     - Maintain test coverage
 
 13. Versioning
-    - Each feature branch need to bump the latest version
+    - Each feature branch need to bump the latest version in `integrations/<name>/pyproject.toml`
+    - Apply a patch bump (e.g. 0.1.1 → 0.1.2) for fixes and minor improvements; a minor bump (e.g. 0.1.x → 0.2.0) for new features
     - In case of merge conflict take the version from the merged branch and bump it
     - Don't merge versions! existing version need to remain as it is and each branch creates its own version
+    - The version in `pyproject.toml` and the new `CHANGELOG.md` heading MUST match
 
 14. Code Quality
     - run `make lint` command on the integration folder before any commit

--- a/integrations/claude/.port/resources/port-app-config.yml
+++ b/integrations/claude/.port/resources/port-app-config.yml
@@ -2,6 +2,7 @@ resources:
   - kind: claude-usage-record
     selector:
       query: .results | length > 0
+      startingDate: '2025-01-01T00:00:00Z'
       bucketWidth: 1d
       groupBy: []
     port:
@@ -21,6 +22,7 @@ resources:
   - kind: claude-cost-record
     selector:
       query: .results | length > 0
+      startingDate: '2025-01-01T00:00:00Z'
       bucketWidth: 1d
     port:
       entity:
@@ -35,6 +37,7 @@ resources:
   - kind: claude-usage-record
     selector:
       query: .results | length > 0
+      startingDate: '2025-01-01T00:00:00Z'
       bucketWidth: 1d
       groupBy:
         - workspace_id
@@ -81,6 +84,7 @@ resources:
   - kind: claude-code-analytics
     selector:
       query: 'true'
+      timeFrame: 30
     port:
       entity:
         mappings:

--- a/integrations/claude/.port/resources/port-app-config.yml
+++ b/integrations/claude/.port/resources/port-app-config.yml
@@ -2,7 +2,6 @@ resources:
   - kind: claude-usage-record
     selector:
       query: .results | length > 0
-      startingDate: '2026-01-01T00:00:00Z'
       bucketWidth: 1d
       groupBy: []
     port:
@@ -22,7 +21,6 @@ resources:
   - kind: claude-cost-record
     selector:
       query: .results | length > 0
-      startingDate: '2026-01-01T00:00:00Z'
       bucketWidth: 1d
     port:
       entity:
@@ -37,7 +35,6 @@ resources:
   - kind: claude-usage-record
     selector:
       query: .results | length > 0
-      startingDate: '2026-01-01T00:00:00Z'
       bucketWidth: 1d
       groupBy:
         - workspace_id
@@ -61,7 +58,6 @@ resources:
   - kind: claude-usage-record
     selector:
       query: .results | length > 0
-      startingDate: '2026-01-01T00:00:00Z'
       bucketWidth: 1d
       groupBy:
         - model
@@ -85,7 +81,6 @@ resources:
   - kind: claude-code-analytics
     selector:
       query: 'true'
-      startingDate: '2026-01-01'
     port:
       entity:
         mappings:

--- a/integrations/claude/CHANGELOG.md
+++ b/integrations/claude/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
-- Made `startingDate` selector field optional for all resource kinds (`claude-usage-record`, `claude-cost-record`, `claude-code-analytics`); defaults to today's date when not set
+- Added `timeFrame` selector field to `claude-code-analytics` kind — accepts a number of days to look back and calls the API once per day for each day in the window. `timeFrame` and `startingDate` are mutually exclusive (one is required); `startingDate` iterates from the given date to today
 
 
 ## 0.1.1 (2026-05-07)

--- a/integrations/claude/CHANGELOG.md
+++ b/integrations/claude/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.2 (2026-05-10)
+
+
+### Improvements
+
+- Made `startingDate` selector field optional for all resource kinds (`claude-usage-record`, `claude-cost-record`, `claude-code-analytics`); defaults to today's date when not set
+
+
 ## 0.1.1 (2026-05-07)
 
 

--- a/integrations/claude/core/options_builder.py
+++ b/integrations/claude/core/options_builder.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from datetime import date
+from datetime import datetime, timezone
 from typing import Literal
 
 from core.options import (
@@ -13,7 +13,7 @@ DEFAULT_PAGE_SIZE = 30
 
 
 def _today_iso() -> str:
-    return date.today().isoformat()
+    return datetime.now(timezone.utc).date().isoformat()
 
 
 def _today_utc() -> str:

--- a/integrations/claude/core/options_builder.py
+++ b/integrations/claude/core/options_builder.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from datetime import date
 from typing import Literal
 
 from core.options import (
@@ -11,14 +12,22 @@ from core.options import (
 DEFAULT_PAGE_SIZE = 30
 
 
+def _today_iso() -> str:
+    return date.today().isoformat()
+
+
+def _today_utc() -> str:
+    return f"{_today_iso()}T00:00:00Z"
+
+
 def build_usage_options(
-    starting_date: str,
+    starting_date: str | None,
     bucket_width: Literal["1m", "1h", "1d"],
     group_by: Sequence[ClaudeUsageGroupBy],
     limit: int = DEFAULT_PAGE_SIZE,
 ) -> ListClaudeUsageReportOptions:
     options: ListClaudeUsageReportOptions = {
-        "starting_at": starting_date,
+        "starting_at": starting_date or _today_utc(),
         "limit": limit,
         "bucket_width": bucket_width,
     }
@@ -28,22 +37,22 @@ def build_usage_options(
 
 
 def build_cost_options(
-    starting_date: str,
+    starting_date: str | None,
     bucket_width: Literal["1d"],
     limit: int = DEFAULT_PAGE_SIZE,
 ) -> ListClaudeCostReportOptions:
     return {
-        "starting_at": starting_date,
+        "starting_at": starting_date or _today_utc(),
         "limit": limit,
         "bucket_width": bucket_width,
     }
 
 
 def build_code_analytics_options(
-    starting_date: str,
+    starting_date: str | None,
     limit: int = DEFAULT_PAGE_SIZE,
 ) -> ListClaudeCodeAnalyticsOptions:
     return {
-        "starting_at": starting_date,
+        "starting_at": starting_date or _today_iso(),
         "limit": limit,
     }

--- a/integrations/claude/core/options_builder.py
+++ b/integrations/claude/core/options_builder.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from datetime import datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from typing import Literal
 
 from core.options import (
@@ -12,22 +12,18 @@ from core.options import (
 DEFAULT_PAGE_SIZE = 30
 
 
-def _today_iso() -> str:
-    return datetime.now(timezone.utc).date().isoformat()
-
-
-def _today_utc() -> str:
-    return f"{_today_iso()}T00:00:00Z"
+def _utc_today() -> date:
+    return datetime.now(timezone.utc).date()
 
 
 def build_usage_options(
-    starting_date: str | None,
+    starting_date: str,
     bucket_width: Literal["1m", "1h", "1d"],
     group_by: Sequence[ClaudeUsageGroupBy],
     limit: int = DEFAULT_PAGE_SIZE,
 ) -> ListClaudeUsageReportOptions:
     options: ListClaudeUsageReportOptions = {
-        "starting_at": starting_date or _today_utc(),
+        "starting_at": starting_date,
         "limit": limit,
         "bucket_width": bucket_width,
     }
@@ -37,22 +33,42 @@ def build_usage_options(
 
 
 def build_cost_options(
-    starting_date: str | None,
+    starting_date: str,
     bucket_width: Literal["1d"],
     limit: int = DEFAULT_PAGE_SIZE,
 ) -> ListClaudeCostReportOptions:
     return {
-        "starting_at": starting_date or _today_utc(),
+        "starting_at": starting_date,
         "limit": limit,
         "bucket_width": bucket_width,
     }
 
 
 def build_code_analytics_options(
-    starting_date: str | None,
+    starting_date: str,
     limit: int = DEFAULT_PAGE_SIZE,
 ) -> ListClaudeCodeAnalyticsOptions:
     return {
-        "starting_at": starting_date or _today_iso(),
+        "starting_at": starting_date,
         "limit": limit,
     }
+
+
+def get_code_analytics_dates(
+    starting_date: str | None,
+    time_frame: int | None,
+) -> list[str]:
+    """Return the ordered list of YYYY-MM-DD dates to query.
+
+    Exactly one of starting_date / time_frame must be non-None
+    (enforced by ClaudeCodeAnalyticsSelector's validator).
+    """
+    today = _utc_today()
+    if time_frame is not None:
+        return [
+            (today - timedelta(days=i)).isoformat()
+            for i in range(time_frame - 1, -1, -1)
+        ]
+    start = date.fromisoformat(starting_date)  # type: ignore[arg-type]
+    num_days = (today - start).days + 1
+    return [(start + timedelta(days=i)).isoformat() for i in range(num_days)]

--- a/integrations/claude/core/options_builder.py
+++ b/integrations/claude/core/options_builder.py
@@ -2,6 +2,8 @@ from collections.abc import Sequence
 from datetime import date, datetime, timedelta, timezone
 from typing import Literal
 
+from loguru import logger
+
 from core.options import (
     ClaudeUsageGroupBy,
     ListClaudeCodeAnalyticsOptions,
@@ -71,4 +73,9 @@ def get_code_analytics_dates(
         ]
     start = date.fromisoformat(starting_date)  # type: ignore[arg-type]
     num_days = (today - start).days + 1
+    if num_days <= 0:
+        logger.warning(
+            f"startingDate '{starting_date}' is in the future — no dates to fetch"
+        )
+        return []
     return [(start + timedelta(days=i)).isoformat() for i in range(num_days)]

--- a/integrations/claude/integration.py
+++ b/integrations/claude/integration.py
@@ -92,7 +92,7 @@ class ClaudeCodeAnalyticsSelector(Selector):
 
     @root_validator
     @classmethod
-    def validate_date_config(cls, values: dict) -> dict:
+    def validate_date_config(cls, values: dict[str, object]) -> dict[str, object]:
         has_starting_date = values.get("starting_date") is not None
         has_time_frame = values.get("time_frame") is not None
         if not has_starting_date and not has_time_frame:

--- a/integrations/claude/integration.py
+++ b/integrations/claude/integration.py
@@ -1,7 +1,7 @@
 from typing import Literal
 from enum import StrEnum
 
-from pydantic import Field, model_validator
+from pydantic import Field, root_validator
 from port_ocean.core.handlers.port_app_config.models import Selector
 
 from port_ocean.core.handlers.port_app_config.models import (
@@ -90,15 +90,16 @@ class ClaudeCodeAnalyticsSelector(Selector):
         gt=0,
     )
 
-    @model_validator(mode="after")
-    def validate_date_config(self) -> "ClaudeCodeAnalyticsSelector":
-        has_starting_date = self.starting_date is not None
-        has_time_frame = self.time_frame is not None
+    @root_validator
+    @classmethod
+    def validate_date_config(cls, values: dict) -> dict:
+        has_starting_date = values.get("starting_date") is not None
+        has_time_frame = values.get("time_frame") is not None
         if not has_starting_date and not has_time_frame:
             raise ValueError("Either 'startingDate' or 'timeFrame' must be provided")
         if has_starting_date and has_time_frame:
             raise ValueError("'startingDate' and 'timeFrame' are mutually exclusive")
-        return self
+        return values
 
 
 class ClaudeUsageRecordResourceConfig(ResourceConfig):

--- a/integrations/claude/integration.py
+++ b/integrations/claude/integration.py
@@ -19,11 +19,11 @@ class ObjectKind(StrEnum):
 
 
 class ClaudeUsageSelector(Selector):
-    starting_date: str = Field(
+    starting_date: str | None = Field(
         alias="startingDate",
-        default="2025-01-01T00:00:00Z",
+        default=None,
         title="Starting Date",
-        description="ISO-8601 UTC start date used as the starting_at query parameter.",
+        description="ISO-8601 UTC start date used as the starting_at query parameter. Defaults to today if not set.",
         pattern=r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$",
     )
     bucket_width: Literal["1m", "1h", "1d"] = Field(
@@ -53,11 +53,11 @@ class ClaudeUsageSelector(Selector):
 
 
 class ClaudeCostSelector(Selector):
-    starting_date: str = Field(
+    starting_date: str | None = Field(
         alias="startingDate",
-        default="2025-01-01T00:00:00Z",
+        default=None,
         title="Starting Date",
-        description="ISO-8601 UTC start date used as the starting_at query parameter.",
+        description="ISO-8601 UTC start date used as the starting_at query parameter. Defaults to today if not set.",
         pattern=r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$",
     )
     bucket_width: Literal["1d"] = Field(
@@ -69,11 +69,11 @@ class ClaudeCostSelector(Selector):
 
 
 class ClaudeCodeAnalyticsSelector(Selector):
-    starting_date: str = Field(
+    starting_date: str | None = Field(
         alias="startingDate",
-        default="2025-01-01",
+        default=None,
         title="Starting Date",
-        description="Start date for Claude Code analytics in YYYY-MM-DD format.",
+        description="Start date for Claude Code analytics in YYYY-MM-DD format. Defaults to today if not set.",
         pattern=r"^\d{4}-\d{2}-\d{2}$",
     )
 

--- a/integrations/claude/integration.py
+++ b/integrations/claude/integration.py
@@ -1,7 +1,7 @@
 from typing import Literal
 from enum import StrEnum
 
-from pydantic import Field
+from pydantic import Field, model_validator
 from port_ocean.core.handlers.port_app_config.models import Selector
 
 from port_ocean.core.handlers.port_app_config.models import (
@@ -19,11 +19,11 @@ class ObjectKind(StrEnum):
 
 
 class ClaudeUsageSelector(Selector):
-    starting_date: str | None = Field(
+    starting_date: str = Field(
         alias="startingDate",
-        default=None,
+        default="2025-01-01T00:00:00Z",
         title="Starting Date",
-        description="ISO-8601 UTC start date used as the starting_at query parameter. Defaults to today if not set.",
+        description="ISO-8601 UTC start date used as the starting_at query parameter.",
         pattern=r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$",
     )
     bucket_width: Literal["1m", "1h", "1d"] = Field(
@@ -53,11 +53,11 @@ class ClaudeUsageSelector(Selector):
 
 
 class ClaudeCostSelector(Selector):
-    starting_date: str | None = Field(
+    starting_date: str = Field(
         alias="startingDate",
-        default=None,
+        default="2025-01-01T00:00:00Z",
         title="Starting Date",
-        description="ISO-8601 UTC start date used as the starting_at query parameter. Defaults to today if not set.",
+        description="ISO-8601 UTC start date used as the starting_at query parameter.",
         pattern=r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$",
     )
     bucket_width: Literal["1d"] = Field(
@@ -73,9 +73,32 @@ class ClaudeCodeAnalyticsSelector(Selector):
         alias="startingDate",
         default=None,
         title="Starting Date",
-        description="Start date for Claude Code analytics in YYYY-MM-DD format. Defaults to today if not set.",
+        description=(
+            "Start date in YYYY-MM-DD format. The integration calls the API once for "
+            "each day from this date to today. Mutually exclusive with timeFrame."
+        ),
         pattern=r"^\d{4}-\d{2}-\d{2}$",
     )
+    time_frame: int | None = Field(
+        alias="timeFrame",
+        default=None,
+        title="Time Frame (days)",
+        description=(
+            "Number of days to look back from today. The integration calls the API "
+            "once per day for each of the last N days. Mutually exclusive with startingDate."
+        ),
+        gt=0,
+    )
+
+    @model_validator(mode="after")
+    def validate_date_config(self) -> "ClaudeCodeAnalyticsSelector":
+        has_starting_date = self.starting_date is not None
+        has_time_frame = self.time_frame is not None
+        if not has_starting_date and not has_time_frame:
+            raise ValueError("Either 'startingDate' or 'timeFrame' must be provided")
+        if has_starting_date and has_time_frame:
+            raise ValueError("'startingDate' and 'timeFrame' are mutually exclusive")
+        return self
 
 
 class ClaudeUsageRecordResourceConfig(ResourceConfig):

--- a/integrations/claude/main.py
+++ b/integrations/claude/main.py
@@ -9,6 +9,7 @@ from core.options_builder import (
     build_code_analytics_options,
     build_cost_options,
     build_usage_options,
+    get_code_analytics_dates,
 )
 from exporter_factory import (
     create_code_analytics_exporter,
@@ -63,11 +64,18 @@ async def on_resync_code_analytics(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     ).selector
     exporter = create_code_analytics_exporter()
 
-    async for page in exporter.get_paginated_resources(
-        build_code_analytics_options(starting_date=code_selector.starting_date)
-    ):
-        if page:
-            yield page
+    dates = get_code_analytics_dates(
+        starting_date=code_selector.starting_date,
+        time_frame=code_selector.time_frame,
+    )
+    logger.info(f"Fetching Claude Code analytics for {len(dates)} day(s)")
+
+    for day in dates:
+        async for page in exporter.get_paginated_resources(
+            build_code_analytics_options(starting_date=day)
+        ):
+            if page:
+                yield page
 
 
 @ocean.on_start()

--- a/integrations/claude/pyproject.toml
+++ b/integrations/claude/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "claude"
-version = "0.1.1"
+version = "0.1.2"
 description = "Claude ocean integration"
 authors = ["Isaac Coffie <isaac@getport.io>"]
 

--- a/integrations/claude/tests/conftest.py
+++ b/integrations/claude/tests/conftest.py
@@ -11,5 +11,5 @@ def _mock_ocean_context() -> Generator[None, None, None]:
     """Mock Port Ocean context so OceanAsyncClient can run in tests."""
     mock_ocean = MagicMock()
     mock_ocean.app.is_saas.return_value = False
-    with patch("port_ocean.helpers.async_client.ocean", mock_ocean):
+    with patch("port_ocean.helpers.async_client.ocean", mock_ocean, create=True):
         yield

--- a/integrations/claude/tests/test_options_builder.py
+++ b/integrations/claude/tests/test_options_builder.py
@@ -9,9 +9,9 @@ from core.options_builder import (
     build_usage_options,
 )
 
-FIXED_UTC = datetime(2026, 5, 10, 23, 30, 0, tzinfo=timezone.utc)
-FIXED_DATE = "2026-05-10"
-FIXED_DATETIME = "2026-05-10T00:00:00Z"
+FIXED_UTC = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+FIXED_DATE = "2026-01-01"
+FIXED_DATETIME = "2026-01-01T00:00:00Z"
 
 
 @pytest.fixture()
@@ -57,8 +57,8 @@ def test_default_date_derived_from_utc_not_local():
     """Date must come from UTC clock — host timezone must not influence the value."""
     with patch("core.options_builder.datetime") as mock_dt:
         # Simulate a host one day behind UTC (e.g. UTC-1 at 00:30 local = 01:30 UTC next day)
-        mock_dt.now.return_value = datetime(2026, 5, 11, 1, 30, 0, tzinfo=timezone.utc)
+        mock_dt.now.return_value = datetime(2026, 1, 1, 1, 30, 0, tzinfo=timezone.utc)
         options = build_code_analytics_options(starting_date=None)
 
-    assert options["starting_at"] == "2026-05-11"
+    assert options["starting_at"] == "2026-01-01"
     mock_dt.now.assert_called_once_with(timezone.utc)

--- a/integrations/claude/tests/test_options_builder.py
+++ b/integrations/claude/tests/test_options_builder.py
@@ -125,7 +125,10 @@ def test_get_code_analytics_dates_starting_today_returns_single_day(
 def test_get_code_analytics_dates_future_starting_date_returns_empty(
     frozen_utc: None,
 ) -> None:
-    dates = get_code_analytics_dates(starting_date="2026-12-31", time_frame=None)
+    from datetime import timedelta
+
+    future = (FIXED_UTC + timedelta(days=30)).date().isoformat()
+    dates = get_code_analytics_dates(starting_date=future, time_frame=None)
     assert dates == []
 
 

--- a/integrations/claude/tests/test_options_builder.py
+++ b/integrations/claude/tests/test_options_builder.py
@@ -1,3 +1,4 @@
+from collections.abc import Generator
 from datetime import datetime, timezone
 from unittest.mock import patch
 
@@ -15,48 +16,49 @@ FIXED_DATETIME = "2026-01-01T00:00:00Z"
 
 
 @pytest.fixture()
-def frozen_utc():
+def frozen_utc() -> Generator[None, None, None]:
     with patch("core.options_builder.datetime") as mock_dt:
         mock_dt.now.return_value = FIXED_UTC
         yield
 
 
-def test_build_usage_options_defaults_to_today_utc(frozen_utc):
+def test_build_usage_options_defaults_to_today_utc(frozen_utc: None) -> None:
     options = build_usage_options(starting_date=None, bucket_width="1d", group_by=[])
     assert options["starting_at"] == FIXED_DATETIME
 
 
-def test_build_usage_options_respects_explicit_date(frozen_utc):
+def test_build_usage_options_respects_explicit_date(frozen_utc: None) -> None:
     options = build_usage_options(
         starting_date="2026-01-01T00:00:00Z", bucket_width="1d", group_by=[]
     )
     assert options["starting_at"] == "2026-01-01T00:00:00Z"
 
 
-def test_build_cost_options_defaults_to_today_utc(frozen_utc):
+def test_build_cost_options_defaults_to_today_utc(frozen_utc: None) -> None:
     options = build_cost_options(starting_date=None, bucket_width="1d")
     assert options["starting_at"] == FIXED_DATETIME
 
 
-def test_build_cost_options_respects_explicit_date(frozen_utc):
-    options = build_cost_options(starting_date="2026-01-01T00:00:00Z", bucket_width="1d")
+def test_build_cost_options_respects_explicit_date(frozen_utc: None) -> None:
+    options = build_cost_options(
+        starting_date="2026-01-01T00:00:00Z", bucket_width="1d"
+    )
     assert options["starting_at"] == "2026-01-01T00:00:00Z"
 
 
-def test_build_code_analytics_options_defaults_to_today_iso(frozen_utc):
+def test_build_code_analytics_options_defaults_to_today_iso(frozen_utc: None) -> None:
     options = build_code_analytics_options(starting_date=None)
     assert options["starting_at"] == FIXED_DATE
 
 
-def test_build_code_analytics_options_respects_explicit_date(frozen_utc):
+def test_build_code_analytics_options_respects_explicit_date(frozen_utc: None) -> None:
     options = build_code_analytics_options(starting_date="2026-01-01")
     assert options["starting_at"] == "2026-01-01"
 
 
-def test_default_date_derived_from_utc_not_local():
+def test_default_date_derived_from_utc_not_local() -> None:
     """Date must come from UTC clock — host timezone must not influence the value."""
     with patch("core.options_builder.datetime") as mock_dt:
-        # Simulate a host one day behind UTC (e.g. UTC-1 at 00:30 local = 01:30 UTC next day)
         mock_dt.now.return_value = datetime(2026, 1, 1, 1, 30, 0, tzinfo=timezone.utc)
         options = build_code_analytics_options(starting_date=None)
 

--- a/integrations/claude/tests/test_options_builder.py
+++ b/integrations/claude/tests/test_options_builder.py
@@ -8,11 +8,11 @@ from core.options_builder import (
     build_code_analytics_options,
     build_cost_options,
     build_usage_options,
+    get_code_analytics_dates,
 )
 
 FIXED_UTC = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
 FIXED_DATE = "2026-01-01"
-FIXED_DATETIME = "2026-01-01T00:00:00Z"
 
 
 @pytest.fixture()
@@ -22,45 +22,111 @@ def frozen_utc() -> Generator[None, None, None]:
         yield
 
 
-def test_build_usage_options_defaults_to_today_utc(frozen_utc: None) -> None:
-    options = build_usage_options(starting_date=None, bucket_width="1d", group_by=[])
-    assert options["starting_at"] == FIXED_DATETIME
+# ---------------------------------------------------------------------------
+# build_usage_options
+# ---------------------------------------------------------------------------
 
 
-def test_build_usage_options_respects_explicit_date(frozen_utc: None) -> None:
+def test_build_usage_options_passes_starting_date() -> None:
     options = build_usage_options(
         starting_date="2026-01-01T00:00:00Z", bucket_width="1d", group_by=[]
     )
     assert options["starting_at"] == "2026-01-01T00:00:00Z"
 
 
-def test_build_cost_options_defaults_to_today_utc(frozen_utc: None) -> None:
-    options = build_cost_options(starting_date=None, bucket_width="1d")
-    assert options["starting_at"] == FIXED_DATETIME
+# ---------------------------------------------------------------------------
+# build_cost_options
+# ---------------------------------------------------------------------------
 
 
-def test_build_cost_options_respects_explicit_date(frozen_utc: None) -> None:
+def test_build_cost_options_passes_starting_date() -> None:
     options = build_cost_options(
         starting_date="2026-01-01T00:00:00Z", bucket_width="1d"
     )
     assert options["starting_at"] == "2026-01-01T00:00:00Z"
 
 
-def test_build_code_analytics_options_defaults_to_today_iso(frozen_utc: None) -> None:
-    options = build_code_analytics_options(starting_date=None)
-    assert options["starting_at"] == FIXED_DATE
+# ---------------------------------------------------------------------------
+# build_code_analytics_options
+# ---------------------------------------------------------------------------
 
 
-def test_build_code_analytics_options_respects_explicit_date(frozen_utc: None) -> None:
+def test_build_code_analytics_options_passes_date() -> None:
     options = build_code_analytics_options(starting_date="2026-01-01")
     assert options["starting_at"] == "2026-01-01"
 
 
-def test_default_date_derived_from_utc_not_local() -> None:
-    """Date must come from UTC clock — host timezone must not influence the value."""
+# ---------------------------------------------------------------------------
+# get_code_analytics_dates — timeFrame
+# ---------------------------------------------------------------------------
+
+
+def test_get_code_analytics_dates_time_frame_count(frozen_utc: None) -> None:
+    dates = get_code_analytics_dates(starting_date=None, time_frame=5)
+    assert len(dates) == 5
+
+
+def test_get_code_analytics_dates_time_frame_ends_on_today(frozen_utc: None) -> None:
+    dates = get_code_analytics_dates(starting_date=None, time_frame=5)
+    assert dates[-1] == FIXED_DATE
+
+
+def test_get_code_analytics_dates_time_frame_is_chronological(frozen_utc: None) -> None:
+    dates = get_code_analytics_dates(starting_date=None, time_frame=5)
+    assert dates == sorted(dates)
+
+
+def test_get_code_analytics_dates_time_frame_1_returns_today(frozen_utc: None) -> None:
+    dates = get_code_analytics_dates(starting_date=None, time_frame=1)
+    assert dates == [FIXED_DATE]
+
+
+# ---------------------------------------------------------------------------
+# get_code_analytics_dates — startingDate
+# ---------------------------------------------------------------------------
+
+
+def test_get_code_analytics_dates_starting_date_includes_today(frozen_utc: None) -> None:
+    dates = get_code_analytics_dates(starting_date="2025-12-30", time_frame=None)
+    assert dates[-1] == FIXED_DATE
+
+
+def test_get_code_analytics_dates_starting_date_includes_start(frozen_utc: None) -> None:
+    dates = get_code_analytics_dates(starting_date="2025-12-30", time_frame=None)
+    assert dates[0] == "2025-12-30"
+
+
+def test_get_code_analytics_dates_starting_date_is_chronological(
+    frozen_utc: None,
+) -> None:
+    dates = get_code_analytics_dates(starting_date="2025-12-29", time_frame=None)
+    assert dates == sorted(dates)
+
+
+def test_get_code_analytics_dates_starting_date_correct_count(
+    frozen_utc: None,
+) -> None:
+    # 2025-12-30 → 2026-01-01 inclusive = 3 days
+    dates = get_code_analytics_dates(starting_date="2025-12-30", time_frame=None)
+    assert len(dates) == 3
+
+
+def test_get_code_analytics_dates_starting_today_returns_single_day(
+    frozen_utc: None,
+) -> None:
+    dates = get_code_analytics_dates(starting_date=FIXED_DATE, time_frame=None)
+    assert dates == [FIXED_DATE]
+
+
+# ---------------------------------------------------------------------------
+# UTC correctness
+# ---------------------------------------------------------------------------
+
+
+def test_get_code_analytics_dates_uses_utc_clock() -> None:
     with patch("core.options_builder.datetime") as mock_dt:
         mock_dt.now.return_value = datetime(2026, 1, 1, 1, 30, 0, tzinfo=timezone.utc)
-        options = build_code_analytics_options(starting_date=None)
+        dates = get_code_analytics_dates(starting_date=None, time_frame=1)
 
-    assert options["starting_at"] == "2026-01-01"
+    assert dates == ["2026-01-01"]
     mock_dt.now.assert_called_once_with(timezone.utc)

--- a/integrations/claude/tests/test_options_builder.py
+++ b/integrations/claude/tests/test_options_builder.py
@@ -122,6 +122,13 @@ def test_get_code_analytics_dates_starting_today_returns_single_day(
     assert dates == [FIXED_DATE]
 
 
+def test_get_code_analytics_dates_future_starting_date_returns_empty(
+    frozen_utc: None,
+) -> None:
+    dates = get_code_analytics_dates(starting_date="2026-12-31", time_frame=None)
+    assert dates == []
+
+
 # ---------------------------------------------------------------------------
 # UTC correctness
 # ---------------------------------------------------------------------------

--- a/integrations/claude/tests/test_options_builder.py
+++ b/integrations/claude/tests/test_options_builder.py
@@ -1,0 +1,64 @@
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from core.options_builder import (
+    build_code_analytics_options,
+    build_cost_options,
+    build_usage_options,
+)
+
+FIXED_UTC = datetime(2026, 5, 10, 23, 30, 0, tzinfo=timezone.utc)
+FIXED_DATE = "2026-05-10"
+FIXED_DATETIME = "2026-05-10T00:00:00Z"
+
+
+@pytest.fixture()
+def frozen_utc():
+    with patch("core.options_builder.datetime") as mock_dt:
+        mock_dt.now.return_value = FIXED_UTC
+        yield
+
+
+def test_build_usage_options_defaults_to_today_utc(frozen_utc):
+    options = build_usage_options(starting_date=None, bucket_width="1d", group_by=[])
+    assert options["starting_at"] == FIXED_DATETIME
+
+
+def test_build_usage_options_respects_explicit_date(frozen_utc):
+    options = build_usage_options(
+        starting_date="2026-01-01T00:00:00Z", bucket_width="1d", group_by=[]
+    )
+    assert options["starting_at"] == "2026-01-01T00:00:00Z"
+
+
+def test_build_cost_options_defaults_to_today_utc(frozen_utc):
+    options = build_cost_options(starting_date=None, bucket_width="1d")
+    assert options["starting_at"] == FIXED_DATETIME
+
+
+def test_build_cost_options_respects_explicit_date(frozen_utc):
+    options = build_cost_options(starting_date="2026-01-01T00:00:00Z", bucket_width="1d")
+    assert options["starting_at"] == "2026-01-01T00:00:00Z"
+
+
+def test_build_code_analytics_options_defaults_to_today_iso(frozen_utc):
+    options = build_code_analytics_options(starting_date=None)
+    assert options["starting_at"] == FIXED_DATE
+
+
+def test_build_code_analytics_options_respects_explicit_date(frozen_utc):
+    options = build_code_analytics_options(starting_date="2026-01-01")
+    assert options["starting_at"] == "2026-01-01"
+
+
+def test_default_date_derived_from_utc_not_local():
+    """Date must come from UTC clock — host timezone must not influence the value."""
+    with patch("core.options_builder.datetime") as mock_dt:
+        # Simulate a host one day behind UTC (e.g. UTC-1 at 00:30 local = 01:30 UTC next day)
+        mock_dt.now.return_value = datetime(2026, 5, 11, 1, 30, 0, tzinfo=timezone.utc)
+        options = build_code_analytics_options(starting_date=None)
+
+    assert options["starting_at"] == "2026-05-11"
+    mock_dt.now.assert_called_once_with(timezone.utc)

--- a/integrations/claude/tests/test_options_builder.py
+++ b/integrations/claude/tests/test_options_builder.py
@@ -86,12 +86,16 @@ def test_get_code_analytics_dates_time_frame_1_returns_today(frozen_utc: None) -
 # ---------------------------------------------------------------------------
 
 
-def test_get_code_analytics_dates_starting_date_includes_today(frozen_utc: None) -> None:
+def test_get_code_analytics_dates_starting_date_includes_today(
+    frozen_utc: None,
+) -> None:
     dates = get_code_analytics_dates(starting_date="2025-12-30", time_frame=None)
     assert dates[-1] == FIXED_DATE
 
 
-def test_get_code_analytics_dates_starting_date_includes_start(frozen_utc: None) -> None:
+def test_get_code_analytics_dates_starting_date_includes_start(
+    frozen_utc: None,
+) -> None:
     dates = get_code_analytics_dates(starting_date="2025-12-30", time_frame=None)
     assert dates[0] == "2025-12-30"
 

--- a/integrations/claude/tests/test_selector.py
+++ b/integrations/claude/tests/test_selector.py
@@ -4,7 +4,7 @@ from pydantic import ValidationError
 from integration import ClaudeCodeAnalyticsSelector
 
 
-def _make_selector(**kwargs: object) -> ClaudeCodeAnalyticsSelector:
+def _make_selector(**kwargs: str | int | None) -> ClaudeCodeAnalyticsSelector:
     return ClaudeCodeAnalyticsSelector(**{"query": "true", **kwargs})
 
 

--- a/integrations/claude/tests/test_selector.py
+++ b/integrations/claude/tests/test_selector.py
@@ -4,23 +4,19 @@ from pydantic import ValidationError
 from integration import ClaudeCodeAnalyticsSelector
 
 
-def _make_selector(**kwargs: str | int | None) -> ClaudeCodeAnalyticsSelector:
-    return ClaudeCodeAnalyticsSelector(**{"query": "true", **kwargs})
-
-
 # ---------------------------------------------------------------------------
 # Valid configurations — exactly one field provided
 # ---------------------------------------------------------------------------
 
 
 def test_selector_accepts_time_frame_only() -> None:
-    sel = _make_selector(timeFrame=30)
+    sel = ClaudeCodeAnalyticsSelector(query="true", timeFrame=30)
     assert sel.time_frame == 30
     assert sel.starting_date is None
 
 
 def test_selector_accepts_starting_date_only() -> None:
-    sel = _make_selector(startingDate="2026-01-01")
+    sel = ClaudeCodeAnalyticsSelector(query="true", startingDate="2026-01-01")
     assert sel.starting_date == "2026-01-01"
     assert sel.time_frame is None
 
@@ -32,14 +28,16 @@ def test_selector_accepts_starting_date_only() -> None:
 
 def test_selector_rejects_neither_field() -> None:
     with pytest.raises(ValidationError, match="Either 'startingDate' or 'timeFrame'"):
-        _make_selector()
+        ClaudeCodeAnalyticsSelector(query="true")
 
 
 def test_selector_rejects_both_fields() -> None:
     with pytest.raises(
         ValidationError, match="'startingDate' and 'timeFrame' are mutually exclusive"
     ):
-        _make_selector(startingDate="2026-01-01", timeFrame=30)
+        ClaudeCodeAnalyticsSelector(
+            query="true", startingDate="2026-01-01", timeFrame=30
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -49,4 +47,4 @@ def test_selector_rejects_both_fields() -> None:
 
 def test_selector_rejects_non_positive_time_frame() -> None:
     with pytest.raises(ValidationError):
-        _make_selector(timeFrame=0)
+        ClaudeCodeAnalyticsSelector(query="true", timeFrame=0)

--- a/integrations/claude/tests/test_selector.py
+++ b/integrations/claude/tests/test_selector.py
@@ -1,0 +1,52 @@
+import pytest
+from pydantic import ValidationError
+
+from integration import ClaudeCodeAnalyticsSelector
+
+
+def _make_selector(**kwargs: object) -> ClaudeCodeAnalyticsSelector:
+    return ClaudeCodeAnalyticsSelector(**{"query": "true", **kwargs})
+
+
+# ---------------------------------------------------------------------------
+# Valid configurations — exactly one field provided
+# ---------------------------------------------------------------------------
+
+
+def test_selector_accepts_time_frame_only() -> None:
+    sel = _make_selector(timeFrame=30)
+    assert sel.time_frame == 30
+    assert sel.starting_date is None
+
+
+def test_selector_accepts_starting_date_only() -> None:
+    sel = _make_selector(startingDate="2026-01-01")
+    assert sel.starting_date == "2026-01-01"
+    assert sel.time_frame is None
+
+
+# ---------------------------------------------------------------------------
+# Invalid configurations — mutual exclusion enforced
+# ---------------------------------------------------------------------------
+
+
+def test_selector_rejects_neither_field() -> None:
+    with pytest.raises(ValidationError, match="Either 'startingDate' or 'timeFrame'"):
+        _make_selector()
+
+
+def test_selector_rejects_both_fields() -> None:
+    with pytest.raises(
+        ValidationError, match="'startingDate' and 'timeFrame' are mutually exclusive"
+    ):
+        _make_selector(startingDate="2026-01-01", timeFrame=30)
+
+
+# ---------------------------------------------------------------------------
+# Field-level validation
+# ---------------------------------------------------------------------------
+
+
+def test_selector_rejects_non_positive_time_frame() -> None:
+    with pytest.raises(ValidationError):
+        _make_selector(timeFrame=0)


### PR DESCRIPTION
## Summary

- Added `timeFrame` selector field to `claude-code-analytics` — accepts an integer number of days to look back from today; the integration calls the Anthropic Claude Code analytics API **once per day** for each day in the window
- `timeFrame` and `startingDate` are **mutually exclusive** — exactly one must be provided (enforced by a Pydantic model validator). `startingDate` iterates from the given date to today, one API call per day
- This design matches the API's per-day response structure (each record carries a `.date` field, unlike usage/cost which are time-bucketed ranges)
- Usage and cost selectors are unchanged — they remain range-based with a required `startingDate`
- Default mapping uses `timeFrame: 30` (last 30 days)

## Test plan
- [ ] Deploy with `timeFrame: 30` — verify 30 API calls are made and data lands for each day
- [ ] Deploy with `timeFrame: 1` — verify only today's data is fetched
- [ ] Deploy with `startingDate: '2026-01-01'` — verify iteration from that date to today
- [ ] Confirm providing both `timeFrame` and `startingDate` raises a validation error
- [ ] Confirm providing neither raises a validation error
- [ ] Confirm usage and cost kinds are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)