### PR TITLE
[Integration][Azure DevOps] Replaced ADO Test Result enrichment on test run with a standalone `test-result` kind

### DIFF
--- a/integrations/azure-devops/CHANGELOG.md
+++ b/integrations/azure-devops/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.9.0 (2026-05-17)
+
+
+### Breaking Changes
+
+- Test results moved to a new `test-result` kind (`includeResults` removed from `test-run`)
+
+
 ## 0.8.35 (2026-05-14)
 
 

--- a/integrations/azure-devops/azure_devops/client/azure_devops_client.py
+++ b/integrations/azure-devops/azure_devops/client/azure_devops_client.py
@@ -70,6 +70,7 @@ MAX_CONCURRENT_REPOS_FOR_FILE_PROCESSING = 25
 MAX_CONCURRENT_REPOS_FOR_PULL_REQUESTS = 25
 MAX_SUBJECTS_PER_LOOKUP = 500
 MAX_CONCURRENT_PROJECTS = 5
+MAX_CONCURRENT_TEST_RUN_RESULTS = 10
 
 # Webhook subscriptions for Azure DevOps events
 AZURE_DEVOPS_WEBHOOK_SUBSCRIPTIONS = [
@@ -2064,24 +2065,18 @@ class AzureDevopsClient(HTTPBaseClient):
     async def _fetch_enriched_test_runs(
         self,
         project_id: str,
-        include_results: bool,
         coverage_config: Optional["CodeCoverageConfig"],
     ) -> AsyncGenerator[list[dict[str, Any]], None]:
         url = f"{self._organization_base_url}/{project_id}/{API_URL_PREFIX}/test/runs"
         params = {"includeRunDetails": True, **API_PARAMS}
         async for runs in self._get_paginated_by_top_and_skip(url, params=params):
-            yield await self._enrich_test_runs(
-                runs, project_id, include_results, coverage_config
-            )
+            yield await self._enrich_test_runs(runs, project_id, coverage_config)
 
     async def fetch_test_runs(
         self,
-        include_results: bool,
         coverage_config: Optional["CodeCoverageConfig"] = None,
     ) -> AsyncGenerator[list[dict[str, Any]], None]:
-        logger.info(
-            f"Starting to fetch test runs with include_results={include_results}"
-        )
+        logger.info("Starting to fetch test runs")
 
         async for projects in self.generate_projects():
             semaphore = asyncio.BoundedSemaphore(MAX_CONCURRENT_PROJECTS)
@@ -2091,7 +2086,6 @@ class AzureDevopsClient(HTTPBaseClient):
                     functools.partial(
                         self._fetch_enriched_test_runs,
                         project["id"],
-                        include_results,
                         coverage_config,
                     ),
                 )
@@ -2129,18 +2123,9 @@ class AzureDevopsClient(HTTPBaseClient):
         self,
         test_runs: list[dict[str, Any]],
         project_id: str,
-        include_results: bool = False,
         coverage_config: Optional["CodeCoverageConfig"] = None,
     ) -> list[dict[str, Any]]:
-        logger.info(
-            f"Enriching {len(test_runs)} test runs for project {project_id}, include_results={include_results}"
-        )
-
-        test_results_tasks: list[Awaitable[list[dict[str, Any]]]] = (
-            [self._fetch_test_results(project_id, run["id"]) for run in test_runs]
-            if include_results
-            else []
-        )
+        logger.info(f"Enriching {len(test_runs)} test runs for project {project_id}")
 
         coverage_tasks: list[Awaitable[dict[str, Any]]] = (
             [
@@ -2158,24 +2143,46 @@ class AzureDevopsClient(HTTPBaseClient):
         )
 
         await self._attach_async_results(
-            test_runs, test_results_tasks, "__testResults", []
-        )
-        await self._attach_async_results(
             test_runs, coverage_tasks, "__codeCoverage", {}
         )
 
         return test_runs
 
-    async def _fetch_test_results(
-        self, project_id: str, run_id: str
-    ) -> list[dict[str, Any]]:
-        """Fetch test results for a specific test run."""
-        results = []
+    async def generate_test_results(
+        self,
+        result_params: dict[str, Any],
+    ) -> AsyncGenerator[list[dict[str, Any]], None]:
+        run_semaphore = asyncio.BoundedSemaphore(MAX_CONCURRENT_TEST_RUN_RESULTS)
+        async for runs_page in self.fetch_test_runs():
+            tasks = [
+                semaphore_async_iterator(
+                    run_semaphore,
+                    functools.partial(
+                        self._fetch_results_for_run,
+                        run["project"]["id"],
+                        run["id"],
+                        result_params,
+                    ),
+                )
+                for run in runs_page
+            ]
+            async for results_batch in stream_async_iterators_tasks(*tasks):
+                yield results_batch
+
+    async def _fetch_results_for_run(
+        self,
+        project_id: str,
+        run_id: int,
+        additional_params: dict[str, Any],
+    ) -> AsyncGenerator[list[dict[str, Any]], None]:
+        url = (
+            f"{self._organization_base_url}/{project_id}/{API_URL_PREFIX}"
+            f"/test/runs/{run_id}/results"
+        )
         async for page in self._get_paginated_by_top_and_continuation_token(
-            f"{self._organization_base_url}/{project_id}/{API_URL_PREFIX}/test/runs/{run_id}/results"
+            url, additional_params=additional_params
         ):
-            results.extend(page)
-        return results
+            yield page
 
     async def _fetch_code_coverage(
         self, project_id: str, build_id: int, coverage_config: "CodeCoverageConfig"
@@ -2203,7 +2210,6 @@ class AzureDevopsClient(HTTPBaseClient):
         self,
         project_id: str,
         build_id: str,
-        include_results: bool = False,
         coverage_config: Optional["CodeCoverageConfig"] = None,
     ) -> list[dict[str, Any]]:
         url = f"{self._organization_base_url}/{project_id}/{API_URL_PREFIX}/test/runs"
@@ -2215,7 +2221,5 @@ class AzureDevopsClient(HTTPBaseClient):
         async for runs in self._get_paginated_by_top_and_skip(url, params=params):
             all_runs.extend(runs)
         if all_runs:
-            await self._enrich_test_runs(
-                all_runs, project_id, include_results, coverage_config
-            )
+            await self._enrich_test_runs(all_runs, project_id, coverage_config)
         return all_runs

--- a/integrations/azure-devops/azure_devops/client/azure_devops_client.py
+++ b/integrations/azure-devops/azure_devops/client/azure_devops_client.py
@@ -2180,7 +2180,7 @@ class AzureDevopsClient(HTTPBaseClient):
             f"/test/runs/{run_id}/results"
         )
         async for page in self._get_paginated_by_top_and_continuation_token(
-            url, additional_params=additional_params
+            url, additional_params={**additional_params, **API_PARAMS}
         ):
             yield page
 

