### PR TITLE
[Integration][Jira] Add support for project components

### DIFF
--- a/integrations/jira/CHANGELOG.md
+++ b/integrations/jira/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.7.41 (2026-06-11)
+
+
+### Improvements
+
+- Added support `component` kind, enabling syncing of project components into Port with issue counts, lead assignments, and assignee routing configuration.
+
+
 ## 0.7.40 (2026-06-11)
 
 

--- a/integrations/jira/CHANGELOG.md
+++ b/integrations/jira/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
-- Added support `component` kind, enabling syncing of project components into Port with issue counts, lead assignments, and assignee routing configuration.
+- Added support for the `component` kind, enabling syncing of project components into Port with issue counts, lead assignments, and assignee routing configuration.
 
 
 ## 0.7.40 (2026-06-11)

--- a/integrations/jira/jira/client.py
+++ b/integrations/jira/jira/client.py
@@ -407,15 +407,11 @@ class JiraClient(OAuthClient):
         ]
 
     @staticmethod
-    def _enrich_with_project_key(
-        components: list[dict[str, Any]], project_key: str
+    def _enrich_with_project(
+        entities: list[dict[str, Any]], project: dict[str, Any]
     ) -> list[dict[str, Any]]:
-        """Inject ``__projectKey`` into each component for relation mapping."""
-        return [
-            {**component, "__projectKey": project_key}
-            for component in components
-            if component.get("id")
-        ]
+        """Inject ``__project`` into each entity in the list for relation mapping."""
+        return [{**entity, "__project": project} for entity in entities]
 
     @staticmethod
     def _validate_existing_webhook(
@@ -979,7 +975,7 @@ class JiraClient(OAuthClient):
 
     async def get_paginated_components_for_project(
         self,
-        project_key: str,
+        project: dict[str, Any],
         component_source: ComponentSource,
         name_filter: str | None = None,
     ) -> AsyncGenerator[list[dict[str, Any]], None]:
@@ -987,10 +983,12 @@ class JiraClient(OAuthClient):
         params: dict[str, Any] = {"componentSource": component_source}
         if name_filter is not None:
             params["query"] = name_filter
-
+        # key would be present, any case it isn't, the API would return an error
+        # which is fine since we require the key to fetch components
+        project_key = project["key"]
         async for batch in self._get_paginated_data(
             f"{self.api_url}/project/{project_key}/component",
             "values",
             initial_params=params,
         ):
-            yield self._enrich_with_project_key(batch, project_key)
+            yield self._enrich_with_project(batch, project)

--- a/integrations/jira/jira/client.py
+++ b/integrations/jira/jira/client.py
@@ -7,7 +7,11 @@ import re
 from httpx import Auth, BasicAuth, Request, Response, Timeout
 from loguru import logger
 
-from jira.overrides import JiraEpicAPIQueryParams, JiraWorklogAPIQueryParams
+from jira.overrides import (
+    JiraEpicAPIQueryParams,
+    JiraWorklogAPIQueryParams,
+    ComponentSource,
+)
 from port_ocean.clients.auth.oauth_client import OAuthClient
 from port_ocean.context.ocean import ocean
 from port_ocean.helpers.async_client import OceanAsyncClient
@@ -400,6 +404,17 @@ class JiraClient(OAuthClient):
         """Inject ``__boardId`` to each entity in the list for later relation mapping."""
         return [
             {**entity, "__boardId": board_id} for entity in entities if entity.get("id")
+        ]
+
+    @staticmethod
+    def _enrich_with_project_key(
+        components: list[dict[str, Any]], project_key: str
+    ) -> list[dict[str, Any]]:
+        """Inject ``__projectKey`` into each component for relation mapping."""
+        return [
+            {**component, "__projectKey": project_key}
+            for component in components
+            if component.get("id")
         ]
 
     @staticmethod
@@ -961,3 +976,21 @@ class JiraClient(OAuthClient):
             url, "worklogs", initial_params=query_params
         ):
             yield [{**worklog, "__issueKey": issue_key} for worklog in batch]
+
+    async def get_paginated_components_for_project(
+        self,
+        project_key: str,
+        component_source: ComponentSource,
+        name_filter: str | None = None,
+    ) -> AsyncGenerator[list[dict[str, Any]], None]:
+        """Yield paginated component batches for a single Jira project."""
+        params: dict[str, Any] = {"componentSource": component_source}
+        if name_filter is not None:
+            params["query"] = name_filter
+
+        async for batch in self._get_paginated_data(
+            f"{self.api_url}/project/{project_key}/component",
+            "values",
+            initial_params=params,
+        ):
+            yield self._enrich_with_project_key(batch, project_key)

--- a/integrations/jira/jira/overrides.py
+++ b/integrations/jira/jira/overrides.py
@@ -326,9 +326,9 @@ class JiraComponentSelector(Selector):
         default=ComponentSource.JIRA,
         description=(
             "Filter by component source. "
-            "'JIRA' returns standard project components, "
-            "'COMPASS' returns Compass global components linked to this project, "
-            "'AUTO' returns both. "
+            "'jira' returns standard project components, "
+            "'compass' returns Compass global components linked to this project, "
+            "'auto' returns both. "
         ),
     )
     name_filter: str | None = Field(

--- a/integrations/jira/jira/overrides.py
+++ b/integrations/jira/jira/overrides.py
@@ -1,3 +1,4 @@
+from enum import StrEnum
 from typing import Literal
 from pydantic import Field, validator, BaseModel
 
@@ -308,6 +309,47 @@ class JiraWorklogResourceConfig(ResourceConfig):
     )
 
 
