### PR TITLE
[Integration][GitHub] Fix GitHubRateLimiter semaphore permit leak when __aenter__ is cancelled

### DIFF
--- a/integrations/github/CHANGELOG.md
+++ b/integrations/github/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 6.0.8 (2026-06-23)
+
+
+### Bug Fixes
+
+- Fix semaphore permit leak in `GitHubRateLimiter.__aenter__` on cancellation
+
+
 ## 6.0.7 (2026-06-22)
 
 

--- a/integrations/github/github/clients/rate_limiter/limiter.py
+++ b/integrations/github/github/clients/rate_limiter/limiter.py
@@ -22,8 +22,16 @@ class GitHubRateLimiter:
 
     async def __aenter__(self) -> "GitHubRateLimiter":
         await self._semaphore.acquire()
-        async with self._lock:
-            await self._enforce_rate_limit()
+        try:
+            async with self._lock:
+                await self._enforce_rate_limit()
+        except BaseException as ctx_error:
+            logger.debug(
+                "github:clients:rate_limiter:GitHubRateLimiter::Error occurred while enforcing rate limit: {error}",
+                error=ctx_error,
+            )
+            self._semaphore.release()
+            raise
         return self
 
     async def __aexit__(

--- a/integrations/github/pyproject.toml
+++ b/integrations/github/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "github-ocean"
-version = "6.0.7"
+version = "6.0.8"
 description = "This integration ingest data from github"
 authors = ["Chukwuemeka Nwaoma <joelchukks@gmail.com>", "Melody Anyaegbulam <melodyogonna@gmail.com>", "Michael Armah <mikeyarmah@gmail.com>"]
 

--- a/integrations/github/tests/github/clients/test_rate_limiter.py
+++ b/integrations/github/tests/github/clients/test_rate_limiter.py
@@ -681,3 +681,74 @@ class TestBaseClientRateLimit403Mapping:
 
         with pytest.raises(httpx.HTTPStatusError):
             await client.make_request(resource, ignore_default_errors=False)
+
+
+class TestRateLimiterSemaphorePermitLeak:
+    @pytest.mark.asyncio
+    async def test_cancelled_sleep_during_aenter_releases_acquired_semaphore_permit(
+        self, client_config: GitHubRateLimiterConfig, github_host: str, mock_sleep: Mock
+    ) -> None:
+        client = MockGitHubClient(github_host, client_config)
+        client.rate_limiter.rate_limit_info = RateLimitInfo(
+            limit=1000, remaining=1, reset_time=int(time.time()) + 30
+        )
+        client.rate_limiter._initialized = True
+        mock_sleep.side_effect = asyncio.CancelledError()
+
+        permits_before_cancelled_aenter = client.rate_limiter._semaphore._value
+
+        with pytest.raises(asyncio.CancelledError):
+            await client.rate_limiter.__aenter__()
+
+        assert client.rate_limiter._semaphore._value == permits_before_cancelled_aenter
+
+    @pytest.mark.asyncio
+    async def test_ten_consecutive_cancelled_sleeps_leave_every_permit_acquirable_afterward(
+        self, github_host: str, mock_sleep: Mock
+    ) -> None:
+        max_concurrent_slots = 10
+        config = GitHubRateLimiterConfig(
+            api_type="rest", max_concurrent=max_concurrent_slots
+        )
+        limiter = GitHubRateLimiterRegistry.get_limiter(github_host, config)
+        mock_sleep.side_effect = asyncio.CancelledError()
+
+        for _ in range(max_concurrent_slots):
+            limiter.rate_limit_info = RateLimitInfo(
+                limit=1000, remaining=1, reset_time=int(time.time()) + 30
+            )
+            limiter._initialized = True
+            with pytest.raises(asyncio.CancelledError):
+                await limiter.__aenter__()
+
+        assert limiter._semaphore._value == max_concurrent_slots
+
+    @pytest.mark.asyncio
+    async def test_non_cancelled_exception_during_aenter_also_releases_acquired_semaphore_permit(
+        self, client_config: GitHubRateLimiterConfig, github_host: str, mock_sleep: Mock
+    ) -> None:
+        client = MockGitHubClient(github_host, client_config)
+        client.rate_limiter.rate_limit_info = RateLimitInfo(
+            limit=1000, remaining=1, reset_time=int(time.time()) + 30
+        )
+        client.rate_limiter._initialized = True
+        mock_sleep.side_effect = RuntimeError("simulated enforcement failure")
+
+        permits_before_failed_aenter = client.rate_limiter._semaphore._value
+
+        with pytest.raises(RuntimeError):
+            await client.rate_limiter.__aenter__()
+
+        assert client.rate_limiter._semaphore._value == permits_before_failed_aenter
+
+    @pytest.mark.asyncio
+    async def test_uncancelled_aenter_and_aexit_still_round_trips_permit_as_before(
+        self, client_config: GitHubRateLimiterConfig, github_host: str, mock_sleep: Mock
+    ) -> None:
+        client = MockGitHubClient(github_host, client_config)
+        permits_before_context = client.rate_limiter._semaphore._value
+
+        async with client.rate_limiter:
+            assert client.rate_limiter._semaphore._value == permits_before_context - 1
+
+        assert client.rate_limiter._semaphore._value == permits_before_context

--- a/integrations/github/tests/github/clients/test_rate_limiter.py
+++ b/integrations/github/tests/github/clients/test_rate_limiter.py
@@ -695,12 +695,18 @@ class TestRateLimiterSemaphorePermitLeak:
         client.rate_limiter._initialized = True
         mock_sleep.side_effect = asyncio.CancelledError()
 
-        permits_before_cancelled_aenter = client.rate_limiter._semaphore._value
-
         with pytest.raises(asyncio.CancelledError):
             await client.rate_limiter.__aenter__()
 
-        assert client.rate_limiter._semaphore._value == permits_before_cancelled_aenter
+        acquired_permits = [
+            await asyncio.wait_for(
+                client.rate_limiter._semaphore.acquire(), timeout=0.1
+            )
+            for _ in range(client_config.max_concurrent)
+        ]
+        assert len(acquired_permits) == client_config.max_concurrent
+        for _ in acquired_permits:
+            client.rate_limiter._semaphore.release()
 
     @pytest.mark.asyncio
     async def test_ten_consecutive_cancelled_sleeps_leave_every_permit_acquirable_afterward(
@@ -721,7 +727,13 @@ class TestRateLimiterSemaphorePermitLeak:
             with pytest.raises(asyncio.CancelledError):
                 await limiter.__aenter__()
 
-        assert limiter._semaphore._value == max_concurrent_slots
+        acquired_permits = [
+            await asyncio.wait_for(limiter._semaphore.acquire(), timeout=0.1)
+            for _ in range(max_concurrent_slots)
+        ]
+        assert len(acquired_permits) == max_concurrent_slots
+        for _ in acquired_permits:
+            limiter._semaphore.release()
 
     @pytest.mark.asyncio
     async def test_non_cancelled_exception_during_aenter_also_releases_acquired_semaphore_permit(
@@ -734,21 +746,48 @@ class TestRateLimiterSemaphorePermitLeak:
         client.rate_limiter._initialized = True
         mock_sleep.side_effect = RuntimeError("simulated enforcement failure")
 
-        permits_before_failed_aenter = client.rate_limiter._semaphore._value
-
         with pytest.raises(RuntimeError):
             await client.rate_limiter.__aenter__()
 
-        assert client.rate_limiter._semaphore._value == permits_before_failed_aenter
+        acquired_permits = [
+            await asyncio.wait_for(
+                client.rate_limiter._semaphore.acquire(), timeout=0.1
+            )
+            for _ in range(client_config.max_concurrent)
+        ]
+        assert len(acquired_permits) == client_config.max_concurrent
+        for _ in acquired_permits:
+            client.rate_limiter._semaphore.release()
 
     @pytest.mark.asyncio
     async def test_uncancelled_aenter_and_aexit_still_round_trips_permit_as_before(
         self, client_config: GitHubRateLimiterConfig, github_host: str, mock_sleep: Mock
     ) -> None:
         client = MockGitHubClient(github_host, client_config)
-        permits_before_context = client.rate_limiter._semaphore._value
 
         async with client.rate_limiter:
-            assert client.rate_limiter._semaphore._value == permits_before_context - 1
+            remaining_after_one_held_permit = [
+                await asyncio.wait_for(
+                    client.rate_limiter._semaphore.acquire(), timeout=0.1
+                )
+                for _ in range(client_config.max_concurrent - 1)
+            ]
+            assert (
+                len(remaining_after_one_held_permit) == client_config.max_concurrent - 1
+            )
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(
+                    client.rate_limiter._semaphore.acquire(), timeout=0.05
+                )
+            for _ in remaining_after_one_held_permit:
+                client.rate_limiter._semaphore.release()
 
-        assert client.rate_limiter._semaphore._value == permits_before_context
+        acquired_permits = [
+            await asyncio.wait_for(
+                client.rate_limiter._semaphore.acquire(), timeout=0.1
+            )
+            for _ in range(client_config.max_concurrent)
+        ]
+        assert len(acquired_permits) == client_config.max_concurrent
+        for _ in acquired_permits:
+            client.rate_limiter._semaphore.release()


### PR DESCRIPTION
# Description

What - Part of the [ZD-9417 rate-limit deadlock investigation (Semaphore Leak Bug)](https://getport.atlassian.net/browse/PORT-18033). This PR treats the semaphore leak in isolation, as a subunit problem. Quota reservation, stale rate_limit_info, and side effects would be treated in follow-up PRs.

Why - `__aenter__` acquired the semaphore, then awaited `_enforce_rate_limit()` (which can sleep for the full rate-limit reset window) with no protection across that await. If anything raised during that sleep, in this case, a webhook processor's 90s timeout cancelling the task. `__aenter__` never returned, so `__aexit__` never ran, and the acquired permit was never released. After exactly `max_concurrent` such cancellations, every slot was gone permanently, even after GitHub's quota reset, since nothing could acquire a permit to find out.

How -


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
