### PR TITLE
[Core] Add Independent Async Iterator Streaming Utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.42.10 (2026-05-25)
+
+### Improvements
+
+- Added a shared async iterator utility for streaming independent iterators while deferring failures until surviving iterators finish.
+
 ## 0.42.9 (2026-05-24)
 
 ### Bug Fixes

--- a/port_ocean/tests/utils/test_async_iterators.py
+++ b/port_ocean/tests/utils/test_async_iterators.py
@@ -22,6 +22,11 @@ async def _fail_after_first() -> AsyncGenerator[int, None]:
     raise RuntimeError("Iterator page failed")
 
 
+async def _cancel_after_first() -> AsyncGenerator[int, None]:
+    yield 1
+    raise asyncio.CancelledError()
+
+
 async def _fail_immediately() -> AsyncGenerator[int, None]:
     should_fail = True
     if should_fail:
@@ -114,6 +119,19 @@ async def test_stream_independent_async_iterators_defers_failures_until_finish()
     assert sorted(items) == [1, 2, 3]
     assert "test sync failed with 1 error(s)" in str(exc_info.value)
     assert isinstance(exc_info.value.exceptions[0], RuntimeError)
+
+
+async def test_stream_independent_async_iterators_handles_independent_cancellation() -> (
+    None
+):
+    items = [
+        item
+        async for item in stream_independent_async_iterators(
+            _cancel_after_first(), _yield_items(2, 3), context="test sync"
+        )
+    ]
+
+    assert sorted(items) == [1, 2, 3]
 
 
 async def test_stream_independent_async_iterators_collects_multiple_failures() -> None:

--- a/port_ocean/tests/utils/test_async_iterators.py
+++ b/port_ocean/tests/utils/test_async_iterators.py
@@ -1,7 +1,51 @@
-from typing import Any, AsyncGenerator
 import asyncio
-from port_ocean.utils.async_iterators import semaphore_async_iterator
+from collections.abc import AsyncGenerator
+from typing import Any
+
 import pytest
+
+from port_ocean.utils import async_iterators
+from port_ocean.utils.async_iterators import (
+    semaphore_async_iterator,
+    stream_independent_async_iterators,
+)
+
+
+async def _yield_items(*items: int) -> AsyncGenerator[int, None]:
+    for item in items:
+        await asyncio.sleep(0)
+        yield item
+
+
+async def _fail_after_first() -> AsyncGenerator[int, None]:
+    yield 1
+    raise RuntimeError("Iterator page failed")
+
+
+async def _fail_immediately() -> AsyncGenerator[int, None]:
+    should_fail = True
+    if should_fail:
+        raise RuntimeError("Iterator failed")
+    yield 1
+
+
+async def _yield_many_items() -> AsyncGenerator[int, None]:
+    for item in range(100):
+        yield item
+
+
+async def _yield_then_fail_while_backpressured() -> AsyncGenerator[int, None]:
+    yield 0
+    yield 1
+    raise RuntimeError("Iterator failed while backpressured")
+
+
+async def _slow_to_cancel() -> AsyncGenerator[int, None]:
+    yield 0
+    try:
+        await asyncio.sleep(3600)
+    except asyncio.CancelledError:
+        await asyncio.sleep(0.1)
 
 
 @pytest.mark.asyncio
@@ -43,3 +87,74 @@ async def test_semaphore_async_iterator() -> None:
         max_concurrent_tasks <= max_concurrency
     ), f"Max concurrent tasks {max_concurrent_tasks} exceeded semaphore limit {max_concurrency}"
     assert concurrent_tasks == 0, "Not all tasks have completed"
