### PR TITLE
[Core] Exclude internal DSP mode diagnostics from integration Event log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.43.4 (2026-05-27)
+
+### Bug Fixes
+
+- Added `local_only` log routing: logs marked with `logger.bind(local_only=True)` are written to stdout only and never shipped to the integration Event log ingest.
 
 ## 0.43.3 (2026-05-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
-## 0.43.10 (2026-06-01)
+## 0.43.11 (2026-06-01)
 
 ### Bug Fixes
 
 - Added `local_only` log routing: logs marked with `logger.bind(local_only=True)` are written to stdout only and never shipped to the integration Event log ingest.
+
+## 0.43.10 (2026-06-01)
 
 ### Improvements
 

--- a/port_ocean/core/integrations/mixins/utils.py
+++ b/port_ocean/core/integrations/mixins/utils.py
@@ -47,7 +47,7 @@ async def is_lakehouse_data_enabled() -> bool:
             return True
         return False
     except Exception as e:
-        logger.warning(
+        logger.bind(local_only=True).warning(
             f"Failed to check lakehouse feature flags, assuming disabled: {e}"
         )
         return False
@@ -68,7 +68,7 @@ async def is_dsp_mode_enabled() -> bool:
         if ocean.config.processing_mode != ProcessingMode.dsp:
             return False
         if not ocean.config.lakehouse_enabled:
-            logger.warning(
+            logger.bind(local_only=True).warning(
                 "DSP mode requested but lakehouse_enabled is False, falling back to ocean-core"
             )
             return False
@@ -78,7 +78,7 @@ async def is_dsp_mode_enabled() -> bool:
             and IntegrationFeatureFlag.DATA_SOURCE_PROCESSOR_ENABLED in flags
         ):
             return True
-        logger.warning(
+        logger.bind(local_only=True).warning(
             "DSP mode requested but required feature flags are missing "
             f"(LAKEHOUSE_ELIGIBLE={IntegrationFeatureFlag.LAKEHOUSE_ELIGIBLE in flags}, "
             f"DATA_SOURCE_PROCESSOR_ENABLED={IntegrationFeatureFlag.DATA_SOURCE_PROCESSOR_ENABLED in flags}), "
@@ -86,7 +86,7 @@ async def is_dsp_mode_enabled() -> bool:
         )
         return False
     except Exception as e:
-        logger.warning(f"Failed to check DSP mode, falling back to ocean-core: {e}")
+        logger.bind(local_only=True).warning(f"Failed to check DSP mode, falling back to ocean-core: {e}")
         return False
 
 

--- a/port_ocean/log/logger_setup.py
+++ b/port_ocean/log/logger_setup.py
@@ -14,6 +14,8 @@ from port_ocean.log.handlers import HTTPMemoryHandler
 from port_ocean.log.sensetive import sensitive_log_filter
 from port_ocean.utils.signal import signal_handler
 
+_sensitive_http_log_filter = sensitive_log_filter.create_filter(full_hide=True)
+
 
 def setup_logger(level: LogLevelType, enable_http_handler: bool) -> None:
     logger.remove()
@@ -56,7 +58,7 @@ def _http_loguru_handler(level: LogLevelType) -> None:
         format=lambda record: "{message}",  # strip loguru decorations (timestamp, level, module) — the HTTP handler builds its own JSON payload
         diagnose=False,  # hide variable values in log backtrace
         enqueue=True,  # process logs in background
-        filter=sensitive_log_filter.create_filter(full_hide=True),
+        filter=_http_log_filter,
     )
     logger.configure(patcher=_combined_patcher)
 
@@ -68,6 +70,12 @@ def _http_loguru_handler(level: LogLevelType) -> None:
 
     queue_listener = QueueListener(queue, http_memory_handler)
     queue_listener.start()
+
+
+def _http_log_filter(record: "loguru.Record") -> bool:
+    if record["extra"].get("local_only"):
+        return False
+    return _sensitive_http_log_filter(record)
 
 
 def _extract_traceback(record: "loguru.Record") -> None:

--- a/port_ocean/tests/core/integrations/mixins/test_integration_utils.py
+++ b/port_ocean/tests/core/integrations/mixins/test_integration_utils.py
@@ -14,9 +14,12 @@ from port_ocean.core.handlers.port_app_config.models import (
     ResourceConfig,
     Selector,
 )
+from port_ocean.core.models import ProcessingMode
 from port_ocean.core.integrations.mixins.utils import (
     extract_jq_deletion_path_revised,
     handle_items_to_parse,
+    is_dsp_mode_enabled,
+    is_lakehouse_data_enabled,
     resync_function_wrapper,
     resync_generator_wrapper,
 )
@@ -731,3 +734,80 @@ class TestResyncGeneratorWrapperDoesNotMutateYieldedBatches:
                 [{"id": "2", "items": [{"sub_id": "b"}]}],
             )
             assert calls[1].kwargs == {"should_log": False}