+class ComponentSource(StrEnum):
+    JIRA = "jira"
+    COMPASS = "compass"
+    AUTO = "auto"
+
+
+class JiraComponentSelector(Selector):
+    component_source: Literal[
+        ComponentSource.JIRA,
+        ComponentSource.COMPASS,
+        ComponentSource.AUTO,
+    ] = Field(
+        alias="componentSource",
+        title="Component Source",
+        default=ComponentSource.JIRA,
+        description=(
+            "Filter by component source. "
+            "'JIRA' returns standard project components, "
+            "'COMPASS' returns Compass global components linked to this project, "
+            "'AUTO' returns both. "
+        ),
+    )
+    name_filter: str | None = Field(
+        default=None,
+        alias="nameFilter",
+        title="Name Filter",
+        description="Filter components by name or description prefix.",
+    )
+
+
+class JiraComponentResourceConfig(ResourceConfig):
+    kind: Literal["component"] = Field(
+        title="Jira Component",
+        description="Jira component resource kind, representing components within Jira projects.",
+    )
+    selector: JiraComponentSelector = Field(
+        title="Component Selector",
+        description="Selector for Jira component resources.",
+    )
+
+
 class JiraPortAppConfig(PortAppConfig):
     resources: list[
         TeamResourceConfig
@@ -320,6 +362,7 @@ class JiraPortAppConfig(PortAppConfig):
         | JiraBacklogResourceConfig
         | JiraEpicResourceConfig
         | JiraWorklogResourceConfig
+        | JiraComponentResourceConfig
     ] = Field(
         default_factory=list
     )  # type: ignore[assignment]

--- a/integrations/jira/kinds.py
+++ b/integrations/jira/kinds.py
@@ -12,3 +12,4 @@ class Kinds(StrEnum):
     BACKLOG = "backlog"
     EPIC = "epic"
     WORKLOG = "worklog"
+    COMPONENT = "component"

--- a/integrations/jira/main.py
+++ b/integrations/jira/main.py
@@ -20,6 +20,7 @@ from jira.overrides import (
     JiraSprintResourceConfig,
     JiraBacklogResourceConfig,
     JiraEpicResourceConfig,
+    JiraComponentResourceConfig,
 )
 from webhook_processors.issue_webhook_processor import IssueWebhookProcessor
 from webhook_processors.project_webhook_processor import ProjectWebhookProcessor
@@ -217,6 +218,24 @@ async def on_resync_worklogs(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
         ]
         async for worklog_batch in stream_async_iterators_tasks(*worklog_streams):
             yield worklog_batch