+
+
+async def test_stream_independent_async_iterators_streams_successful_items() -> None:
+    items = [
+        item
+        async for item in stream_independent_async_iterators(
+            _yield_items(1, 2), _yield_items(3), context="test sync"
+        )
+    ]
+
+    assert sorted(items) == [1, 2, 3]
+
+
+async def test_stream_independent_async_iterators_defers_failures_until_finish() -> (
+    None
+):
+    items: list[int] = []
+
+    with pytest.raises(ExceptionGroup) as exc_info:
+        async for item in stream_independent_async_iterators(
+            _fail_after_first(), _yield_items(2, 3), context="test sync"
+        ):
+            items.append(item)
+
+    assert sorted(items) == [1, 2, 3]
+    assert "test sync failed with 1 error(s)" in str(exc_info.value)
+    assert isinstance(exc_info.value.exceptions[0], RuntimeError)
+
+
+async def test_stream_independent_async_iterators_collects_multiple_failures() -> None:
+    with pytest.raises(ExceptionGroup) as exc_info:
+        async for _ in stream_independent_async_iterators(
+            _fail_immediately(), _fail_after_first(), context="test sync"
+        ):
+            pass
+
+    assert len(exc_info.value.exceptions) == 2
+
+
+async def test_stream_independent_async_iterators_closes_while_backpressured() -> None:
+    iterator = stream_independent_async_iterators(
+        _yield_many_items(), context="test sync"
+    )
+
+    assert await anext(iterator) == 0
+    await asyncio.wait_for(iterator.aclose(), timeout=1)
+
+
+async def test_stream_independent_async_iterators_closes_while_error_is_backpressured() -> (
+    None
+):
+    iterator = stream_independent_async_iterators(
+        _yield_then_fail_while_backpressured(), context="test sync"
+    )
+
+    assert await anext(iterator) == 0
+    await asyncio.sleep(0)
+    await asyncio.wait_for(iterator.aclose(), timeout=1)
+
+
+async def test_stream_independent_async_iterators_cleanup_wait_is_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(async_iterators, "CANCELLED_TASK_CLEANUP_TIMEOUT", 0.01)
+    iterator = stream_independent_async_iterators(
+        _slow_to_cancel(), context="test sync"
+    )
+
+    assert await anext(iterator) == 0
+    await asyncio.wait_for(iterator.aclose(), timeout=1)
+    await asyncio.sleep(0.2)

--- a/port_ocean/utils/async_iterators.py
+++ b/port_ocean/utils/async_iterators.py
@@ -132,6 +132,7 @@ async def _consume_iterator(
     index: int,
     iterator: typing.AsyncIterable[T],
     queue: asyncio.Queue[_IteratorItem[T] | _IteratorFinished],
+    is_closing: asyncio.Event,
     context: str,
 ) -> None:
     error: Exception | None = None
@@ -151,9 +152,7 @@ async def _consume_iterator(
         )
 
     finally:
-        current_task = asyncio.current_task()
-
-        if current_task and current_task.cancelling():
+        if is_closing.is_set():
             return
 
         await queue.put(_IteratorFinished(error=error))
@@ -180,6 +179,7 @@ async def stream_independent_async_iterators(
     )
 
     errors: list[Exception] = []
