### PR TITLE
[Core] send ocean core version to in get integration + polling bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.42.9 (2026-05-24)
+
+### Bug Fixes
+
+- Fixed polling resync-request detection so stale manual resync requests are not replayed after the first regular polling resync.
+
 ## 0.42.8 (2026-05-21)
 
 ### Improvements

--- a/port_ocean/clients/port/mixins/integrations.py
+++ b/port_ocean/clients/port/mixins/integrations.py
@@ -77,12 +77,11 @@ class IntegrationClientMixin:
         logger.info(f"Fetching integration with id: {self.integration_identifier}")
         request_kwargs: dict[str, Any] = {
             "headers": await self.auth.headers(),
-        }
-        if is_polling:
-            request_kwargs["params"] = {
+            "params": {
                 "oceanCoreVersion": ocean_core_version,
-                "isPolling": "true",
-            }
+                "isPolling": "true" if is_polling else "false",
+            },
+        }
         response = await self.client.get(
             f"{self.auth.api_url}/integration/{self.integration_identifier}",
             **request_kwargs,

--- a/port_ocean/core/event_listener/polling.py
+++ b/port_ocean/core/event_listener/polling.py
@@ -27,7 +27,7 @@ class PollingEventListenerSettings(EventListenerSettings):
 
     type: Literal[EventListenerType.POLLING]
     resync_on_start: bool = True
-    interval: int = 10
+    interval: int = 60
 
 
 class PollingEventListener(BaseEventListener):

--- a/port_ocean/core/event_listener/polling.py
+++ b/port_ocean/core/event_listener/polling.py
@@ -27,7 +27,7 @@ class PollingEventListenerSettings(EventListenerSettings):
 
     type: Literal[EventListenerType.POLLING]
     resync_on_start: bool = True
-    interval: int = 60
+    interval: int = 10
 
 
 class PollingEventListener(BaseEventListener):
@@ -65,8 +65,9 @@ class PollingEventListener(BaseEventListener):
         Determine whether a newer integration resync request should trigger a resync.
 
         Returns `True` only when `last_updated_at` is a valid timestamp and it is newer
-        than the last processed resync-request timestamp. If no previous timestamp is
-        stored, a valid `last_updated_at` triggers a resync.
+        than the last processed resync-request timestamp. If no request timestamp was
+        stored yet, the integration-state timestamp is used as the first baseline so
+        old resync requests are not replayed after a regular polling resync.
 
         `last_resync_request_updated_at` is treated as a watermark for resync-request
         events and is not reset by integration-change based resyncs. This intentionally
@@ -84,13 +85,16 @@ class PollingEventListener(BaseEventListener):
         except ValueError:
             return False
 
-        if not last_processed_resync_request_updated_at:
+        baseline_updated_at = (
+            last_processed_resync_request_updated_at
+            or ocean.app.resync_state_updater.last_integration_state_updated_at
+        )
+
+        if not baseline_updated_at:
             return True
 
         try:
-            current_state_updated_at = convert_str_to_utc_datetime(
-                last_processed_resync_request_updated_at
-            )
+            current_state_updated_at = convert_str_to_utc_datetime(baseline_updated_at)
         except ValueError:
             return True
 

--- a/port_ocean/tests/core/event_listener/test_polling.py
+++ b/port_ocean/tests/core/event_listener/test_polling.py
@@ -218,6 +218,27 @@ def test_should_not_resync_when_resync_request_timestamp_is_invalid(
     assert listener.should_resync_from_resync_request("not-a-timestamp") is False
 
 
+def test_should_not_resync_old_request_when_request_watermark_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = SimpleNamespace(
+        resync_state_updater=SimpleNamespace(
+            last_integration_state_updated_at="2024-01-01T00:10:00Z",
+            last_resync_request_updated_at=None,
+        )
+    )
+    monkeypatch.setattr(polling_module, "ocean", SimpleNamespace(app=app))
+
+    listener = PollingEventListener(
+        events={"on_resync": AsyncMock(return_value=True)},
+        event_listener_config=PollingEventListenerSettings(
+            type=EventListenerType.POLLING
+        ),
+    )
+
+    assert listener.should_resync_from_resync_request("2024-01-01T00:05:00Z") is False
+
+
 @pytest.mark.asyncio
 async def test_polling_does_not_resync_repeatedly_for_same_resync_request(
     monkeypatch: pytest.MonkeyPatch,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.42.8"
+version = "0.42.9"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

- This branch fixes polling-based manual resync detection. When the resync-request watermark is missing, Ocean now uses the last integration-state update timestamp as the baseline, preventing stale manual resync requests from being replayed after the first regular polling resync.

- Send ocean core version, isPolling on each request.

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