+
+
+@ocean.on_resync(Kinds.COMPONENT)
+async def on_resync_components(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
+    client = get_or_create_jira_client()
+    selector = cast(JiraComponentResourceConfig, event.resource_config).selector
+
+    async for projects_batch in client.get_paginated_projects():
+        component_streams = [
+            client.get_paginated_components_for_project(
+                project["key"],
+                selector.component_source,
+                name_filter=selector.name_filter,
+            )
+            for project in projects_batch
+        ]
+        async for component_batch in stream_async_iterators_tasks(*component_streams):
+            yield component_batch
 
 
 # Called once when the integration starts.

--- a/integrations/jira/main.py
+++ b/integrations/jira/main.py
@@ -228,7 +228,7 @@ async def on_resync_components(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     async for projects_batch in client.get_paginated_projects():
         component_streams = [
             client.get_paginated_components_for_project(
-                project["key"],
+                project,
                 selector.component_source,
                 name_filter=selector.name_filter,
             )

--- a/integrations/jira/pyproject.toml
+++ b/integrations/jira/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jira"
-version = "0.7.40"
+version = "0.7.41"
 description = "Integration to bring information from Jira into Port"
 authors = ["Mor Paz <mor@getport.io>"]
 

--- a/integrations/jira/pyproject.toml
+++ b/integrations/jira/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jira"
-version = "0.7.41"
+version = "0.7.42"
 description = "Integration to bring information from Jira into Port"
 authors = ["Mor Paz <mor@getport.io>"]
 

--- a/integrations/jira/tests/test_client.py
+++ b/integrations/jira/tests/test_client.py
@@ -2812,29 +2812,6 @@ class TestGetPaginatedComponentsForProject:
             assert component["componentBean"] is None
             assert component["__projectKey"] == "PROJECTKEY"
 
-    async def test_excludes_components_without_id(
-        self, mock_jira_client: JiraClient
-    ) -> None:
-        component_without_id = {"name": "Orphaned", "description": "No ID field"}
-        with patch.object(
-            mock_jira_client, "_send_api_request", new_callable=AsyncMock
-        ) as mock_req:
-            mock_req.return_value = {
-                "startAt": 0,
-                "maxResults": 50,
-                "total": 1,
-                "isLast": True,
-                "values": [MOCK_COMPONENT_WITH_ISSUE_COUNT, component_without_id],
-            }
-            results = []
-            async for batch in mock_jira_client.get_paginated_components_for_project(
-                "HSP", ComponentSource.JIRA
-            ):
-                results.extend(batch)
-
-            assert len(results) == 1
-            assert results[0]["id"] == "10000"
-
     async def test_yields_nothing_when_project_has_no_components(
         self, mock_jira_client: JiraClient
     ) -> None:

--- a/integrations/jira/tests/test_client.py
+++ b/integrations/jira/tests/test_client.py
@@ -19,6 +19,7 @@ from jira.client import (
     JiraClient,
 )
 from jira.overrides import JiraIssueSelector
+from jira.overrides import ComponentSource
 
 
 MOCK_BOARD_API_RESPONSE = {
@@ -228,6 +229,87 @@ MOCK_EPIC_DONE = {
     "name": "MVP",
     "summary": "MVP",
     "done": True,
+}
+
+MOCK_COMPONENT_LEAD = {
+    "accountId": "5b10a2844c20165700ede21g",
+    "accountType": "atlassian",
+    "active": False,
+    "displayName": "Mia Krystof",
+    "key": "",
+    "name": "",
+    "self": "https://your-domain.atlassian.net/rest/api/2/user?accountId=5b10a2844c20165700ede21g",
+    "avatarUrls": {
+        "16x16": "https://avatar-management--avatars.server-location.prod.public.atl-paas.net/initials/MK-5.png?size=16&s=16",
+        "24x24": "https://avatar-management--avatars.server-location.prod.public.atl-paas.net/initials/MK-5.png?size=24&s=24",
+        "32x32": "https://avatar-management--avatars.server-location.prod.public.atl-paas.net/initials/MK-5.png?size=32&s=32",
+        "48x48": "https://avatar-management--avatars.server-location.prod.public.atl-paas.net/initials/MK-5.png?size=48&s=48",
+    },
+}
+
+MOCK_COMPONENT_WITH_ISSUE_COUNT = {
+    "id": "10000",
+    "name": "Component 1",
+    "description": "This is a Jira component",
+    "assigneeType": "PROJECT_LEAD",
+    "isAssigneeTypeValid": False,
+    "issueCount": 1,
+    "project": "HSP",
+    "projectId": 10000,
+    "realAssigneeType": "PROJECT_LEAD",
+    "self": "https://your-domain.atlassian.net/rest/api/2/component/10000",
+    "lead": MOCK_COMPONENT_LEAD,
+    "assignee": MOCK_COMPONENT_LEAD,
+    "realAssignee": MOCK_COMPONENT_LEAD,
+    "componentBean": {
+        "ari": "ari:cloud:compass:fdb3fdec-4e70-be56-11ee-0242ac120002:component/fdb3fdec-4e70-11ee-be56-0242ac120002/fdb3fdec-11ee-4e70-be56-0242ac120002",
+        "id": "10000",
+        "name": "Component 1",
+        "description": "This is a Jira component",
+        "project": "HSP",
+        "projectId": 10000,
+        "isAssigneeTypeValid": False,
+        "assigneeType": "PROJECT_LEAD",
+        "lead": MOCK_COMPONENT_LEAD,
+        "assignee": MOCK_COMPONENT_LEAD,
+        "realAssignee": MOCK_COMPONENT_LEAD,
+        "realAssigneeType": "PROJECT_LEAD",
+        "self": "https://your-domain.atlassian.net/rest/api/2/component/10000",
+        "metadata": {"icon": "https://www.example.com/icon.png"},
+    },
+}
+
+MOCK_COMPONENT_WITHOUT_LEAD = {
+    "id": "10050",
+    "name": "PXA",
+    "description": "This is another Jira component",
+    "assigneeType": "PROJECT_DEFAULT",
+    "isAssigneeTypeValid": True,
+    "issueCount": 5,
+    "project": "PROJECTKEY",
+    "projectId": 10001,
+    "realAssigneeType": "PROJECT_DEFAULT",
+    "self": "https://your-domain.atlassian.net/rest/api/2/component/10050",
+    "lead": None,
+    "assignee": None,
+    "realAssignee": None,
+    "componentBean": None,
+}
+
+MOCK_COMPONENTS_PAGE = {
+    "startAt": 0,
+    "maxResults": 2,
+    "total": 7,
+    "isLast": False,
+    "values": [MOCK_COMPONENT_WITH_ISSUE_COUNT, MOCK_COMPONENT_WITHOUT_LEAD],
+}
+
+MOCK_EMPTY_PAGE = {
+    "startAt": 0,
+    "maxResults": 50,
+    "total": 0,
+    "isLast": True,
+    "values": [],
 }
 
 
@@ -2571,3 +2653,226 @@ class TestGetPaginatedEpicsFanOut:
 
             assert mock_request.call_count == board_count
             assert len(all_epics) == board_count * epics_per_board
+
+
+@pytest.mark.asyncio
+class TestGetPaginatedComponentsForProject:
+
+    async def test_sends_component_source_as_query_param(
+        self, mock_jira_client: JiraClient
+    ) -> None:
+        with patch.object(
+            mock_jira_client, "_send_api_request", new_callable=AsyncMock
+        ) as mock_req:
+            mock_req.return_value = MOCK_EMPTY_PAGE
+            async for _ in mock_jira_client.get_paginated_components_for_project(
+                "HSP", ComponentSource.JIRA
+            ):
+                pass
+            assert mock_req.call_args[1]["params"]["componentSource"] == "jira"
+
+    async def test_sends_compass_source_when_specified(
+        self, mock_jira_client: JiraClient
+    ) -> None:
+        with patch.object(
+            mock_jira_client, "_send_api_request", new_callable=AsyncMock
+        ) as mock_req:
+            mock_req.return_value = MOCK_EMPTY_PAGE
+            async for _ in mock_jira_client.get_paginated_components_for_project(
+                "HSP", ComponentSource.COMPASS
+            ):
+                pass
+            assert mock_req.call_args[1]["params"]["componentSource"] == "compass"
+
+    async def test_includes_query_param_when_name_filter_provided(
+        self, mock_jira_client: JiraClient
+    ) -> None:
+        with patch.object(
+            mock_jira_client, "_send_api_request", new_callable=AsyncMock
+        ) as mock_req:
+            mock_req.return_value = MOCK_EMPTY_PAGE
+            async for _ in mock_jira_client.get_paginated_components_for_project(
+                "HSP", ComponentSource.JIRA, name_filter="Component"
+            ):
+                pass
+            assert mock_req.call_args[1]["params"]["query"] == "Component"
+
+    async def test_omits_query_param_when_name_filter_is_none(
+        self, mock_jira_client: JiraClient
+    ) -> None:
+        with patch.object(
+            mock_jira_client, "_send_api_request", new_callable=AsyncMock
+        ) as mock_req:
+            mock_req.return_value = MOCK_EMPTY_PAGE
+            async for _ in mock_jira_client.get_paginated_components_for_project(
+                "HSP", ComponentSource.JIRA
+            ):
+                pass
+            assert "query" not in mock_req.call_args[1]["params"]
+
+    async def test_injects_project_key_into_every_component(
+        self, mock_jira_client: JiraClient
+    ) -> None:
+        with patch.object(
+            mock_jira_client, "_send_api_request", new_callable=AsyncMock
+        ) as mock_req:
+            mock_req.return_value = MOCK_COMPONENTS_PAGE
+            results = []
+            async for batch in mock_jira_client.get_paginated_components_for_project(
+                "HSP", ComponentSource.JIRA
+            ):
+                results.extend(batch)
+            assert all(c["__projectKey"] == "HSP" for c in results)
+
+    async def test_preserves_all_top_level_component_fields(
+        self, mock_jira_client: JiraClient
+    ) -> None:
+        with patch.object(
+            mock_jira_client, "_send_api_request", new_callable=AsyncMock
+        ) as mock_req:
+            mock_req.return_value = {
+                **MOCK_COMPONENTS_PAGE,
+                "values": [MOCK_COMPONENT_WITH_ISSUE_COUNT],
+            }
+            results = []
+            async for batch in mock_jira_client.get_paginated_components_for_project(
+                "HSP", ComponentSource.JIRA
+            ):
+                results.extend(batch)
+
+            component = results[0]
+            assert component["id"] == "10000"
+            assert component["name"] == "Component 1"
+            assert component["description"] == "This is a Jira component"
+            assert component["assigneeType"] == "PROJECT_LEAD"
+            assert component["issueCount"] == 1
+            assert component["project"] == "HSP"
+            assert component["projectId"] == 10000
+            assert component["realAssigneeType"] == "PROJECT_LEAD"
+            assert component["isAssigneeTypeValid"] is False
+
+    async def test_preserves_lead_object_for_relation_mapping(
+        self, mock_jira_client: JiraClient
+    ) -> None:
+        with patch.object(
+            mock_jira_client, "_send_api_request", new_callable=AsyncMock
+        ) as mock_req:
+            mock_req.return_value = {
+                **MOCK_COMPONENTS_PAGE,
+                "values": [MOCK_COMPONENT_WITH_ISSUE_COUNT],
+            }
+            results = []
+            async for batch in mock_jira_client.get_paginated_components_for_project(
+                "HSP", ComponentSource.JIRA
+            ):
+                results.extend(batch)
+
+            lead = results[0]["lead"]
+            assert lead["accountId"] == "5b10a2844c20165700ede21g"
+            assert lead["displayName"] == "Mia Krystof"
+
+    async def test_preserves_component_bean_ari_for_compass_components(
+        self, mock_jira_client: JiraClient
+    ) -> None:
+        with patch.object(
+            mock_jira_client, "_send_api_request", new_callable=AsyncMock
+        ) as mock_req:
+            mock_req.return_value = {
+                **MOCK_COMPONENTS_PAGE,
+                "values": [MOCK_COMPONENT_WITH_ISSUE_COUNT],
+            }
+            results = []
+            async for batch in mock_jira_client.get_paginated_components_for_project(
+                "HSP", ComponentSource.JIRA
+            ):
+                results.extend(batch)
+
+            ari = results[0]["componentBean"]["ari"]
+            assert ari.startswith("ari:cloud:compass:")
+
+    async def test_handles_component_with_null_lead_and_no_component_bean(
+        self, mock_jira_client: JiraClient
+    ) -> None:
+        with patch.object(
+            mock_jira_client, "_send_api_request", new_callable=AsyncMock
+        ) as mock_req:
+            mock_req.return_value = {
+                **MOCK_COMPONENTS_PAGE,
+                "values": [MOCK_COMPONENT_WITHOUT_LEAD],
+            }
+            results = []
+            async for batch in mock_jira_client.get_paginated_components_for_project(
+                "PROJECTKEY", ComponentSource.JIRA
+            ):
+                results.extend(batch)
+
+            component = results[0]
+            assert component["id"] == "10050"
+            assert component["lead"] is None
+            assert component["componentBean"] is None
+            assert component["__projectKey"] == "PROJECTKEY"
+
+    async def test_excludes_components_without_id(
+        self, mock_jira_client: JiraClient
+    ) -> None:
+        component_without_id = {"name": "Orphaned", "description": "No ID field"}
+        with patch.object(
+            mock_jira_client, "_send_api_request", new_callable=AsyncMock
+        ) as mock_req:
+            mock_req.return_value = {
+                "startAt": 0,
+                "maxResults": 50,
+                "total": 1,
+                "isLast": True,
+                "values": [MOCK_COMPONENT_WITH_ISSUE_COUNT, component_without_id],
+            }
+            results = []
+            async for batch in mock_jira_client.get_paginated_components_for_project(
+                "HSP", ComponentSource.JIRA
+            ):
+                results.extend(batch)
+
+            assert len(results) == 1
+            assert results[0]["id"] == "10000"
+
+    async def test_yields_nothing_when_project_has_no_components(
+        self, mock_jira_client: JiraClient
+    ) -> None:
+        with patch.object(
+            mock_jira_client, "_send_api_request", new_callable=AsyncMock
+        ) as mock_req:
+            mock_req.return_value = MOCK_EMPTY_PAGE
+            results = []
+            async for batch in mock_jira_client.get_paginated_components_for_project(
+                "HSP", ComponentSource.JIRA
+            ):
+                results.extend(batch)
+            assert results == []
+
+    async def test_yields_all_components_across_multiple_pages(
+        self, mock_jira_client: JiraClient
+    ) -> None:
+        page_one = {
+            "startAt": 0,
+            "maxResults": 1,
+            "total": 2,
+            "isLast": False,
+            "values": [MOCK_COMPONENT_WITH_ISSUE_COUNT],
+        }
+        page_two = {
+            "startAt": 1,
+            "maxResults": 1,
+            "total": 2,
+            "isLast": True,
+            "values": [MOCK_COMPONENT_WITHOUT_LEAD],
+        }
+        with patch.object(
+            mock_jira_client, "_send_api_request", new_callable=AsyncMock
+        ) as mock_req:
+            mock_req.side_effect = [page_one, page_two]
+            results = []
+            async for batch in mock_jira_client.get_paginated_components_for_project(
+                "HSP", ComponentSource.JIRA
+            ):
+                results.extend(batch)
+            assert [r["id"] for r in results] == ["10000", "10050"]

--- a/integrations/jira/tests/test_client.py
+++ b/integrations/jira/tests/test_client.py
@@ -312,6 +312,13 @@ MOCK_EMPTY_PAGE = {
     "values": [],
 }
 
+MOCK_PROJECT_HSP = {"id": "10000", "key": "HSP", "name": "HSP Project"}
+MOCK_PROJECT_PROJECTKEY = {
+    "id": "10001",
+    "key": "PROJECTKEY",
+    "name": "Projectkey Project",
+}
+
 
 @pytest.fixture(autouse=True)
 def mock_ocean_context() -> None:
@@ -2666,7 +2673,7 @@ class TestGetPaginatedComponentsForProject:
         ) as mock_req:
             mock_req.return_value = MOCK_EMPTY_PAGE
             async for _ in mock_jira_client.get_paginated_components_for_project(
-                "HSP", ComponentSource.JIRA
+                MOCK_PROJECT_HSP, ComponentSource.JIRA
             ):
                 pass
             assert mock_req.call_args[1]["params"]["componentSource"] == "jira"
@@ -2679,7 +2686,7 @@ class TestGetPaginatedComponentsForProject:
         ) as mock_req:
             mock_req.return_value = MOCK_EMPTY_PAGE
             async for _ in mock_jira_client.get_paginated_components_for_project(
-                "HSP", ComponentSource.COMPASS
+                MOCK_PROJECT_HSP, ComponentSource.COMPASS
             ):
                 pass
             assert mock_req.call_args[1]["params"]["componentSource"] == "compass"
@@ -2692,7 +2699,7 @@ class TestGetPaginatedComponentsForProject:
         ) as mock_req:
             mock_req.return_value = MOCK_EMPTY_PAGE
             async for _ in mock_jira_client.get_paginated_components_for_project(
-                "HSP", ComponentSource.JIRA, name_filter="Component"
+                MOCK_PROJECT_HSP, ComponentSource.JIRA, name_filter="Component"
             ):
                 pass
             assert mock_req.call_args[1]["params"]["query"] == "Component"
@@ -2705,12 +2712,12 @@ class TestGetPaginatedComponentsForProject:
         ) as mock_req:
             mock_req.return_value = MOCK_EMPTY_PAGE
             async for _ in mock_jira_client.get_paginated_components_for_project(
-                "HSP", ComponentSource.JIRA
+                MOCK_PROJECT_HSP, ComponentSource.JIRA
             ):
                 pass
             assert "query" not in mock_req.call_args[1]["params"]
 
