### PR TITLE
[Integration][Azure-Devops] Add code-coverage as a separate kind decoupled from test-runs

### DIFF
--- a/integrations/azure-devops/CHANGELOG.md
+++ b/integrations/azure-devops/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.8.40 (2026-05-19)
+
+
+### Features
+
+- Added `build-code-coverage` as a separate kind, decoupled from the `test-run` kind
+
+
 ## 0.8.39 (2026-05-19)
 
 

--- a/integrations/azure-devops/CHANGELOG.md
+++ b/integrations/azure-devops/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
-- Added `code-coverage` as a separate kind, decoupled from the `test-run` kind
+- Added `build-code-coverage` as a separate kind, decoupled from the `test-run` kind
 
 
 ## 0.8.34 (2026-05-14)

--- a/integrations/azure-devops/CHANGELOG.md
+++ b/integrations/azure-devops/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.8.35 (2026-05-14)
+
+
+### Features
+
+- Added `code-coverage` as a separate kind, decoupled from the `test-run` kind
+
+
 ## 0.8.34 (2026-05-14)
 
 

--- a/integrations/azure-devops/azure_devops/client/azure_devops_client.py
+++ b/integrations/azure-devops/azure_devops/client/azure_devops_client.py
@@ -70,6 +70,7 @@ MAX_CONCURRENT_REPOS_FOR_FILE_PROCESSING = 25
 MAX_CONCURRENT_REPOS_FOR_PULL_REQUESTS = 25
 MAX_SUBJECTS_PER_LOOKUP = 500
 MAX_CONCURRENT_PROJECTS = 5
+MAX_CONCURRENT_BUILD_CODE_COVERAGES = 10
 
 # Webhook subscriptions for Azure DevOps events
 AZURE_DEVOPS_WEBHOOK_SUBSCRIPTIONS = [
@@ -771,6 +772,7 @@ class AzureDevopsClient(HTTPBaseClient):
         ):
             yield self._enrich_builds_with_project_data(builds, project)
 
