### PR TITLE
[Core] fix ocean entities search fail over 1m entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Bug Fixes
 
 - Fixed resync reconciliation to fetch datasource entities before the resync start time using the datasource pagination endpoint.
+
 ## 0.43.1 (2026-05-26)
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.43.1 (2026-05-27)
+
+### Bug Fixes
+
+- Fixed resync reconciliation to fetch datasource entities before the resync start time using the datasource pagination endpoint.
+
 ## 0.43.0 (2026-05-25)
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.43.1 (2026-05-26)
+
+### Improvements
+
+- Updated Port entity reconciliation search to use the datasource-entities paginated route for query-based searches, mapping `$updatedAt` filter values to the request body `before` field.
+
 ## 0.43.0 (2026-05-25)
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
-## 0.43.1 (2026-05-26)
-
-### Improvements
-
-- Updated Port entity reconciliation search to use the datasource-entities paginated route for query-based searches, mapping `$updatedAt` filter values to the request body `before` field.
-
 ## 0.43.0 (2026-05-25)
 
 ### Improvements

--- a/port_ocean/clients/port/mixins/entities.py
+++ b/port_ocean/clients/port/mixins/entities.py
@@ -521,7 +521,7 @@ class EntityClientMixin:
         )
 
     async def _search_entities_by_datasource_paginated(
-        self, user_agent_type: UserAgentType
+        self, user_agent_type: UserAgentType, before: str | None = None
     ) -> list[Entity]:
         datasource_prefix = f"port-ocean/{self.auth.integration_type}/"
         datasource_suffix = (
@@ -538,6 +538,9 @@ class EntityClientMixin:
                 "datasource_prefix": datasource_prefix,
                 "datasource_suffix": datasource_suffix,
             }
+
+            if before:
+                request_body["before"] = before
 
             if next_from:
                 request_body["from"] = next_from
@@ -565,38 +568,32 @@ class EntityClientMixin:
         query: dict[Any, Any],
         parameters_to_include: list[str] | None,
     ) -> list[Entity]:
-        default_query = {
-            "combinator": "and",
-            "rules": [
-                {
-                    "property": "$datasource",
-                    "operator": "contains",
-                    "value": f"port-ocean/{self.auth.integration_type}/",
-                },
-                {
-                    "property": "$datasource",
-                    "operator": "contains",
-                    "value": f"/{self.auth.integration_identifier}/{user_agent_type.value}",
-                },
-            ],
-        }
+        # search-by-query supports reconciliation updatedAt filtering by passing
+        # the rule's "from" value as datasource endpoint's "before" field.
+        _ = parameters_to_include
 
-        if query.get("rules"):
-            query["rules"].extend(default_query["rules"])
+        updated_at_before: str | None = None
+        for rule in query.get("rules", []):
+            if rule.get("property") != "$updatedAt":
+                continue
 
-        response = await self.client.post(
-            f"{self.auth.api_url}/entities/search",
-            json=query,
-            headers=await self.auth.headers(user_agent_type),
-            params={
-                "exclude_calculated_properties": "true",
-                "include": parameters_to_include or ["blueprint", "identifier"],
-            },
-            extensions={"retryable": True},
+            value = rule.get("value")
+            if isinstance(value, dict):
+                if isinstance(value.get("from"), str):
+                    updated_at_before = value["from"]
+                    break
+                if isinstance(value.get("before"), str):
+                    updated_at_before = value["before"]
+                    break
+
+            if isinstance(value, str):
+                updated_at_before = value
+                break
+
+        return await self._search_entities_by_datasource_paginated(
+            user_agent_type=user_agent_type,
+            before=updated_at_before,
         )
-
-        handle_port_status_code(response)
-        return [Entity.parse_obj(result) for result in response.json()["entities"]]
 
     async def search_batch_entities(
         self, user_agent_type: UserAgentType, entities_to_search: list[Entity]

--- a/port_ocean/clients/port/mixins/entities.py
+++ b/port_ocean/clients/port/mixins/entities.py
@@ -510,9 +510,12 @@ class EntityClientMixin:
         user_agent_type: UserAgentType,
         query: dict[Any, Any] | None = None,
         parameters_to_include: list[str] | None = None,
+        before: str | None = None,
     ) -> list[Entity]:
         if query is None:
-            return await self._search_entities_by_datasource_paginated(user_agent_type)
+            return await self._search_entities_by_datasource_paginated(
+                user_agent_type, before=before
+            )
 
         return await self._search_entities_by_query(
             user_agent_type=user_agent_type,
@@ -521,7 +524,7 @@ class EntityClientMixin:
         )
 
     async def _search_entities_by_datasource_paginated(
-        self, user_agent_type: UserAgentType
+        self, user_agent_type: UserAgentType, before: str | None = None
     ) -> list[Entity]:
         datasource_prefix = f"port-ocean/{self.auth.integration_type}/"
         datasource_suffix = (
@@ -538,6 +541,9 @@ class EntityClientMixin:
                 "datasource_prefix": datasource_prefix,
                 "datasource_suffix": datasource_suffix,
             }
+
+            if before:
+                request_body["before"] = before
 
             if next_from:
                 request_body["from"] = next_from

--- a/port_ocean/clients/port/mixins/entities.py
+++ b/port_ocean/clients/port/mixins/entities.py
@@ -542,7 +542,7 @@ class EntityClientMixin:
                 "datasource_suffix": datasource_suffix,
             }
 