-    async def test_injects_project_key_into_every_component(
+    async def test_injects_full_project_into_every_component(
         self, mock_jira_client: JiraClient
     ) -> None:
         with patch.object(
@@ -2719,10 +2726,10 @@ class TestGetPaginatedComponentsForProject:
             mock_req.return_value = MOCK_COMPONENTS_PAGE
             results = []
             async for batch in mock_jira_client.get_paginated_components_for_project(
-                "HSP", ComponentSource.JIRA
+                MOCK_PROJECT_HSP, ComponentSource.JIRA
             ):
                 results.extend(batch)
-            assert all(c["__projectKey"] == "HSP" for c in results)
+            assert all(c["__project"] == MOCK_PROJECT_HSP for c in results)
 
     async def test_preserves_all_top_level_component_fields(
         self, mock_jira_client: JiraClient
@@ -2736,7 +2743,7 @@ class TestGetPaginatedComponentsForProject:
             }
             results = []
             async for batch in mock_jira_client.get_paginated_components_for_project(
-                "HSP", ComponentSource.JIRA
+                MOCK_PROJECT_HSP, ComponentSource.JIRA
             ):
                 results.extend(batch)
 
@@ -2763,7 +2770,7 @@ class TestGetPaginatedComponentsForProject:
             }
             results = []
             async for batch in mock_jira_client.get_paginated_components_for_project(
-                "HSP", ComponentSource.JIRA
+                MOCK_PROJECT_HSP, ComponentSource.JIRA
             ):
                 results.extend(batch)
 
@@ -2783,7 +2790,7 @@ class TestGetPaginatedComponentsForProject:
             }
             results = []
             async for batch in mock_jira_client.get_paginated_components_for_project(
-                "HSP", ComponentSource.JIRA
+                MOCK_PROJECT_HSP, ComponentSource.JIRA
             ):
                 results.extend(batch)
 
