### PR TITLE
[Core] Normalize Whitespace-only Integration Config Strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.41.9 (2026-05-12)
+
+### Bug fixes
+
+- Strip whitespace from dynamic integration config string values to prevent whitespace-only values from being treated as configured.
+
 ## 0.41.8 (2026-05-12)
 
 ### Improvements

--- a/port_ocean/config/dynamic.py
+++ b/port_ocean/config/dynamic.py
@@ -41,6 +41,13 @@ class Configuration(BaseModel, extra=Extra.allow):
     sensitive: bool = False
 
 
+def normalize_string(value: Any) -> Any:
+    if isinstance(value, str):
+        value = value.strip()
+
+    return value
+
+
 def dynamic_parse(value: Any, field: ModelField) -> Any:
     should_json_load = issubclass(field.annotation, dict) or issubclass(
         field.annotation, list
@@ -89,7 +96,10 @@ def default_config_factory(configurations: Any) -> Type[BaseModel]:
         __base__=BaseOceanModel,
         **fields,
         __validators__={
-            "dynamic_parse": validator("*", pre=True, allow_reuse=True)(dynamic_parse)
+            "normalize_string": validator("*", pre=True, allow_reuse=True)(
+                normalize_string
+            ),
+            "dynamic_parse": validator("*", pre=True, allow_reuse=True)(dynamic_parse),
         },
     )
     return dynamic_model

--- a/port_ocean/tests/config/test_config.py
+++ b/port_ocean/tests/config/test_config.py
@@ -1,7 +1,8 @@
 import pytest
 from pydantic import BaseModel
-from port_ocean.config.dynamic import NoTrailingSlashUrl
+from port_ocean.config.dynamic import NoTrailingSlashUrl, default_config_factory
 from typing import cast
+from pydantic import parse_obj_as
 
 
 class TestClass(BaseModel):
@@ -36,3 +37,33 @@ def test_trailing_slash_not_valid_no_domain() -> None:
 def test_trailing_empty() -> None:
     cls = TestClass(url=None)
     assert cls.url is None
+
+
+def test_dynamic_config_strips_whitespace_only_optional_string() -> None:
+    ConfigModel = default_config_factory(
+        [
+            {
+                "name": "webhookSecret",
+                "type": "string",
+                "required": False,
+            }
+        ]
+    )
+
+    cfg = parse_obj_as(ConfigModel, {"webhook_secret": "   "})
+    assert cfg.webhook_secret == ""
+
+
+def test_dynamic_config_strips_surrounding_whitespace() -> None:
+    ConfigModel = default_config_factory(
+        [
+            {
+                "name": "webhookSecret",
+                "type": "string",
+                "required": False,
+            }
+        ]
+    )
+
+    cfg = parse_obj_as(ConfigModel, {"webhook_secret": "  abc  "})
+    assert cfg.webhook_secret == "abc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.41.8"
+version = "0.41.9"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What -
Normalize dynamic integration config string values by stripping whitespace, and add regression tests to ensure whitespace-only optional strings don’t accidentally enable “configured” behavior (e.g., webhook secret enforcement).

Why -
Whitespace-only values like `webhookSecret="   "` are currently treated as configured, which can unintentionally enable webhook signature verification and cause webhook processing failures.

How -
- Add a pre-parse string normalizer in `port_ocean/config/dynamic.py` to `strip()` string config values.
- Add unit tests in `port_ocean/tests/config/test_config.py` covering whitespace-only and surrounding-whitespace cases.
- Update `ocean/CHANGELOG.md` with a bug fix entry.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [x] Integration able to create all default resources from scratch
- [x] Resync finishes successfully
- [x] Resync able to create entities
- [x] Resync able to update entities
- [x] Resync able to detect and delete entities
- [x] Scheduled resync able to abort existing resync and start a new one
- [x] Tested with at least 2 integrations from scratch
- [x] Tested with Kafka and Polling event listeners
- [x] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [x] Integration able to create all default resources from scratch
- [x] Completed a full resync from a freshly installed integration and it completed successfully
- [x] Resync able to create entities
- [x] Resync able to update entities
- [x] Resync able to detect and delete entities
- [x] Resync finishes successfully
- [x] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [x] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [x] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)