### PR TITLE
[Integration][Checkmarx-one] Ignored and skip 500s for checkmarx RC and added more visible colums

### DIFF
--- a/integrations/checkmarx-one/CHANGELOG.md
+++ b/integrations/checkmarx-one/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
-## 0.3.0-rc3 (2026-05-08)
+## 0.3.0-rc4 (2026-06-08)
 
 
 ### Improvements

--- a/integrations/checkmarx-one/CHANGELOG.md
+++ b/integrations/checkmarx-one/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
-## 0.3.0-rc5 (2026-06-18)
+## 0.3.0-rc4 (2026-06-18)
 
 
 ### Improvements

--- a/integrations/checkmarx-one/CHANGELOG.md
+++ b/integrations/checkmarx-one/CHANGELOG.md
@@ -7,11 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
-## 0.3.0-rc4 (2026-06-08)
+## 0.3.0-rc5 (2026-06-18)
 
 
 ### Improvements
 
+- Added `BFL`, `cvss-score`, and `notes-json` to SAST `visible-columns` request.
 - Added `latestScansOnly` selector to `scanFilter` which syncs only the latest completed scan per `project + branch`, preventing stale findings from older scans.
 - Added `__branch` to all finding payloads (SAST, KICS, SCA, containers, API security) for use in custom mappings.
 - Webhook processors now populate `deleted_raw_results` with previous scan findings when `latestScansOnly=true`, keeping live events in sync with resync behaviour.

--- a/integrations/checkmarx-one/checkmarx_one/clients/client.py
+++ b/integrations/checkmarx-one/checkmarx_one/clients/client.py
@@ -35,6 +35,11 @@ class CheckmarxOneClient:
             message="Resource not found at endpoint",
         ),
         IgnoredError(
+            status=500,
+            message="Internal Server Error — Checkmarx API server error, skipping resource",
+            type="INTERNAL_SERVER_ERROR",
+        ),
+        IgnoredError(
             status=502,
             message="Bad Gateway — transient upstream error",
             type="BAD_GATEWAY",
@@ -223,6 +228,8 @@ class CheckmarxOneClient:
 
             try:
                 response = await self.send_api_request(endpoint, params=page_params)
+                if not response:
+                    break
                 has_next_page = response.get("has_next", False)
                 next_page_number = response["next_page_number"]
                 items: List[dict[str, Any]] = response.get(

--- a/integrations/checkmarx-one/checkmarx_one/utils.py
+++ b/integrations/checkmarx-one/checkmarx_one/utils.py
@@ -51,6 +51,9 @@ def sast_visible_columns() -> List[str]:
         "status",
         "state",
         "nodes",
+        "BFL",
+        "cvss-score",
+        "notes-json",
     ]
 
 

--- a/integrations/checkmarx-one/pyproject.toml
+++ b/integrations/checkmarx-one/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "checkmarx-one"
-version = "0.3.0-rc3"
+version = "0.3.0-rc4"
 description = "An integration for checkmarx project, scan and scan results types"
 authors = ["victor adebayo <victor.adebayo@port.io>", "Chukwuemeka Nwaoma <joelchukks@gmail.com>"]
 

--- a/integrations/checkmarx-one/pyproject.toml
+++ b/integrations/checkmarx-one/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "checkmarx-one"
-version = "0.3.0-rc4"
+version = "0.3.0-rc5"
 description = "An integration for checkmarx project, scan and scan results types"
 authors = ["victor adebayo <victor.adebayo@port.io>", "Chukwuemeka Nwaoma <joelchukks@gmail.com>"]
 

--- a/integrations/checkmarx-one/pyproject.toml
+++ b/integrations/checkmarx-one/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "checkmarx-one"
-version = "0.3.0-rc5"
+version = "0.3.0-rc4"
 description = "An integration for checkmarx project, scan and scan results types"
 authors = ["victor adebayo <victor.adebayo@port.io>", "Chukwuemeka Nwaoma <joelchukks@gmail.com>"]
 

--- a/integrations/checkmarx-one/tests/checkmarx_one/clients/test_base_client.py
+++ b/integrations/checkmarx-one/tests/checkmarx_one/clients/test_base_client.py
@@ -179,15 +179,31 @@ class TestCheckmarxOneClient:
                 await client.send_api_request("/test-endpoint")
 
     @pytest.mark.asyncio
-    async def test_send_api_request_other_http_error(
-        self, client: CheckmarxOneClient
-    ) -> None:
-        """Test API request with other HTTP error."""
+    async def test_send_api_request_500_error(self, client: CheckmarxOneClient) -> None:
+        """Test API request with 500 error is ignored."""
         mock_response = MagicMock()
         mock_response.status_code = 500
         mock_response.text = "Internal Server Error"
         mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
             "500 Internal Server Error", request=MagicMock(), response=mock_response
+        )
+
+        with patch("checkmarx_one.clients.client.http_async_client") as mock_client:
+            mock_client.request = AsyncMock(return_value=mock_response)
+            result = await client.send_api_request("/test-endpoint")
+
+            assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_send_api_request_other_http_error(
+        self, client: CheckmarxOneClient
+    ) -> None:
+        """Test API request with non-ignored HTTP error."""
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.text = "Bad Request"
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "400 Bad Request", request=MagicMock(), response=mock_response
         )
 
         with patch("checkmarx_one.clients.client.http_async_client") as mock_client:

