### PR TITLE
[Core] fix DSP lifecycle URL inference from logAttributes.ingestUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.43.4 (2026-05-29)
+
+### Bug Fixes
+
+- Fixed DSP lifecycle URL: derive ingest host from `OCEAN__PORT__BASE_URL` (EU/US static map) at construction time. Removes the runtime Port API fetch introduced in 0.43.3 and the resulting 404 on `/v1/lifecycle` paths.
+
 ## 0.43.3 (2026-05-27)
 
 ### Improvements

--- a/port_ocean/clients/dsp/lifecycle.py
+++ b/port_ocean/clients/dsp/lifecycle.py
@@ -16,9 +16,13 @@ US_PORT_API_BASE = "https://api.us.getport.io"
 EU_LIFECYCLE_INGEST_URL = "https://ingest.getport.io"
 US_LIFECYCLE_INGEST_URL = "https://ingest.us.getport.io"
 
+LOCAL_PORT_API_BASE = "http://api.localhost:9080"
+LOCAL_LIFECYCLE_INGEST_URL = "http://ingest.localhost:9080"
+
 _PORT_API_TO_LIFECYCLE_INGEST: dict[str, str] = {
     EU_PORT_API_BASE: EU_LIFECYCLE_INGEST_URL,
     US_PORT_API_BASE: US_LIFECYCLE_INGEST_URL,
+    LOCAL_PORT_API_BASE: LOCAL_LIFECYCLE_INGEST_URL,
 }
 
 
@@ -30,6 +34,8 @@ def resolve_lifecycle_ingest_url(port_api_base_url: str) -> str:
     normalized = port_api_base_url.rstrip("/")
     if normalized in _PORT_API_TO_LIFECYCLE_INGEST:
         return _PORT_API_TO_LIFECYCLE_INGEST[normalized]
