### PR TITLE
[Core] bypass strict X.509 verification introduced in Python 3.13 or disable SSL verification at all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.42.10 (2026-05-25)
+
+### Improvements
+
+- Added Ocean-level SSL verification settings for Port and third-party HTTP clients, including support for disabling Python strict X.509 verification while preserving HTTPX certificate authority behavior.
+
 ## 0.42.9 (2026-05-24)
 
 ### Bug Fixes

--- a/docs/framework-guides/docs/framework/advanced-configuration.md
+++ b/docs/framework-guides/docs/framework/advanced-configuration.md
@@ -66,3 +66,65 @@ SSL_CERT_FILE=/path/to/cacert.pem
 These variables provide fine-grained control over SSL/TLS configurations in environments where default settings are not sufficient or need customization for specific requirements.
 
 For more information take a look at the HTTPX [SSL configuration documentation](https://www.python-httpx.org/environment_variables/#sslkeylogfile).
+
+## SSL certificate validation
+
+Ocean can configure SSL certificate verification separately for Port-owned requests and third-party integration requests.
+
+Port SSL settings apply to Ocean's internal Port clients, including requests to Port's API and Port lifecycle services. Third-party SSL settings apply to Ocean's shared third-party HTTP client (`http_async_client`) and to `OceanAsyncClient` instances that do not explicitly pass a `verify` value.
+
+These settings do not automatically affect integrations that create their own raw `httpx.AsyncClient` instances.
+
+### Port API and lifecycle requests
+
+- `OCEAN__PORT_VERIFY_SSL`: Enables or disables SSL certificate verification for Port-owned requests.
+  - Default: `true`
+  - Set to `false` to pass `verify=False` to HTTPX.
+  - When this is `false`, `OCEAN__PORT_DISABLE_STRICT_SSL_VERIFICATION` is ignored because certificate verification is disabled completely.
+
+- `OCEAN__PORT_DISABLE_STRICT_SSL_VERIFICATION`: Disables only Python's strict X.509 verification flag for Port-owned requests.
+  - Default: `false`
+  - Set to `true` to keep certificate verification enabled while removing `ssl.VERIFY_X509_STRICT` from the SSL context.
+
+### Third-party integration requests
+
+- `OCEAN__THIRD_PARTY_VERIFY_SSL`: Enables or disables SSL certificate verification for Ocean-managed third-party requests.
+  - Default: `true`
+  - Set to `false` to pass `verify=False` to HTTPX.
+  - When this is `false`, `OCEAN__THIRD_PARTY_DISABLE_STRICT_SSL_VERIFICATION` is ignored because certificate verification is disabled completely.
+
+- `OCEAN__THIRD_PARTY_DISABLE_STRICT_SSL_VERIFICATION`: Disables only Python's strict X.509 verification flag for Ocean-managed third-party requests.
+  - Default: `false`
+  - Set to `true` to keep certificate verification enabled while removing `ssl.VERIFY_X509_STRICT` from the SSL context.
+
+### Strict verification mode
+
+When one of the `*_DISABLE_STRICT_SSL_VERIFICATION` settings is `true`, Ocean creates a custom SSL context and passes it to HTTPX. The context keeps HTTPX's usual certificate authority lookup order:
+
+1. `SSL_CERT_FILE`, if set
+2. `SSL_CERT_DIR`, if set
+3. HTTPX's default `certifi` CA bundle
+
+Ocean then removes only the `ssl.VERIFY_X509_STRICT` flag from that context. Use this mode when certificate validation should remain enabled, but Python's strict X.509 checks are too strict for a certificate chain you already trust.
+
+### Usage examples
+
+```bash showLineNumbers
+# Keep Port certificate verification enabled, but disable strict X.509 checks.
+export OCEAN__PORT_DISABLE_STRICT_SSL_VERIFICATION=true
+
+# Disable Port certificate verification completely. Not recommended for production.
+export OCEAN__PORT_VERIFY_SSL=false
+
+# Keep third-party certificate verification enabled, but disable strict X.509 checks.
+export OCEAN__THIRD_PARTY_DISABLE_STRICT_SSL_VERIFICATION=true
+
+# Disable third-party certificate verification completely. Not recommended for production.
+export OCEAN__THIRD_PARTY_VERIFY_SSL=false
+```
+
+### Security considerations
+
+- Prefer `*_DISABLE_STRICT_SSL_VERIFICATION=true` over `*_VERIFY_SSL=false` when you only need to work around strict X.509 validation.
+- Use `*_VERIFY_SSL=false` only for local development, testing, or controlled troubleshooting. It disables certificate verification completely and makes requests vulnerable to man-in-the-middle attacks.
+- If you need custom trusted certificate authorities, configure `SSL_CERT_FILE` or `SSL_CERT_DIR` instead of disabling verification.

--- a/port_ocean/clients/lifecycle.py
+++ b/port_ocean/clients/lifecycle.py
@@ -6,6 +6,7 @@ import httpx
 from loguru import logger
 
 from port_ocean.clients.port.authentication import PortAuthentication
+from port_ocean.helpers.ssl import SSLClientType, get_ssl_context
 from port_ocean.version import __integration_version__, __version__
 
 
@@ -41,7 +42,10 @@ class LifecycleClient:
     def __init__(self, base_url: str, auth: PortAuthentication) -> None:
         self.base_url = base_url.rstrip("/")
         self.auth = auth
-        self._client = httpx.AsyncClient(timeout=httpx.Timeout(10))
+        self._client = httpx.AsyncClient(
+            timeout=httpx.Timeout(10),
+            verify=get_ssl_context(SSLClientType.PORT),
+        )
 
     def _build_body(self, status: str, **extra: Any) -> dict[str, Any]:
         return {"status": status, **extra}

--- a/port_ocean/clients/port/utils.py
+++ b/port_ocean/clients/port/utils.py
@@ -9,6 +9,7 @@ from werkzeug.local import LocalStack, LocalProxy
 
 from port_ocean.clients.port.retry_transport import TokenRetryTransport
 from port_ocean.helpers.async_client import OceanAsyncClient
+from port_ocean.helpers.ssl import get_ssl_context, SSLClientType
 
 if TYPE_CHECKING:
     from port_ocean.clients.port.client import PortClient
@@ -40,6 +41,7 @@ OCEAN_INFO_PREFIX = "ocean_info_"
 def _get_http_client_context(port_client: "PortClient") -> httpx.AsyncClient:
     client = _http_client.top
     if client is None:
+        ssl_context = get_ssl_context(SSLClientType.PORT)
         client = OceanAsyncClient(
             TokenRetryTransport,
             transport_kwargs={
@@ -49,6 +51,7 @@ def _get_http_client_context(port_client: "PortClient") -> httpx.AsyncClient:
             },
             timeout=PORT_HTTPX_TIMEOUT,
             limits=PORT_HTTPX_LIMITS,
+            verify=ssl_context,
         )
         _http_client.push(client)
 

--- a/port_ocean/config/settings.py
+++ b/port_ocean/config/settings.py
@@ -109,6 +109,10 @@ class IntegrationConfiguration(BaseOceanSettings, extra=Extra.allow):
         gt=0,
     )
     client_timeout: int = 60
