### PR TITLE
[Core] Refactor integration mixins to include selector hash functionality for apply mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.43.18 (2026-06-15)
+
+### Improvements
+
+- Added `selectorHash` to lakehouse raw-data metadata payloads. The value is computed from each resource selector query using trimmed-query SHA-256 (`selector.query.trim()`), and omitted when the selector query is empty.
+
 ## 0.43.17 (2026-06-11)
 
 ### Improvements

--- a/port_ocean/clients/port/mixins/integrations.py
+++ b/port_ocean/clients/port/mixins/integrations.py
@@ -387,6 +387,7 @@ class IntegrationClientMixin:
                     "operation": entry["metadata"]["operation"].value,
                     "extractionTimestamp": entry["metadata"]["extraction_timestamp"],
                     "resourceIndex": entry["metadata"]["resource_index"],
+                    "selectorHash": entry["metadata"].get("selector_hash"),
                 },
             }
             if environment_data := entry.get("environment_data"):

--- a/port_ocean/clients/port/utils.py
+++ b/port_ocean/clients/port/utils.py
@@ -1,13 +1,14 @@
 from typing import TYPE_CHECKING
 
 import httpx
+
+from port_ocean.context.event import EventType, event
+from port_ocean.exceptions.context import EventContextNotFoundError
 from loguru import logger
-from werkzeug.local import LocalProxy, LocalStack
+from werkzeug.local import LocalStack, LocalProxy
 
 from port_ocean.clients.port.retry_transport import TokenRetryTransport
-from port_ocean.context.event import EventType, event
 from port_ocean.context.ocean import ocean
-from port_ocean.exceptions.context import EventContextNotFoundError
 from port_ocean.helpers.async_client import OceanAsyncClient
 from port_ocean.helpers.ssl import resolve_verify_param
 
@@ -91,7 +92,7 @@ def handle_port_status_code(
 ) -> None:
     if should_log and response.is_error:
         escaped_response_text = response.text.replace("{", "{{").replace("}", "}}")
-        error_message = f"Request failed with status code: {response.status_code}, Error: {escaped_response_text}, url: {response.url}"
+        error_message = f"Request failed with status code: {response.status_code}, Error: {escaped_response_text}"
         if response.status_code >= 500 and response.headers.get("x-trace-id"):
             logger.error(
                 error_message,

--- a/port_ocean/clients/port/utils.py
+++ b/port_ocean/clients/port/utils.py
@@ -1,14 +1,13 @@
 from typing import TYPE_CHECKING
 
 import httpx
-
-from port_ocean.context.event import EventType, event
-from port_ocean.exceptions.context import EventContextNotFoundError
 from loguru import logger
-from werkzeug.local import LocalStack, LocalProxy
+from werkzeug.local import LocalProxy, LocalStack
 
 from port_ocean.clients.port.retry_transport import TokenRetryTransport
+from port_ocean.context.event import EventType, event
 from port_ocean.context.ocean import ocean
+from port_ocean.exceptions.context import EventContextNotFoundError
 from port_ocean.helpers.async_client import OceanAsyncClient
 from port_ocean.helpers.ssl import resolve_verify_param
 
@@ -92,7 +91,7 @@ def handle_port_status_code(
 ) -> None:
     if should_log and response.is_error:
         escaped_response_text = response.text.replace("{", "{{").replace("}", "}}")
-        error_message = f"Request failed with status code: {response.status_code}, Error: {escaped_response_text}"
+        error_message = f"Request failed with status code: {response.status_code}, Error: {escaped_response_text}, url: {response.url}"
         if response.status_code >= 500 and response.headers.get("x-trace-id"):
             logger.error(
                 error_message,

--- a/port_ocean/core/integrations/mixins/live_events.py
+++ b/port_ocean/core/integrations/mixins/live_events.py
@@ -12,6 +12,7 @@ from port_ocean.core.integrations.mixins.utils import (
     handle_items_to_parse,
     is_dsp_mode_enabled,
     is_lakehouse_data_enabled,
+    selector_hash_from_resource,
 )
 from port_ocean.core.models import Entity, LakehouseDataEntry, LakehouseDataEntryBatch, LakehouseDataEntryMetadata, LakehouseOperation, LakehouseEventType
 from port_ocean.core.ocean_types import RAW_ITEM
@@ -137,6 +138,9 @@ class LiveEventsMixin(HandlerMixin):
                                 operation=LakehouseOperation.UPSERT,
                                 resource_index=resource_index,
                                 extraction_timestamp=int(datetime.now().timestamp() * 1000),
+                                selector_hash=selector_hash_from_resource(
+                                    webhook_event_raw_result.resource
+                                ),
                             ),
                             export_env_variables=webhook_event_raw_result.resource.selector.export_env_variables,
                         )