+    if "api.localhost" in normalized:
+        return LOCAL_LIFECYCLE_INGEST_URL
     logger.warning(
         f"Unrecognised Port API base URL {port_api_base_url!r}; "
         f"defaulting lifecycle ingest URL to {EU_LIFECYCLE_INGEST_URL}"

--- a/port_ocean/clients/dsp/lifecycle.py
+++ b/port_ocean/clients/dsp/lifecycle.py
@@ -1,20 +1,42 @@
 import asyncio
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, TypedDict
+from typing import Any
 
 import httpx
 from loguru import logger
 
 from port_ocean.clients.port.authentication import PortAuthentication
-from port_ocean.clients.port.utils import handle_port_status_code
+from port_ocean.context.ocean import ocean
 from port_ocean.helpers.async_client import OceanAsyncClient
 from port_ocean.helpers.retry import RetryConfig
+from port_ocean.helpers.ssl import resolve_verify_param
 from port_ocean.version import __integration_version__, __version__
+
+EU_PORT_API_BASE = "https://api.getport.io"
+US_PORT_API_BASE = "https://api.us.getport.io"
+EU_LIFECYCLE_INGEST_URL = "https://ingest.getport.io"
+US_LIFECYCLE_INGEST_URL = "https://ingest.us.getport.io"
+
+_PORT_API_TO_LIFECYCLE_INGEST: dict[str, str] = {
+    EU_PORT_API_BASE: EU_LIFECYCLE_INGEST_URL,
+    US_PORT_API_BASE: US_LIFECYCLE_INGEST_URL,
+}
 
 
 def _truncate(text: str, max_len: int = 256) -> str:
     return text if len(text) <= max_len else text[:max_len] + "…"
+
+
+def resolve_lifecycle_ingest_url(port_api_base_url: str) -> str:
+    normalized = port_api_base_url.rstrip("/")
+    if normalized in _PORT_API_TO_LIFECYCLE_INGEST:
+        return _PORT_API_TO_LIFECYCLE_INGEST[normalized]
+    logger.warning(
+        f"Unrecognised Port API base URL {port_api_base_url!r}; "
+        f"defaulting lifecycle ingest URL to {EU_LIFECYCLE_INGEST_URL}"
+    )
+    return EU_LIFECYCLE_INGEST_URL
 
 
 class OceanResyncHttpClient(OceanAsyncClient):
@@ -24,6 +46,7 @@ class OceanResyncHttpClient(OceanAsyncClient):
         self._lifecycle_auth = auth
         super().__init__(
             timeout=timeout,
+            verify=resolve_verify_param(ocean.config.ssl.port),
             retry_config=RetryConfig(
                 retryable_methods=[
                     "POST",
@@ -71,64 +94,12 @@ class GranularityType(Enum):
     RECONCILIATION = "RECONCILIATION"
 
 
-class LogAttributes(TypedDict):
-    ingestUrl: str
-
-
 class LifecycleClient(OceanResyncHttpClient):
     """Client for the integration-life-cycle service."""
 
-    def __init__(
-        self,
-        auth: PortAuthentication,
-        integration_identifier: str | None = None,
-        base_url: str | None = None,
-    ) -> None:
-        self.integration_identifier = integration_identifier
-        self._lifecycle_base_url = base_url.rstrip("/") if base_url else None
-        self._log_attributes: LogAttributes | None = None
+    def __init__(self, base_url: str, auth: PortAuthentication) -> None:
+        self._lifecycle_base_url = base_url.rstrip("/")
         super().__init__(auth=auth)
-
-    async def get_log_attributes(self) -> LogAttributes | None:
-        if self._log_attributes is None:
-            try:
-                headers = await self._lifecycle_auth.headers()
-                response = await self.get(
-                    f"{self._lifecycle_auth.api_url}/integration/{self.integration_identifier}",
-                    headers=headers,
-                )
-                handle_port_status_code(response)
-                integration = response.json().get("integration", {})
-                log_attributes: LogAttributes | None = integration.get("logAttributes")
-                if log_attributes:
-                    self._log_attributes = log_attributes
-            except asyncio.CancelledError:
-                raise
-            except Exception as exc:
-                logger.error(f"Failed to get log attributes from Port API: {exc}")
-                self._log_attributes = None
-        return self._log_attributes
-
-    async def get_lifecycle_base_url(self) -> str:
-        if self._lifecycle_base_url is None:
-            try:
-                log_attributes = await self.get_log_attributes()
-                if log_attributes:
-                    ingest_url = log_attributes.get("ingestUrl")
-                    if ingest_url:
-                        self._lifecycle_base_url = ingest_url.rstrip("/")
-                    else:
-                        logger.warning("ingestUrl not found in log attributes")
-                        self._lifecycle_base_url = ""
-                else:
-                    logger.error("No log attributes available")
-                    self._lifecycle_base_url = ""
-            except asyncio.CancelledError:
-                raise
-            except Exception as exc:
-                logger.error(f"Failed to infer lifecycle base URL: {exc}")
-                self._lifecycle_base_url = ""
-        return self._lifecycle_base_url
 
     def _build_body(self, status: str, **extra: Any) -> dict[str, Any]:
         return {"status": status, **extra}
@@ -148,7 +119,6 @@ class LifecycleClient(OceanResyncHttpClient):
         integration_type: str,
         started_at: datetime | None = None,
     ) -> None:
-        await self.get_lifecycle_base_url()
         started_at = started_at or datetime.now(tz=timezone.utc)
         body = self._build_body(
             "started",
@@ -164,7 +134,6 @@ class LifecycleClient(OceanResyncHttpClient):
     async def notify_resync_finished(
         self, resync_id: str, integration_id: str, integration_type: str
     ) -> None:
-        await self.get_lifecycle_base_url()
         body = self._build_body(
             "finished",
             integration_id=integration_id,
@@ -178,7 +147,6 @@ class LifecycleClient(OceanResyncHttpClient):
     async def notify_resync_failed(
         self, resync_id: str, integration_id: str, integration_type: str
     ) -> None:
-        await self.get_lifecycle_base_url()
         body = self._build_body("failed")
         logger.info(f"Notifying lifecycle API resync failed, resync_id={resync_id}")
         await self._do_post(self._resync_url(resync_id), json=body)
@@ -186,7 +154,6 @@ class LifecycleClient(OceanResyncHttpClient):
     async def notify_resync_aborted(
         self, resync_id: str, integration_id: str, integration_type: str
     ) -> None:
-        await self.get_lifecycle_base_url()
         body = self._build_body("aborted")
         logger.info(f"Notifying lifecycle API resync aborted, resync_id={resync_id}")
         await self._do_post(self._resync_url(resync_id), json=body)
@@ -215,7 +182,6 @@ class LifecycleClient(OceanResyncHttpClient):
         started_at: datetime | None = None,
         kind_identifier: str | None = None,
     ) -> None:
-        await self.get_lifecycle_base_url()
         started_at = started_at or datetime.now(tz=timezone.utc)
         body = self._build_granular_body(
             "started",
@@ -236,7 +202,6 @@ class LifecycleClient(OceanResyncHttpClient):
         granularity: GranularityType,
         kind_identifier: str | None = None,
     ) -> None:
-        await self.get_lifecycle_base_url()
         body = self._build_granular_body(
             "finished", kind_identifier, integration_type=integration_type
         )
@@ -251,7 +216,6 @@ class LifecycleClient(OceanResyncHttpClient):
         granularity: GranularityType,
         kind_identifier: str | None = None,
     ) -> None:
-        await self.get_lifecycle_base_url()
         body = self._build_granular_body("failed", kind_identifier)
         logger.info(
             f"Notifying lifecycle API for status=failed granularity={granularity.value}"
@@ -264,7 +228,6 @@ class LifecycleClient(OceanResyncHttpClient):
         granularity: GranularityType,
         kind_identifier: str | None = None,
     ) -> None:
-        await self.get_lifecycle_base_url()
         body = self._build_granular_body("aborted", kind_identifier)
         logger.info(
             f"Notifying lifecycle API for status=aborted granularity={granularity.value}"

--- a/port_ocean/clients/dsp/lifecycle.py
+++ b/port_ocean/clients/dsp/lifecycle.py
@@ -7,10 +7,8 @@ import httpx
 from loguru import logger
 
 from port_ocean.clients.port.authentication import PortAuthentication
-from port_ocean.context.ocean import ocean
 from port_ocean.helpers.async_client import OceanAsyncClient
 from port_ocean.helpers.retry import RetryConfig
-from port_ocean.helpers.ssl import resolve_verify_param
 from port_ocean.version import __integration_version__, __version__
 
 EU_PORT_API_BASE = "https://api.getport.io"
@@ -46,7 +44,6 @@ class OceanResyncHttpClient(OceanAsyncClient):
         self._lifecycle_auth = auth
         super().__init__(
             timeout=timeout,
-            verify=resolve_verify_param(ocean.config.ssl.port),
             retry_config=RetryConfig(
                 retryable_methods=[
                     "POST",

--- a/port_ocean/ocean.py
+++ b/port_ocean/ocean.py
@@ -13,7 +13,10 @@ import port_ocean.helpers.metric.metric
 from port_ocean.cache.base import CacheProvider
 from port_ocean.cache.disk import DiskCacheProvider
 from port_ocean.cache.memory import InMemoryCacheProvider
-from port_ocean.clients.dsp.lifecycle import LifecycleClient
+from port_ocean.clients.dsp.lifecycle import (
+    LifecycleClient,
+    resolve_lifecycle_ingest_url,
+)
 from port_ocean.clients.port.client import PortClient
 from port_ocean.config.settings import IntegrationConfiguration
 from port_ocean.context.ocean import (
@@ -111,7 +114,7 @@ class Ocean:
             self.port_client, self.config.scheduled_resync_interval
         )
         self.lifecycle_client: LifecycleClient = LifecycleClient(
-            integration_identifier=self.config.integration.identifier,
+            base_url=resolve_lifecycle_ingest_url(str(self.config.port.base_url)),
             auth=self.port_client.auth,
         )
         self.app_initialized = False

--- a/port_ocean/tests/clients/test_lifecycle_client.py
+++ b/port_ocean/tests/clients/test_lifecycle_client.py
@@ -593,6 +593,25 @@ class TestResolveLifecycleIngestUrl:
             == "http://ingest.localhost:9080"
         )
 
+    def test_local_api_base_url_with_trailing_slash(self) -> None:
+        assert (
+            resolve_lifecycle_ingest_url("http://api.localhost:9080/")
+            == "http://ingest.localhost:9080"
+        )
+
+    def test_local_resolver_wires_through_lifecycle_client(self) -> None:
+        client = LifecycleClient(
+            base_url=resolve_lifecycle_ingest_url("http://api.localhost:9080"),
+            auth=MagicMock(),
+        )
+        assert (
+            client._resync_url("r1") == "http://ingest.localhost:9080/v1/lifecycle/r1"
+        )
+        assert (
+            client._granular_url("e1", GranularityType.KIND)
+            == "http://ingest.localhost:9080/v1/lifecycle/e1/kind"
+        )
+
     def test_resolver_wires_through_lifecycle_client(self) -> None:
         client = LifecycleClient(
             base_url=resolve_lifecycle_ingest_url("https://api.us.getport.io"),

--- a/port_ocean/tests/clients/test_lifecycle_client.py
+++ b/port_ocean/tests/clients/test_lifecycle_client.py
@@ -10,19 +10,13 @@ from port_ocean.clients.dsp.lifecycle import (
     LifecycleClient,
     resolve_lifecycle_ingest_url,
 )
-from port_ocean.config.settings import SslClientSettings
 from port_ocean.helpers.retry import RetryTransport
 
 
 @pytest.fixture(autouse=True)
 def mock_ocean_context() -> Generator[MagicMock, None, None]:
-    mock_ocean = MagicMock()
-    mock_ocean.app.is_saas = MagicMock(return_value=False)
-    mock_ocean.config.ssl.port = SslClientSettings()
-    with (
-        patch("port_ocean.helpers.async_client.ocean", new=mock_ocean),
-        patch("port_ocean.clients.dsp.lifecycle.ocean", new=mock_ocean),
-    ):
+    with patch("port_ocean.helpers.async_client.ocean") as mock_ocean:
+        mock_ocean.app.is_saas = MagicMock(return_value=False)
         yield mock_ocean
 
 
@@ -131,11 +125,15 @@ class TestNotifyResyncStarted:
     async def test_defaults_started_at(
         self, lifecycle_client: LifecycleClient, mock_post: AsyncMock
     ) -> None:
+        before = datetime.now(tz=timezone.utc)
         await lifecycle_client.notify_resync_started(
             resync_id="r1", integration_id="i1", integration_type="github"
         )
+        after = datetime.now(tz=timezone.utc)
+
         body = mock_post.call_args[1]["json"]
-        assert "started_at" in body
+        started_at = datetime.fromisoformat(body["started_at"])
+        assert before <= started_at <= after
 
     @pytest.mark.asyncio
     async def test_swallows_exception(
@@ -261,19 +259,6 @@ class TestNotifyGranularStarted:
         assert "event_id" not in body
 
     @pytest.mark.asyncio
-    async def test_reconciliation_uses_granular_url(
-        self, lifecycle_client: LifecycleClient, mock_post: AsyncMock
-    ) -> None:
-        await lifecycle_client.notify_started(
-            event_id="r1",
-            integration_id="i1",
-            integration_type="github",
-            granularity=GranularityType.RECONCILIATION,
-        )
-        url = mock_post.call_args[0][0]
-        assert url == "http://localhost:3017/v1/lifecycle/r1/reconciliation"
-
-    @pytest.mark.asyncio
     async def test_kind_identifier_included_when_provided(
         self, lifecycle_client: LifecycleClient, mock_post: AsyncMock
     ) -> None:
@@ -302,91 +287,6 @@ class TestNotifyGranularStarted:
 
 
 class TestLifecycleClientIntegration:
-    @pytest.mark.asyncio
-    async def test_notify_finished_includes_versions(
-        self, lifecycle_client: LifecycleClient, mock_post: AsyncMock
-    ) -> None:
-        await lifecycle_client.notify_resync_finished(
-            resync_id="r1", integration_id="i1", integration_type="github"
-        )
-        body = mock_post.call_args[1]["json"]
-        assert "integration_version" in body
-        assert "ocean_version" in body
-
-    @pytest.mark.asyncio
-    async def test_notify_failed_minimal_body(
-        self, lifecycle_client: LifecycleClient, mock_post: AsyncMock
-    ) -> None:
-        await lifecycle_client.notify_resync_failed(
-            resync_id="r1", integration_id="i1", integration_type="github"
-        )
-        body = mock_post.call_args[1]["json"]
-        assert body == {"status": "failed"}
-
-    @pytest.mark.asyncio
-    async def test_notify_finished_granular(
-        self, lifecycle_client: LifecycleClient, mock_post: AsyncMock
-    ) -> None:
-        await lifecycle_client.notify_finished(
-            event_id="e1",
-            integration_type="github",
-            granularity=GranularityType.BATCH,
-        )
-        url = mock_post.call_args[0][0]
-        assert url == "http://localhost:3017/v1/lifecycle/e1/batch"
-        body = mock_post.call_args[1]["json"]
-        assert body["status"] == "finished"
-        assert body["integration_type"] == "github"
-
-    @pytest.mark.asyncio
-    async def test_notify_failed_granular(
-        self, lifecycle_client: LifecycleClient, mock_post: AsyncMock
-    ) -> None:
-        await lifecycle_client.notify_failed(
-            event_id="e1",
-            granularity=GranularityType.LIVE_EVENT,
-        )
-        url = mock_post.call_args[0][0]
-        assert url == "http://localhost:3017/v1/lifecycle/e1/live_event"
-        body = mock_post.call_args[1]["json"]
-        assert body["status"] == "failed"
-
-    @pytest.mark.asyncio
-    async def test_notify_aborted_granular(
-        self, lifecycle_client: LifecycleClient, mock_post: AsyncMock
-    ) -> None:
-        await lifecycle_client.notify_aborted(
-            event_id="e1",
-            granularity=GranularityType.KIND,
-            kind_identifier="service-123",
-        )
-        url = mock_post.call_args[0][0]
-        assert url == "http://localhost:3017/v1/lifecycle/e1/kind"
-        body = mock_post.call_args[1]["json"]
-        assert body["status"] == "aborted"
-        assert body["kind_identifier"] == "service-123"
-
-    @pytest.mark.asyncio
-    async def test_base_url_normalization(self, mock_auth: MagicMock) -> None:
-        # Test with trailing slash
-        client = LifecycleClient(base_url="http://localhost:3017/", auth=mock_auth)
-        assert client._resync_url("r1") == "http://localhost:3017/v1/lifecycle/r1"
-
-    @pytest.mark.asyncio
-    async def test_started_at_defaults_to_now(
-        self, lifecycle_client: LifecycleClient, mock_post: AsyncMock
-    ) -> None:
-        before = datetime.now(tz=timezone.utc)
-        await lifecycle_client.notify_resync_started(
-            resync_id="r1", integration_id="i1", integration_type="github"
-        )
-        after = datetime.now(tz=timezone.utc)
-
-        body = mock_post.call_args[1]["json"]
-        started_at = datetime.fromisoformat(body["started_at"])
-
-        assert before <= started_at <= after
-
     @pytest.mark.asyncio
     async def test_granular_started_at_defaults(
         self, lifecycle_client: LifecycleClient, mock_post: AsyncMock
@@ -686,3 +586,17 @@ class TestResolveLifecycleIngestUrl:
             result = resolve_lifecycle_ingest_url("https://api.custom.example.com")
             assert result == "https://ingest.getport.io"
             mock_logger.warning.assert_called_once()
+
+    def test_resolver_wires_through_lifecycle_client(self) -> None:
+        client = LifecycleClient(
+            base_url=resolve_lifecycle_ingest_url("https://api.us.getport.io"),
+            auth=MagicMock(),
+        )
+        assert (
+            client._resync_url("r1")
+            == "https://ingest.us.getport.io/v1/lifecycle/r1"
+        )
+        assert (
+            client._granular_url("e1", GranularityType.KIND)
+            == "https://ingest.us.getport.io/v1/lifecycle/e1/kind"
+        )

--- a/port_ocean/tests/clients/test_lifecycle_client.py
+++ b/port_ocean/tests/clients/test_lifecycle_client.py
@@ -593,8 +593,7 @@ class TestResolveLifecycleIngestUrl:
             auth=MagicMock(),
         )
         assert (
-            client._resync_url("r1")
-            == "https://ingest.us.getport.io/v1/lifecycle/r1"
+            client._resync_url("r1") == "https://ingest.us.getport.io/v1/lifecycle/r1"
         )
         assert (
             client._granular_url("e1", GranularityType.KIND)

--- a/port_ocean/tests/clients/test_lifecycle_client.py
+++ b/port_ocean/tests/clients/test_lifecycle_client.py
@@ -5,14 +5,24 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 
-from port_ocean.clients.dsp.lifecycle import GranularityType, LifecycleClient
+from port_ocean.clients.dsp.lifecycle import (
+    GranularityType,
+    LifecycleClient,
+    resolve_lifecycle_ingest_url,
+)
+from port_ocean.config.settings import SslClientSettings
 from port_ocean.helpers.retry import RetryTransport
 
 
 @pytest.fixture(autouse=True)
 def mock_ocean_context() -> Generator[MagicMock, None, None]:
-    with patch("port_ocean.helpers.async_client.ocean") as mock_ocean:
-        mock_ocean.app.is_saas = MagicMock(return_value=False)
+    mock_ocean = MagicMock()
+    mock_ocean.app.is_saas = MagicMock(return_value=False)
+    mock_ocean.config.ssl.port = SslClientSettings()
+    with (
+        patch("port_ocean.helpers.async_client.ocean", new=mock_ocean),
+        patch("port_ocean.clients.dsp.lifecycle.ocean", new=mock_ocean),
+    ):
         yield mock_ocean
 
 
@@ -658,76 +668,21 @@ class TestRetryBehavior:
         mock_logger.warning.assert_called_once()
 
 
-class TestDynamicIngestUrl:
-    @pytest.mark.asyncio
-    async def test_get_log_attributes(self, mock_auth: MagicMock) -> None:
-        client = LifecycleClient(integration_identifier="test-int", auth=mock_auth)
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.json = MagicMock(
-            return_value={
-                "integration": {
-                    "logAttributes": {"ingestUrl": "https://ingest.port.io"}
-                }
-            }
+class TestResolveLifecycleIngestUrl:
+    def test_eu_base_url(self) -> None:
+        assert (
+            resolve_lifecycle_ingest_url("https://api.getport.io")
+            == "https://ingest.getport.io"
         )
 
-        with patch.object(
-            client, "get", new=AsyncMock(return_value=mock_response)
-        ) as mock_get:
-            log_attrs = await client.get_log_attributes()
-            assert log_attrs == {"ingestUrl": "https://ingest.port.io"}
-            mock_get.assert_called_once_with(
-                f"{mock_auth.api_url}/integration/test-int",
-                headers={"Authorization": "Bearer test-token"},
-            )
-
-    @pytest.mark.asyncio
-    async def test_get_lifecycle_base_url_dynamic(self, mock_auth: MagicMock) -> None:
-        client = LifecycleClient(integration_identifier="test-int", auth=mock_auth)
-        mock_response = MagicMock(spec=httpx.Response)
-        mock_response.status_code = 200
-        mock_response.json = MagicMock(
-            return_value={
-                "integration": {
-                    "logAttributes": {"ingestUrl": "https://ingest.port.io/"}
-                }
-            }
+    def test_us_base_url(self) -> None:
+        assert (
+            resolve_lifecycle_ingest_url("https://api.us.getport.io")
+            == "https://ingest.us.getport.io"
         )
 
-        with patch.object(client, "get", new=AsyncMock(return_value=mock_response)):
-            base_url = await client.get_lifecycle_base_url()
-            assert base_url == "https://ingest.port.io"
-            # verify cache works
-            base_url_cached = await client.get_lifecycle_base_url()
-            assert base_url_cached == "https://ingest.port.io"
-
-    @pytest.mark.asyncio
-    async def test_get_log_attributes_error_handling(
-        self, mock_auth: MagicMock
-    ) -> None:
-        client = LifecycleClient(integration_identifier="test-int", auth=mock_auth)
-        with (
-            patch.object(
-                client, "get", new=AsyncMock(side_effect=httpx.HTTPError("API error"))
-            ),
-            patch("port_ocean.clients.dsp.lifecycle.logger") as mock_logger,
-        ):
-            log_attrs = await client.get_log_attributes()
-            assert log_attrs is None
-            mock_logger.error.assert_called_once()
-
-    @pytest.mark.asyncio
-    async def test_get_lifecycle_base_url_error_handling(
-        self, mock_auth: MagicMock
-    ) -> None:
-        client = LifecycleClient(integration_identifier="test-int", auth=mock_auth)
-        with (
-            patch.object(
-                client, "get", new=AsyncMock(side_effect=Exception("Parsing error"))
-            ),
-            patch("port_ocean.clients.dsp.lifecycle.logger") as mock_logger,
-        ):
-            base_url = await client.get_lifecycle_base_url()
-            assert base_url == ""
-            mock_logger.error.assert_called()
+    def test_unknown_url_defaults_to_eu_with_warning(self) -> None:
+        with patch("port_ocean.clients.dsp.lifecycle.logger") as mock_logger:
+            result = resolve_lifecycle_ingest_url("https://api.custom.example.com")
+            assert result == "https://ingest.getport.io"
+            mock_logger.warning.assert_called_once()

--- a/port_ocean/tests/clients/test_lifecycle_client.py
+++ b/port_ocean/tests/clients/test_lifecycle_client.py
@@ -587,6 +587,12 @@ class TestResolveLifecycleIngestUrl:
             assert result == "https://ingest.getport.io"
             mock_logger.warning.assert_called_once()
 
+    def test_local_api_base_url_maps_to_ingest_localhost(self) -> None:
+        assert (
+            resolve_lifecycle_ingest_url("http://api.localhost:9080")
+            == "http://ingest.localhost:9080"
+        )
+
     def test_resolver_wires_through_lifecycle_client(self) -> None:
         client = LifecycleClient(
             base_url=resolve_lifecycle_ingest_url("https://api.us.getport.io"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.43.3"
+version = "0.43.4"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
Derive the ingest host root from Port API log ingest URLs so lifecycle events post to /v1/lifecycle instead of a nested /logs/integration path. Use the Port auth client for the integration lookup (ssl.port profile) and fall back to OCEAN__PORT__INGEST_URL when inference fails. Bump to 0.43.4.

# Description

What -

Why -

How -

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
