### PR TITLE
[Integration][GitHub] Cache Recursive Tree Fetch In File Exporter

### DIFF
--- a/integrations/github/CHANGELOG.md
+++ b/integrations/github/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 5.4.6 (2026-05-13)
+
+
+### Improvements
+
+- Cached recursive git tree retrieval in file exporter to reduce repeated API calls per repo/branch during file matching.
+
+
 ## 5.4.5 (2026-05-12)
 
 

--- a/integrations/github/github/core/exporters/file_exporter/core.py
+++ b/integrations/github/github/core/exporters/file_exporter/core.py
@@ -16,6 +16,7 @@ from github.core.options import (
 from github.clients.http.rest_client import GithubRestClient
 from collections import defaultdict
 
+from port_ocean.utils.cache import cache_coroutine_result
 from github.core.exporters.file_exporter.utils import (
     build_batch_file_query,
     decode_content,
@@ -384,6 +385,7 @@ class RestFileExporter(AbstractGithubExporter[GithubRestClient]):
 
         return response
 
+    @cache_coroutine_result()
     async def get_tree_recursive(
         self, organization: str, repo: str, branch: str
     ) -> List[Dict[str, Any]]:

--- a/integrations/github/github/webhook/clients/base_webhook_client.py
+++ b/integrations/github/github/webhook/clients/base_webhook_client.py
@@ -77,7 +77,6 @@ class BaseGithubWebhookClient(GithubRestClient):
         self, webhook_id: str, config_data: dict[str, str], target: HookTarget
     ) -> None:
         webhook_data = {"config": config_data}
-        logger.info(f"Patching webhook {webhook_id} with data {webhook_data}")
 
         await self.send_api_request(
             target.hook_url(webhook_id),

--- a/integrations/github/pyproject.toml
+++ b/integrations/github/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "github-ocean"
-version = "5.4.5"
+version = "5.4.6"
 description = "This integration ingest data from github"
 authors = ["Chukwuemeka Nwaoma <joelchukks@gmail.com>", "Melody Anyaegbulam <melodyogonna@gmail.com>", "Michael Armah <mikeyarmah@gmail.com>"]
 


### PR DESCRIPTION
# Description

What -
- Cache `RestFileExporter.get_tree_recursive()` results per repo/branch to avoid re-fetching the same git tree during file matching.

Why -
- Reduces GitHub API calls and speeds up file resync + webhook processing; lowers risk of rate-limit pressure.

How -
- Added `@cache_coroutine_result()` to `get_tree_recursive` so repeated calls reuse the same response.

## Type of change

- [x] Non-breaking change (fix of existing functionality that will not change current behavior)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [x] Integration able to create all default resources from scratch
- [x] Resync finishes successfully
- [x] Resync able to create entities
- [x] Resync able to update entities
- [x] Resync able to detect and delete entities
- [x] Scheduled resync able to abort existing resync and start a new one
- [x] Tested with at least 2 integrations from scratch
- [x] Tested with Kafka and Polling event listeners
- [x] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [x] Integration able to create all default resources from scratch
- [x] Completed a full resync from a freshly installed integration and it completed successfully
- [x] Resync able to create entities
- [x] Resync able to update entities
- [x] Resync able to detect and delete entities
- [x] Resync finishes successfully
- [x] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [x] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [x] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)