+    port_verify_ssl: bool = True
+    port_disable_strict_ssl_verification: bool = False
+    third_party_verify_ssl: bool = True
+    third_party_disable_strict_ssl_verification: bool = False
     create_port_resources_origin: CreatePortResourcesOrigin | None = None
     send_raw_data_examples: bool = True
     oauth_access_token_file_path: str | None = None

--- a/port_ocean/helpers/async_client.py
+++ b/port_ocean/helpers/async_client.py
@@ -1,4 +1,4 @@
-from typing import Any, Type
+from typing import Any, AsyncGenerator, Dict, List, Type
 
 import httpx
 from loguru import logger
@@ -6,8 +6,8 @@ from port_ocean.context.ocean import ocean
 
 from port_ocean.helpers.ip_blocker import IPBlockerTransport
 from port_ocean.helpers.retry import RetryTransport, RetryConfig
+from port_ocean.helpers.ssl import SSLClientType, get_ssl_context
 from port_ocean.helpers.stream import Stream
-from typing import AsyncGenerator, List, Dict
 
 
 class OceanAsyncClient(httpx.AsyncClient):
@@ -27,6 +27,8 @@ class OceanAsyncClient(httpx.AsyncClient):
         self._transport_kwargs = transport_kwargs
         self._transport_class = transport_class
         self._retry_config = retry_config