@@ -149,6 +153,9 @@ class LiveEventsMixin(HandlerMixin):
                                 operation=LakehouseOperation.DELETE,
                                 resource_index=resource_index,
                                 extraction_timestamp=int(datetime.now().timestamp() * 1000),
+                                selector_hash=selector_hash_from_resource(
+                                    webhook_event_raw_result.resource
+                                ),
                             ),
                             export_env_variables=webhook_event_raw_result.resource.selector.export_env_variables,
                         )

--- a/port_ocean/core/integrations/mixins/sync_raw.py
+++ b/port_ocean/core/integrations/mixins/sync_raw.py
@@ -27,6 +27,7 @@ from port_ocean.core.integrations.mixins.utils import (
     is_dsp_mode_enabled,
     is_lakehouse_data_enabled,
     is_resource_supported,
+    selector_hash_from_resource,
     start_kind_tracking,
     stop_kind_tracking,
     unsupported_kind_response,
@@ -467,7 +468,12 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
 
         if raw_results:
             if lakehouse_data_enabled and buffer:
-                metadata = LakehouseDataEntryMetadata(operation=LakehouseOperation.UPSERT, resource_index=index, extraction_timestamp=int(datetime.now().timestamp() * 1000))
+                metadata = LakehouseDataEntryMetadata(
+                    operation=LakehouseOperation.UPSERT,
+                    resource_index=index,
+                    extraction_timestamp=int(datetime.now().timestamp() * 1000),
+                    selector_hash=selector_hash_from_resource(resource_config),
+                )
                 lakehouse_data_entry = build_lakehouse_data_entry(
                     items=raw_results,
                     metadata=metadata,
@@ -498,7 +504,12 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                 async for items in generator:
                     batch_index += 1
                     if lakehouse_data_enabled and buffer:
-                        metadata = LakehouseDataEntryMetadata(operation=LakehouseOperation.UPSERT, resource_index=index, extraction_timestamp=int(datetime.now().timestamp() * 1000))
+                        metadata = LakehouseDataEntryMetadata(
+                            operation=LakehouseOperation.UPSERT,
+                            resource_index=index,
+                            extraction_timestamp=int(datetime.now().timestamp() * 1000),
+                            selector_hash=selector_hash_from_resource(resource_config),
+                        )
                         lakehouse_data_entry = build_lakehouse_data_entry(
                             items=items,
                             metadata=metadata,

--- a/port_ocean/core/integrations/mixins/utils.py
+++ b/port_ocean/core/integrations/mixins/utils.py
@@ -11,6 +11,7 @@ from loguru import logger
 from port_ocean.clients.port.utils import _http_client as _port_http_client
 from port_ocean.context.ocean import ocean
 from port_ocean.core.handlers import JQEntityProcessor
+from port_ocean.core.handlers.port_app_config.models import ResourceConfig
 from port_ocean.core.ocean_types import (
     ASYNC_GENERATOR_RESYNC_TYPE,
     RAW_RESULT,
@@ -59,7 +60,7 @@ def build_lakehouse_data_entry(
     return entry
 
 
-def selector_query_from_resource(resource: Any) -> str | None:
+def selector_query_from_resource(resource: ResourceConfig) -> str | None:
     query = getattr(getattr(resource, "selector", None), "query", None)
     if not isinstance(query, str):
         return None
@@ -72,7 +73,7 @@ def selector_hash_from_query(query: str) -> str:
     return hashlib.sha256(query.encode("utf-8")).hexdigest()
 
 
-def selector_hash_from_resource(resource: Any) -> str | None:
+def selector_hash_from_resource(resource: ResourceConfig) -> str | None:
     query = selector_query_from_resource(resource)
     if not query:
         return None

--- a/port_ocean/core/integrations/mixins/utils.py
+++ b/port_ocean/core/integrations/mixins/utils.py
@@ -1,4 +1,5 @@
 import asyncio
+import hashlib
 import multiprocessing
 import os
 import re
@@ -56,6 +57,27 @@ def build_lakehouse_data_entry(
     if environment_data is not None:
         entry["environment_data"] = environment_data
     return entry
+
+
+def selector_query_from_resource(resource: Any) -> str | None:
+    query = getattr(getattr(resource, "selector", None), "query", None)
+    if not isinstance(query, str):
+        return None
+
+    trimmed = query.strip()
+    return trimmed if trimmed else None
+
+
+def selector_hash_from_query(query: str) -> str:
+    return hashlib.sha256(query.encode("utf-8")).hexdigest()
+
+
+def selector_hash_from_resource(resource: Any) -> str | None:
+    query = selector_query_from_resource(resource)
+    if not query:
+        return None
+
+    return selector_hash_from_query(query)
 
 
 async def is_lakehouse_data_enabled() -> bool:

--- a/port_ocean/core/models.py
+++ b/port_ocean/core/models.py
@@ -243,6 +243,7 @@ class LakehouseDataEntryMetadata(TypedDict):
     operation: LakehouseOperation
     resource_index: int
     extraction_timestamp: int
+    selector_hash: NotRequired[str | None]
 
 
 class LakehouseDataEntry(TypedDict):

--- a/port_ocean/tests/clients/port/mixins/test_integrations_lakehouse.py
+++ b/port_ocean/tests/clients/port/mixins/test_integrations_lakehouse.py
@@ -77,6 +77,7 @@ async def test_post_integration_raw_data_default_operation(
         assert entry["response"] == {}
         assert entry["metadata"]["operation"] == "upsert"
         assert entry["metadata"]["resourceIndex"] == 0
+        assert entry["metadata"]["selectorHash"] is None
         assert "extractionTimestamp" in entry["metadata"]
         assert "resyncStartTime" not in body
         assert "eventId" not in body
@@ -505,3 +506,27 @@ async def test_post_integration_raw_data_batch_includes_environment_data(
     body = lakehouse_integration_client.client.post.call_args[1]["json"]
 
     assert body["data"][0]["environment_data"] == {"FOO": "bar", "MISSING": None}
+
+
+async def test_post_integration_raw_data_batch_includes_selector_hash(
+    lakehouse_integration_client: IntegrationClientMixin,
+) -> None:
+    raw_data = [{"name": "repo-one"}]
+    sync_id = "sync-selector-hash"
+    kind = "repository"
+
+    event = make_single_entry_lakehouse_batch(
+        raw_data,
+        kind=kind,
+        index=0,
+        selector_hash="abc123",
+    )
+
+    with patch("port_ocean.clients.port.mixins.integrations.handle_port_status_code"):
+        await lakehouse_integration_client.post_integration_raw_data_batch(
+            sync_id, event
+        )
+
+    lakehouse_integration_client.client.post.assert_called_once()
+    body = lakehouse_integration_client.client.post.call_args[1]["json"]
+    assert body["data"][0]["metadata"]["selectorHash"] == "abc123"

--- a/port_ocean/tests/core/handlers/mixins/test_live_events_lakehouse.py
+++ b/port_ocean/tests/core/handlers/mixins/test_live_events_lakehouse.py
@@ -218,6 +218,10 @@ async def test_send_webhook_raw_data_to_lakehouse_enabled_upsert(
         assert data_entries[0]["metadata"]["operation"] == LakehouseOperation.UPSERT
         assert data_entries[0]["items"] == raw_data
         assert data_entries[0]["metadata"]["resource_index"] == 0
+        assert (
+            data_entries[0]["metadata"]["selector_hash"]
+            == "b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b"
+        )
 
 
 @pytest.mark.asyncio
@@ -263,6 +267,10 @@ async def test_send_webhook_raw_data_to_lakehouse_enabled_delete(
         assert data_entries[0]["metadata"]["operation"] == LakehouseOperation.DELETE
         assert data_entries[0]["items"] == raw_data
         assert data_entries[0]["metadata"]["resource_index"] == 0
+        assert (
+            data_entries[0]["metadata"]["selector_hash"]
+            == "b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b"
+        )
 
 
 @pytest.mark.asyncio
@@ -374,8 +382,16 @@ async def test_send_webhook_raw_data_to_lakehouse_both_operations(
         assert upsert_entry["metadata"]["operation"] == LakehouseOperation.UPSERT
         assert upsert_entry["items"] == upsert_data
         assert upsert_entry["metadata"]["resource_index"] == 0
+        assert (
+            upsert_entry["metadata"]["selector_hash"]
+            == "b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b"
+        )
 
         delete_entry = data_entries[1]
         assert delete_entry["metadata"]["operation"] == LakehouseOperation.DELETE
         assert delete_entry["items"] == delete_data
         assert delete_entry["metadata"]["resource_index"] == 0
+        assert (
+            delete_entry["metadata"]["selector_hash"]
+            == "b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b"
+        )

--- a/port_ocean/tests/core/integrations/mixins/test_integration_utils.py
+++ b/port_ocean/tests/core/integrations/mixins/test_integration_utils.py
@@ -24,6 +24,9 @@ from port_ocean.core.integrations.mixins.utils import (
     is_lakehouse_data_enabled,
     resync_function_wrapper,
     resync_generator_wrapper,
+    selector_hash_from_query,
+    selector_hash_from_resource,
+    selector_query_from_resource,
 )
 from port_ocean.core.models import LakehouseOperation
 
@@ -71,6 +74,93 @@ class TestBuildLakehouseDataEntry:
         )
 
         assert "environment_data" not in entry
+
+
+class TestSelectorHashHelpers:
+    def test_selector_query_from_resource_returns_trimmed_query(self) -> None:
+        resource = ResourceConfig(
+            kind="test-kind",
+            selector=Selector(query="  .foo | .bar  "),
+            port=PortResourceConfig(
+                entity=MappingsConfig(
+                    mappings=EntityMapping(
+                        identifier=".id",
+                        title=".name",
+                        blueprint='"test"',
+                        properties={},
+                        relations={},
+                    )
+                )
+            ),
+        )
+
+        assert selector_query_from_resource(resource) == ".foo | .bar"
+
+    def test_selector_query_from_resource_returns_none_for_whitespace(self) -> None:
+        resource = ResourceConfig(
+            kind="test-kind",
+            selector=Selector(query="   "),
+            port=PortResourceConfig(
+                entity=MappingsConfig(
+                    mappings=EntityMapping(
+                        identifier=".id",
+                        title=".name",
+                        blueprint='"test"',
+                        properties={},
+                        relations={},
+                    )
+                )
+            ),
+        )
+
+        assert selector_query_from_resource(resource) is None
+
+    def test_selector_hash_from_query_uses_sha256_hex(self) -> None:
+        assert (
+            selector_hash_from_query(".foo")
+            == "013b54afaf52ac0983a4ac123b01e809ab7ac8862e67a50f09fcce1293d265c3"
+        )
+
+    def test_selector_hash_from_resource_returns_hash_for_trimmed_query(self) -> None:
+        resource = ResourceConfig(
+            kind="test-kind",
+            selector=Selector(query="  .foo  "),
+            port=PortResourceConfig(
+                entity=MappingsConfig(
+                    mappings=EntityMapping(
+                        identifier=".id",
+                        title=".name",
+                        blueprint='"test"',
+                        properties={},
+                        relations={},
+                    )
+                )
+            ),
+        )
+
+        assert (
+            selector_hash_from_resource(resource)
+            == "013b54afaf52ac0983a4ac123b01e809ab7ac8862e67a50f09fcce1293d265c3"
+        )
+
+    def test_selector_hash_from_resource_returns_none_for_empty_query(self) -> None:
+        resource = ResourceConfig(
+            kind="test-kind",
+            selector=Selector(query=" "),
+            port=PortResourceConfig(
+                entity=MappingsConfig(
+                    mappings=EntityMapping(
+                        identifier=".id",
+                        title=".name",
+                        blueprint='"test"',
+                        properties={},
+                        relations={},
+                    )
+                )
+            ),
+        )
+
+        assert selector_hash_from_resource(resource) is None
 
 
 class TestExtractJqDeletionPathRevised:

--- a/port_ocean/tests/helpers/lakehouse_batch.py
+++ b/port_ocean/tests/helpers/lakehouse_batch.py
@@ -25,6 +25,7 @@ def make_single_entry_lakehouse_batch(
     event_id: str | None = None,
     extraction_timestamp: int | None = None,
     export_env_variables: list[str] | None = None,
+    selector_hash: str | None = None,
 ) -> LakehouseDataEntryBatch:
     """Build a batch payload with one data entry (mirrors typical single-chunk sends)."""
     et = event_type or LakehouseEventType.LIVE_EVENT
@@ -41,6 +42,7 @@ def make_single_entry_lakehouse_batch(
             "operation": operation,
             "resource_index": index,
             "extraction_timestamp": ts,
+            "selector_hash": selector_hash,
         },
     }
     if export_env_variables is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.43.17"
+version = "0.43.18"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION



# Description

What -
This change improves the traceability of resource queries and enhances the overall data integrity in the integration process.

- Added `selector_hash` to `LakehouseDataEntryMetadata` for better tracking of resource queries.
- Implemented `selector_hash_from_resource` utility to generate a hash from resource selectors.
- Updated `LiveEventsMixin` and `SyncRawMixin` to utilize the new selector hash in metadata.
- Enhanced tests to validate the inclusion of selector hashes in integration responses and ensure correct functionality.

Why -
We need it for the apply mapping flow



## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


