### PR TITLE
[Core] Make JQEntityProcessor._search_as_bool resilient to runtime ValueErrors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.42.2 (2026-05-14)
+
+### Bug Fixes
+
+- Fixed JQ selector queries crashing the batch when a regex operator receives null input now skipping with a warning.
+
+
 ## 0.42.1 (2026-05-14)
 
 ### Improvements

--- a/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
+++ b/port_ocean/core/handlers/entity_processor/jq_entity_processor.py
@@ -123,9 +123,13 @@ class JQEntityProcessor(BaseEntityProcessor):
         except JQInputNotJsonSerializableError:
             func = compile_jq(compiled_pattern, make_json_compatible(data))
 
-        value = func.first()
-        if isinstance(value, bool):
-            return value
+        try:
+            value = func.first()
+            if isinstance(value, bool):
+                return value
+        except ValueError as exc:
+            self._log_search_failure(pattern, exc)
+            return False
         raise EntityProcessorException(
             f"Expected boolean value for pattern {pattern!r}, got value:{value} of type: {type(value)} instead"
         )

--- a/port_ocean/core/handlers/entity_processor/jq_entity_processor_sync.py
+++ b/port_ocean/core/handlers/entity_processor/jq_entity_processor_sync.py
@@ -94,11 +94,15 @@ class JQEntityProcessorSync:
     def _search_as_bool(data: dict[str, Any] | str, pattern: str) -> bool:
         compiled_pattern = JQEntityProcessorSync._compile(pattern)
         try:
-            value = compile_jq(compiled_pattern, data).first()
-        except JQInputNotJsonSerializableError:
-            value = compile_jq(compiled_pattern, make_json_compatible(data)).first()
-        if isinstance(value, bool):
-            return value
+            try:
+                value = compile_jq(compiled_pattern, data).first()
+            except JQInputNotJsonSerializableError:
+                value = compile_jq(compiled_pattern, make_json_compatible(data)).first()
+            if isinstance(value, bool):
+                return value
+        except ValueError as exc:
+            JQEntityProcessorSync._log_search_failure(pattern, exc)
+            return False
         raise EntityProcessorException(
             f"Expected boolean value for pattern {pattern!r}, got value:{value} of type: {type(value)} instead"
         )

--- a/port_ocean/tests/core/handlers/entity_processor/test_jq_entity_processor.py
+++ b/port_ocean/tests/core/handlers/entity_processor/test_jq_entity_processor.py
@@ -246,6 +246,24 @@ class TestJQEntityProcessor:
         with pytest.raises(Exception):
             await mocked_processor._search_as_bool(data, pattern)
 
+    async def test_search_as_bool_runtime_value_error_returns_false(
+        self, mocked_processor: JQEntityProcessor
+    ) -> None:
+        data = {"name": None}
+        pattern = '.name | test("^integration-")'
+        messages: list[str] = []
+        logger_id = logger.add(lambda msg: messages.append(str(msg)), level="WARNING")
+        try:
+            result = await mocked_processor._search_as_bool(data, pattern)
+        finally:
+            logger.remove(logger_id)
+        assert result is False
+        assert any(
+            "null (null) cannot be matched, as it is not a string" in m
+            for m in messages
+        )
+        assert any('.name | test("^integration-")' in m for m in messages)
+
     async def test_search_as_bool_non_bool_includes_pattern(
         self, mocked_processor: JQEntityProcessor
     ) -> None:

--- a/port_ocean/tests/core/handlers/entity_processor/test_jq_entity_processor_sync.py
+++ b/port_ocean/tests/core/handlers/entity_processor/test_jq_entity_processor_sync.py
@@ -229,6 +229,27 @@ class TestJQEntityProcessorSync:
         with pytest.raises(Exception):
             mocked_processor._search_as_bool(data, pattern)
 
+    def test_search_as_bool_runtime_value_error_returns_false(
+        self, mocked_processor: JQEntityProcessorSync
+    ) -> None:
+        """A JQ runtime ValueError (e.g. test() on null) should be swallowed:
+        the entity is filtered out (returns False) and a WARNING is logged
+        including the offending pattern."""
+        data = {"name": None}
+        pattern = '.name | test("^integration-")'
+        messages: list[str] = []
+        logger_id = logger.add(lambda msg: messages.append(str(msg)), level="WARNING")
+        try:
+            result = mocked_processor._search_as_bool(data, pattern)
+        finally:
+            logger.remove(logger_id)
+        assert result is False
+        assert any(
+            "null (null) cannot be matched, as it is not a string" in m
+            for m in messages
+        )
+        assert any('.name | test("^integration-")' in m for m in messages)
+
     def test_search_as_object(self, mocked_processor: JQEntityProcessorSync) -> None:
         """Test search_as_object with simple object mapping."""
         data = {"foo": {"bar": "baz"}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.42.1"
+version = "0.42.2"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What -
- **Core** (`port_ocean.core.handlers.entity_processor`): in `JQEntityProcessor._search_as_bool` (and the sync mirror `JQEntityProcessorSync._search_as_bool`), wrap the JQ runtime evaluation in `try/except ValueError`. A failing selector query now logs a structured WARNING with the offending pattern and returns `False` (entity is filtered out) instead of bubbling a fatal `ValueError` that aborts the whole batch.

Why -
A customer's resync was aborting with an `ExceptionGroup` of four `ValueError: null (null) cannot be matched, as it is not a string` — their mapping uses `test()` / `match()` against a nullable upstream field, and one null value was poisoning the entire batch. The JQ error is per-entity and recoverable: today it's fatal only because `_search_as_bool` doesn't guard `func.first()` against runtime errors. Skipping the offending entity with a warning preserves the rest of the resync.

How -
- `port_ocean/core/handlers/entity_processor/jq_entity_processor.py`: minimal `try/except ValueError` around the JQ `.first()` call inside `_search_as_bool`; log a WARNING and return `False`. Compile errors and "expected boolean" errors remain loud.
- `port_ocean/core/handlers/entity_processor/jq_entity_processor_sync.py`: same change applied to the sync implementation so behavior stays consistent across both processors.
- Tests added in `port_ocean/tests/core/handlers/entity_processor/test_jq_entity_processor.py` and `test_jq_entity_processor_sync.py` covering the `ValueError → False + warning` path.
- `pyproject.toml` / `CHANGELOG.md`: bump to `0.42.2`, bug-fix entry under "Bug Fixes".

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector
- [ ] Specifically validated: a mapping whose selector calls `test()` / `match()` against a nullable field now logs a WARNING and skips the offending entity instead of aborting the batch