--- a/integrations/checkmarx-one/tests/checkmarx_one/core/exporters/test_sast_exporter.py
+++ b/integrations/checkmarx-one/tests/checkmarx_one/core/exporters/test_sast_exporter.py
@@ -79,6 +79,9 @@ class TestCheckmarxSastExporter:
                 "status",
                 "state",
                 "nodes",
+                "BFL",
+                "cvss-score",
+                "notes-json",
             ],
         }
 
@@ -207,6 +210,9 @@ class TestCheckmarxSastExporter:
                 "status",
                 "state",
                 "nodes",
+                "BFL",
+                "cvss-score",
+                "notes-json",
             ],
         }
 
@@ -278,7 +284,7 @@ class TestCheckmarxSastExporter:
 
         assert params["scan-id"] == "different-scan-456"
         assert "visible-columns" in params
-        assert len(params["visible-columns"]) == 18  # All expected columns (18, not 19)
+        assert len(params["visible-columns"]) == 21
 
     def test_visible_columns_includes_scan_id(
         self, exporter: CheckmarxSastExporter
@@ -327,6 +333,9 @@ class TestCheckmarxSastExporter:
             "status",
             "state",
             "nodes",
+            "BFL",
+            "cvss-score",
+            "notes-json",
         ]
 
         for field in expected_fields:


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Ignore Checkmarx API 500s and stop API-sec pagination on empty responses
<code>🐞 Bug fix</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

# Description

What -

Why -

How -

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Treat Checkmarx One HTTP 500s as ignorable to avoid sync failures.
• Stop API Security pagination when ignored errors yield empty responses.
• Improve resilience against transient Checkmarx server-side errors.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["Integration sync"] --> B["CheckmarxOneClient"] --> C["send_api_request()"] --> D["Checkmarx One API"]
  C --> E["Ignored errors (incl. 500)"] --> F["Return empty {}"] --> G["API-sec pagination stops"]
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Retry 500s with bounded backoff before ignoring</b></summary>

- ➕ Recovers from transient 500s without dropping data
- ➕ More observable: can log retries and final failure
- ➖ Adds latency to sync loops
- ➖ Needs careful limits to avoid rate-limit amplification

</details>

<details>
<summary><b>2. Make ignored status codes configurable per environment</b></summary>

- ➕ Allows stricter behavior in production and leniency in RC/test
- ➕ Reduces risk of masking real server-side issues permanently
- ➖ Adds configuration surface area and documentation burden
- ➖ Potential for misconfiguration across deployments

</details>

<details>
<summary><b>3. Return a structured sentinel (e.g., None/Error object) instead of {}</b></summary>

- ➕ Forces callers to handle &#x27;ignored&#x27; vs &#x27;empty data&#x27; explicitly
- ➕ Reduces ambiguity between a legitimate empty response and an ignored error
- ➖ Requires broader refactor across call sites
- ➖ Higher risk of breaking existing pagination consumers

</details>

**Recommendation:** The PR’s approach is pragmatic given known Checkmarx-side 500s: adding 500 to the ignored list aligns with existing handling for 502/503, and the pagination guard prevents downstream KeyError behavior when an ignored error yields {}. If data completeness becomes a concern, consider adding a bounded retry for 500s (or making ignored statuses configurable) as a follow-up.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>client.py</strong> <code>Ignore HTTP 500s and break API-sec pagination on empty responses</code> <code>+7/-0</code></summary>

<br/>

>Ignore HTTP 500s and break API-sec pagination on empty responses
>
><pre>
>• Adds HTTP 500 to the client’s default ignored errors so transient Checkmarx server errors are logged and skipped. Updates the API Security pagination loop to exit when the API response is empty (e.g., when an ignored error returns {}).
></pre>
>
><a href='https://github.com/port-labs/ocean/pull/3355/files#diff-7408e192bf759e54170a4433b33a93368642bc089f78f18ad1304648bf45fee3'>integrations/checkmarx-one/checkmarx_one/clients/client.py</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>