### PR TITLE
[Integration][Custom] Support `lastPagePath` for page pagination

### DIFF
--- a/integrations/custom/.port/spec.yaml
+++ b/integrations/custom/.port/spec.yaml
@@ -142,6 +142,16 @@ configurations:
           in: ["offset", "page", "cursor"]
         then:
           required: false
+  - name: lastPagePath
+    required: false
+    type: string
+    description: "Dot-notation path to a boolean field where truthy means 'this is the last page' (e.g., Spring Data REST 'data.last'). Inverted semantics vs hasMorePath. If both are set, hasMorePath takes precedence."
+    dependencies:
+      - on: paginationType
+        when:
+          equals: page
+        then:
+          required: false
   - name: nextLinkPath
     required: false
     type: string

--- a/integrations/custom/.port/spec.yaml
+++ b/integrations/custom/.port/spec.yaml
@@ -220,6 +220,7 @@ interface:
         - startPage
         - cursorPath
         - hasMorePath
+        - lastPagePath
         - nextLinkPath
         - headerLinkRel
         - timeout

--- a/integrations/custom/CHANGELOG.md
+++ b/integrations/custom/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.6.34 (2026-05-28)
+
+
+### Improvements
+
+- Added `lastPagePath` config for page pagination to support inverted stop signals (e.g. Spring `data.last`)
+
+
 ## 0.6.33 (2026-05-28)
 
 

--- a/integrations/custom/README.md
+++ b/integrations/custom/README.md
@@ -114,7 +114,7 @@ OCEAN__INTEGRATION__CONFIG__PAGE_SIZE=100
 OCEAN__INTEGRATION__CONFIG__OFFSET_PARAM=offset    # Default: "offset"
 OCEAN__INTEGRATION__CONFIG__LIMIT_PARAM=limit      # Default: "limit"
 
-# Optional: Custom parameter names for page pagination  
+# Optional: Custom parameter names for page pagination
 OCEAN__INTEGRATION__CONFIG__PAGE_PARAM=page        # Default: "page"
 OCEAN__INTEGRATION__CONFIG__SIZE_PARAM=size        # Default: "size"
 OCEAN__INTEGRATION__CONFIG__START_PAGE=1           # Default: 1
@@ -122,6 +122,24 @@ OCEAN__INTEGRATION__CONFIG__START_PAGE=1           # Default: 1
 # Optional: Custom parameter names for cursor pagination
 OCEAN__INTEGRATION__CONFIG__CURSOR_PARAM=cursor    # Default: "cursor"
 OCEAN__INTEGRATION__CONFIG__LIMIT_PARAM=limit      # Default: "limit"
+
+# Optional: Pagination stop signals
+OCEAN__INTEGRATION__CONFIG__HAS_MORE_PATH=meta.has_more    # Truthy = more pages (default semantics)
+OCEAN__INTEGRATION__CONFIG__LAST_PAGE_PATH=data.last       # Truthy = STOP (inverted, for Spring/Harness APIs)
+```
+
+#### Spring Data REST / Harness example
+
+For APIs returning `{ "data": { "content": [...], "last": false, "number": 0 } }`:
+
+```bash
+OCEAN__INTEGRATION__CONFIG__PAGINATION_TYPE=page
+OCEAN__INTEGRATION__CONFIG__PAGINATION_PARAM=page
+OCEAN__INTEGRATION__CONFIG__SIZE_PARAM=size
+OCEAN__INTEGRATION__CONFIG__START_PAGE=0          # Spring is 0-based
+OCEAN__INTEGRATION__CONFIG__PAGE_SIZE=10
+OCEAN__INTEGRATION__CONFIG__LAST_PAGE_PATH=data.last
+# In port-app-config per resource: data_path: .data.content
 ```
 
 ### Optional Configuration
@@ -302,7 +320,7 @@ GET /api/v1/users?offset=50&limit=50
 # ... continues until no more data
 ```
 
-### Page/Size Pagination  
+### Page/Size Pagination
 ```yaml
 # Integration config:
 OCEAN__INTEGRATION__CONFIG__PAGINATION_TYPE=page
@@ -311,7 +329,7 @@ OCEAN__INTEGRATION__CONFIG__START_PAGE=1
 
 # Requests made:
 GET /api/v1/users?page=1&size=25
-GET /api/v1/users?page=2&size=25  
+GET /api/v1/users?page=2&size=25
 # ... continues until no more data
 ```
 