+    is_closing = asyncio.Event()
 
     tasks = [
         asyncio.create_task(
@@ -187,6 +187,7 @@ async def stream_independent_async_iterators(
                 index=index,
                 iterator=iterator,
                 queue=queue,
+                is_closing=is_closing,
                 context=context,
             )
         )
@@ -207,6 +208,7 @@ async def stream_independent_async_iterators(
                 yield message.item
 
     finally:
+        is_closing.set()
         for task in tasks:
             if not task.done():
                 task.cancel()

--- a/port_ocean/utils/async_iterators.py
+++ b/port_ocean/utils/async_iterators.py
@@ -148,7 +148,7 @@ async def _consume_iterator(
         error = exc
 
         logger.exception(
-            f"{context} iterator {index} failed; continuing remaining siblings"
+            f"{context} iterator {index} failed; continuing remaining"
         )
 
     finally:

--- a/port_ocean/utils/async_iterators.py
+++ b/port_ocean/utils/async_iterators.py
@@ -147,9 +147,7 @@ async def _consume_iterator(
     except Exception as exc:
         error = exc
 
-        logger.exception(
-            f"{context} iterator {index} failed; continuing remaining"
-        )
+        logger.exception(f"{context} iterator {index} failed; continuing remaining")
 
     finally:
         if is_closing.is_set():

--- a/port_ocean/utils/async_iterators.py
+++ b/port_ocean/utils/async_iterators.py
@@ -127,7 +127,7 @@ async def semaphore_async_iterator(
             yield result
 
 
-async def _consume_iterator(
+async def _stream_iterator_to_queue(
     *,
     index: int,
     iterator: typing.AsyncIterable[T],
@@ -181,7 +181,7 @@ async def stream_independent_async_iterators(
 
     tasks = [
         asyncio.create_task(
-            _consume_iterator(
+            _stream_iterator_to_queue(
                 index=index,
                 iterator=iterator,
                 queue=queue,

--- a/port_ocean/utils/async_iterators.py
+++ b/port_ocean/utils/async_iterators.py
@@ -1,6 +1,24 @@
+import asyncio
 import typing
+from dataclasses import dataclass
 
 import aiostream
+from loguru import logger
+
+CANCELLED_TASK_CLEANUP_TIMEOUT = 10
+
+T = typing.TypeVar("T")
+
+
+@dataclass(slots=True)
+class _IteratorItem(typing.Generic[T]):
+    item: T
+
+
+@dataclass(slots=True)
+class _IteratorFinished:
+    error: Exception | None = None
+
 
 if typing.TYPE_CHECKING:
     from asyncio import Semaphore
@@ -107,3 +125,108 @@ async def semaphore_async_iterator(
     async with semaphore:
         async for result in function():
             yield result
+
+
+async def _consume_iterator(
+    *,
+    index: int,
+    iterator: typing.AsyncIterable[T],
+    queue: asyncio.Queue[_IteratorItem[T] | _IteratorFinished],
+    context: str,
+) -> None:
+    error: Exception | None = None
+
+    try:
+        async for item in iterator:
+            await queue.put(_IteratorItem(item))
+
+    except asyncio.CancelledError:
+        raise
+
+    except Exception as exc:
+        error = exc
+
+        logger.exception(
+            f"{context} iterator {index} failed; continuing remaining siblings"
+        )
+
+    finally:
+        current_task = asyncio.current_task()
+
+        if current_task and current_task.cancelling():
+            return
+
+        await queue.put(_IteratorFinished(error=error))
+
+
+async def stream_independent_async_iterators(
+    *iterators: typing.AsyncIterable[T], context: str
+) -> typing.AsyncGenerator[T, None]:
+    """
+    Stream multiple async iterators concurrently while deferring failures.
+
+    Characteristics:
+    - Items are yielded as they arrive.
+    - Ordering is nondeterministic.
+    - One iterator failing does not stop others.
+    - Errors are raised as an ExceptionGroup after surviving iterators finish.
+    - Errors are only surfaced if the stream is fully consumed.
+    """
+    if not iterators:
+        return
+
+    queue: asyncio.Queue[_IteratorItem[T] | _IteratorFinished] = asyncio.Queue(
+        maxsize=max(len(iterators) * 2, 32)
+    )
+
+    errors: list[Exception] = []
+
+    tasks = [
+        asyncio.create_task(
+            _consume_iterator(
+                index=index,
+                iterator=iterator,
+                queue=queue,
+                context=context,
+            )
+        )
+        for index, iterator in enumerate(iterators)
+    ]
+
+    try:
+        remaining = len(tasks)
+        while remaining:
+            message = await queue.get()
+
+            if isinstance(message, _IteratorFinished):
+                remaining -= 1
+
+                if message.error is not None:
+                    errors.append(message.error)
+            else:
+                yield message.item
+
+    finally:
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+
+        done, pending = await asyncio.wait(
+            tasks,
+            timeout=CANCELLED_TASK_CLEANUP_TIMEOUT,
+        )
+
+        await asyncio.gather(*done, return_exceptions=True)
+
+        if pending:
+            logger.warning(
+                f"{context} cleanup timed out after "
+                f"{CANCELLED_TASK_CLEANUP_TIMEOUT} seconds while waiting "
+                f"for {len(pending)} cancelled iterator task(s)"
+            )
+
+    if errors:
+        raise ExceptionGroup(
+            f"{context} failed with {len(errors)} error(s)",
+            errors,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.42.9"
+version = "0.42.10"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What - Added a shared Ocean utility for streaming independent async iterators concurrently while deferring iterator failures until surviving iterators finish.

Why - Independent sync streams should continue yielding retrievable data when one stream fails, while still surfacing errors at the end so incomplete syncs can avoid unsafe reconciliation deletes.

How - Added `stream_independent_async_iterators` with deferred error aggregation, cancellation-aware producer cleanup, bounded cleanup waiting, and focused tests for success, failure aggregation, backpressure, and cancellation paths.

## Type of change

- [x] Non-breaking change (fix of existing functionality that will not change current behavior)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [x] Integration able to create all default resources from scratch
- [x] Resync finishes successfully
- [x] Resync able to create entities
- [x] Resync able to update entities
- [x] Resync able to detect and delete entities
- [x] Scheduled resync able to abort existing resync and start a new one
- [x] Tested with at least 2 integrations from scratch
- [x] Tested with Kafka and Polling event listeners
- [x] Tested deletion of entities that don't pass the selector

### Integration testing checklist

- [x] Integration able to create all default resources from scratch
- [x] Completed a full resync from a freshly installed integration and it completed successfully
- [x] Resync able to create entities
- [x] Resync able to update entities
- [x] Resync able to detect and delete entities
- [x] Resync finishes successfully
- [x] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [x] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [x] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)