+        if "verify" not in kwargs:
+            kwargs["verify"] = get_ssl_context(SSLClientType.THIRD_PARTY)
         super().__init__(**kwargs)
 
     def _wrap_with_ip_blocker_if_needed(

--- a/port_ocean/helpers/ssl.py
+++ b/port_ocean/helpers/ssl.py
@@ -1,0 +1,93 @@
+"""
+SSL configuration helpers for the ocean framework.
+"""
+
+import os
+import ssl
+from enum import Enum
+from typing import Any
+
+import certifi
+from loguru import logger
+
+from port_ocean.context.ocean import ocean
+from port_ocean.exceptions.context import PortOceanContextNotFoundError
+
+
+class SSLClientType(Enum):
+    """Type of client to configure SSL for"""
+
+    PORT = "PORT"
+    THIRD_PARTY = "THIRD_PARTY"
+
+
+def _get_ocean_config_value(name: str, default: Any) -> Any:
+    try:
+        return getattr(ocean.config, name)
+    except (AttributeError, PortOceanContextNotFoundError):
+        return default
+
+
+def _create_httpx_default_ssl_context() -> ssl.SSLContext:
+    if os.environ.get("SSL_CERT_FILE"):
+        return ssl.create_default_context(cafile=os.environ["SSL_CERT_FILE"])
+    if os.environ.get("SSL_CERT_DIR"):
+        return ssl.create_default_context(capath=os.environ["SSL_CERT_DIR"])
+    return ssl.create_default_context(cafile=certifi.where())
+
+
+def get_ssl_context(
+    client_type: SSLClientType = SSLClientType.PORT,
+) -> ssl.SSLContext | bool:
+    """
+    Get SSL context configuration based on ocean settings.
+
+    Args:
+        client_type: Type of client to get SSL context for (PORT or THIRD_PARTY)
+
+    Settings for Port client (client_type=PORT):
+        OCEAN__PORT_VERIFY_SSL: Enable/disable SSL verification (default: True)
+        OCEAN__PORT_DISABLE_STRICT_SSL_VERIFICATION: Disable strict x509 verification introduced in Python 3.13 (default: False)
+
+    Settings for Third Party clients (client_type=THIRD_PARTY):
+        OCEAN__THIRD_PARTY_VERIFY_SSL: Enable/disable SSL verification (default: True)
+        OCEAN__THIRD_PARTY_DISABLE_STRICT_SSL_VERIFICATION: Disable strict x509 verification introduced in Python 3.13 (default: False)
+
+    Returns:
+        SSLContext for custom verification settings, False to disable verification, or True for default verification.
+    """
+
+    if client_type == SSLClientType.THIRD_PARTY:
+        verify_ssl = _get_ocean_config_value("third_party_verify_ssl", True)
+        disable_strict_ssl_verification = _get_ocean_config_value(
+            "third_party_disable_strict_ssl_verification",
+            False,
+        )
+    else:
+        verify_ssl = _get_ocean_config_value("port_verify_ssl", True)
+        disable_strict_ssl_verification = _get_ocean_config_value(
+            "port_disable_strict_ssl_verification",
+            False,
+        )
+
+    client_name = "third party" if client_type == SSLClientType.THIRD_PARTY else "Port"
+
+    if not verify_ssl:
+        logger.warning(
+            f"SSL certificate verification is disabled for {client_name} client. "
+            f"This is not recommended for production use."
+        )
+        return False
+
+    if disable_strict_ssl_verification:
+        logger.warning(
+            f"Strict X.509 certificate verification is disabled for {client_name} client. "
+            f"This may affect security."
+        )
+        context = _create_httpx_default_ssl_context()
+        # Remove VERIFY_X509_STRICT flag that is set by default starting Python 3.13
+        # See: https://docs.python.org/3/library/ssl.html#ssl.create_default_context
+        context.verify_flags &= ~ssl.VERIFY_X509_STRICT
+        return context
+
+    return True

--- a/port_ocean/tests/helpers/test_ssl.py
+++ b/port_ocean/tests/helpers/test_ssl.py
@@ -1,0 +1,210 @@
+import ssl
+from types import SimpleNamespace
+from typing import Any
+
+import httpx
+import pytest
+
+from port_ocean.config.settings import IntegrationConfiguration, PortSettings
+from port_ocean.helpers import async_client as async_client_module
+from port_ocean.helpers.ssl import (
+    SSLClientType,
+    _create_httpx_default_ssl_context,
+    get_ssl_context,
+)
+
+
+class RecordingTransport(httpx.AsyncBaseTransport):
+    captured_kwargs: dict[str, Any] = {}
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.__class__.captured_kwargs = kwargs
+
+    async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, request=request)
+
+
+def test_ssl_settings_are_loaded_from_ocean_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("OCEAN__PORT_VERIFY_SSL", "false")
+    monkeypatch.setenv("OCEAN__PORT_DISABLE_STRICT_SSL_VERIFICATION", "true")
+    monkeypatch.setenv("OCEAN__THIRD_PARTY_VERIFY_SSL", "false")
+    monkeypatch.setenv("OCEAN__THIRD_PARTY_DISABLE_STRICT_SSL_VERIFICATION", "true")
+
+    config = IntegrationConfiguration(
+        port=PortSettings(client_id="client-id", client_secret="client-secret")
+    )
+
+    assert config.port_verify_ssl is False
+    assert config.port_disable_strict_ssl_verification is True
+    assert config.third_party_verify_ssl is False
+    assert config.third_party_disable_strict_ssl_verification is True
+
+
+def test_get_ssl_context_uses_port_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "port_ocean.helpers.ssl.ocean",
+        SimpleNamespace(
+            config=SimpleNamespace(
+                port_verify_ssl=False,
+                port_disable_strict_ssl_verification=False,
+            )
+        ),
+    )
+
+    assert get_ssl_context(SSLClientType.PORT) is False
+
+
+def test_get_ssl_context_uses_third_party_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "port_ocean.helpers.ssl.ocean",
+        SimpleNamespace(
+            config=SimpleNamespace(
+                third_party_verify_ssl=False,
+                third_party_disable_strict_ssl_verification=False,
+            )
+        ),
+    )
+
+    assert get_ssl_context(SSLClientType.THIRD_PARTY) is False
+
+
+def test_get_ssl_context_can_disable_strict_verification(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "port_ocean.helpers.ssl.ocean",
+        SimpleNamespace(
+            config=SimpleNamespace(
+                port_verify_ssl=True,
+                port_disable_strict_ssl_verification=True,
+            )
+        ),
+    )
+
+    context = get_ssl_context(SSLClientType.PORT)
+
+    assert isinstance(context, ssl.SSLContext)
+    assert not context.verify_flags & ssl.VERIFY_X509_STRICT
+
+
+def test_create_httpx_default_ssl_context_uses_certifi_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_kwargs: dict[str, Any] = {}
+    original_create_default_context = ssl.create_default_context
+
+    def create_default_context(**kwargs: Any) -> ssl.SSLContext:
+        captured_kwargs.update(kwargs)
+        return original_create_default_context()
+
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    monkeypatch.delenv("SSL_CERT_DIR", raising=False)
+    monkeypatch.setattr(
+        "port_ocean.helpers.ssl.ssl.create_default_context",
+        create_default_context,
+    )
+    monkeypatch.setattr("port_ocean.helpers.ssl.certifi.where", lambda: "/certifi.pem")
+
+    _create_httpx_default_ssl_context()
+
+    assert captured_kwargs == {"cafile": "/certifi.pem"}
+
+
+def test_create_httpx_default_ssl_context_prefers_ssl_cert_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_kwargs: dict[str, Any] = {}
+    original_create_default_context = ssl.create_default_context
+
+    def create_default_context(**kwargs: Any) -> ssl.SSLContext:
+        captured_kwargs.update(kwargs)
+        return original_create_default_context()
+
+    monkeypatch.setenv("SSL_CERT_FILE", "/custom/cert-file.pem")
+    monkeypatch.setenv("SSL_CERT_DIR", "/custom/cert-dir")
+    monkeypatch.setattr(
+        "port_ocean.helpers.ssl.ssl.create_default_context",
+        create_default_context,
+    )
+
+    _create_httpx_default_ssl_context()
+
+    assert captured_kwargs == {"cafile": "/custom/cert-file.pem"}
+
+
+def test_create_httpx_default_ssl_context_uses_ssl_cert_dir(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_kwargs: dict[str, Any] = {}
+    original_create_default_context = ssl.create_default_context
+
+    def create_default_context(**kwargs: Any) -> ssl.SSLContext:
+        captured_kwargs.update(kwargs)
+        return original_create_default_context()
+
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    monkeypatch.setenv("SSL_CERT_DIR", "/custom/cert-dir")
+    monkeypatch.setattr(
+        "port_ocean.helpers.ssl.ssl.create_default_context",
+        create_default_context,
+    )
+
+    _create_httpx_default_ssl_context()
+
+    assert captured_kwargs == {"capath": "/custom/cert-dir"}
+
+
+@pytest.mark.asyncio
+async def test_ocean_async_client_defaults_to_third_party_ssl_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        async_client_module.httpx,
+        "AsyncHTTPTransport",
+        RecordingTransport,
+    )
+    monkeypatch.setattr(
+        async_client_module.OceanAsyncClient,
+        "_wrap_with_ip_blocker_if_needed",
+        lambda _, transport: transport,
+    )
+    monkeypatch.setattr(
+        async_client_module,
+        "get_ssl_context",
+        lambda client_type: client_type == SSLClientType.PORT,
+    )
+
+    client = async_client_module.OceanAsyncClient(trust_env=False)
+    await client.aclose()
+
+    assert RecordingTransport.captured_kwargs["verify"] is False
+
+
+@pytest.mark.asyncio
+async def test_ocean_async_client_keeps_explicit_verify_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        async_client_module.httpx,
+        "AsyncHTTPTransport",
+        RecordingTransport,
+    )
+    monkeypatch.setattr(
+        async_client_module.OceanAsyncClient,
+        "_wrap_with_ip_blocker_if_needed",
+        lambda _, transport: transport,
+    )
+    monkeypatch.setattr(
+        async_client_module,
+        "get_ssl_context",
+        lambda _: pytest.fail("explicit verify should not resolve default SSL config"),
+    )
+
+    client = async_client_module.OceanAsyncClient(verify=True, trust_env=False)
+    await client.aclose()
+
+    assert RecordingTransport.captured_kwargs["verify"] is True