-            if before:
+            if before is not None:
                 request_body["before"] = before
 
             if next_from:

--- a/port_ocean/clients/port/mixins/entities.py
+++ b/port_ocean/clients/port/mixins/entities.py
@@ -521,7 +521,7 @@ class EntityClientMixin:
         )
 
     async def _search_entities_by_datasource_paginated(
-        self, user_agent_type: UserAgentType, before: str | None = None
+        self, user_agent_type: UserAgentType
     ) -> list[Entity]:
         datasource_prefix = f"port-ocean/{self.auth.integration_type}/"
         datasource_suffix = (
@@ -538,9 +538,6 @@ class EntityClientMixin:
                 "datasource_prefix": datasource_prefix,
                 "datasource_suffix": datasource_suffix,
             }
-
-            if before:
-                request_body["before"] = before
 
             if next_from:
                 request_body["from"] = next_from
@@ -568,32 +565,38 @@ class EntityClientMixin:
         query: dict[Any, Any],
         parameters_to_include: list[str] | None,
     ) -> list[Entity]:
-        # search-by-query supports reconciliation updatedAt filtering by passing
-        # the rule's "from" value as datasource endpoint's "before" field.
-        _ = parameters_to_include
+        default_query = {
+            "combinator": "and",
+            "rules": [
+                {
+                    "property": "$datasource",
+                    "operator": "contains",
+                    "value": f"port-ocean/{self.auth.integration_type}/",
+                },
+                {
+                    "property": "$datasource",
+                    "operator": "contains",
+                    "value": f"/{self.auth.integration_identifier}/{user_agent_type.value}",
+                },
+            ],
+        }
 
-        updated_at_before: str | None = None
-        for rule in query.get("rules", []):
-            if rule.get("property") != "$updatedAt":
-                continue
+        if query.get("rules"):
+            query["rules"].extend(default_query["rules"])
 
