### PR TITLE
[Integration][Github] Drop min page size for graphql pagination to 1

### DIFF
--- a/integrations/github/CHANGELOG.md
+++ b/integrations/github/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 6.0.12 (2026-06-25)
+
+
+### Improvements
+
+- Reduce GraphQL API minimum page size to 1, add tests to formalize page-recovery behavior
+
+
 ## 6.0.11 (2026-06-25)
 
 

--- a/integrations/github/github/clients/auth/retry_transport.py
+++ b/integrations/github/github/clients/auth/retry_transport.py
@@ -17,7 +17,7 @@ RETRYABLE_5XX_STATUS_CODES = (500, 502, 504)
 # Floors for the 5xx-recovery page-size backoff. We shrink the page on each retry
 # down to these sizes before giving up, since smaller pages reliably succeed.
 MIN_REST_PAGE_SIZE = 25
-MIN_GRAPHQL_PAGE_SIZE = 5
+MIN_GRAPHQL_PAGE_SIZE = 1
 GRAPHQL_REDUCTION_SIZE = 5
 
 

--- a/integrations/github/pyproject.toml
+++ b/integrations/github/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "github-ocean"
-version = "6.0.11"
+version = "6.0.12"
 description = "This integration ingest data from github"
 authors = ["Chukwuemeka Nwaoma <joelchukks@gmail.com>", "Melody Anyaegbulam <melodyogonna@gmail.com>", "Michael Armah <mikeyarmah@gmail.com>"]
 

--- a/integrations/github/tests/github/clients/auth/test_retry_transport.py
+++ b/integrations/github/tests/github/clients/auth/test_retry_transport.py
@@ -438,6 +438,39 @@ class TestGitHubRetryTransportPageSizeBackoff:
         assert new_body["variables"]["first"] == 100 - GRAPHQL_REDUCTION_SIZE
 
     @pytest.mark.asyncio
+    async def test_graphql_reduction_does_not_persist_across_requests(self) -> None:
+        """The transport keeps no cross-request page-size state.
+
+        Each reduction is derived solely from the request it is handed, so once a
+        request succeeds the next full-size request is shrunk from full size
+        again rather than continuing to step down from a prior request's reduced
+        size. This is what lets the page size return to its original value (the
+        client rebuilds the payload at PAGE_SIZE per page) instead of ratcheting
+        ever smaller across pages.
+        """
+        transport = _make_transport()
+        body = {"query": "{ viewer { login } }", "variables": {"first": 100}}
+
+        first_req = httpx.Request("POST", "https://api.github.com/graphql", json=body)
+        reduced = await transport._reduced_page_request(
+            first_req, httpx.Response(500, request=first_req)
+        )
+        assert (
+            json.loads(reduced.content)["variables"]["first"]
+            == 100 - GRAPHQL_REDUCTION_SIZE
+        )
+
+        # A brand-new full-size request reduces from 100 again, not from 95.
+        fresh_req = httpx.Request("POST", "https://api.github.com/graphql", json=body)
+        reduced_again = await transport._reduced_page_request(
+            fresh_req, httpx.Response(500, request=fresh_req)
+        )
+        assert (
+            json.loads(reduced_again.content)["variables"]["first"]
+            == 100 - GRAPHQL_REDUCTION_SIZE
+        )
+
+    @pytest.mark.asyncio
     async def test_reduced_graphql_request_has_consistent_content_length(self) -> None:
         """The rebuilt GraphQL request's Content-Length matches its new body
         (regression: copying the original header described the wrong byte count)."""

--- a/integrations/github/tests/github/clients/http/test_graphql_client.py
+++ b/integrations/github/tests/github/clients/http/test_graphql_client.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, patch, MagicMock
 import httpx
 from github.clients.auth.abstract_authenticator import AbstractGitHubAuthenticator
 from github.clients.auth.retry_transport import GitHubRetryTransport
-from github.clients.http.graphql_client import GithubGraphQLClient
+from github.clients.http.graphql_client import GithubGraphQLClient, PAGE_SIZE
 from github.helpers.exceptions import GraphQLClientError, GraphQLErrorGroup
 
 _GQL_HOST = "https://api.github.com"
@@ -200,6 +200,58 @@ class TestGithubGraphQLClient:
             assert len(results) == 2
             assert results[0] == [{"id": 1, "name": "repo1"}]
             assert results[1] == [{"id": 2, "name": "repo2"}]
+
+    @pytest.mark.asyncio
+    async def test_send_paginated_request_resets_page_size_each_page(
+        self, authenticator: AbstractGitHubAuthenticator
+    ) -> None:
+        """Every page is built fresh at PAGE_SIZE — a reduced page size never persists.
+
+        GitHubRetryTransport shrinks `variables.first` only within a single
+        request's retry chain; the reduced request never flows back to the
+        client. Because send_paginated_request rebuilds the payload from scratch
+        on every iteration, each page returns to the full PAGE_SIZE regardless of
+        how far a previous page was shrunk to recover from a 5xx.
+        """
+        client = GithubGraphQLClient(
+            organization="test-org",
+            github_host="https://api.github.com",
+            authenticator=authenticator,
+        )
+
+        first_response_data = {
+            "data": {
+                "organization": {
+                    "repositories": {
+                        "nodes": [{"id": 1, "name": "repo1"}],
+                        "pageInfo": {"hasNextPage": True, "endCursor": "cursor1"},
+                    }
+                }
+            }
+        }
+        second_response_data = {
+            "data": {
+                "organization": {
+                    "repositories": {
+                        "nodes": [{"id": 2, "name": "repo2"}],
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    }
+                }
+            }
+        }
+
+        mock_send = AsyncMock(side_effect=[first_response_data, second_response_data])
+        with patch.object(client, "send_api_request", mock_send):
+            async for _ in client.send_paginated_request(
+                "query", params={"__path": "organization.repositories"}
+            ):
+                pass
+
+        page_sizes = [
+            call.kwargs["json_data"]["variables"]["first"]
+            for call in mock_send.call_args_list
+        ]
+        assert page_sizes == [PAGE_SIZE, PAGE_SIZE]
 
     @pytest.mark.asyncio
     async def test_send_paginated_request_empty_response(


### PR DESCRIPTION
# Description

What - Drop minimum page-size for Graphql pagination to 1. Also add tests formalizing page recovery to 25 as expected.

Why - Some requests could still timeout at page size of 5.

How -

## Type of change

Please leave one option from the following and delete the rest:

- [ x ] Non-breaking change (fix of existing functionality that will not change current behavior)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