--- a/integrations/azure-devops/azure_devops/client/azure_devops_client.py
+++ b/integrations/azure-devops/azure_devops/client/azure_devops_client.py
@@ -2072,6 +2072,7 @@ class AzureDevopsClient(HTTPBaseClient):
         async for runs in self._get_paginated_by_top_and_skip(url, params=params):
             yield await self._enrich_test_runs(runs, project_id, coverage_config)
 
+    @cache_iterator_result()
     async def fetch_test_runs(
         self,
         coverage_config: Optional["CodeCoverageConfig"] = None,

--- a/integrations/azure-devops/azure_devops/misc.py
+++ b/integrations/azure-devops/azure_devops/misc.py
@@ -27,6 +27,7 @@ class Kind(StrEnum):
     RELEASE_DEPLOYMENT = "release-deployment"
     PIPELINE_DEPLOYMENT = "pipeline-deployment"
     TEST_RUN = "test-run"
+    TEST_RESULT = "test-result"
     FILE = "file"
     USER = "user"
     FOLDER = "folder"

--- a/integrations/azure-devops/azure_devops/webhooks/webhook_processors/test_run_webhook_processor.py
+++ b/integrations/azure-devops/azure_devops/webhooks/webhook_processors/test_run_webhook_processor.py
@@ -46,7 +46,6 @@ class TestRunWebhookProcessor(AzureDevOpsBaseWebhookProcessor):
         test_runs = await client.get_test_runs_by_build(
             project_id,
             build_id,
-            config.selector.include_results,
             config.selector.code_coverage,
         )
         if not test_runs:

--- a/integrations/azure-devops/examples/example-test-result.json
+++ b/integrations/azure-devops/examples/example-test-result.json
@@ -1,0 +1,63 @@
+{
+  "id": 100000,
+  "project": {
+    "id": "5aca29c0-dd0e-4459-98a3-5b432e55e7a8",
+    "name": "dummy-project",
+    "url": "[REDACTED]/_apis/projects/dummy-project"
+  },
+  "startedDate": "2026-05-10T19:11:56.713Z",
+  "completedDate": "2026-05-10T19:11:56.713Z",
+  "outcome": "Passed",
+  "revision": 1,
+  "state": "Completed",
+  "testCase": {
+    "name": "test_dummy"
+  },
+  "testRun": {
+    "id": "2",
+    "name": "Dummy Test Run",
+    "url": "[REDACTED]/dummy-project/_apis/test/Runs/2"
+  },
+  "lastUpdatedDate": "2026-05-10T19:11:57.177Z",
+  "priority": 0,
+  "build": {
+    "id": "9",
+    "name": "20260510.2",
+    "url": "[REDACTED]/_apis/build/Builds/9"
+  },
+  "createdDate": "2026-05-10T19:11:57.177Z",
+  "url": "[REDACTED]/dummy-project/_apis/test/Runs/2/Results/100000",
+  "failureType": "None",
+  "automatedTestStorage": "tests",
+  "automatedTestType": "JUnit",
+  "testCaseTitle": "test_dummy",
+  "customFields": [],
+  "testCaseReferenceId": 1,
+  "runBy": {
+    "displayName": "Jane Doe",
+    "url": "[REDACTED]/_apis/Identities/00000000-0000-0000-0000-000000000001",
+    "_links": {
+      "avatar": {
+        "href": "[REDACTED]/_apis/GraphProfile/MemberAvatars/aad.000000000000000000000000000000000001"
+      }
+    },
+    "id": "00000000-0000-0000-0000-000000000001",
+    "uniqueName": "jane.doe@example.com",
+    "imageUrl": "[REDACTED]/_apis/GraphProfile/MemberAvatars/aad.000000000000000000000000000000000001",
+    "descriptor": "aad.000000000000000000000000000000000001"
+  },
+  "lastUpdatedBy": {
+    "displayName": "dummy-project Build Service",
+    "url": "[REDACTED]/_apis/Identities/00000000-0000-0000-0000-000000000002",
+    "_links": {
+      "avatar": {
+        "href": "[REDACTED]/_apis/GraphProfile/MemberAvatars/svc.000000000000000000000000000000000002"
+      }
+    },
+    "id": "00000000-0000-0000-0000-000000000002",
+    "uniqueName": "Build\\5aca29c0-dd0e-4459-98a3-5b432e55e7a8",
+    "imageUrl": "[REDACTED]/_apis/GraphProfile/MemberAvatars/svc.000000000000000000000000000000000002",
+    "descriptor": "svc.000000000000000000000000000000000002"
+  },
+  "automatedTestName": "test_dummy"
+}

--- a/integrations/azure-devops/integration.py
+++ b/integrations/azure-devops/integration.py
@@ -214,12 +214,6 @@ class CodeCoverageConfig(BaseModel):
 
 
 class AzureDevopsTestRunSelector(Selector):
-    include_results: bool = Field(
-        default=True,
-        alias="includeResults",
-        title="Include Results",
-        description="Whether to include test results for each test run, defaults to true",
-    )
     code_coverage: Optional[CodeCoverageConfig] = Field(
         default=None,
         alias="codeCoverage",
@@ -236,6 +230,60 @@ class AzureDevopsTestRunResourceConfig(ResourceConfig):
     selector: AzureDevopsTestRunSelector = Field(
         title="Test run selector",
         description="Selector for the test run resource.",
+    )
+
+
+class AzureDevopsTestResultSelector(Selector):
+    outcomes: Optional[
+        list[
+            Literal[
+                "unspecified",
+                "none",
+                "passed",
+                "failed",
+                "inconclusive",
+                "timeout",
+                "aborted",
+                "blocked",
+                "notExecuted",
+                "warning",
+                "error",
+                "notApplicable",
+                "paused",
+                "inProgress",
+                "notImpacted",
+            ]
+        ]
+    ] = Field(
+        default=None,
+        alias="outcomes",
+        title="Outcomes",
+        description="Filter test results by outcome. When omitted, all outcomes are fetched.",
+    )
+    details_to_include: Optional[
+        Literal["none", "iterations", "workItems", "subResults", "point"]
+    ] = Field(
+        default=None,
+        alias="detailsToInclude",
+        title="Details to Include",
+        description="Extra detail level to expand on each result.",
+    )
+
+    def to_params(self) -> dict[str, Any]:
+        data = self.dict(by_alias=True, exclude_none=True, exclude={"query"})
+        if "outcomes" in data:
+            data["outcomes"] = ",".join(data["outcomes"])
+        return data
+
+
+class AzureDevopsTestResultResourceConfig(ResourceConfig):
+    kind: Literal["test-result"] = Field(
+        title="Azure Devops Test Result",
+        description="Azure Devops test result resource kind.",
+    )
+    selector: AzureDevopsTestResultSelector = Field(
+        title="Test result selector",
+        description="Selector for the test result resource.",
     )
 
 
@@ -609,6 +657,7 @@ class GitPortAppConfig(PortAppConfig):
         | AzureDevopsFileResourceConfig
         | AzureDevopsPipelineResourceConfig
         | AzureDevopsTestRunResourceConfig
+        | AzureDevopsTestResultResourceConfig
         | AzureDevopsPullRequestResourceConfig
         | AzureDevopsAdvancedSecurityResourceConfig
         | AzureDevopsRepositoryResourceConfig

--- a/integrations/azure-devops/main.py
+++ b/integrations/azure-devops/main.py
@@ -63,6 +63,7 @@ from integration import (
     AzureDevopsTeamResourceConfig,
     AzureDevopsWorkItemResourceConfig,
     AzureDevopsTestRunResourceConfig,
+    AzureDevopsTestResultResourceConfig,
     AzureDevopsPullRequestResourceConfig,
     AzureDevopsAdvancedSecurityResourceConfig,
     AzureDevopsRepositoryResourceConfig,
@@ -419,14 +420,22 @@ async def resync_folders(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
 async def resync_test_runs(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     azure_devops_client = AzureDevopsClient.create_from_ocean_config()
     selector = cast(AzureDevopsTestRunResourceConfig, event.resource_config).selector
-    include_results = selector.include_results
-    coverage_config = selector.code_coverage
 
-    async for test_runs in azure_devops_client.fetch_test_runs(
-        include_results, coverage_config
-    ):
+    async for test_runs in azure_devops_client.fetch_test_runs(selector.code_coverage):
         logger.info(f"Fetched {len(test_runs)} test runs")
         yield test_runs
+
+
+@ocean.on_resync(Kind.TEST_RESULT)
+async def resync_test_results(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
+    azure_devops_client = AzureDevopsClient.create_from_ocean_config()
+    selector = cast(AzureDevopsTestResultResourceConfig, event.resource_config).selector
+
+    async for test_results in azure_devops_client.generate_test_results(
+        selector.to_params()
+    ):
+        logger.info(f"Resyncing {len(test_results)} test results")
+        yield test_results
 
 
 @ocean.on_resync(Kind.ITERATION)

--- a/integrations/azure-devops/pyproject.toml
+++ b/integrations/azure-devops/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "azure-devops"
-version = "0.8.35"
+version = "0.9.0"
 description = "An Azure Devops Ocean integration"
 authors = ["Matan Geva <matang@getport.io>"]
 

--- a/integrations/azure-devops/tests/azure_devops/client/test_azure_devops_client.py
+++ b/integrations/azure-devops/tests/azure_devops/client/test_azure_devops_client.py
@@ -3782,9 +3782,7 @@ async def test_fetch_test_runs(mock_event_context: MagicMock) -> None:
             ):
                 # ACT
                 test_runs: List[Dict[str, Any]] = []
-                async for test_run_batch in client.fetch_test_runs(
-                    include_results=False
-                ):
+                async for test_run_batch in client.fetch_test_runs():
                     test_runs.extend(test_run_batch)
 
                 # ASSERT
@@ -3795,81 +3793,6 @@ async def test_fetch_test_runs(mock_event_context: MagicMock) -> None:
                 assert test_runs[1]["id"] == 2
                 assert test_runs[1]["name"] == "Test Run 2"
                 assert test_runs[1]["project"]["id"] == "proj1"
-
-
-@pytest.mark.asyncio
-async def test_fetch_test_runs_with_results(mock_event_context: MagicMock) -> None:
-    client = AzureDevopsClient(
-        MOCK_ORG_URL, MOCK_PERSONAL_ACCESS_TOKEN, MOCK_AUTH_USERNAME
-    )
-
-    # MOCK
-    async def mock_generate_projects() -> AsyncGenerator[List[Dict[str, Any]], None]:
-        yield [{"id": "proj1", "name": "Project One"}]
-
-    async def mock_get_paginated_by_top_and_continuation_token(
-        url: str, additional_params: Optional[Dict[str, Any]] = None, **kwargs: Any
-    ) -> AsyncGenerator[List[Dict[str, Any]], None]:
-        if "test/runs" in url and "/results" not in url:
-            # Verify that includeRunDetails is set to True
-            assert additional_params is not None
-            assert additional_params.get("includeRunDetails") is True
-            yield EXPECTED_TEST_RUNS
-        elif "test/runs/1/results" in url:
-            yield [EXPECTED_TEST_RESULTS[0]]
-        elif "test/runs/2/results" in url:
-            yield [EXPECTED_TEST_RESULTS[1]]
-        else:
-            yield []
-
-    async with event_context("test_event"):
-        with patch.object(
-            client, "generate_projects", side_effect=mock_generate_projects
-        ):
-
-            async def mock_get_paginated_by_top_and_skip(
-                url: str, params: Optional[Dict[str, Any]] = None, **kwargs: Any
-            ) -> AsyncGenerator[List[Dict[str, Any]], None]:
-                if "test/runs" in url and "/results" not in url:
-                    # Verify that includeRunDetails is set to True
-                    assert params is not None
-                    assert params.get("includeRunDetails") is True
-                    yield EXPECTED_TEST_RUNS
-                else:
-                    yield []
-
-            with patch.object(
-                client,
-                "_get_paginated_by_top_and_continuation_token",
-                side_effect=mock_get_paginated_by_top_and_continuation_token,
-            ):
-                with patch.object(
-                    client,
-                    "_get_paginated_by_top_and_skip",
-                    side_effect=mock_get_paginated_by_top_and_skip,
-                ):
-                    # ACT
-                    test_runs: List[Dict[str, Any]] = []
-                    async for test_run_batch in client.fetch_test_runs(
-                        include_results=True
-                    ):
-                        test_runs.extend(test_run_batch)
-
-                    # ASSERT
-                    assert len(test_runs) == 2
-                    assert test_runs[0]["id"] == 1
-                    assert test_runs[0]["name"] == "Test Run 1"
-                    assert test_runs[0]["project"]["id"] == "proj1"
-                    assert "__testResults" in test_runs[0]
-                    assert len(test_runs[0]["__testResults"]) == 1
-                    assert test_runs[0]["__testResults"][0]["id"] == 100000
-
-                    assert test_runs[1]["id"] == 2
-                    assert test_runs[1]["name"] == "Test Run 2"
-                    assert test_runs[1]["project"]["id"] == "proj1"
-                    assert "__testResults" in test_runs[1]
-                    assert len(test_runs[1]["__testResults"]) == 1
-                    assert test_runs[1]["__testResults"][0]["id"] == 100001
 
 
 @pytest.mark.asyncio
@@ -3894,104 +3817,10 @@ async def test_fetch_test_runs_will_skip_404(
             patch.object(client._client, "request", side_effect=mock_make_request),
         ):
             test_runs: List[Dict[str, Any]] = []
-            async for test_run_batch in client.fetch_test_runs(include_results=False):
+            async for test_run_batch in client.fetch_test_runs():
                 test_runs.extend(test_run_batch)
 
             assert not test_runs
-
-
-@pytest.mark.asyncio
-async def test_enrich_test_runs() -> None:
-    client = AzureDevopsClient(
-        MOCK_ORG_URL, MOCK_PERSONAL_ACCESS_TOKEN, MOCK_AUTH_USERNAME
-    )
-
-    test_runs = [
-        {
-            "id": 1,
-            "name": "Test Run 1",
-            "build": {"id": 123},
-            "project": {"id": "proj1", "name": "Project One"},
-        },
-        {
-            "id": 2,
-            "name": "Test Run 2",
-            "build": {"id": 124},
-            "project": {"id": "proj1", "name": "Project One"},
-        },
-    ]
-
-    async def mock_fetch_test_results(
-        project_id: str, run_id: str
-    ) -> List[Dict[str, Any]]:
-        if run_id == 1 or run_id == "1":
-            return [EXPECTED_TEST_RESULTS[0]]
-        elif run_id == 2 or run_id == "2":
-            return [EXPECTED_TEST_RESULTS[1]]
-        return []
-
-    with patch.object(
-        client,
-        "_fetch_test_results",
-        side_effect=mock_fetch_test_results,
-    ):
-        # ACT
-        enriched_test_runs = await client._enrich_test_runs(
-            test_runs, "proj1", include_results=True
-        )
-
-        # ASSERT
-        assert len(enriched_test_runs) == 2
-        assert enriched_test_runs[0]["project"]["id"] == "proj1"
-        assert "__testResults" in enriched_test_runs[0]
-        assert len(enriched_test_runs[0]["__testResults"]) == 1
-        assert enriched_test_runs[0]["__testResults"][0]["id"] == 100000
-
-        assert enriched_test_runs[1]["project"]["id"] == "proj1"
-        assert "__testResults" in enriched_test_runs[1]
-        assert len(enriched_test_runs[1]["__testResults"]) == 1
-        assert enriched_test_runs[1]["__testResults"][0]["id"] == 100001
-
-
-@pytest.mark.asyncio
-async def test_enrich_test_runs_without_results() -> None:
-    client = AzureDevopsClient(
-        MOCK_ORG_URL, MOCK_PERSONAL_ACCESS_TOKEN, MOCK_AUTH_USERNAME
-    )
-
-    test_runs = [
-        {
-            "id": 1,
-            "name": "Test Run 1",
-            "build": {"id": 123},
-            "project": {"id": "proj1", "name": "Project One"},
-        },
-        {
-            "id": 2,
-            "name": "Test Run 2",
-            "build": {"id": 124},
-            "project": {"id": "proj1", "name": "Project One"},
-        },
-    ]
-
-    # ACT
-    enriched_test_runs = await client._enrich_test_runs(
-        test_runs, "proj1", include_results=False
-    )
-
-    # ASSERT
-    assert len(enriched_test_runs) == 2
-    assert enriched_test_runs[0]["project"]["id"] == "proj1"
-    assert "__testResults" in enriched_test_runs[0]
-    assert len(enriched_test_runs[0]["__testResults"]) == 0
-    assert "__codeCoverage" in enriched_test_runs[0]
-    assert enriched_test_runs[0]["__codeCoverage"] == {}
-
-    assert enriched_test_runs[1]["project"]["id"] == "proj1"
-    assert "__testResults" in enriched_test_runs[1]
-    assert len(enriched_test_runs[1]["__testResults"]) == 0
-    assert "__codeCoverage" in enriched_test_runs[1]
-    assert enriched_test_runs[1]["__codeCoverage"] == {}
 
 
 @pytest.mark.asyncio
@@ -4037,7 +3866,7 @@ async def test_enrich_test_runs_with_coverage() -> None:
     ):
         # ACT
         enriched_test_runs = await client._enrich_test_runs(
-            test_runs, "proj1", include_results=False, coverage_config=coverage_config
+            test_runs, "proj1", coverage_config=coverage_config
         )
 
         # ASSERT
@@ -4048,6 +3877,7 @@ async def test_enrich_test_runs_with_coverage() -> None:
             enriched_test_runs[0]["__codeCoverage"]["coverageData"]["linesCovered"]
             == 100
         )
+        assert "__testResults" not in enriched_test_runs[0]
 
         assert enriched_test_runs[1]["project"]["id"] == "proj1"
         assert "__codeCoverage" in enriched_test_runs[1]
@@ -4055,91 +3885,7 @@ async def test_enrich_test_runs_with_coverage() -> None:
             enriched_test_runs[1]["__codeCoverage"]["coverageData"]["linesCovered"]
             == 80
         )
-
-
-@pytest.mark.asyncio
-async def test_enrich_test_runs_with_results_and_coverage() -> None:
-    """Test enriching test runs with both results and coverage data."""
-    client = AzureDevopsClient(
-        MOCK_ORG_URL, MOCK_PERSONAL_ACCESS_TOKEN, MOCK_AUTH_USERNAME
-    )
-
-    test_runs = [
-        {
-            "id": 1,
-            "name": "Test Run 1",
-            "build": {"id": 123},
-            "project": {"id": "proj1", "name": "Project One"},
-        },
-        {
-            "id": 2,
-            "name": "Test Run 2",
-            "build": {"id": 124},
-            "project": {"id": "proj1", "name": "Project One"},
-        },
-    ]
-
-    # Mock coverage config
-    from integration import CodeCoverageConfig
-
-    coverage_config = CodeCoverageConfig(flags=1)
-
-    async def mock_fetch_test_results(
-        project_id: str, run_id: str
-    ) -> List[Dict[str, Any]]:
-        if run_id == 1 or run_id == "1":
-            return [EXPECTED_TEST_RESULTS[0]]
-        elif run_id == 2 or run_id == "2":
-            return [EXPECTED_TEST_RESULTS[1]]
-        return []
-
-    async def mock_fetch_code_coverage(
-        project_id: str, build_id: int, config: CodeCoverageConfig
-    ) -> Dict[str, Any]:
-        if build_id == 123:
-            return {"coverageData": {"linesCovered": 100, "linesNotCovered": 50}}
-        elif build_id == 124:
-            return {"coverageData": {"linesCovered": 80, "linesNotCovered": 20}}
-        return {}
-
-    with (
-        patch.object(
-            client,
-            "_fetch_test_results",
-            side_effect=mock_fetch_test_results,
-        ),
-        patch.object(
-            client,
-            "_fetch_code_coverage",
-            side_effect=mock_fetch_code_coverage,
-        ),
-    ):
-        # ACT
-        enriched_test_runs = await client._enrich_test_runs(
-            test_runs, "proj1", include_results=True, coverage_config=coverage_config
-        )
-
-        # ASSERT
-        assert len(enriched_test_runs) == 2
-        assert enriched_test_runs[0]["project"]["id"] == "proj1"
-        assert "__testResults" in enriched_test_runs[0]
-        assert "__codeCoverage" in enriched_test_runs[0]
-        assert len(enriched_test_runs[0]["__testResults"]) == 1
-        assert enriched_test_runs[0]["__testResults"][0]["id"] == 100000
-        assert (
-            enriched_test_runs[0]["__codeCoverage"]["coverageData"]["linesCovered"]
-            == 100
-        )
-
-        assert enriched_test_runs[1]["project"]["id"] == "proj1"
-        assert "__testResults" in enriched_test_runs[1]
-        assert "__codeCoverage" in enriched_test_runs[1]
-        assert len(enriched_test_runs[1]["__testResults"]) == 1
-        assert enriched_test_runs[1]["__testResults"][0]["id"] == 100001
-        assert (
-            enriched_test_runs[1]["__codeCoverage"]["coverageData"]["linesCovered"]
-            == 80
-        )
+        assert "__testResults" not in enriched_test_runs[1]
 
 
 @pytest.mark.asyncio
@@ -4178,7 +3924,7 @@ async def test_enrich_test_runs_without_build() -> None:
         side_effect=mock_fetch_code_coverage,
     ):
         enriched_test_runs = await client._enrich_test_runs(
-            test_runs, "proj1", include_results=False, coverage_config=coverage_config
+            test_runs, "proj1", coverage_config=coverage_config
         )
 
         assert len(enriched_test_runs) == 2
@@ -4248,35 +3994,6 @@ async def test_fetch_code_coverage_no_response() -> None:
 
         # ASSERT
         assert coverage_data == {}
-
-
-@pytest.mark.asyncio
-async def test_fetch_test_results() -> None:
-    """Test fetching test results for a specific test run."""
-    client = AzureDevopsClient(
-        MOCK_ORG_URL, MOCK_PERSONAL_ACCESS_TOKEN, MOCK_AUTH_USERNAME
-    )
-
-    async def mock_get_paginated_by_top_and_continuation_token(
-        url: str, **kwargs: Any
-    ) -> AsyncGenerator[List[Dict[str, Any]], None]:
-        if "test/runs/1/results" in url:
-            yield [EXPECTED_TEST_RESULTS[0]]
-        else:
-            yield []
-
-    with patch.object(
-        client,
-        "_get_paginated_by_top_and_continuation_token",
-        side_effect=mock_get_paginated_by_top_and_continuation_token,
-    ):
-        # ACT
-        results = await client._fetch_test_results("proj1", "1")
-
-        # ASSERT
-        assert len(results) == 1
-        assert results[0]["id"] == 100000
-        assert results[0]["outcome"] == "Passed"
 
 
 @pytest.mark.asyncio
@@ -5030,6 +4747,10 @@ async def test_get_test_runs_by_build_with_enrichment(
         MOCK_ORG_URL, MOCK_PERSONAL_ACCESS_TOKEN, MOCK_AUTH_USERNAME
     )
 
+    from integration import CodeCoverageConfig
+
+    coverage_config = CodeCoverageConfig(flags=1)
+
     async def mock_get_paginated_by_top_and_skip(
         url: str, params: Optional[Dict[str, Any]] = None, **kwargs: Any
     ) -> AsyncGenerator[List[Dict[str, Any]], None]:
@@ -5040,12 +4761,10 @@ async def test_get_test_runs_by_build_with_enrichment(
     async def mock_enrich_test_runs(
         test_runs: List[Dict[str, Any]],
         project_id: str,
-        include_results: bool = False,
         coverage_config: Any = None,
     ) -> None:
         for run in test_runs:
-            if include_results:
-                run["__testResults"] = [{"id": 100000}]
+            run["__codeCoverage"] = {"coverageData": {"linesCovered": 1}}
 
     async with event_context("test_event"):
         with patch.object(
@@ -5059,13 +4778,13 @@ async def test_get_test_runs_by_build_with_enrichment(
                 side_effect=mock_enrich_test_runs,
             ) as mock_enrich:
                 result = await client.get_test_runs_by_build(
-                    "proj1", "789", include_results=True
+                    "proj1", "789", coverage_config
                 )
 
                 assert len(result) == 2
-                assert "__testResults" in result[0]
-                assert result[0]["__testResults"][0]["id"] == 100000
-                mock_enrich.assert_called_once_with(result, "proj1", True, None)
+                assert "__codeCoverage" in result[0]
+                assert "__testResults" not in result[0]
+                mock_enrich.assert_called_once_with(result, "proj1", coverage_config)
 
 
 @pytest.mark.asyncio
@@ -5092,3 +4811,252 @@ async def test_get_test_runs_by_build_empty(
 
                 assert len(result) == 0
                 mock_enrich.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_generate_test_results_streams_pages_per_run(
+    mock_event_context: MagicMock,
+) -> None:
+    client = AzureDevopsClient(
+        MOCK_ORG_URL, MOCK_PERSONAL_ACCESS_TOKEN, MOCK_AUTH_USERNAME
+    )
+
+    async def mock_generate_projects() -> AsyncGenerator[List[Dict[str, Any]], None]:
+        yield [{"id": "proj1", "name": "Project One"}]
+
+    async def mock_get_paginated_by_top_and_skip(
+        url: str, params: Optional[Dict[str, Any]] = None, **kwargs: Any
+    ) -> AsyncGenerator[List[Dict[str, Any]], None]:
+        yield [EXPECTED_TEST_RUNS[0]]
+
+    async def mock_get_paginated_by_top_and_continuation_token(
+        url: str, additional_params: Optional[Dict[str, Any]] = None, **kwargs: Any
+    ) -> AsyncGenerator[List[Dict[str, Any]], None]:
+        yield [EXPECTED_TEST_RESULTS[0]]
+        yield [EXPECTED_TEST_RESULTS[1]]
+
+    async with event_context("test_event"):
+        with (
+            patch.object(
+                client, "generate_projects", side_effect=mock_generate_projects
+            ),
+            patch.object(
+                client,
+                "_get_paginated_by_top_and_skip",
+                side_effect=mock_get_paginated_by_top_and_skip,
+            ),
+            patch.object(
+                client,
+                "_get_paginated_by_top_and_continuation_token",
+                side_effect=mock_get_paginated_by_top_and_continuation_token,
+            ),
+        ):
+            batches: List[List[Dict[str, Any]]] = []
+            async for batch in client.generate_test_results({}):
+                batches.append(batch)
+
+            assert len(batches) == 2
+            flat = [item for batch in batches for item in batch]
+            assert len(flat) == 2
+            for item in flat:
+                assert "__projectId" not in item
+                assert "__projectName" not in item
+                assert "__runId" not in item
+                assert item["project"]["id"]
+                assert item["testRun"]["id"]
+
+
+@pytest.mark.asyncio
+async def test_generate_test_results_fans_out_across_runs(
+    mock_event_context: MagicMock,
+) -> None:
+    client = AzureDevopsClient(
+        MOCK_ORG_URL, MOCK_PERSONAL_ACCESS_TOKEN, MOCK_AUTH_USERNAME
+    )
+
+    runs = [
+        {"id": 10, "project": {"id": "proj1", "name": "Project One"}},
+        {"id": 11, "project": {"id": "proj1", "name": "Project One"}},
+        {"id": 12, "project": {"id": "proj1", "name": "Project One"}},
+    ]
+
+    async def mock_generate_projects() -> AsyncGenerator[List[Dict[str, Any]], None]:
+        yield [{"id": "proj1", "name": "Project One"}]
+
+    async def mock_get_paginated_by_top_and_skip(
+        url: str, params: Optional[Dict[str, Any]] = None, **kwargs: Any
+    ) -> AsyncGenerator[List[Dict[str, Any]], None]:
+        yield runs
+
+    invoked_run_ids: List[int] = []
+
+    async def mock_get_paginated_by_top_and_continuation_token(
+        url: str, additional_params: Optional[Dict[str, Any]] = None, **kwargs: Any
+    ) -> AsyncGenerator[List[Dict[str, Any]], None]:
+        run_id = int(url.rsplit("/runs/", 1)[1].split("/", 1)[0])
+        invoked_run_ids.append(run_id)
+        yield [
+            {
+                "id": 1000 + run_id,
+                "outcome": "Passed",
+                "testRun": {"id": str(run_id)},
+            }
+        ]
+
+    async with event_context("test_event"):
+        with (
+            patch.object(
+                client, "generate_projects", side_effect=mock_generate_projects
+            ),
+            patch.object(
+                client,
+                "_get_paginated_by_top_and_skip",
+                side_effect=mock_get_paginated_by_top_and_skip,
+            ),
+            patch.object(
+                client,
+                "_get_paginated_by_top_and_continuation_token",
+                side_effect=mock_get_paginated_by_top_and_continuation_token,
+            ),
+        ):
+            flat: List[Dict[str, Any]] = []
+            async for batch in client.generate_test_results({}):
+                flat.extend(batch)
+
+            assert sorted(invoked_run_ids) == [10, 11, 12]
+            assert {item["testRun"]["id"] for item in flat} == {"10", "11", "12"}
+            assert len(flat) == 3
+
+
+@pytest.mark.asyncio
+async def test_generate_test_results_propagates_params(
+    mock_event_context: MagicMock,
+) -> None:
+    client = AzureDevopsClient(
+        MOCK_ORG_URL, MOCK_PERSONAL_ACCESS_TOKEN, MOCK_AUTH_USERNAME
+    )
+
+    async def mock_generate_projects() -> AsyncGenerator[List[Dict[str, Any]], None]:
+        yield [{"id": "proj1", "name": "Project One"}]
+
+    async def mock_get_paginated_by_top_and_skip(
+        url: str, params: Optional[Dict[str, Any]] = None, **kwargs: Any
+    ) -> AsyncGenerator[List[Dict[str, Any]], None]:
+        yield [{"id": 7, "project": {"id": "proj1", "name": "Project One"}}]
+
+    captured_params: Dict[str, Any] = {}
+
+    async def mock_get_paginated_by_top_and_continuation_token(
+        url: str, additional_params: Optional[Dict[str, Any]] = None, **kwargs: Any
+    ) -> AsyncGenerator[List[Dict[str, Any]], None]:
+        captured_params.update(additional_params or {})
+        yield []
+
+    result_params = {"outcomes": "failed,passed", "detailsToInclude": "iterations"}
+
+    async with event_context("test_event"):
+        with (
+            patch.object(
+                client, "generate_projects", side_effect=mock_generate_projects
+            ),
+            patch.object(
+                client,
+                "_get_paginated_by_top_and_skip",
+                side_effect=mock_get_paginated_by_top_and_skip,
+            ),
+            patch.object(
+                client,
+                "_get_paginated_by_top_and_continuation_token",
+                side_effect=mock_get_paginated_by_top_and_continuation_token,
+            ),
+        ):
+            async for _ in client.generate_test_results(result_params):
+                pass
+
+            assert captured_params == result_params
+
+
+@pytest.mark.asyncio
+async def test_generate_test_results_two_level_fanout(
+    mock_event_context: MagicMock,
+) -> None:
+    client = AzureDevopsClient(
+        MOCK_ORG_URL, MOCK_PERSONAL_ACCESS_TOKEN, MOCK_AUTH_USERNAME
+    )
+
+    async def mock_generate_projects() -> AsyncGenerator[List[Dict[str, Any]], None]:
+        yield [
+            {"id": "projA", "name": "Project A"},
+            {"id": "projB", "name": "Project B"},
+        ]
+
+    async def mock_get_paginated_by_top_and_skip(
+        url: str, params: Optional[Dict[str, Any]] = None, **kwargs: Any
+    ) -> AsyncGenerator[List[Dict[str, Any]], None]:
+        if "/projA/" in url:
+            yield [
+                {"id": 1, "project": {"id": "projA", "name": "Project A"}},
+                {"id": 2, "project": {"id": "projA", "name": "Project A"}},
+            ]
+        elif "/projB/" in url:
+            yield [
+                {"id": 3, "project": {"id": "projB", "name": "Project B"}},
+                {"id": 4, "project": {"id": "projB", "name": "Project B"}},
+            ]
+        else:
+            yield []
+
+    invocations: List[tuple[str, int]] = []
+
+    async def mock_get_paginated_by_top_and_continuation_token(
+        url: str, additional_params: Optional[Dict[str, Any]] = None, **kwargs: Any
+    ) -> AsyncGenerator[List[Dict[str, Any]], None]:
+        project_id = url.split("/_apis/", 1)[0].rsplit("/", 1)[-1]
+        run_id = int(url.rsplit("/runs/", 1)[1].split("/", 1)[0])
+        invocations.append((project_id, run_id))
+        yield [{"id": 10 * run_id}]
+
+    async with event_context("test_event"):
+        with (
+            patch.object(
+                client, "generate_projects", side_effect=mock_generate_projects
+            ),
+            patch.object(
+                client,
+                "_get_paginated_by_top_and_skip",
+                side_effect=mock_get_paginated_by_top_and_skip,
+            ),
+            patch.object(
+                client,
+                "_get_paginated_by_top_and_continuation_token",
+                side_effect=mock_get_paginated_by_top_and_continuation_token,
+            ),
+        ):
+            flat: List[Dict[str, Any]] = []
+            async for batch in client.generate_test_results({}):
+                flat.extend(batch)
+
+            assert sorted(invocations) == [
+                ("projA", 1),
+                ("projA", 2),
+                ("projB", 3),
+                ("projB", 4),
+            ]
+            assert len(flat) == 4
+
+
+@pytest.mark.asyncio
+async def test_test_result_selector_to_params_omits_unset() -> None:
+    from integration import AzureDevopsTestResultSelector
+
+    bare = AzureDevopsTestResultSelector(query="true").to_params()
+    assert bare == {}
+
+    full = AzureDevopsTestResultSelector(
+        query="true", outcomes=["failed", "passed"], detailsToInclude="iterations"
+    ).to_params()
+    assert full == {
+        "outcomes": "failed,passed",
+        "detailsToInclude": "iterations",
+    }
+    assert "query" not in full

--- a/integrations/azure-devops/tests/azure_devops/client/test_azure_devops_client.py
+++ b/integrations/azure-devops/tests/azure_devops/client/test_azure_devops_client.py
@@ -4973,7 +4973,7 @@ async def test_generate_test_results_propagates_params(
             async for _ in client.generate_test_results(result_params):
                 pass
 
-            assert captured_params == result_params
+            assert captured_params == {**result_params, "api-version": "7.1"}
 
 
 @pytest.mark.asyncio

--- a/integrations/azure-devops/tests/azure_devops/webhooks/webhook_processors/test_test_run_webhook_processor.py
+++ b/integrations/azure-devops/tests/azure_devops/webhooks/webhook_processors/test_test_run_webhook_processor.py
@@ -126,7 +126,6 @@ async def test_handle_event_success(
     }
     resource_config = MagicMock()
     resource_config.kind = "test-run"
-    resource_config.selector.include_results = True
     resource_config.selector.code_coverage = None
 
     result = await test_run_processor.handle_event(payload, resource_config)
@@ -136,7 +135,7 @@ async def test_handle_event_success(
     assert result.updated_raw_results[0]["id"] == 10
     assert result.updated_raw_results[1]["id"] == 11
     mock_client.get_test_runs_by_build.assert_called_once_with(
-        "project-123", "456", True, None
+        "project-123", "456", None
     )
 
 
@@ -159,7 +158,6 @@ async def test_handle_event_no_test_runs(
     }
     resource_config = MagicMock()
     resource_config.kind = "test-run"
-    resource_config.selector.include_results = False
     resource_config.selector.code_coverage = None
 
     result = await test_run_processor.handle_event(payload, resource_config)


### PR DESCRIPTION
# Description

**What**
Introduce a new first-class `test-result` kind in the Azure DevOps integration, decoupled from `test-run`. Results now have their own resync handler, blueprint, and selectors (`outcomes`, `detailsToInclude`) aligned with the [ADO Test Results List API](https://learn.microsoft.com/en-us/rest/api/azure/devops/test/results/list?view=azure-devops-rest-7.1).

**Why**
On the previous design, `test-run` resync embedded every run's full result set under `__testResults` after an unbounded `asyncio.gather` across all runs. For large-scale orgs (thousands of runs × thousands of results per run), this buffered the whole catalog in memory before yielding a single batch, made each test-run entity payload obese, and coupled run-ingest latency to result volume.

**How**
`generate_test_results(result_params)` streams page-by-page across `(project × run × result-page)` by composing the existing `fetch_test_runs()` with a bounded run-level semaphore (`MAX_CONCURRENT_TEST_RUN_RESULTS=10`) feeding `stream_async_iterators_tasks`. Each result page is yielded as it arrives — total in-flight memory bounded to `PAGE_SIZE × MAX_CONCURRENT_TEST_RUN_RESULTS` records. The mapping references the native `.project.id` and `.testRun.id` fields the ADO API already returns, so no per-result enrichment is needed.

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Breaking changes

- Removed `includeResults` from the `test-run` selector.
- Removed the `__testResults` enrichment on `test-run` entities, mappings that referenced `.__testResults` must migrate to the new `test-result` kind.
- Bumped integration version to `0.9.0`.

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector

### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [x] Example raw data for the new `test-result` kind added under `integrations/azure-devops/examples/example-test-result.json`; blueprint and mapping shipped in `.port/resources/`.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] Live-events deferred for `test-result` (resync only in v1); existing `test-run` live-events preserved.
- [ ] Docs PR link [here](#)

### Preflight checklist

- [x] Handled rate limiting (inherited from `AzureDevOpsRateLimiter`)
- [x] Handled pagination (continuation-token paging through `_get_paginated_by_top_and_continuation_token`)
- [x] Implemented the code in async
- [ ] Support Multi account


## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.
<img width="1144" height="779" alt="image" src="https://github.com/user-attachments/assets/799a5bbe-e350-484f-849a-7a6f2121a851" />
<img width="1355" height="665" alt="image" src="https://github.com/user-attachments/assets/f99926aa-8a24-4261-b96d-03587b805543" />


## API Documentation

- [Azure DevOps — Test Results List](https://learn.microsoft.com/en-us/rest/api/azure/devops/test/results/list?view=azure-devops-rest-7.1)
- [ResultDetails enum](https://learn.microsoft.com/en-us/rest/api/azure/devops/test/results/list?view=azure-devops-rest-7.1&tabs=HTTP#resultdetails)
- [TestOutcome enum](https://learn.microsoft.com/en-us/rest/api/azure/devops/test/results/list?view=azure-devops-rest-7.1&tabs=HTTP#testoutcome)