-            value = rule.get("value")
-            if isinstance(value, dict):
-                if isinstance(value.get("from"), str):
-                    updated_at_before = value["from"]
-                    break
-                if isinstance(value.get("before"), str):
-                    updated_at_before = value["before"]
-                    break
-
-            if isinstance(value, str):
-                updated_at_before = value
-                break
-
-        return await self._search_entities_by_datasource_paginated(
-            user_agent_type=user_agent_type,
-            before=updated_at_before,
+        response = await self.client.post(
+            f"{self.auth.api_url}/entities/search",
+            json=query,
+            headers=await self.auth.headers(user_agent_type),
+            params={
+                "exclude_calculated_properties": "true",
+                "include": parameters_to_include or ["blueprint", "identifier"],
+            },
+            extensions={"retryable": True},
         )
+
+        handle_port_status_code(response)
+        return [Entity.parse_obj(result) for result in response.json()["entities"]]
 
     async def search_batch_entities(
         self, user_agent_type: UserAgentType, entities_to_search: list[Entity]

--- a/port_ocean/core/integrations/mixins/sync_raw.py
+++ b/port_ocean/core/integrations/mixins/sync_raw.py
@@ -1006,31 +1006,19 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
             resync_start_time: datetime | None = event.attributes.get(
                 "resync_start_time"
             )
-            query: dict[Any, Any] | None = None
             if not (resync_start_time and isinstance(resync_start_time, datetime)):
                 logger.warning(
                     "Resync start time is not set, fetching all entities from Port with no updatedAt filter"
                 )
+                before: str | None = None
             else:
-                query = {
-                    "combinator": "and",
-                    "rules": [
-                        {
-                            "property": "$updatedAt",
-                            "operator": "notBetween",
-                            "value": {
-                                "from": resync_start_time.isoformat(),
-                                "to": datetime.now(timezone.utc).isoformat(),
-                            },
-                        },
-                    ],
-                }
+                before = resync_start_time.isoformat()
             logger.info(
                 "Fetching current entity state from Port",
                 entities_synced=len(generated_entities),
             )
             entities_at_port = await ocean.port_client.search_entities(
-                user_agent_type, query
+                user_agent_type, before=before
             )
             entities_to_delete = max(0, len(entities_at_port) - len(generated_entities))
             logger.info(

--- a/port_ocean/integration_testing/port_mock.py
+++ b/port_ocean/integration_testing/port_mock.py
@@ -59,6 +59,11 @@ class PortMockResponder:
             "/v1/entities/search",
             self._handle_search_entities,
         )
+        self.transport.add_route(
+            "POST",
+            "/v1/blueprints/entities/datasource-entities",
+            self._handle_datasource_entities,
+        )
 
         # Bulk entity upsert — must be before generic blueprints route
         self.transport.add_route(
@@ -143,6 +148,16 @@ class PortMockResponder:
     def _handle_search_entities(self, request: httpx.Request) -> dict[str, Any]:
         """Handle POST /v1/entities/search — returns entities for reconciliation diff."""
         return {"json": {"ok": True, "entities": self.search_entities_response}}
+
+    def _handle_datasource_entities(self, request: httpx.Request) -> dict[str, Any]:
+        """Handle POST /v1/blueprints/entities/datasource-entities for reconciliation."""
+        return {
+            "json": {
+                "ok": True,
+                "entities": self.search_entities_response,
+                "next": None,
+            }
+        }
 
     def _handle_integration(self, request: httpx.Request) -> dict[str, Any]:
         return {

--- a/port_ocean/tests/clients/port/mixins/test_entities.py
+++ b/port_ocean/tests/clients/port/mixins/test_entities.py
@@ -213,6 +213,38 @@ async def test_search_entities_uses_datasource_route_when_query_is_none(
     assert sent_json["datasource_suffix"] == "/test-identifier/sync"
 
 
+async def test_search_entities_passes_before_to_datasource_route(
+    entity_client: EntityClientMixin,
+) -> None:
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"entities": [], "next": None}
+    mock_response.is_error = False
+    mock_response.status_code = 200
+    mock_response.headers = {}
+    entity_client.client.post = AsyncMock(return_value=mock_response)  # type: ignore
+    entity_client.auth.headers = AsyncMock(  # type: ignore
+        return_value={"Authorization": "Bearer test"}
+    )
+
+    entity_client.auth.integration_type = "test-integration"
+    entity_client.auth.integration_identifier = "test-identifier"
+    entity_client.auth.api_url = "https://api.getport.io/v1"
+
+    mock_user_agent_type = MagicMock()
+    mock_user_agent_type.value = "sync"
+    before = "2026-03-03T12:00:00+00:00"
+
+    await entity_client.search_entities(
+        user_agent_type=mock_user_agent_type,
+        query=None,
+        before=before,
+    )
+
+    call_args = entity_client.client.post.call_args
+    sent_json = call_args[1]["json"]
+    assert sent_json["before"] == before
+
+
 async def test_search_entities_uses_datasource_route_when_query_is_none_two_pages(
     entity_client: EntityClientMixin,
 ) -> None:

--- a/port_ocean/tests/clients/port/mixins/test_entities.py
+++ b/port_ocean/tests/clients/port/mixins/test_entities.py
@@ -281,54 +281,6 @@ async def test_search_entities_uses_datasource_route_when_query_is_none_two_page
     assert second_sent_json["datasource_suffix"] == "/test-identifier/sync"
 
 
-async def test_search_entities_query_uses_before_field_from_updated_at_rule(
-    entity_client: EntityClientMixin,
-) -> None:
-    """Test that query search uses datasource route with updatedAt before filter."""
-    mock_response = MagicMock()
-    mock_response.json.return_value = {"entities": [], "next": None}
-    mock_response.is_error = False
-    mock_response.status_code = 200
-    mock_response.headers = {}
-    entity_client.client.post = AsyncMock(return_value=mock_response)  # type: ignore
-    entity_client.auth.headers = AsyncMock(return_value={"Authorization": "Bearer test"})  # type: ignore
-
-    entity_client.auth.integration_type = "test-integration"
-    entity_client.auth.integration_identifier = "test-identifier"
-    entity_client.auth.api_url = "https://api.getport.io/v1"
-
-    mock_user_agent_type = MagicMock()
-    mock_user_agent_type.value = "sync"
-    updated_at_from = "2026-03-03T12:00:00+00:00"
-    query = {
-        "combinator": "and",
-        "rules": [
-            {
-                "property": "$updatedAt",
-                "operator": "notBetween",
-                "value": {"from": updated_at_from, "to": "2026-03-03T12:00:05+00:00"},
-            }
-        ],
-    }
-
-    await entity_client.search_entities(
-        user_agent_type=mock_user_agent_type,
-        query=query,
-    )
-
-    entity_client.client.post.assert_called_once()
-    call_args = entity_client.client.post.call_args
-    assert (
-        call_args[0][0]
-        == "https://api.getport.io/v1/blueprints/entities/datasource-entities"
-    )
-
-    sent_json = call_args[1]["json"]
-    assert sent_json["datasource_prefix"] == "port-ocean/test-integration/"
-    assert sent_json["datasource_suffix"] == "/test-identifier/sync"
-    assert sent_json["before"] == updated_at_from
-
-
 async def test_upsert_entities_in_batches_with_dictionary_identifier(
     entity_client: EntityClientMixin,
 ) -> None:

--- a/port_ocean/tests/clients/port/mixins/test_entities.py
+++ b/port_ocean/tests/clients/port/mixins/test_entities.py
@@ -281,6 +281,54 @@ async def test_search_entities_uses_datasource_route_when_query_is_none_two_page
     assert second_sent_json["datasource_suffix"] == "/test-identifier/sync"
 
 
+async def test_search_entities_query_uses_before_field_from_updated_at_rule(
+    entity_client: EntityClientMixin,
+) -> None:
+    """Test that query search uses datasource route with updatedAt before filter."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"entities": [], "next": None}
+    mock_response.is_error = False
+    mock_response.status_code = 200
+    mock_response.headers = {}
+    entity_client.client.post = AsyncMock(return_value=mock_response)  # type: ignore
+    entity_client.auth.headers = AsyncMock(return_value={"Authorization": "Bearer test"})  # type: ignore
+
+    entity_client.auth.integration_type = "test-integration"
+    entity_client.auth.integration_identifier = "test-identifier"
+    entity_client.auth.api_url = "https://api.getport.io/v1"
+
+    mock_user_agent_type = MagicMock()
+    mock_user_agent_type.value = "sync"
+    updated_at_from = "2026-03-03T12:00:00+00:00"
+    query = {
+        "combinator": "and",
+        "rules": [
+            {
+                "property": "$updatedAt",
+                "operator": "notBetween",
+                "value": {"from": updated_at_from, "to": "2026-03-03T12:00:05+00:00"},
+            }
+        ],
+    }
+
+    await entity_client.search_entities(
+        user_agent_type=mock_user_agent_type,
+        query=query,
+    )
+
+    entity_client.client.post.assert_called_once()
+    call_args = entity_client.client.post.call_args
+    assert (
+        call_args[0][0]
+        == "https://api.getport.io/v1/blueprints/entities/datasource-entities"
+    )
+
+    sent_json = call_args[1]["json"]
+    assert sent_json["datasource_prefix"] == "port-ocean/test-integration/"
+    assert sent_json["datasource_suffix"] == "/test-identifier/sync"
+    assert sent_json["before"] == updated_at_from
+
+
 async def test_upsert_entities_in_batches_with_dictionary_identifier(
     entity_client: EntityClientMixin,
 ) -> None:

--- a/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
+++ b/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
@@ -6,7 +6,6 @@ from port_ocean.core.utils.entity_topological_sorter import EntityTopologicalSor
 from port_ocean.exceptions.core import OceanAbortException
 import pytest
 from unittest.mock import MagicMock, AsyncMock, patch
-import builtins
 from port_ocean.ocean import Ocean
 from port_ocean.context.ocean import PortOceanContext
 from port_ocean.core.handlers.port_app_config.models import (
@@ -1255,46 +1254,28 @@ async def test_reconciliation_search_entities_uses_resync_start_time_filter(
     mock_sync_raw_mixin: SyncRawMixin,
     mock_ocean: Ocean,
 ) -> None:
-    """Reconciliation must fetch entities from Port with updatedAt notBetween resync_start_time and now.
+    """Reconciliation must fetch entities from Port before resync_start_time.
 
     This guards against the race where live events create/update entities during a resync:
     those entities have updatedAt after resync_start_time and must be excluded from the
     delete diff so they are not incorrectly deleted.
     """
-    resync_start_time = datetime(2026, 3, 3, 12, 0, 0, tzinfo=timezone.utc)
+
+    class FixedDatetime(datetime):
+        @classmethod
+        def now(cls, tz: Any = None) -> "FixedDatetime":
+            return cls(2026, 3, 3, 12, 0, 0, tzinfo=tz)
+
+    resync_start_time = FixedDatetime(2026, 3, 3, 12, 0, 0, tzinfo=timezone.utc)
     mock_ocean.port_client.search_entities = AsyncMock(return_value=[])  # type: ignore
     mock_sync_raw_mixin.sort_and_upsert_failed_entities = AsyncMock()  # type: ignore
 
-    mock_dt = MagicMock(spec=datetime)
-    mock_dt.now.return_value = resync_start_time
-
-    def isinstance_accepts_mock_dt(
-        obj: object, type_or_tuple: type | tuple[type, ...]
-    ) -> bool:
-        if type_or_tuple is mock_dt and isinstance(obj, datetime):
-            return True
-        return builtins.isinstance(obj, type_or_tuple)
-
-    with (
-        patch("port_ocean.core.integrations.mixins.sync_raw.datetime", mock_dt),
-        patch(
-            "port_ocean.core.integrations.mixins.sync_raw.isinstance",
-            isinstance_accepts_mock_dt,
-        ),
-    ):
+    with patch("port_ocean.core.integrations.mixins.sync_raw.datetime", FixedDatetime):
         await mock_sync_raw_mixin.sync_raw_all()
 
     mock_ocean.port_client.search_entities.assert_called_once()
     call_args = mock_ocean.port_client.search_entities.call_args
-    query = call_args.args[1]
-    assert query["combinator"] == "and"
-    rules = query["rules"]
-    assert len(rules) == 1
-    rule = rules[0]
-    assert rule["property"] == "$updatedAt"
-    assert rule["operator"] == "notBetween"
-    assert rule["value"]["from"] == resync_start_time.isoformat()
-    assert "to" in rule["value"]
+    assert call_args.kwargs["before"] == resync_start_time.isoformat()
 
 
 # ---------------------------------------------------------------------------

--- a/port_ocean/tests/helpers/fake_port_api.py
+++ b/port_ocean/tests/helpers/fake_port_api.py
@@ -60,6 +60,11 @@ async def search_entities() -> Dict[str, Any]:
     return {"ok": True, "entities": []}
 
 
+@app.router.post("/v1/blueprints/entities/datasource-entities")
+async def datasource_entities() -> Dict[str, Any]:
+    return {"ok": True, "entities": [], "next": None}
+
+
 @app.router.get("/v1/integration/{integration_id}")
 @app.router.patch("/v1/integration/{integration_id}")
 @app.router.patch("/v1/integration/{integration_id}/resync-state")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.43.1"
+version = "0.43.2"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.43.0"
+version = "0.43.1"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.43.1"
+version = "0.43.0"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

Implemented a safer resync reconciliation flow by fetching entities via the datasource pagination endpoint with a before filter set to resync_start_time.
This prevents entities updated during resync from being treated as stale and accidentally deleted, + fix reconcillion failing when the catalog has more than 1M entities.
## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