+    @cache_iterator_result()
     async def generate_builds(self) -> AsyncGenerator[list[dict[str, Any]], None]:
         """Generate builds across all projects in the organization.
 
@@ -2203,16 +2205,25 @@ class AzureDevopsClient(HTTPBaseClient):
         self,
         coverage_config: "CodeCoverageConfig",
     ) -> AsyncGenerator[list[dict[str, Any]], None]:
+        semaphore = asyncio.BoundedSemaphore(MAX_CONCURRENT_BUILD_CODE_COVERAGES)
         async for builds in self.generate_builds():
             coverage_entities: list[dict[str, Any]] = []
-            tasks = [
-                self._fetch_code_coverage(
-                    build["__projectId"], build["id"], coverage_config
-                )
-                for build in builds
-            ]
-            results = await asyncio.gather(*tasks, return_exceptions=True)
-            for build, result in zip(builds, results):
+
+            async def _guarded_fetch(
+                build: dict[str, Any],
+            ) -> tuple[dict[str, Any], dict[str, Any] | BaseException]:
+                async with semaphore:
+                    try:
+                        result = await self._fetch_code_coverage(
+                            build["__projectId"], build["id"], coverage_config
+                        )
+                        return build, result
+                    except Exception as exc:
+                        return build, exc
+
+            tasks = [_guarded_fetch(build) for build in builds]
+            results = await asyncio.gather(*tasks)
+            for build, result in results:
                 if isinstance(result, BaseException):
                     logger.error(
                         "Error fetching code coverage for build %s: %s",

--- a/integrations/azure-devops/azure_devops/client/azure_devops_client.py
+++ b/integrations/azure-devops/azure_devops/client/azure_devops_client.py
@@ -2199,7 +2199,7 @@ class AzureDevopsClient(HTTPBaseClient):
         """Return empty coverage for test runs without a build (e.g., manual test runs)."""
         return {}
 
-    async def generate_code_coverages(
+    async def generate_build_code_coverages(
         self,
         coverage_config: "CodeCoverageConfig",
     ) -> AsyncGenerator[list[dict[str, Any]], None]:

--- a/integrations/azure-devops/azure_devops/client/azure_devops_client.py
+++ b/integrations/azure-devops/azure_devops/client/azure_devops_client.py
@@ -2199,6 +2199,46 @@ class AzureDevopsClient(HTTPBaseClient):
         """Return empty coverage for test runs without a build (e.g., manual test runs)."""
         return {}
 
+    async def generate_code_coverages(
+        self,
+        coverage_config: "CodeCoverageConfig",
+    ) -> AsyncGenerator[list[dict[str, Any]], None]:
+        async for builds in self.generate_builds():
+            coverage_entities: list[dict[str, Any]] = []
+            tasks = [
+                self._fetch_code_coverage(
+                    build["__projectId"], build["id"], coverage_config
+                )
+                for build in builds
+            ]
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            for build, result in zip(builds, results):
+                if isinstance(result, BaseException):
+                    logger.error(
+                        "Error fetching code coverage for build %s: %s",
+                        build["id"],
+                        result,
+                    )
+                    continue
+                if not result or not result.get("value"):
+                    continue
+                for coverage in result["value"]:
+                    coverage["__build"] = build
+                    coverage_entities.append(coverage)
+            if coverage_entities:
+                yield coverage_entities
+
+    async def get_code_coverage_for_build(
+        self,
+        project_id: str,
+        build_id: int,
+        coverage_config: "CodeCoverageConfig",
+    ) -> list[dict[str, Any]]:
+        result = await self._fetch_code_coverage(project_id, build_id, coverage_config)
+        if not result or not result.get("value"):
+            return []
+        return result["value"]
+
     async def get_test_runs_by_build(
         self,
         project_id: str,

--- a/integrations/azure-devops/azure_devops/misc.py
+++ b/integrations/azure-devops/azure_devops/misc.py
@@ -27,7 +27,7 @@ class Kind(StrEnum):
     RELEASE_DEPLOYMENT = "release-deployment"
     PIPELINE_DEPLOYMENT = "pipeline-deployment"
     TEST_RUN = "test-run"
-    CODE_COVERAGE = "code-coverage"
+    BUILD_CODE_COVERAGE = "build-code-coverage"
     FILE = "file"
     USER = "user"
     FOLDER = "folder"

--- a/integrations/azure-devops/azure_devops/misc.py
+++ b/integrations/azure-devops/azure_devops/misc.py
@@ -27,6 +27,7 @@ class Kind(StrEnum):
     RELEASE_DEPLOYMENT = "release-deployment"
     PIPELINE_DEPLOYMENT = "pipeline-deployment"
     TEST_RUN = "test-run"
+    CODE_COVERAGE = "code-coverage"
     FILE = "file"
     USER = "user"
     FOLDER = "folder"

--- a/integrations/azure-devops/integration.py
+++ b/integrations/azure-devops/integration.py
@@ -239,7 +239,7 @@ class AzureDevopsTestRunResourceConfig(ResourceConfig):
     )
 
 
-class AzureDevopsCodeCoverageSelector(Selector):
+class AzureDevopsBuildCodeCoverageSelector(Selector):
     code_coverage: CodeCoverageConfig = Field(
         default_factory=CodeCoverageConfig,
         alias="codeCoverage",
@@ -248,14 +248,14 @@ class AzureDevopsCodeCoverageSelector(Selector):
     )
 
 
-class AzureDevopsCodeCoverageResourceConfig(ResourceConfig):
-    kind: Literal["code-coverage"] = Field(
-        title="Azure Devops Code Coverage",
-        description="Azure Devops code coverage resource kind.",
+class AzureDevopsBuildCodeCoverageResourceConfig(ResourceConfig):
+    kind: Literal["build-code-coverage"] = Field(
+        title="Azure Devops Build Code Coverage",
+        description="Azure Devops build code coverage resource kind.",
     )
-    selector: AzureDevopsCodeCoverageSelector = Field(
-        title="Code coverage selector",
-        description="Selector for the code coverage resource.",
+    selector: AzureDevopsBuildCodeCoverageSelector = Field(
+        title="Build code coverage selector",
+        description="Selector for the build code coverage resource.",
     )
 
 
@@ -629,7 +629,7 @@ class GitPortAppConfig(PortAppConfig):
         | AzureDevopsFileResourceConfig
         | AzureDevopsPipelineResourceConfig
         | AzureDevopsTestRunResourceConfig
-        | AzureDevopsCodeCoverageResourceConfig
+        | AzureDevopsBuildCodeCoverageResourceConfig
         | AzureDevopsPullRequestResourceConfig
         | AzureDevopsAdvancedSecurityResourceConfig
         | AzureDevopsRepositoryResourceConfig

--- a/integrations/azure-devops/integration.py
+++ b/integrations/azure-devops/integration.py
@@ -239,6 +239,26 @@ class AzureDevopsTestRunResourceConfig(ResourceConfig):
     )
 
 
+class AzureDevopsCodeCoverageSelector(Selector):
+    code_coverage: CodeCoverageConfig = Field(
+        default_factory=CodeCoverageConfig,
+        alias="codeCoverage",
+        title="Code Coverage",
+        description="Code coverage configuration. Flags control detail level: 1 for Modules, 2 for Functions, 4 for BlockData. Values are additive (e.g. 7 for all).",
+    )
+
+
+class AzureDevopsCodeCoverageResourceConfig(ResourceConfig):
+    kind: Literal["code-coverage"] = Field(
+        title="Azure Devops Code Coverage",
+        description="Azure Devops code coverage resource kind.",
+    )
+    selector: AzureDevopsCodeCoverageSelector = Field(
+        title="Code coverage selector",
+        description="Selector for the code coverage resource.",
+    )
+
+
 class AzureDevopsPullRequestSelector(Selector):
     min_time_in_days: int = Field(
         default=7,
@@ -609,6 +629,7 @@ class GitPortAppConfig(PortAppConfig):
         | AzureDevopsFileResourceConfig
         | AzureDevopsPipelineResourceConfig
         | AzureDevopsTestRunResourceConfig
+        | AzureDevopsCodeCoverageResourceConfig
         | AzureDevopsPullRequestResourceConfig
         | AzureDevopsAdvancedSecurityResourceConfig
         | AzureDevopsRepositoryResourceConfig

--- a/integrations/azure-devops/main.py
+++ b/integrations/azure-devops/main.py
@@ -63,6 +63,7 @@ from integration import (
     AzureDevopsTeamResourceConfig,
     AzureDevopsWorkItemResourceConfig,
     AzureDevopsTestRunResourceConfig,
+    AzureDevopsCodeCoverageResourceConfig,
     AzureDevopsPullRequestResourceConfig,
     AzureDevopsAdvancedSecurityResourceConfig,
     AzureDevopsRepositoryResourceConfig,
@@ -427,6 +428,21 @@ async def resync_test_runs(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     ):
         logger.info(f"Fetched {len(test_runs)} test runs")
         yield test_runs
+
+
+@ocean.on_resync(Kind.CODE_COVERAGE)
+async def resync_code_coverages(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
+    azure_devops_client = AzureDevopsClient.create_from_ocean_config()
+    selector = cast(
+        AzureDevopsCodeCoverageResourceConfig, event.resource_config
+    ).selector
+    coverage_config = selector.code_coverage
+
+    async for coverages in azure_devops_client.generate_code_coverages(
+        coverage_config,
+    ):
+        logger.info(f"Fetched {len(coverages)} code coverage entries")
+        yield coverages
 
 
 @ocean.on_resync(Kind.ITERATION)

--- a/integrations/azure-devops/main.py
+++ b/integrations/azure-devops/main.py
@@ -63,7 +63,7 @@ from integration import (
     AzureDevopsTeamResourceConfig,
     AzureDevopsWorkItemResourceConfig,
     AzureDevopsTestRunResourceConfig,
-    AzureDevopsCodeCoverageResourceConfig,
+    AzureDevopsBuildCodeCoverageResourceConfig,
     AzureDevopsPullRequestResourceConfig,
     AzureDevopsAdvancedSecurityResourceConfig,
     AzureDevopsRepositoryResourceConfig,
@@ -430,18 +430,18 @@ async def resync_test_runs(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
         yield test_runs
 
 
-@ocean.on_resync(Kind.CODE_COVERAGE)
-async def resync_code_coverages(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
+@ocean.on_resync(Kind.BUILD_CODE_COVERAGE)
+async def resync_build_code_coverages(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     azure_devops_client = AzureDevopsClient.create_from_ocean_config()
     selector = cast(
-        AzureDevopsCodeCoverageResourceConfig, event.resource_config
+        AzureDevopsBuildCodeCoverageResourceConfig, event.resource_config
     ).selector
     coverage_config = selector.code_coverage
 
-    async for coverages in azure_devops_client.generate_code_coverages(
+    async for coverages in azure_devops_client.generate_build_code_coverages(
         coverage_config,
     ):
-        logger.info(f"Fetched {len(coverages)} code coverage entries")
+        logger.info(f"Fetched {len(coverages)} build code coverage entries")
         yield coverages
 
 

--- a/integrations/azure-devops/pyproject.toml
+++ b/integrations/azure-devops/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "azure-devops"
-version = "0.8.34"
+version = "0.8.35"
 description = "An Azure Devops Ocean integration"
 authors = ["Matan Geva <matang@getport.io>"]
 

--- a/integrations/azure-devops/pyproject.toml
+++ b/integrations/azure-devops/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "azure-devops"
-version = "0.8.39"
+version = "0.8.40"
 description = "An Azure Devops Ocean integration"
 authors = ["Matan Geva <matang@getport.io>"]
 

--- a/integrations/azure-devops/tests/azure_devops/client/test_azure_devops_client.py
+++ b/integrations/azure-devops/tests/azure_devops/client/test_azure_devops_client.py
@@ -5095,7 +5095,7 @@ async def test_get_test_runs_by_build_empty(
 
 
 @pytest.mark.asyncio
-async def test_generate_code_coverages() -> None:
+async def test_generate_build_code_coverages() -> None:
     client = AzureDevopsClient(
         MOCK_ORG_URL, MOCK_PERSONAL_ACCESS_TOKEN, MOCK_AUTH_USERNAME
     )
@@ -5141,7 +5141,7 @@ async def test_generate_code_coverages() -> None:
     ):
         results: list[list[dict[str, Any]]] = []
         coverage_config = CodeCoverageConfig(flags=1)
-        async for batch in client.generate_code_coverages(coverage_config):
+        async for batch in client.generate_build_code_coverages(coverage_config):
             results.append(batch)
 
         assert len(results) == 1
@@ -5153,7 +5153,7 @@ async def test_generate_code_coverages() -> None:
 
 
 @pytest.mark.asyncio
-async def test_generate_code_coverages_no_coverage() -> None:
+async def test_generate_build_code_coverages_no_coverage() -> None:
     client = AzureDevopsClient(
         MOCK_ORG_URL, MOCK_PERSONAL_ACCESS_TOKEN, MOCK_AUTH_USERNAME
     )
@@ -5178,7 +5178,7 @@ async def test_generate_code_coverages_no_coverage() -> None:
     ):
         results: list[list[dict[str, Any]]] = []
         coverage_config = CodeCoverageConfig(flags=1)
-        async for batch in client.generate_code_coverages(coverage_config):
+        async for batch in client.generate_build_code_coverages(coverage_config):
             results.append(batch)
 
         assert len(results) == 0

--- a/integrations/azure-devops/tests/azure_devops/client/test_azure_devops_client.py
+++ b/integrations/azure-devops/tests/azure_devops/client/test_azure_devops_client.py
@@ -5092,3 +5092,145 @@ async def test_get_test_runs_by_build_empty(
 
                 assert len(result) == 0
                 mock_enrich.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_generate_code_coverages() -> None:
+    client = AzureDevopsClient(
+        MOCK_ORG_URL, MOCK_PERSONAL_ACCESS_TOKEN, MOCK_AUTH_USERNAME
+    )
+
+    mock_builds = [
+        {"id": 100, "__projectId": "proj1", "__project": {"id": "proj1", "name": "Project One"}},
+        {"id": 101, "__projectId": "proj1", "__project": {"id": "proj1", "name": "Project One"}},
+    ]
+
+    mock_coverage_response_100 = {
+        "value": [
+            {
+                "configuration": {"id": 51, "flavor": "Debug", "platform": "Any CPU"},
+                "state": "0",
+                "modules": [
+                    {
+                        "name": "myapp.dll",
+                        "statistics": {"blocksCovered": 10, "linesCovered": 50, "linesNotCovered": 10},
+                    }
+                ],
+                "codeCoverageFileUrl": "https://dev.azure.com/coverage/100",
+            }
+        ],
+        "count": 1,
+    }
+    mock_coverage_response_101: dict[str, Any] = {"value": [], "count": 0}
+
+    async def mock_generate_builds() -> AsyncGenerator[List[Dict[str, Any]], None]:
+        yield mock_builds
+
+    from integration import CodeCoverageConfig
+
+    async def mock_fetch_code_coverage(
+        project_id: str, build_id: int, config: CodeCoverageConfig
+    ) -> Dict[str, Any]:
+        if build_id == 100:
+            return mock_coverage_response_100
+        return mock_coverage_response_101
+
+    with (
+        patch.object(client, "generate_builds", side_effect=mock_generate_builds),
+        patch.object(client, "_fetch_code_coverage", side_effect=mock_fetch_code_coverage),
+    ):
+        results: list[list[dict[str, Any]]] = []
+        coverage_config = CodeCoverageConfig(flags=1)
+        async for batch in client.generate_code_coverages(coverage_config):
+            results.append(batch)
+
+        assert len(results) == 1
+        assert len(results[0]) == 1
+        coverage = results[0][0]
+        assert coverage["configuration"]["id"] == 51
+        assert coverage["__build"]["id"] == 100
+        assert coverage["__build"]["__projectId"] == "proj1"
+
+
+@pytest.mark.asyncio
+async def test_generate_code_coverages_no_coverage() -> None:
+    client = AzureDevopsClient(
+        MOCK_ORG_URL, MOCK_PERSONAL_ACCESS_TOKEN, MOCK_AUTH_USERNAME
+    )
+
+    mock_builds = [
+        {"id": 200, "__projectId": "proj1", "__project": {"id": "proj1"}},
+    ]
+
+    async def mock_generate_builds() -> AsyncGenerator[List[Dict[str, Any]], None]:
+        yield mock_builds
+
+    from integration import CodeCoverageConfig
+
+    async def mock_fetch_code_coverage(
+        project_id: str, build_id: int, config: CodeCoverageConfig
+    ) -> Dict[str, Any]:
+        return {}
+
+    with (
+        patch.object(client, "generate_builds", side_effect=mock_generate_builds),
+        patch.object(client, "_fetch_code_coverage", side_effect=mock_fetch_code_coverage),
+    ):
+        results: list[list[dict[str, Any]]] = []
+        coverage_config = CodeCoverageConfig(flags=1)
+        async for batch in client.generate_code_coverages(coverage_config):
+            results.append(batch)
+
+        assert len(results) == 0
+
+
+@pytest.mark.asyncio
+async def test_get_code_coverage_for_build() -> None:
+    client = AzureDevopsClient(
+        MOCK_ORG_URL, MOCK_PERSONAL_ACCESS_TOKEN, MOCK_AUTH_USERNAME
+    )
+
+    mock_response = {
+        "value": [
+            {
+                "configuration": {"id": 51, "flavor": "Debug", "platform": "Any CPU"},
+                "state": "0",
+                "modules": [{"name": "myapp.dll", "statistics": {"linesCovered": 50}}],
+            }
+        ],
+        "count": 1,
+    }
+
+    from integration import CodeCoverageConfig
+
+    async def mock_fetch_code_coverage(
+        project_id: str, build_id: int, config: CodeCoverageConfig
+    ) -> Dict[str, Any]:
+        return mock_response
+
+    with patch.object(client, "_fetch_code_coverage", side_effect=mock_fetch_code_coverage):
+        coverage_config = CodeCoverageConfig(flags=7)
+        result = await client.get_code_coverage_for_build("proj1", 100, coverage_config)
+
+        assert len(result) == 1
+        assert result[0]["configuration"]["id"] == 51
+
+
+@pytest.mark.asyncio
+async def test_get_code_coverage_for_build_empty() -> None:
+    client = AzureDevopsClient(
+        MOCK_ORG_URL, MOCK_PERSONAL_ACCESS_TOKEN, MOCK_AUTH_USERNAME
+    )
+
+    from integration import CodeCoverageConfig
+
+    async def mock_fetch_code_coverage(
+        project_id: str, build_id: int, config: CodeCoverageConfig
+    ) -> Dict[str, Any]:
+        return {}
+
+    with patch.object(client, "_fetch_code_coverage", side_effect=mock_fetch_code_coverage):
+        coverage_config = CodeCoverageConfig(flags=1)
+        result = await client.get_code_coverage_for_build("proj1", 100, coverage_config)
+
+        assert len(result) == 0

--- a/integrations/azure-devops/tests/azure_devops/client/test_azure_devops_client.py
+++ b/integrations/azure-devops/tests/azure_devops/client/test_azure_devops_client.py
@@ -5101,8 +5101,16 @@ async def test_generate_build_code_coverages() -> None:
     )
 
     mock_builds = [
-        {"id": 100, "__projectId": "proj1", "__project": {"id": "proj1", "name": "Project One"}},
-        {"id": 101, "__projectId": "proj1", "__project": {"id": "proj1", "name": "Project One"}},
+        {
+            "id": 100,
+            "__projectId": "proj1",
+            "__project": {"id": "proj1", "name": "Project One"},
+        },
+        {
+            "id": 101,
+            "__projectId": "proj1",
+            "__project": {"id": "proj1", "name": "Project One"},
+        },
     ]
 
     mock_coverage_response_100 = {
@@ -5113,7 +5121,11 @@ async def test_generate_build_code_coverages() -> None:
                 "modules": [
                     {
                         "name": "myapp.dll",
-                        "statistics": {"blocksCovered": 10, "linesCovered": 50, "linesNotCovered": 10},
+                        "statistics": {
+                            "blocksCovered": 10,
+                            "linesCovered": 50,
+                            "linesNotCovered": 10,
+                        },
                     }
                 ],
                 "codeCoverageFileUrl": "https://dev.azure.com/coverage/100",
@@ -5137,7 +5149,9 @@ async def test_generate_build_code_coverages() -> None:
 
     with (
         patch.object(client, "generate_builds", side_effect=mock_generate_builds),
-        patch.object(client, "_fetch_code_coverage", side_effect=mock_fetch_code_coverage),
+        patch.object(
+            client, "_fetch_code_coverage", side_effect=mock_fetch_code_coverage
+        ),
     ):
         results: list[list[dict[str, Any]]] = []
         coverage_config = CodeCoverageConfig(flags=1)
@@ -5174,7 +5188,9 @@ async def test_generate_build_code_coverages_no_coverage() -> None:
 
     with (
         patch.object(client, "generate_builds", side_effect=mock_generate_builds),
-        patch.object(client, "_fetch_code_coverage", side_effect=mock_fetch_code_coverage),
+        patch.object(
+            client, "_fetch_code_coverage", side_effect=mock_fetch_code_coverage
+        ),
     ):
         results: list[list[dict[str, Any]]] = []
         coverage_config = CodeCoverageConfig(flags=1)
@@ -5208,7 +5224,9 @@ async def test_get_code_coverage_for_build() -> None:
     ) -> Dict[str, Any]:
         return mock_response
 
-    with patch.object(client, "_fetch_code_coverage", side_effect=mock_fetch_code_coverage):
+    with patch.object(
+        client, "_fetch_code_coverage", side_effect=mock_fetch_code_coverage
+    ):
         coverage_config = CodeCoverageConfig(flags=7)
         result = await client.get_code_coverage_for_build("proj1", 100, coverage_config)
 
@@ -5229,7 +5247,9 @@ async def test_get_code_coverage_for_build_empty() -> None:
     ) -> Dict[str, Any]:
         return {}
 
-    with patch.object(client, "_fetch_code_coverage", side_effect=mock_fetch_code_coverage):
+    with patch.object(
+        client, "_fetch_code_coverage", side_effect=mock_fetch_code_coverage
+    ):
         coverage_config = CodeCoverageConfig(flags=1)
         result = await client.get_code_coverage_for_build("proj1", 100, coverage_config)
 


### PR DESCRIPTION
# Description

What — Adds code-coverage as a separate kind in the Azure DevOps integration, decoupled from test-run. 

Why - Currently, code coverage data is bundled into the test-run kind as an enrichment field (__codeCoverage). Separating them gives customers independent control over each.

How - The new kind iterates builds via the existing generate_builds() method and calls the ADO `/_apis/test/codecoverage` endpoint per build. Coverage entries from the value[] response array are flattened and enriched with __build context.

## Type of change

Please leave one option from the following and delete the rest:

- [X] New feature (non-breaking change which adds functionality)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [X] Integration able to create all default resources from scratch
- [X] Resync finishes successfully
- [X] Resync able to create entities
- [X] Resync able to update entities
- [X] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
