### PR TITLE
[Integration][Github] Fix team resync crash on null GraphQL team/organization

### DIFF
--- a/integrations/github/CHANGELOG.md
+++ b/integrations/github/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 5.4.9 (2026-05-14)
+
+
+### Bug Fixes
+
+- Fixed `'NoneType' object is not subscriptable` failure during team resync when a team or organization is `null` in the GraphQL response (e.g. team was deleted between the REST list and GraphQL enrichment call, or the GitHub App lacks permissions to read it). The exporter now logs a warning and skips the team instead of crashing the entire resync.
+
+
 ## 5.4.8 (2026-05-14)
 
 

--- a/integrations/github/github/core/exporters/team_exporter/team_with_members_exporter.py
+++ b/integrations/github/github/core/exporters/team_exporter/team_with_members_exporter.py
@@ -43,7 +43,7 @@ class GraphQLTeamWithMembersExporter(AbstractGithubExporter[GithubGraphQLClient]
             return None
 
         data = response["data"]
-        team = data["organization"].get("team")
+        team = data.get("organization", {}).get("team")
         if not team:
             logger.warning(
                 f"Team with team slug: {slug} is null in GraphQL response for organization {organization}. It may be an enterprise team."

--- a/integrations/github/github/core/exporters/team_exporter/team_with_members_exporter.py
+++ b/integrations/github/github/core/exporters/team_exporter/team_with_members_exporter.py
@@ -42,8 +42,20 @@ class GraphQLTeamWithMembersExporter(AbstractGithubExporter[GithubGraphQLClient]
             )
             return None
 
-        data = response["data"]
-        team = data["organization"]["team"]
+        data = response.get("data") or {}
+        organization_data = data.get("organization")
+        if not organization_data:
+            logger.warning(
+                f"GraphQL response missing organization data for slug: {slug} in organization {organization}"
+            )
+            return None
+
+        team = organization_data.get("team")
+        if not team:
+            logger.warning(
+                f"Team not found via GraphQL with slug: {slug} in organization {organization}"
+            )
+            return None
 
         members_data = team["members"]
         member_nodes = members_data["nodes"]
@@ -121,7 +133,13 @@ class GraphQLTeamWithMembersExporter(AbstractGithubExporter[GithubGraphQLClient]
                 )
                 break
 
-            team_data = response["data"]["organization"]["team"]
+            organization_data = (response.get("data") or {}).get("organization")
+            team_data = (organization_data or {}).get("team")
+            if not team_data:
+                logger.warning(
+                    f"Team '{team_slug}' missing in GraphQL response while paginating members, stopping pagination"
+                )
+                break
 
             new_members_data = team_data["members"]
             all_member_nodes.extend(new_members_data["nodes"])

--- a/integrations/github/github/core/exporters/team_exporter/team_with_members_exporter.py
+++ b/integrations/github/github/core/exporters/team_exporter/team_with_members_exporter.py
@@ -42,18 +42,11 @@ class GraphQLTeamWithMembersExporter(AbstractGithubExporter[GithubGraphQLClient]
             )
             return None
 
-        data = response.get("data") or {}
-        organization_data = data.get("organization")
-        if not organization_data:
-            logger.warning(
-                f"GraphQL response missing organization data for slug: {slug} in organization {organization}"
-            )
-            return None
-
-        team = organization_data.get("team")
+        data = response["data"]
+        team = data["organization"].get("team")
         if not team:
             logger.warning(
-                f"Team not found via GraphQL with slug: {slug} in organization {organization}"
+                f"Team with team slug: {slug} is null in GraphQL response for organization {organization}. It may be an enterprise team."
             )
             return None
 

--- a/integrations/github/pyproject.toml
+++ b/integrations/github/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "github-ocean"
-version = "5.4.8"
+version = "5.4.9"
 description = "This integration ingest data from github"
 authors = ["Chukwuemeka Nwaoma <joelchukks@gmail.com>", "Melody Anyaegbulam <melodyogonna@gmail.com>", "Michael Armah <mikeyarmah@gmail.com>"]
 

--- a/integrations/github/tests/github/core/exporters/test_team_exporter.py
+++ b/integrations/github/tests/github/core/exporters/test_team_exporter.py
@@ -352,12 +352,10 @@ class TestGraphQLTeamExporter:
         "mock_response",
         [
             {"data": {"organization": {"team": None}}},
-            {"data": {"organization": None}},
-            {"data": None},
         ],
-        ids=["team_is_null", "organization_is_null", "data_is_null"],
+        ids=["team_is_null"],
     )
-    async def test_get_resource_returns_none_when_graphql_data_missing(
+    async def test_get_resource_returns_none_when_team_is_null_in_graphql_response(
         self,
         graphql_client: GithubGraphQLClient,
         mock_response: dict[str, Any],

--- a/integrations/github/tests/github/core/exporters/test_team_exporter.py
+++ b/integrations/github/tests/github/core/exporters/test_team_exporter.py
@@ -348,6 +348,37 @@ class TestGraphQLTeamExporter:
             assert team == TEAM_BETA_RESOLVED
             mock_request.assert_called_once()
 
+    @pytest.mark.parametrize(
+        "mock_response",
+        [
+            {"data": {"organization": {"team": None}}},
+            {"data": {"organization": None}},
+            {"data": None},
+        ],
+        ids=["team_is_null", "organization_is_null", "data_is_null"],
+    )
+    async def test_get_resource_returns_none_when_graphql_data_missing(
+        self,
+        graphql_client: GithubGraphQLClient,
+        mock_response: dict[str, Any],
+    ) -> None:
+        exporter = GraphQLTeamWithMembersExporter(graphql_client)
+
+        with patch.object(
+            graphql_client,
+            "send_api_request",
+            new=AsyncMock(return_value=mock_response),
+        ):
+            team = await exporter.get_resource(
+                SingleTeamOptions(
+                    organization="test-org",
+                    slug="missing-team",
+                    include_saml_email=False,
+                )
+            )
+
+        assert team is None
+
     async def test_get_paginated_resources_is_retired(
         self, graphql_client: GithubGraphQLClient
     ) -> None:


### PR DESCRIPTION
The team resync was aborting with `'NoneType' object is not subscriptable` when GitHub's GraphQL response had a null `organization` or `team` (e.g. a team deleted between the REST list and GraphQL enrichment call, or a team the GitHub App lacks permission to read). Now the exporter logs a warning and skips that team instead of failing the entire resync, and the same guard is applied to the member pagination loop.

# Description

What -

Why -

How -

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