@@ -2802,7 +2809,7 @@ class TestGetPaginatedComponentsForProject:
             }
             results = []
             async for batch in mock_jira_client.get_paginated_components_for_project(
-                "PROJECTKEY", ComponentSource.JIRA
+                MOCK_PROJECT_PROJECTKEY, ComponentSource.JIRA
             ):
                 results.extend(batch)
 
@@ -2810,7 +2817,7 @@ class TestGetPaginatedComponentsForProject:
             assert component["id"] == "10050"
             assert component["lead"] is None
             assert component["componentBean"] is None
-            assert component["__projectKey"] == "PROJECTKEY"
+            assert component["__project"]["key"] == "PROJECTKEY"
 
     async def test_yields_nothing_when_project_has_no_components(
         self, mock_jira_client: JiraClient
@@ -2821,7 +2828,7 @@ class TestGetPaginatedComponentsForProject:
             mock_req.return_value = MOCK_EMPTY_PAGE
             results = []
             async for batch in mock_jira_client.get_paginated_components_for_project(
-                "HSP", ComponentSource.JIRA
+                MOCK_PROJECT_HSP, ComponentSource.JIRA
             ):
                 results.extend(batch)
             assert results == []
@@ -2849,7 +2856,7 @@ class TestGetPaginatedComponentsForProject:
             mock_req.side_effect = [page_one, page_two]
             results = []
             async for batch in mock_jira_client.get_paginated_components_for_project(
-                "HSP", ComponentSource.JIRA
+                MOCK_PROJECT_HSP, ComponentSource.JIRA
             ):
                 results.extend(batch)
             assert [r["id"] for r in results] == ["10000", "10050"]

--- a/integrations/jira/tests/test_overrides.py
+++ b/integrations/jira/tests/test_overrides.py
@@ -1,4 +1,5 @@
 import pytest
+from pydantic import ValidationError
 from jira.overrides import (
     JiraPortAppConfig,
     JiraBoardResourceConfig,
@@ -10,6 +11,9 @@ from jira.overrides import (
     JiraWorklogResourceConfig,
     JiraWorklogSelector,
     JiraEpicResourceConfig,
+    ComponentSource,
+    JiraComponentResourceConfig,
+    JiraComponentSelector,
 )
 
 
@@ -105,6 +109,18 @@ EPIC_MAPPING = {
     "relations": {
         "board": ".__boardId",
     },
+}
+
+COMPONENT_MAPPING = {
+    "entity": {
+        "mappings": {
+            "identifier": ".id | tostring",
+            "title": ".name",
+            "blueprint": '"jiraComponent"',
+            "properties": {},
+            "relations": {},
+        }
+    }
 }
 
 
@@ -948,3 +964,125 @@ def test_jira_backlog_selector_all_fields_combined() -> None:
     assert selector.jql == "project = PORT"
     assert selector.fields == ["id", "key", "summary"]
     assert selector.use_software_api is False
+
+
+def test_component_source_values_match_jira_api() -> None:
+    assert ComponentSource.JIRA == "jira"
+    assert ComponentSource.COMPASS == "compass"
+    assert ComponentSource.AUTO == "auto"
+
+
+def test_component_selector_component_source_defaults_to_jira() -> None:
+    config = JiraPortAppConfig.parse_obj(
+        {
+            "resources": [
+                {
+                    "kind": "component",
+                    "selector": {"query": "true"},
+                    "port": COMPONENT_MAPPING,
+                }
+            ]
+        }
+    )
+    resource = config.resources[0]
+    assert isinstance(resource, JiraComponentResourceConfig)
+    assert resource.selector.component_source == ComponentSource.JIRA
+
+
+def test_component_selector_accepts_compass_source() -> None:
+    config = JiraPortAppConfig.parse_obj(
+        {
+            "resources": [
+                {
+                    "kind": "component",
+                    "selector": {"query": "true", "componentSource": "compass"},
+                    "port": COMPONENT_MAPPING,
+                }
+            ]
+        }
+    )
+    resource = config.resources[0]
+    assert isinstance(resource, JiraComponentResourceConfig)
+    assert resource.selector.component_source == ComponentSource.COMPASS
+
+
+def test_component_selector_accepts_auto_source() -> None:
+    config = JiraPortAppConfig.parse_obj(
+        {
+            "resources": [
+                {
+                    "kind": "component",
+                    "selector": {"query": "true", "componentSource": "auto"},
+                    "port": COMPONENT_MAPPING,
+                }
+            ]
+        }
+    )
+    resource = config.resources[0]
+    assert isinstance(resource, JiraComponentResourceConfig)
+    assert resource.selector.component_source == ComponentSource.AUTO
+
+
+def test_component_selector_rejects_invalid_component_source() -> None:
+    with pytest.raises(ValidationError):
+        JiraPortAppConfig.parse_obj(
+            {
+                "resources": [
+                    {
+                        "kind": "component",
+                        "selector": {"query": "true", "componentSource": "invalid"},
+                        "port": COMPONENT_MAPPING,
+                    }
+                ]
+            }
+        )
+
+
+def test_component_selector_name_filter_defaults_to_none() -> None:
+    config = JiraPortAppConfig.parse_obj(
+        {
+            "resources": [
+                {
+                    "kind": "component",
+                    "selector": {"query": "true"},
+                    "port": COMPONENT_MAPPING,
+                }
+            ]
+        }
+    )
+    resource = config.resources[0]
+    assert isinstance(resource, JiraComponentResourceConfig)
+    assert resource.selector.name_filter is None
+
+
+def test_component_selector_accepts_name_filter() -> None:
+    config = JiraPortAppConfig.parse_obj(
+        {
+            "resources": [
+                {
+                    "kind": "component",
+                    "selector": {"query": "true", "nameFilter": "backend"},
+                    "port": COMPONENT_MAPPING,
+                }
+            ]
+        }
+    )
+    resource = config.resources[0]
+    assert isinstance(resource, JiraComponentResourceConfig)
+    assert resource.selector.name_filter == "backend"
+
+
+def test_jira_port_app_config_resolves_component_resource_config() -> None:
+    config = JiraPortAppConfig.parse_obj(
+        {
+            "resources": [
+                {
+                    "kind": "component",
+                    "selector": {"query": "true"},
+                    "port": COMPONENT_MAPPING,
+                }
+            ]
+        }
+    )
+    assert isinstance(config.resources[0], JiraComponentResourceConfig)
+    assert isinstance(config.resources[0].selector, JiraComponentSelector)


### PR DESCRIPTION
# Description

What - 

Add a `component` kind that syncs Jira project components into Port as `jiraComponent` blueprint entities.

Why - 

Components are a first-class Jira concept used to categorise issues within a project. Without this kind, customers have no way to represent component ownership, issue distribution across components, or lead assignments in their Port catalog.

How - 

Fans out per project using `GET /rest/api/{apiVersion}/project/{key}/component`, which returns the enriched `ComponentWithIssueCount` schema including `issueCount`, `lead`, `assigneeType`, and `componentBean.ari` for Compass-linked components. `_enrich_with_project_key` injects `__projectKey` into each component at fetch time for relation mapping, following the same static method pattern as `_enrich_with_board_id`. `ComponentSource` StrEnum exposes `jira` (default), `compass`, and `auto` to match the Jira API values, with `jira` as the default to protect instances not using Compass from ingesting global Compass components. The kind is resync-only, Jira emits no webhook events for component changes.

## Type of change

- [x] New feature (non-breaking change which adds functionality)


<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

<img width="1019" height="707" alt="Screenshot 2026-06-11 at 15 57 17" src="https://github.com/user-attachments/assets/2dc3ba11-5913-4116-92d4-e11672a560d0" />
<img width="1027" height="562" alt="Screenshot 2026-06-11 at 15 57 27" src="https://github.com/user-attachments/assets/538be441-7dfd-438d-8b27-37a67d8f6674" />


## API Documentation

https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-project-components/#api-rest-api-2-project-projectidorkey-component-get