@@ -455,7 +473,7 @@ resources:
 
 ### Custom Project Management Tool
 ```yaml
-# Integration config  
+# Integration config
 OCEAN__INTEGRATION__CONFIG__BASE_URL=https://projects.internal.com
 OCEAN__INTEGRATION__CONFIG__AUTH_TYPE=api_key
 OCEAN__INTEGRATION__CONFIG__API_KEY=proj-key-456
@@ -490,7 +508,7 @@ OCEAN__INTEGRATION__CONFIG__USERNAME=api_user
 OCEAN__INTEGRATION__CONFIG__PASSWORD=api_pass
 OCEAN__INTEGRATION__CONFIG__PAGINATION_TYPE=none
 
-# Resource mapping  
+# Resource mapping
 resources:
   - kind: api_resource
     selector:
@@ -558,7 +576,7 @@ poetry run python debug.py
 ### Adding New Features
 The integration follows standard Ocean patterns:
 - Authentication logic in `http_server/client.py`
-- Configuration models in `integration.py` 
+- Configuration models in `integration.py`
 - Resync handlers in `main.py`
 - Client factory in `initialize_client.py`
 
@@ -603,12 +621,6 @@ This will show:
 
 For issues or questions:
 1. Check the [Ocean Integration Documentation](https://ocean.getport.io/)
-2. Review API logs for detailed error information  
+2. Review API logs for detailed error information
 3. Test endpoints manually to verify API behavior
 4. Contact Port support with integration logs
-
-
-
-
-
-

--- a/integrations/custom/http_server/handlers.py
+++ b/integrations/custom/http_server/handlers.py
@@ -38,7 +38,7 @@ def _dict_response_has_next(
         if value is not None:
             return bool(value)
 
-    if last_page_path and not has_more_path:
+    if last_page_path:
         value = get_nested_value(response_data, last_page_path)
         if value is not None:
             return not bool(value)

--- a/integrations/custom/http_server/handlers.py
+++ b/integrations/custom/http_server/handlers.py
@@ -15,6 +15,37 @@ import httpx
 # ============================================================================
 
 
+def _dict_response_has_next(
+    response_data: Dict[str, Any],
+    config: Dict[str, Any],
+    get_nested_value: Callable[[Dict[str, Any], str], Any],
+    *,
+    default_has_next: Callable[[Dict[str, Any]], bool],
+) -> bool:
+    """Determine whether more pages exist. Precedence:
+
+    - has_more_path: truthy resolved value means continue.
+    - last_page_path: truthy resolved value means stop (inverted).
+    - default_has_next: handler-specific heuristic fallback.
+
+    None (missing field) at any path falls through to the next check.
+    """
+    has_more_path = config.get("has_more_path", "")
+    last_page_path = config.get("last_page_path", "")
+
+    if has_more_path:
+        value = get_nested_value(response_data, has_more_path)
+        if value is not None:
+            return bool(value)
+
+    if last_page_path and not has_more_path:
+        value = get_nested_value(response_data, last_page_path)
+        if value is not None:
+            return not bool(value)
+
+    return default_has_next(response_data)
+
+
 class PaginationHandler:
     """Base class for pagination handlers"""
 
@@ -86,9 +117,15 @@ class PagePagination(PaginationHandler):
         page_param = self.config.get("pagination_param", "page")
         size_param = self.config.get("size_param", "size")
         start_page = int(self.config.get("start_page", 1))
-        has_more_path = self.config.get("has_more_path", "")
 
         page = start_page
+
+        def _page_default_has_next(data: Dict[str, Any]) -> bool:
+            return (
+                data.get("next_page") is not None
+                or data.get("next") is not None
+                or data.get("hasMore", False)
+            )
 
         while True:
             current_params = {
@@ -107,14 +144,12 @@ class PagePagination(PaginationHandler):
 
             # Check for next page
             if isinstance(response_data, dict):
-                if has_more_path:
-                    has_next = self.get_nested_value(response_data, has_more_path)
-                else:
-                    has_next = (
-                        response_data.get("next_page") is not None
-                        or response_data.get("next") is not None
-                        or response_data.get("hasMore", False)
-                    )
+                has_next = _dict_response_has_next(
+                    response_data,
+                    self.config,
+                    self.get_nested_value,
+                    default_has_next=_page_default_has_next,
+                )
                 if not has_next:
                     break
             else:

--- a/integrations/custom/pyproject.toml
+++ b/integrations/custom/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "custom"
-version = "0.6.33"
+version = "0.6.34"
 description = "Ocean Custom Integration"
 authors = ["Port Team <support@getport.io>"]
 

--- a/integrations/custom/tests/test_pagination_handlers.py
+++ b/integrations/custom/tests/test_pagination_handlers.py
@@ -7,6 +7,7 @@ import pytest
 from http_server.handlers import (
     NextLinkPagination,
     HeaderLinkPagination,
+    PagePagination,
     get_pagination_handler,
     PAGINATION_HANDLERS,
 )
@@ -261,6 +262,24 @@ class TestPaginationHandlerRegistry:
         )
         assert isinstance(handler, NonePagination)
 
+    def test_page_in_registry(self) -> None:
+        """Test that page pagination type is registered"""
+        assert "page" in PAGINATION_HANDLERS
+        assert PAGINATION_HANDLERS["page"] == PagePagination
+
+    def test_get_pagination_handler_page(self) -> None:
+        """Test get_pagination_handler returns PagePagination for page type"""
+        mock_client = MagicMock()
+        handler = get_pagination_handler(
+            pagination_type="page",
+            client=mock_client,
+            config={},
+            extract_items_fn=MagicMock(),
+            make_request_fn=MagicMock(),
+            get_nested_value_fn=MagicMock(),
+        )
+        assert isinstance(handler, PagePagination)
+
     def test_header_link_in_registry(self) -> None:
         """Test that header_link pagination type is registered"""
         assert "header_link" in PAGINATION_HANDLERS
@@ -441,6 +460,352 @@ class TestHeaderLinkPagination:
         handler = HeaderLinkPagination(
             client=mock_client,
             config={"header_link_rel": "nextPage"},
+            extract_items_fn=mock_extract_items,
+            make_request_fn=mock_make_request,
+            get_nested_value_fn=mock_get_nested_value,
+        )
+
+        results: List[List[Dict[str, Any]]] = []
+        async for batch in handler.fetch_all(
+            url="https://api.example.com/items",
+            method="GET",
+            params={},
+            headers={},
+        ):
+            results.append(batch)
+
+        assert len(results) == 2
+
+
+class TestPagePagination:
+    """Test cases for PagePagination handler"""
+
+    @pytest.fixture
+    def mock_client(self) -> MagicMock:
+        return MagicMock()
+
+    @pytest.fixture
+    def mock_extract_items(self) -> MagicMock:
+        return MagicMock(
+            side_effect=lambda data: data if isinstance(data, list) else [data]
+        )
+
+    @pytest.fixture
+    def mock_get_nested_value(self) -> MagicMock:
+        def _get_nested(data: Dict[str, Any], path: str) -> Any:
+            keys = path.split(".")
+            value: Any = data
+            for key in keys:
+                if isinstance(value, dict):
+                    value = value.get(key)
+                else:
+                    return None
+            return value
+
+        return MagicMock(side_effect=_get_nested)
+
+    async def test_spring_envelope_multi_page(
+        self,
+        mock_client: MagicMock,
+        mock_extract_items: MagicMock,
+        mock_get_nested_value: MagicMock,
+    ) -> None:
+        """Test Spring Data REST style with data.last: false/false/true"""
+        page1 = {
+            "status": "SUCCESS",
+            "data": {
+                "content": [{"id": "1"}, {"id": "2"}],
+                "totalPages": 3,
+                "last": False,
+                "number": 0,
+                "size": 10,
+            },
+        }
+        page2 = {
+            "status": "SUCCESS",
+            "data": {
+                "content": [{"id": "3"}, {"id": "4"}],
+                "totalPages": 3,
+                "last": False,
+                "number": 1,
+                "size": 10,
+            },
+        }
+        page3 = {
+            "status": "SUCCESS",
+            "data": {
+                "content": [{"id": "5"}],
+                "totalPages": 3,
+                "last": True,
+                "number": 2,
+                "size": 10,
+            },
+        }
+
+        responses = [page1, page2, page3]
+        response_index = 0
+        captured_params: List[Optional[Dict[str, Any]]] = []
+
+        async def mock_make_request(
+            url: str,
+            method: str,
+            params: Optional[Dict[str, Any]],
+            headers: Dict[str, str],
+            body: Optional[Dict[str, Any]] = None,
+        ) -> MagicMock:
+            nonlocal response_index
+            captured_params.append(params)
+            mock_response = MagicMock()
+            mock_response.json.return_value = responses[response_index]
+            response_index += 1
+            return mock_response
+
+        handler = PagePagination(
+            client=mock_client,
+            config={
+                "pagination_param": "page",
+                "size_param": "size",
+                "start_page": "0",
+                "page_size": "10",
+                "last_page_path": "data.last",
+            },
+            extract_items_fn=mock_extract_items,
+            make_request_fn=mock_make_request,
+            get_nested_value_fn=mock_get_nested_value,
+        )
+
+        results: List[List[Dict[str, Any]]] = []
+        async for batch in handler.fetch_all(
+            url="https://api.example.com/items",
+            method="GET",
+            params={},
+            headers={},
+        ):
+            results.append(batch)
+
+        assert len(results) == 3
+        assert results[0] == [page1]
+        assert results[1] == [page2]
+        assert results[2] == [page3]
+
+        assert captured_params[0] == {"page": 0, "size": 10}
+        assert captured_params[1] == {"page": 1, "size": 10}
+        assert captured_params[2] == {"page": 2, "size": 10}
+
+    async def test_default_heuristic(
+        self,
+        mock_client: MagicMock,
+        mock_extract_items: MagicMock,
+        mock_get_nested_value: MagicMock,
+    ) -> None:
+        """Test default heuristic with hasMore: true then false"""
+        page1 = {"items": [{"id": "1"}], "hasMore": True}
+        page2 = {"items": [{"id": "2"}], "hasMore": False}
+
+        responses = [page1, page2]
+        response_index = 0
+
+        async def mock_make_request(
+            url: str,
+            method: str,
+            params: Optional[Dict[str, Any]],
+            headers: Dict[str, str],
+            body: Optional[Dict[str, Any]] = None,
+        ) -> MagicMock:
+            nonlocal response_index
+            mock_response = MagicMock()
+            mock_response.json.return_value = responses[response_index]
+            response_index += 1
+            return mock_response
+
+        handler = PagePagination(
+            client=mock_client,
+            config={"page_size": "10"},
+            extract_items_fn=mock_extract_items,
+            make_request_fn=mock_make_request,
+            get_nested_value_fn=mock_get_nested_value,
+        )
+
+        results: List[List[Dict[str, Any]]] = []
+        async for batch in handler.fetch_all(
+            url="https://api.example.com/items",
+            method="GET",
+            params={},
+            headers={},
+        ):
+            results.append(batch)
+
+        assert len(results) == 2
+
+    async def test_has_more_path_regression(
+        self,
+        mock_client: MagicMock,
+        mock_extract_items: MagicMock,
+        mock_get_nested_value: MagicMock,
+    ) -> None:
+        """Test has_more_path still works (regression)"""
+        page1 = {"data": {"has_more": True, "items": [{"id": "1"}]}}
+        page2 = {"data": {"has_more": False, "items": [{"id": "2"}]}}
+
+        responses = [page1, page2]
+        response_index = 0
+
+        async def mock_make_request(
+            url: str,
+            method: str,
+            params: Optional[Dict[str, Any]],
+            headers: Dict[str, str],
+            body: Optional[Dict[str, Any]] = None,
+        ) -> MagicMock:
+            nonlocal response_index
+            mock_response = MagicMock()
+            mock_response.json.return_value = responses[response_index]
+            response_index += 1
+            return mock_response
+
+        handler = PagePagination(
+            client=mock_client,
+            config={"page_size": "10", "has_more_path": "data.has_more"},
+            extract_items_fn=mock_extract_items,
+            make_request_fn=mock_make_request,
+            get_nested_value_fn=mock_get_nested_value,
+        )
+
+        results: List[List[Dict[str, Any]]] = []
+        async for batch in handler.fetch_all(
+            url="https://api.example.com/items",
+            method="GET",
+            params={},
+            headers={},
+        ):
+            results.append(batch)
+
+        assert len(results) == 2
+
+    async def test_has_more_path_takes_precedence(
+        self,
+        mock_client: MagicMock,
+        mock_extract_items: MagicMock,
+        mock_get_nested_value: MagicMock,
+    ) -> None:
+        """Test has_more_path wins when both has_more_path and last_page_path are set"""
+        page1 = {"data": {"has_more": True, "last": True}, "items": [{"id": "1"}]}
+        page2 = {"data": {"has_more": False, "last": False}, "items": [{"id": "2"}]}
+
+        responses = [page1, page2]
+        response_index = 0
+
+        async def mock_make_request(
+            url: str,
+            method: str,
+            params: Optional[Dict[str, Any]],
+            headers: Dict[str, str],
+            body: Optional[Dict[str, Any]] = None,
+        ) -> MagicMock:
+            nonlocal response_index
+            mock_response = MagicMock()
+            mock_response.json.return_value = responses[response_index]
+            response_index += 1
+            return mock_response
+
+        handler = PagePagination(
+            client=mock_client,
+            config={
+                "page_size": "10",
+                "has_more_path": "data.has_more",
+                "last_page_path": "data.last",
+            },
+            extract_items_fn=mock_extract_items,
+            make_request_fn=mock_make_request,
+            get_nested_value_fn=mock_get_nested_value,
+        )
+
+        results: List[List[Dict[str, Any]]] = []
+        async for batch in handler.fetch_all(
+            url="https://api.example.com/items",
+            method="GET",
+            params={},
+            headers={},
+        ):
+            results.append(batch)
+
+        # has_more_path wins: page1 has_more=True -> continue, page2 has_more=False -> stop
+        assert len(results) == 2
+
+    async def test_missing_last_field_falls_through(
+        self,
+        mock_client: MagicMock,
+        mock_extract_items: MagicMock,
+        mock_get_nested_value: MagicMock,
+    ) -> None:
+        """Test that missing last_page_path field falls through to defaults"""
+        page1 = {"data": {"items": [{"id": "1"}]}, "hasMore": True}
+        page2 = {"data": {"items": [{"id": "2"}]}, "hasMore": False}
+
+        responses = [page1, page2]
+        response_index = 0
+
+        async def mock_make_request(
+            url: str,
+            method: str,
+            params: Optional[Dict[str, Any]],
+            headers: Dict[str, str],
+            body: Optional[Dict[str, Any]] = None,
+        ) -> MagicMock:
+            nonlocal response_index
+            mock_response = MagicMock()
+            mock_response.json.return_value = responses[response_index]
+            response_index += 1
+            return mock_response
+
+        handler = PagePagination(
+            client=mock_client,
+            config={"page_size": "10", "last_page_path": "data.last"},
+            extract_items_fn=mock_extract_items,
+            make_request_fn=mock_make_request,
+            get_nested_value_fn=mock_get_nested_value,
+        )
+
+        results: List[List[Dict[str, Any]]] = []
+        async for batch in handler.fetch_all(
+            url="https://api.example.com/items",
+            method="GET",
+            params={},
+            headers={},
+        ):
+            results.append(batch)
+
+        assert len(results) == 2
+
+    async def test_has_more_path_missing_field_falls_through(
+        self,
+        mock_client: MagicMock,
+        mock_extract_items: MagicMock,
+        mock_get_nested_value: MagicMock,
+    ) -> None:
+        """Test that missing has_more_path field falls through to defaults"""
+        page1 = {"items": [{"id": "1"}], "hasMore": True}
+        page2 = {"items": [{"id": "2"}], "hasMore": False}
+
+        responses = [page1, page2]
+        response_index = 0
+
+        async def mock_make_request(
+            url: str,
+            method: str,
+            params: Optional[Dict[str, Any]],
+            headers: Dict[str, str],
+            body: Optional[Dict[str, Any]] = None,
+        ) -> MagicMock:
+            nonlocal response_index
+            mock_response = MagicMock()
+            mock_response.json.return_value = responses[response_index]
+            response_index += 1
+            return mock_response
+
+        handler = PagePagination(
+            client=mock_client,
+            config={"page_size": "10", "has_more_path": "data.has_more"},
             extract_items_fn=mock_extract_items,
             make_request_fn=mock_make_request,
             get_nested_value_fn=mock_get_nested_value,


### PR DESCRIPTION
# Description

What
- Add lastPagePath / last_page_path integration config for page and offset pagination in the custom Ocean integration.
- Introduce shared _dict_response_has_next() in integrations/custom/http_server/handlers.py with tri-state semantics (None vs False vs True).
- Wire the helper into PagePagination.
- Document Spring/Harness-style setup in spec.yaml, README.md, and CHANGELOG.md (version bump).
- Add unit tests for PagePagination and registry coverage.

Why
-Customers using page pagination against Spring Data REST–style APIs (e.g. Harness) expose data.last where false means more pages and true means stop. The existing hasMorePath treats truthy as “continue,” so has_more_path=data.last stops after the first page. There is no supported way to express “stop when this field is true.”

How
- last_page_path: dot-notation path where a truthy value means last page → stop; continuation is has_next = not bool(value).
- has_more_path: unchanged semantics (truthy → continue); takes precedence when both are set.
- Missing path (None): fall through to existing defaults instead of terminating early (also fixes has_more_path configured but absent stopping after one page).
- Customer config example:
    - paginationType=page, lastPagePath=data.last, startPage=0, pageSize=10
    - Resource `data_path`: .data.content


## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [x] Handled pagination
- [x] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

- [Spring Data REST pagination](https://docs.spring.io/spring-data/rest/reference/paging-and-sorting.html)
- Customer-reported Harness API envelope (status, data.content, data.last, data.totalPages, data.number)