--- a/port_ocean/tests/helpers/test_ssl.py
+++ b/port_ocean/tests/helpers/test_ssl.py
@@ -163,7 +163,7 @@ async def test_ocean_async_client_defaults_to_third_party_ssl_settings(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
-        async_client_module.httpx,
+        httpx,
         "AsyncHTTPTransport",
         RecordingTransport,
     )
@@ -189,7 +189,7 @@ async def test_ocean_async_client_keeps_explicit_verify_override(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
-        async_client_module.httpx,
+        httpx,
         "AsyncHTTPTransport",
         RecordingTransport,
     )

--- a/port_ocean/utils/async_http.py
+++ b/port_ocean/utils/async_http.py
@@ -4,6 +4,7 @@ from werkzeug.local import LocalStack, LocalProxy
 from port_ocean.context.ocean import ocean
 from port_ocean.helpers.async_client import OceanAsyncClient
 from port_ocean.helpers.retry import RetryTransport
+from port_ocean.helpers.ssl import get_ssl_context, SSLClientType
 
 _http_client: LocalStack[httpx.AsyncClient] = LocalStack()
 
@@ -11,9 +12,11 @@ _http_client: LocalStack[httpx.AsyncClient] = LocalStack()
 def _get_http_client_context() -> httpx.AsyncClient:
     client = _http_client.top
     if client is None:
+        ssl_context = get_ssl_context(SSLClientType.THIRD_PARTY)
         client = OceanAsyncClient(
             RetryTransport,
             timeout=ocean.config.client_timeout,
+            verify=ssl_context,
         )
         _http_client.push(client)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.42.9"
+version = "0.42.10"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What - Added Ocean-level SSL verification controls for both Port-owned HTTP clients and Ocean-managed third-party HTTP clients. This includes options to fully disable SSL verification or only disable Python’s strict X.509 verification checks.

Why - Python 3.13 introduced stricter default X.509 certificate validation, which can break environments with otherwise trusted certificate chains. The new settings give users a targeted workaround while preserving secure defaults and keeping Port and third-party SSL behavior configurable separately.

How - Added new Ocean config settings, centralized SSL resolution in port_ocean.helpers.ssl, wired Port clients to use Port SSL settings, and wired OceanAsyncClient / http_async_client to use third-party SSL settings. Strict verification mode now preserves HTTPX’s CA lookup behavior (SSL_CERT_FILE, SSL_CERT_DIR, then certifi) and only removes ssl.VERIFY_X509_STRICT. Added tests, docs, changelog entry, and bumped Ocean core to 0.42.10.

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