+
+
+class TestProcessingModes:
+    @pytest.mark.asyncio
+    async def test_is_dsp_mode_enabled_uses_local_only_warning_for_missing_flags(
+        self,
+    ) -> None:
+        with patch("port_ocean.core.integrations.mixins.utils.ocean") as mock_ocean_context:
+            mock_ocean_context.config.processing_mode = ProcessingMode.dsp
+            mock_ocean_context.config.lakehouse_enabled = True
+            mock_ocean_context.port_client.get_organization_feature_flags = AsyncMock(
+                return_value=[]
+            )
+
+            with patch("port_ocean.core.integrations.mixins.utils.logger") as mock_logger:
+                mock_bound = mock_logger.bind.return_value
+                result = await is_dsp_mode_enabled()
+
+        assert result is False
+        mock_logger.bind.assert_called_with(local_only=True)
+        mock_bound.warning.assert_called_once()
+        assert "required feature flags are missing" in mock_bound.warning.call_args.args[0]
+
+    @pytest.mark.asyncio
+    async def test_is_dsp_mode_enabled_uses_local_only_warning_when_lakehouse_disabled(
+        self,
+    ) -> None:
+        with patch("port_ocean.core.integrations.mixins.utils.ocean") as mock_ocean_context:
+            mock_ocean_context.config.processing_mode = ProcessingMode.dsp
+            mock_ocean_context.config.lakehouse_enabled = False
+
+            with patch("port_ocean.core.integrations.mixins.utils.logger") as mock_logger:
+                mock_bound = mock_logger.bind.return_value
+                result = await is_dsp_mode_enabled()
+
+        assert result is False
+        mock_logger.bind.assert_called_with(local_only=True)
+        mock_bound.warning.assert_called_once()
+        assert "lakehouse_enabled is False" in mock_bound.warning.call_args.args[0]
+
+    @pytest.mark.asyncio
+    async def test_is_dsp_mode_enabled_uses_local_only_warning_on_exception(
+        self,
+    ) -> None:
+        with patch("port_ocean.core.integrations.mixins.utils.ocean") as mock_ocean_context:
+            mock_ocean_context.config.processing_mode = ProcessingMode.dsp
+            mock_ocean_context.config.lakehouse_enabled = True
+            mock_ocean_context.port_client.get_organization_feature_flags = AsyncMock(
+                side_effect=Exception("connection error")
+            )
+
+            with patch("port_ocean.core.integrations.mixins.utils.logger") as mock_logger:
+                mock_bound = mock_logger.bind.return_value
+                result = await is_dsp_mode_enabled()
+
+        assert result is False
+        mock_logger.bind.assert_called_with(local_only=True)
+        mock_bound.warning.assert_called_once()
+        assert "Failed to check DSP mode" in mock_bound.warning.call_args.args[0]
+
+    @pytest.mark.asyncio
+    async def test_is_lakehouse_data_enabled_uses_local_only_warning_on_exception(
+        self,
+    ) -> None:
+        with patch("port_ocean.core.integrations.mixins.utils.ocean") as mock_ocean_context:
+            mock_ocean_context.port_client.get_organization_feature_flags = AsyncMock(
+                side_effect=Exception("timeout")
+            )
+
+            with patch("port_ocean.core.integrations.mixins.utils.logger") as mock_logger:
+                mock_bound = mock_logger.bind.return_value
+                result = await is_lakehouse_data_enabled()
+
+        assert result is False
+        mock_logger.bind.assert_called_with(local_only=True)
+        mock_bound.warning.assert_called_once()
+        assert "Failed to check lakehouse feature flags" in mock_bound.warning.call_args.args[0]

