### PR TITLE
[Integration][Github] Add Labeled and Unlabeled to Pull Request Webhook Actions

### DIFF
--- a/integrations/github/CHANGELOG.md
+++ b/integrations/github/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 5.5.1 (2026-05-20)
+
+
+### Improvements
+
+- Added `labeled` and `unlabeled` to the supported `pull_request` webhook actions so PR label changes are processed in real time.
+
+
 ## 5.5.0 (2026-05-19)
 
 

--- a/integrations/github/changelog/3236.improvement.md
+++ b/integrations/github/changelog/3236.improvement.md
@@ -1,0 +1,1 @@
+Added `labeled` and `unlabeled` to the supported `pull_request` webhook actions so PR label changes are processed in real time. Previously these actions were dropped at the webhook processor, meaning PR `labels` updates were only picked up at the next `synchronize` event or scheduled resync.

--- a/integrations/github/changelog/3236.improvement.md
+++ b/integrations/github/changelog/3236.improvement.md
@@ -1,1 +1,0 @@
-Added `labeled` and `unlabeled` to the supported `pull_request` webhook actions so PR label changes are processed in real time. Previously these actions were dropped at the webhook processor, meaning PR `labels` updates were only picked up at the next `synchronize` event or scheduled resync.

--- a/integrations/github/github/webhook/events.py
+++ b/integrations/github/github/webhook/events.py
@@ -26,6 +26,8 @@ PULL_REQUEST_EVENTS = [
     "unassigned",
     "review_request_removed",
     "closed",
+    "labeled",
+    "unlabeled",
 ]
 
 TEAM_UPSERT_EVENTS = ["created", "edited"]

--- a/integrations/github/pyproject.toml
+++ b/integrations/github/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "github-ocean"
-version = "5.5.0"
+version = "5.5.1"
 description = "This integration ingest data from github"
 authors = ["Chukwuemeka Nwaoma <joelchukks@gmail.com>", "Melody Anyaegbulam <melodyogonna@gmail.com>", "Michael Armah <mikeyarmah@gmail.com>"]
 


### PR DESCRIPTION
# Description
What -
Adds `labeled` and `unlabeled` to the `PULL_REQUEST_EVENTS` allowlist in the GitHub integration's webhook processor (`integrations/github/github/webhook/events.py`).

Why -
`pull_request_webhook_processor._should_process_event` checks `event.payload.get("action") in PULL_REQUEST_EVENTS`. Without `labeled` / `unlabeled` in that list, Port-Ocean silently drops those webhook events. The `labels` property on `githubPullRequest` entities is only updated at the next `synchronize` event or scheduled
resync, which breaks real-time label-driven automations.

For comparison, `ISSUE_UPSERT_EVENTS` in the same file already includes both `labeled` and `unlabeled`. This PR brings PR-side handling to parity with issue-side handling.

Fixes #3236.

How -
- 2-line addition to `PULL_REQUEST_EVENTS`
- Existing test `test_validate_payload_valid` iterates `for action in PULL_REQUEST_EVENTS` and auto-covers the new entries
- Towncrier fragment added under `improvement`

## Type of change

- [x] Non-breaking change (fix of existing functionality that will not change current behavior)

### Core testing checklist

This is a 2-line addition to an event-filter allowlist. No resync, entity, or listener behavior is changed.

- [x] Resync finishes successfully (unaffected by this change)
- [x] Resync able to create / update / detect-and-delete entities (unaffected)
- [x] Scheduled resync behavior unaffected
- N/A: Tested with Kafka and Polling event listeners , this change only affects which actions of the `pull_request` webhook get processed; listener mechanics are unchanged
- N/A: Tested with at least 2 integrations from scratch , scope is the github integration only

### Integration testing checklist

N/A , no resource kinds added or modified.

### Preflight checklist

- N/A: Rate limiting , no new API calls
- N/A: Pagination , no list endpoints involved
- N/A: Async , no new code paths
- N/A: Multi-account , scope is webhook event filtering only

## Screenshots

N/A , internal allowlist change, no user-facing UI.

## API Documentation

N/A , no new APIs involved. The added actions are standard GitHub webhook actions documented at https://docs.github.com/en/webhooks/webhook-events-and-payloads#pull_request.