--- a/port_ocean/tests/log/test_integration_log_filter.py
+++ b/port_ocean/tests/log/test_integration_log_filter.py
@@ -1,0 +1,109 @@
+from logging import LogRecord
+from logging.handlers import QueueHandler
+from queue import Empty, Queue
+
+from loguru import logger
+
+from port_ocean.log.logger_setup import _http_log_filter
+from port_ocean.log.sensetive import sensitive_log_filter
+
+
+def test_sensitive_filter_still_applies_to_local_only_logs() -> None:
+    # Verifies that local_only logs are still scrubbed by the sensitive filter
+    # before reaching stdout — the local_only flag must not bypass data redaction.
+    # AKIA + 16 uppercase chars matches the Amazon AWS Access Key ID pattern.
+    aws_key = "AKIAIOSFODNN7EXAMPLE"
+    stdout_queue: Queue[LogRecord] = Queue()
+    logger_id = logger.add(
+        QueueHandler(stdout_queue),
+        level="WARNING",
+        format="{message}",
+        diagnose=False,
+        enqueue=True,
+        filter=sensitive_log_filter.create_filter(),
+    )
+
+    try:
+        logger.bind(local_only=True).warning(f"token: {aws_key}")
+        logger.complete()
+    finally:
+        logger.remove(logger_id)
+
+    records: list[LogRecord] = []
+    while True:
+        try:
+            records.append(stdout_queue.get_nowait())
+        except Empty:
+            break
+
+    assert len(records) == 1
+    assert aws_key not in records[0].msg
+    assert "[REDACTED]" in records[0].msg
+
+
+def test_http_log_filter_excludes_local_only_logs() -> None:
+    # Unit test for the filter function itself: a record marked local_only must
+    # be rejected (False), while a regular record must be accepted (True).
+    local_record = {"extra": {"local_only": True}, "message": "local warning"}
+    regular_record = {"extra": {}, "message": "regular warning"}
+
+    assert _http_log_filter(local_record) is False  # type: ignore[arg-type]
+    assert _http_log_filter(regular_record) is True  # type: ignore[arg-type]
+
+
+def test_local_only_warning_never_reaches_http_sink() -> None:
+    # Verifies that a local_only log in isolation produces zero entries in the
+    # HTTP sink queue — the message must not ship to the integration event log.
+    queue: Queue[LogRecord] = Queue()
+    queue_handler = QueueHandler(queue)
+    logger_id = logger.add(
+        queue_handler,
+        level="WARNING",
+        format="{message}",
+        diagnose=False,
+        enqueue=True,
+        filter=_http_log_filter,
+    )
+
+    try:
+        logger.bind(local_only=True).warning("local only — must not ship")
+        logger.complete()
+    finally:
+        logger.remove(logger_id)
+
+    assert queue.empty()
+
+
+def test_local_only_warning_is_blocked_from_http_sink() -> None:
+    # Verifies interleaving: regular logs before and after a local_only log both
+    # reach the HTTP sink, while the local_only log in the middle does not. This
+    # ensures local_only binding does not leak and affect surrounding log calls.
+    queue: Queue[LogRecord] = Queue()
+    queue_handler = QueueHandler(queue)
+    logger_id = logger.add(
+        queue_handler,
+        level="WARNING",
+        format="{message}",
+        diagnose=False,
+        enqueue=True,
+        filter=_http_log_filter,
+    )
+
+    try:
+        logger.warning("first visible warning")
+        logger.bind(local_only=True).warning("hidden local warning")
+        logger.warning("second visible warning")
+        logger.complete()
+    finally:
+        logger.remove(logger_id)
+
+    records: list[LogRecord] = []
+    while True:
+        try:
+            records.append(queue.get_nowait())
+        except Empty:
+            break
+
+    assert len(records) == 2
+    assert records[0].msg == "first visible warning"
+    assert records[1].msg == "second visible warning"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.43.10"
+version = "0.43.11"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.43.3"
+version = "0.43.4"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
Added `local_only` log routing: logs marked with `logger.bind(local_only=True)` are written to stdout only and never shipped to the integration Event log ingest.


# Description

What -

Why -

How -

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
