### PR TITLE
[Core] Add Redis stream consumer processing latency observability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.44.5 (2026-06-30)
+
+### Improvements
+
+- Added Redis stream consumer observability: logs now include `stream_key`, `time_until_consumed_ms` (queue-to-consume latency from `queuedAt`), and `time_until_acked_ms` (queue-to-ack latency) for each message.
+
 ## 0.44.4 (2026-06-28)
 
 ### Improvements

--- a/port_ocean/config/settings.py
+++ b/port_ocean/config/settings.py
@@ -138,6 +138,14 @@ class LiveEventsRedisSettings(BaseOceanModel, extra=Extra.allow):
         ge=1,
         description="Maximum number of stream entries to return per XREADGROUP call.",
     )
+    stream_ttl_seconds: int | None = Field(
+        default=3600,
+        ge=1,
+        description=(
+            "TTL in seconds for the Redis stream when the consumer creates it "
+            "via MKSTREAM. Set to null to disable stream expiry."
+        ),
+    )
     # PEL requeue worker settings
     pel_requeue_worker_enabled: bool = Field(
         default=True,

--- a/port_ocean/consumers/redis_stream_consumer.py
+++ b/port_ocean/consumers/redis_stream_consumer.py
@@ -199,16 +199,20 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
             except Exception as error:
                 logger.exception(
                     "Unexpected error in Redis stream read loop",
+                    stream_key=self._stream_key,
                     error=str(error),
                 )
 
     async def _handle_message(self, message_id: str, fields: dict[str, str]) -> None:
         start_time = time.monotonic()
         webhook_path: str | None = None
-        time_until_consumed_ms = self._time_until_consumed_ms(fields.get("queuedAt"))
+        time_until_consumed_ms = self._time_until_consumed_ms(
+            fields.get("queuedAt"), stream_key=self._stream_key
+        )
         if time_until_consumed_ms is not None:
             logger.info(
                 "Redis stream message consumed",
+                stream_key=self._stream_key,
                 message_id=message_id,
                 time_until_consumed_ms=time_until_consumed_ms,
             )
@@ -217,6 +221,7 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
             if not raw_webhook_path:
                 logger.warning(
                     "Redis stream message missing webhookPath, acknowledging",
+                    stream_key=self._stream_key,
                     message_id=message_id,
                 )
                 return
@@ -225,6 +230,7 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
             if webhook_path not in self._registered_paths:
                 logger.warning(
                     "No processors registered for webhookPath, acknowledging",
+                    stream_key=self._stream_key,
                     webhook_path=webhook_path,
                     message_id=message_id,
                 )
@@ -254,14 +260,18 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
         except Exception as error:
             logger.exception(
                 "Failed to handle Redis stream message",
+                stream_key=self._stream_key,
                 message_id=message_id,
                 error=str(error),
             )
         finally:
             elapsed_ms = round((time.monotonic() - start_time) * 1000, 2)
-            time_until_acked_ms = self._time_until_consumed_ms(fields.get("queuedAt"))
+            time_until_acked_ms = self._time_until_consumed_ms(
+                fields.get("queuedAt"), stream_key=self._stream_key
+            )
             logger.info(
                 "Redis stream message processed",
+                stream_key=self._stream_key,
                 message_id=message_id,
                 webhook_path=webhook_path,
                 elapsed_ms=elapsed_ms,
@@ -271,7 +281,10 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
 
     @staticmethod
     def _time_until_consumed_ms(
-        queued_at: str | None, *, now: datetime | None = None
+        queued_at: str | None,
+        *,
+        now: datetime | None = None,
+        stream_key: str | None = None,
     ) -> float | None:
         if not queued_at:
             return None
@@ -284,6 +297,7 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
         except (ValueError, OSError, OverflowError):
             logger.warning(
                 "Invalid queuedAt in Redis stream message",
+                stream_key=stream_key,
                 queued_at=queued_at,
             )
             return None

--- a/port_ocean/consumers/redis_stream_consumer.py
+++ b/port_ocean/consumers/redis_stream_consumer.py
@@ -318,6 +318,7 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
             )
         finally:
             elapsed_ms = round((time.monotonic() - start_time) * 1000, 2)
+            await self._ack(message_id)
             time_until_acked_ms = self._time_since_queued_ms(queued_time)
             logger.info(
                 "Redis stream message processed",
@@ -327,7 +328,6 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
                 elapsed_ms=elapsed_ms,
                 time_until_acked_ms=time_until_acked_ms,
             )
-            await self._ack(message_id)
 
     @staticmethod
     def _parse_queued_at(
@@ -360,7 +360,17 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
             return None
 
         reference_time = now or datetime.now(timezone.utc)
-        return round((reference_time - queued_time).total_seconds() * 1000, 2)
+        delta_ms = (reference_time - queued_time).total_seconds() * 1000
+        if delta_ms < 0:
+            logger.warning(
+                "queuedAt is in the future relative to consumer clock",
+                queued_time=queued_time.isoformat(),
+                reference_time=reference_time.isoformat(),
+                delta_ms=round(delta_ms, 2),
+            )
+            return 0.0
+
+        return round(delta_ms, 2)
 
     @staticmethod
     def _normalize_webhook_path(webhook_path: str) -> str:

--- a/port_ocean/consumers/redis_stream_consumer.py
+++ b/port_ocean/consumers/redis_stream_consumer.py
@@ -261,13 +261,6 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
             fields.get("queuedAt"), stream_key=self._stream_key
         )
         time_until_consumed_ms = self._time_since_queued_ms(queued_time)
-        if time_until_consumed_ms is not None:
-            logger.info(
-                "Redis stream message consumed",
-                stream_key=self._stream_key,
-                message_id=message_id,
-                time_until_consumed_ms=time_until_consumed_ms,
-            )
         try:
             raw_webhook_path = fields.get("webhookPath")
             if not raw_webhook_path:
@@ -326,6 +319,7 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
                 message_id=message_id,
                 webhook_path=webhook_path,
                 elapsed_ms=elapsed_ms,
+                time_until_consumed_ms=time_until_consumed_ms,
                 time_until_acked_ms=time_until_acked_ms,
             )
 

--- a/port_ocean/consumers/redis_stream_consumer.py
+++ b/port_ocean/consumers/redis_stream_consumer.py
@@ -363,18 +363,6 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
         return round((reference_time - queued_time).total_seconds() * 1000, 2)
 
     @staticmethod
-    def _time_until_consumed_ms(
-        queued_at: str | None,
-        *,
-        now: datetime | None = None,
-        stream_key: str | None = None,
-    ) -> float | None:
-        queued_time = RedisStreamConsumer._parse_queued_at(
-            queued_at, stream_key=stream_key
-        )
-        return RedisStreamConsumer._time_since_queued_ms(queued_time, now=now)
-
-    @staticmethod
     def _normalize_webhook_path(webhook_path: str) -> str:
         """Map ingestion HTTP paths to integration processor paths.
 

--- a/port_ocean/consumers/redis_stream_consumer.py
+++ b/port_ocean/consumers/redis_stream_consumer.py
@@ -206,9 +206,10 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
     async def _handle_message(self, message_id: str, fields: dict[str, str]) -> None:
         start_time = time.monotonic()
         webhook_path: str | None = None
-        time_until_consumed_ms = self._time_until_consumed_ms(
+        queued_time = self._parse_queued_at(
             fields.get("queuedAt"), stream_key=self._stream_key
         )
+        time_until_consumed_ms = self._time_since_queued_ms(queued_time)
         if time_until_consumed_ms is not None:
             logger.info(
                 "Redis stream message consumed",
@@ -266,9 +267,7 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
             )
         finally:
             elapsed_ms = round((time.monotonic() - start_time) * 1000, 2)
-            time_until_acked_ms = self._time_until_consumed_ms(
-                fields.get("queuedAt"), stream_key=self._stream_key
-            )
+            time_until_acked_ms = self._time_since_queued_ms(queued_time)
             logger.info(
                 "Redis stream message processed",
                 stream_key=self._stream_key,
@@ -280,18 +279,16 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
             await self._ack(message_id)
 
     @staticmethod
-    def _time_until_consumed_ms(
+    def _parse_queued_at(
         queued_at: str | None,
         *,
-        now: datetime | None = None,
         stream_key: str | None = None,
-    ) -> float | None:
+    ) -> datetime | None:
         if not queued_at:
             return None
 
-        consumed_at = now or datetime.now(timezone.utc)
         try:
-            queued_time = datetime.fromtimestamp(
+            return datetime.fromtimestamp(
                 float(queued_at) / 1_000_000_000, tz=timezone.utc
             )
         except (ValueError, OSError, OverflowError):
@@ -302,7 +299,29 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
             )
             return None
 
-        return round((consumed_at - queued_time).total_seconds() * 1000, 2)
+    @staticmethod
+    def _time_since_queued_ms(
+        queued_time: datetime | None,
+        *,
+        now: datetime | None = None,
+    ) -> float | None:
+        if queued_time is None:
+            return None
+
+        reference_time = now or datetime.now(timezone.utc)
+        return round((reference_time - queued_time).total_seconds() * 1000, 2)
+
+    @staticmethod
+    def _time_until_consumed_ms(
+        queued_at: str | None,
+        *,
+        now: datetime | None = None,
+        stream_key: str | None = None,
+    ) -> float | None:
+        queued_time = RedisStreamConsumer._parse_queued_at(
+            queued_at, stream_key=stream_key
+        )
+        return RedisStreamConsumer._time_since_queued_ms(queued_time, now=now)
 
     @staticmethod
     def _normalize_webhook_path(webhook_path: str) -> str:

--- a/port_ocean/consumers/redis_stream_consumer.py
+++ b/port_ocean/consumers/redis_stream_consumer.py
@@ -20,6 +20,7 @@ from port_ocean.consumers.abstract_live_events_consumer import (
     AbstractLiveEventsConsumer,
 )
 from port_ocean.consumers.pel_requeue import PELRequeueWorker
+from port_ocean.consumers.redis_stream_utils import is_missing_stream_or_group_error
 from port_ocean.context.ocean import ocean
 from port_ocean.exceptions.live_events import InvalidLiveEventsRedisStreamFieldError
 from port_ocean.core.handlers.webhook.webhook_event import (
@@ -154,7 +155,18 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
     async def _ack(self, message_id: str) -> None:
         if self._redis is None:
             return
-        await self._redis.xack(self._stream_key, self._consumer_group, message_id)
+        try:
+            await self._redis.xack(self._stream_key, self._consumer_group, message_id)
+        except ResponseError as error:
+            if not is_missing_stream_or_group_error(error):
+                raise
+            logger.warning(
+                "Redis stream or consumer group missing during ack, recreating",
+                stream_key=self._stream_key,
+                message_id=message_id,
+                error=str(error),
+            )
+            await self._ensure_consumer_group()
 
     def _require_redis(self) -> Redis:
         if self._redis is None:
@@ -165,16 +177,39 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
 
     async def _ensure_consumer_group(self) -> None:
         redis = self._require_redis()
+        stream_existed = bool(await redis.exists(self._stream_key))
+        consumer_group_created = False
         try:
             await redis.xgroup_create(
                 self._stream_key,
                 self._consumer_group,
-                id="$",
+                id="0" if stream_existed else "$",
                 mkstream=True,
             )
+            consumer_group_created = True
         except ResponseError as error:
             if "BUSYGROUP" not in str(error):
                 raise
+
+        if (
+            consumer_group_created
+            and not stream_existed
+            and self._settings.stream_ttl_seconds is not None
+        ):
+            await redis.expire(self._stream_key, self._settings.stream_ttl_seconds)
+            logger.info(
+                "Set TTL on newly created Redis stream",
+                stream_key=self._stream_key,
+                stream_ttl_seconds=self._settings.stream_ttl_seconds,
+            )
+
+    async def _recover_missing_stream(self) -> None:
+        logger.warning(
+            "Redis stream or consumer group missing, recreating",
+            stream_key=self._stream_key,
+            consumer_group=self._consumer_group,
+        )
+        await self._ensure_consumer_group()
 
     async def _read_loop(self) -> None:
         redis = self._require_redis()
@@ -196,6 +231,22 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
                         await self._handle_message(message_id, fields)
             except asyncio.CancelledError:
                 break
+            except ResponseError as error:
+                if is_missing_stream_or_group_error(error):
+                    try:
+                        await self._recover_missing_stream()
+                    except Exception as recovery_error:
+                        logger.exception(
+                            "Failed to recreate Redis stream consumer group",
+                            stream_key=self._stream_key,
+                            error=str(recovery_error),
+                        )
+                else:
+                    logger.exception(
+                        "Unexpected Redis error in stream read loop",
+                        stream_key=self._stream_key,
+                        error=str(error),
+                    )
             except Exception as error:
                 logger.exception(
                     "Unexpected error in Redis stream read loop",

--- a/port_ocean/consumers/redis_stream_consumer.py
+++ b/port_ocean/consumers/redis_stream_consumer.py
@@ -183,7 +183,7 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
             await redis.xgroup_create(
                 self._stream_key,
                 self._consumer_group,
-                id="0" if stream_existed else "$",
+                id="$",
                 mkstream=True,
             )
             consumer_group_created = True

--- a/port_ocean/consumers/redis_stream_consumer.py
+++ b/port_ocean/consumers/redis_stream_consumer.py
@@ -6,6 +6,7 @@ import socket
 import tempfile
 import time
 from collections.abc import Awaitable, Callable
+from datetime import datetime, timezone
 from typing import Any
 from uuid import uuid4
 
@@ -204,6 +205,13 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
     async def _handle_message(self, message_id: str, fields: dict[str, str]) -> None:
         start_time = time.monotonic()
         webhook_path: str | None = None
+        time_until_consumed_ms = self._time_until_consumed_ms(fields.get("queuedAt"))
+        if time_until_consumed_ms is not None:
+            logger.info(
+                "Redis stream message consumed",
+                message_id=message_id,
+                time_until_consumed_ms=time_until_consumed_ms,
+            )
         try:
             raw_webhook_path = fields.get("webhookPath")
             if not raw_webhook_path:
@@ -251,13 +259,36 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
             )
         finally:
             elapsed_ms = round((time.monotonic() - start_time) * 1000, 2)
+            time_until_acked_ms = self._time_until_consumed_ms(fields.get("queuedAt"))
             logger.info(
                 "Redis stream message processed",
                 message_id=message_id,
                 webhook_path=webhook_path,
                 elapsed_ms=elapsed_ms,
+                time_until_acked_ms=time_until_acked_ms,
             )
             await self._ack(message_id)
+
+    @staticmethod
+    def _time_until_consumed_ms(
+        queued_at: str | None, *, now: datetime | None = None
+    ) -> float | None:
+        if not queued_at:
+            return None
+
+        consumed_at = now or datetime.now(timezone.utc)
+        try:
+            queued_time = datetime.fromtimestamp(
+                float(queued_at) / 1_000_000_000, tz=timezone.utc
+            )
+        except (ValueError, OSError, OverflowError):
+            logger.warning(
+                "Invalid queuedAt in Redis stream message",
+                queued_at=queued_at,
+            )
+            return None
+
+        return round((consumed_at - queued_time).total_seconds() * 1000, 2)
 
     @staticmethod
     def _normalize_webhook_path(webhook_path: str) -> str:

--- a/port_ocean/consumers/redis_stream_utils.py
+++ b/port_ocean/consumers/redis_stream_utils.py
@@ -1,0 +1,9 @@
+from redis.exceptions import ResponseError
+
+
+def is_missing_stream_or_group_error(error: Exception) -> bool:
+    """Return True when Redis reports a missing stream key or consumer group."""
+    if not isinstance(error, ResponseError):
+        return False
+
+    return "NOGROUP" in str(error).upper()

--- a/port_ocean/tests/config/test_live_events_redis_settings.py
+++ b/port_ocean/tests/config/test_live_events_redis_settings.py
@@ -10,6 +10,7 @@ class TestLiveEventsRedisSettingsValidation:
 
         assert settings.enable_tls is False
         assert settings.pel_requeue_worker_enabled is True
+        assert settings.stream_ttl_seconds == 3600
 
     def test_pel_requeue_worker_enabled_from_env(
         self, monkeypatch: pytest.MonkeyPatch
@@ -27,6 +28,19 @@ class TestLiveEventsRedisSettingsValidation:
         config = IntegrationConfiguration()
 
         assert config.live_events.redis.pel_requeue_worker_enabled is True
+
+    def test_stream_ttl_seconds_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from port_ocean.config.settings import IntegrationConfiguration
+
+        monkeypatch.setenv("OCEAN__LIVE_EVENTS__REDIS__STREAM_TTL_SECONDS", "7200")
+        monkeypatch.setenv("OCEAN__PORT__CLIENT_ID", "test-client-id")
+        monkeypatch.setenv("OCEAN__PORT__CLIENT_SECRET", "test-client-secret")
+        monkeypatch.setenv("OCEAN__INTEGRATION__TYPE", "test")
+        monkeypatch.setenv("OCEAN__INTEGRATION__IDENTIFIER", "test-id")
+
+        config = IntegrationConfiguration()
+
+        assert config.live_events.redis.stream_ttl_seconds == 7200
 
     def test_accepts_rediss_url_with_tls_enabled(self) -> None:
         settings = LiveEventsRedisSettings(

--- a/port_ocean/tests/consumers/test_redis_stream_consumer.py
+++ b/port_ocean/tests/consumers/test_redis_stream_consumer.py
@@ -401,7 +401,7 @@ class TestRedisStreamConsumerGroupCreation:
         mock_redis.expire.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_uses_start_id_zero_when_stream_already_exists(
+    async def test_uses_start_id_dollar_when_stream_already_exists(
         self,
         mock_ocean_config: MagicMock,
     ) -> None:
@@ -422,7 +422,7 @@ class TestRedisStreamConsumerGroupCreation:
             consumer._redis = mock_redis
             await consumer._ensure_consumer_group()
 
-        assert mock_redis.xgroup_create.await_args.kwargs["id"] == "0"
+        assert mock_redis.xgroup_create.await_args.kwargs["id"] == "$"
         mock_redis.expire.assert_not_awaited()
 
     @pytest.mark.asyncio

--- a/port_ocean/tests/consumers/test_redis_stream_consumer.py
+++ b/port_ocean/tests/consumers/test_redis_stream_consumer.py
@@ -787,17 +787,12 @@ class TestRedisStreamConsumer:
                 )
 
         mock_logger_info.assert_any_call(
-            "Redis stream message consumed",
-            stream_key="1111111/live-events/raw/event-stream",
-            message_id="1700000000000-0",
-            time_until_consumed_ms=2000.0,
-        )
-        mock_logger_info.assert_any_call(
             "Redis stream message processed",
             stream_key="1111111/live-events/raw/event-stream",
             message_id="1700000000000-0",
             webhook_path="/webhook",
             elapsed_ms=ANY,
+            time_until_consumed_ms=2000.0,
             time_until_acked_ms=2500.0,
         )
 

--- a/port_ocean/tests/consumers/test_redis_stream_consumer.py
+++ b/port_ocean/tests/consumers/test_redis_stream_consumer.py
@@ -533,10 +533,17 @@ class TestRedisStreamConsumer:
             )
             consumer._ack = AsyncMock()  # type: ignore[method-assign]
 
-            with patch.object(
-                RedisStreamConsumer,
-                "_time_until_consumed_ms",
-                side_effect=[2000.0, 2500.0],
+            with (
+                patch.object(
+                    RedisStreamConsumer,
+                    "_parse_queued_at",
+                    return_value=datetime.fromtimestamp(1700000000, tz=timezone.utc),
+                ),
+                patch.object(
+                    RedisStreamConsumer,
+                    "_time_since_queued_ms",
+                    side_effect=[2000.0, 2500.0],
+                ),
             ):
                 await consumer._handle_message(
                     "1700000000000-0",
@@ -561,6 +568,47 @@ class TestRedisStreamConsumer:
             webhook_path="/webhook",
             elapsed_ms=ANY,
             time_until_acked_ms=2500.0,
+        )
+
+    @pytest.mark.asyncio
+    async def test_handle_message_logs_invalid_queued_at_once(
+        self,
+        redis_settings: LiveEventsRedisSettings,
+        mock_ocean_config: MagicMock,
+    ) -> None:
+        path = "/webhook"
+        on_message = AsyncMock()
+
+        with (
+            patch(
+                "port_ocean.consumers.redis_stream_consumer.ocean", mock_ocean_config
+            ),
+            patch(
+                "port_ocean.consumers.redis_stream_consumer.logger.warning"
+            ) as mock_logger_warning,
+        ):
+            consumer = RedisStreamConsumer(
+                redis_settings=redis_settings,
+                stream_key="1111111/live-events/raw/event-stream",
+                on_message=on_message,
+                registered_paths={path},
+            )
+            consumer._ack = AsyncMock()  # type: ignore[method-assign]
+
+            await consumer._handle_message(
+                "1700000000000-0",
+                {
+                    "payload": json.dumps({}),
+                    "headers": json.dumps({}),
+                    "webhookPath": "integration/webhook",
+                    "queuedAt": "not-a-timestamp",
+                },
+            )
+
+        mock_logger_warning.assert_called_once_with(
+            "Invalid queuedAt in Redis stream message",
+            stream_key="1111111/live-events/raw/event-stream",
+            queued_at="not-a-timestamp",
         )
 
     @pytest.mark.asyncio

--- a/port_ocean/tests/consumers/test_redis_stream_consumer.py
+++ b/port_ocean/tests/consumers/test_redis_stream_consumer.py
@@ -9,6 +9,7 @@ from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 from redis.asyncio.connection import SSLConnection
+from redis.exceptions import ResponseError
 
 from port_ocean.config.settings import LiveEventsRedisSettings
 from port_ocean.consumers.live_events_stream_key import (
@@ -274,6 +275,209 @@ class TestRedisStreamConsumerConnection:
 
         mock_redis.xreadgroup.assert_awaited_once()
         assert mock_redis.xreadgroup.await_args.kwargs["count"] == 25
+
+    @pytest.mark.asyncio
+    async def test_read_loop_recreates_consumer_group_when_stream_missing(
+        self,
+        mock_ocean_config: MagicMock,
+    ) -> None:
+        settings = LiveEventsRedisSettings(
+            url="redis://localhost:6379",
+            block_ms=100,
+        )
+        mock_redis = AsyncMock()
+        read_calls = 0
+
+        async def read_side_effect(**_kwargs: object) -> list[object]:
+            nonlocal read_calls
+            read_calls += 1
+            if read_calls == 1:
+                raise ResponseError(
+                    "NOGROUP No such key 'stream' or consumer group 'test.integration'"
+                )
+            consumer._is_running = False
+            return []
+
+        mock_redis.xreadgroup = AsyncMock(side_effect=read_side_effect)
+
+        with patch(
+            "port_ocean.consumers.redis_stream_consumer.ocean", mock_ocean_config
+        ):
+            consumer = RedisStreamConsumer(
+                redis_settings=settings,
+                stream_key="stream",
+                on_message=AsyncMock(),
+            )
+            consumer._redis = mock_redis
+            consumer._is_running = True
+            consumer._ensure_consumer_group = AsyncMock()
+
+            await consumer._read_loop()
+
+        consumer._ensure_consumer_group.assert_awaited_once()
+        assert mock_redis.xreadgroup.await_count == 2
+
+
+class TestRedisStreamConsumerGroupCreation:
+    @pytest.mark.asyncio
+    async def test_sets_ttl_when_consumer_creates_stream(
+        self,
+        mock_ocean_config: MagicMock,
+    ) -> None:
+        settings = LiveEventsRedisSettings(
+            url="redis://localhost:6379",
+            stream_ttl_seconds=3600,
+        )
+        mock_redis = AsyncMock()
+        mock_redis.exists = AsyncMock(return_value=0)
+        mock_redis.xgroup_create = AsyncMock()
+        mock_redis.expire = AsyncMock()
+
+        with patch(
+            "port_ocean.consumers.redis_stream_consumer.ocean", mock_ocean_config
+        ):
+            consumer = RedisStreamConsumer(
+                redis_settings=settings,
+                stream_key="stream",
+                on_message=AsyncMock(),
+            )
+            consumer._redis = mock_redis
+            await consumer._ensure_consumer_group()
+
+        mock_redis.expire.assert_awaited_once_with("stream", 3600)
+
+    @pytest.mark.asyncio
+    async def test_skips_ttl_when_stream_already_exists(
+        self,
+        mock_ocean_config: MagicMock,
+    ) -> None:
+        settings = LiveEventsRedisSettings(
+            url="redis://localhost:6379",
+            stream_ttl_seconds=3600,
+        )
+        mock_redis = AsyncMock()
+        mock_redis.exists = AsyncMock(return_value=1)
+        mock_redis.xgroup_create = AsyncMock()
+        mock_redis.expire = AsyncMock()
+
+        with patch(
+            "port_ocean.consumers.redis_stream_consumer.ocean", mock_ocean_config
+        ):
+            consumer = RedisStreamConsumer(
+                redis_settings=settings,
+                stream_key="stream",
+                on_message=AsyncMock(),
+            )
+            consumer._redis = mock_redis
+            await consumer._ensure_consumer_group()
+
+        mock_redis.expire.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_skips_ttl_when_disabled(
+        self,
+        mock_ocean_config: MagicMock,
+    ) -> None:
+        settings = LiveEventsRedisSettings(
+            url="redis://localhost:6379",
+            stream_ttl_seconds=None,
+        )
+        mock_redis = AsyncMock()
+        mock_redis.exists = AsyncMock(return_value=0)
+        mock_redis.xgroup_create = AsyncMock()
+        mock_redis.expire = AsyncMock()
+
+        with patch(
+            "port_ocean.consumers.redis_stream_consumer.ocean", mock_ocean_config
+        ):
+            consumer = RedisStreamConsumer(
+                redis_settings=settings,
+                stream_key="stream",
+                on_message=AsyncMock(),
+            )
+            consumer._redis = mock_redis
+            await consumer._ensure_consumer_group()
+
+        mock_redis.expire.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_uses_start_id_zero_when_stream_already_exists(
+        self,
+        mock_ocean_config: MagicMock,
+    ) -> None:
+        settings = LiveEventsRedisSettings(url="redis://localhost:6379")
+        mock_redis = AsyncMock()
+        mock_redis.exists = AsyncMock(return_value=1)
+        mock_redis.xgroup_create = AsyncMock()
+        mock_redis.expire = AsyncMock()
+
+        with patch(
+            "port_ocean.consumers.redis_stream_consumer.ocean", mock_ocean_config
+        ):
+            consumer = RedisStreamConsumer(
+                redis_settings=settings,
+                stream_key="stream",
+                on_message=AsyncMock(),
+            )
+            consumer._redis = mock_redis
+            await consumer._ensure_consumer_group()
+
+        assert mock_redis.xgroup_create.await_args.kwargs["id"] == "0"
+        mock_redis.expire.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_uses_start_id_dollar_when_creating_empty_stream(
+        self,
+        mock_ocean_config: MagicMock,
+    ) -> None:
+        settings = LiveEventsRedisSettings(url="redis://localhost:6379")
+        mock_redis = AsyncMock()
+        mock_redis.exists = AsyncMock(return_value=0)
+        mock_redis.xgroup_create = AsyncMock()
+        mock_redis.expire = AsyncMock()
+
+        with patch(
+            "port_ocean.consumers.redis_stream_consumer.ocean", mock_ocean_config
+        ):
+            consumer = RedisStreamConsumer(
+                redis_settings=settings,
+                stream_key="stream",
+                on_message=AsyncMock(),
+            )
+            consumer._redis = mock_redis
+            await consumer._ensure_consumer_group()
+
+        assert mock_redis.xgroup_create.await_args.kwargs["id"] == "$"
+        mock_redis.expire.assert_awaited_once_with("stream", 3600)
+
+    @pytest.mark.asyncio
+    async def test_skips_ttl_when_consumer_group_already_exists(
+        self,
+        mock_ocean_config: MagicMock,
+    ) -> None:
+        settings = LiveEventsRedisSettings(
+            url="redis://localhost:6379",
+            stream_ttl_seconds=3600,
+        )
+        mock_redis = AsyncMock()
+        mock_redis.exists = AsyncMock(return_value=0)
+        mock_redis.xgroup_create = AsyncMock(
+            side_effect=ResponseError("BUSYGROUP Consumer Group name already exists")
+        )
+        mock_redis.expire = AsyncMock()
+
+        with patch(
+            "port_ocean.consumers.redis_stream_consumer.ocean", mock_ocean_config
+        ):
+            consumer = RedisStreamConsumer(
+                redis_settings=settings,
+                stream_key="stream",
+                on_message=AsyncMock(),
+            )
+            consumer._redis = mock_redis
+            await consumer._ensure_consumer_group()
+
+        mock_redis.expire.assert_not_awaited()
 
 
 class TestRedisStreamConsumerPelWorkerLifecycle:

--- a/port_ocean/tests/consumers/test_redis_stream_consumer.py
+++ b/port_ocean/tests/consumers/test_redis_stream_consumer.py
@@ -550,11 +550,13 @@ class TestRedisStreamConsumer:
 
         mock_logger_info.assert_any_call(
             "Redis stream message consumed",
+            stream_key="1111111/live-events/raw/event-stream",
             message_id="1700000000000-0",
             time_until_consumed_ms=2000.0,
         )
         mock_logger_info.assert_any_call(
             "Redis stream message processed",
+            stream_key="1111111/live-events/raw/event-stream",
             message_id="1700000000000-0",
             webhook_path="/webhook",
             elapsed_ms=ANY,

--- a/port_ocean/tests/consumers/test_redis_stream_consumer.py
+++ b/port_ocean/tests/consumers/test_redis_stream_consumer.py
@@ -4,7 +4,8 @@ import json
 import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import datetime, timezone
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 from redis.asyncio.connection import SSLConnection
@@ -480,6 +481,84 @@ class TestRedisStreamConsumer:
                 "integration/webhook/monitor-events"
             )
             == "/webhook/monitor-events"
+        )
+
+    def test_time_until_consumed_ms_from_unix_nanoseconds(self) -> None:
+        queued_at = "1700000000000000000"
+        consumed_at = datetime.fromtimestamp(1700000001.5, tz=timezone.utc)
+
+        assert (
+            RedisStreamConsumer._time_until_consumed_ms(queued_at, now=consumed_at)
+            == 1500.0
+        )
+
+    def test_time_until_consumed_ms_from_unix_nanoseconds_with_fraction(self) -> None:
+        queued_at = "1700000000500000000"
+        consumed_at = datetime.fromtimestamp(1700000002.0, tz=timezone.utc)
+
+        assert (
+            RedisStreamConsumer._time_until_consumed_ms(queued_at, now=consumed_at)
+            == 1500.0
+        )
+
+    def test_time_until_consumed_ms_returns_none_when_missing(self) -> None:
+        assert RedisStreamConsumer._time_until_consumed_ms(None) is None
+        assert RedisStreamConsumer._time_until_consumed_ms("") is None
+
+    def test_time_until_consumed_ms_returns_none_for_invalid_timestamp(self) -> None:
+        assert RedisStreamConsumer._time_until_consumed_ms("not-a-timestamp") is None
+
+    @pytest.mark.asyncio
+    async def test_handle_message_logs_time_until_consumed(
+        self,
+        redis_settings: LiveEventsRedisSettings,
+        mock_ocean_config: MagicMock,
+    ) -> None:
+        path = "/webhook"
+        on_message = AsyncMock()
+
+        with (
+            patch(
+                "port_ocean.consumers.redis_stream_consumer.ocean", mock_ocean_config
+            ),
+            patch(
+                "port_ocean.consumers.redis_stream_consumer.logger.info"
+            ) as mock_logger_info,
+        ):
+            consumer = RedisStreamConsumer(
+                redis_settings=redis_settings,
+                stream_key="1111111/live-events/raw/event-stream",
+                on_message=on_message,
+                registered_paths={path},
+            )
+            consumer._ack = AsyncMock()  # type: ignore[method-assign]
+
+            with patch.object(
+                RedisStreamConsumer,
+                "_time_until_consumed_ms",
+                side_effect=[2000.0, 2500.0],
+            ):
+                await consumer._handle_message(
+                    "1700000000000-0",
+                    {
+                        "payload": json.dumps({}),
+                        "headers": json.dumps({}),
+                        "webhookPath": "integration/webhook",
+                        "queuedAt": "1700000000000000000",
+                    },
+                )
+
+        mock_logger_info.assert_any_call(
+            "Redis stream message consumed",
+            message_id="1700000000000-0",
+            time_until_consumed_ms=2000.0,
+        )
+        mock_logger_info.assert_any_call(
+            "Redis stream message processed",
+            message_id="1700000000000-0",
+            webhook_path="/webhook",
+            elapsed_ms=ANY,
+            time_until_acked_ms=2500.0,
         )
 
     @pytest.mark.asyncio

--- a/port_ocean/tests/consumers/test_redis_stream_consumer.py
+++ b/port_ocean/tests/consumers/test_redis_stream_consumer.py
@@ -717,6 +717,25 @@ class TestRedisStreamConsumer:
             == 1500.0
         )
 
+    def test_time_since_queued_ms_clamps_negative_delta_to_zero(self) -> None:
+        queued_time = datetime.fromtimestamp(1700000001.5, tz=timezone.utc)
+        consumed_at = datetime.fromtimestamp(1700000000, tz=timezone.utc)
+
+        with patch(
+            "port_ocean.consumers.redis_stream_consumer.logger.warning"
+        ) as mock_warning:
+            assert (
+                RedisStreamConsumer._time_since_queued_ms(queued_time, now=consumed_at)
+                == 0.0
+            )
+
+        mock_warning.assert_called_once_with(
+            "queuedAt is in the future relative to consumer clock",
+            queued_time=queued_time.isoformat(),
+            reference_time=consumed_at.isoformat(),
+            delta_ms=-1500.0,
+        )
+
     def test_time_since_queued_ms_returns_none_when_queued_time_missing(self) -> None:
         assert RedisStreamConsumer._time_since_queued_ms(None) is None
 

--- a/port_ocean/tests/consumers/test_redis_stream_consumer.py
+++ b/port_ocean/tests/consumers/test_redis_stream_consumer.py
@@ -310,7 +310,7 @@ class TestRedisStreamConsumerConnection:
             )
             consumer._redis = mock_redis
             consumer._is_running = True
-            consumer._ensure_consumer_group = AsyncMock()
+            consumer._ensure_consumer_group = AsyncMock()  # type: ignore[method-assign]
 
             await consumer._read_loop()
 

--- a/port_ocean/tests/consumers/test_redis_stream_consumer.py
+++ b/port_ocean/tests/consumers/test_redis_stream_consumer.py
@@ -687,30 +687,38 @@ class TestRedisStreamConsumer:
             == "/webhook/monitor-events"
         )
 
-    def test_time_until_consumed_ms_from_unix_nanoseconds(self) -> None:
+    def test_parse_queued_at_from_unix_nanoseconds(self) -> None:
         queued_at = "1700000000000000000"
+
+        assert RedisStreamConsumer._parse_queued_at(
+            queued_at
+        ) == datetime.fromtimestamp(1700000000, tz=timezone.utc)
+
+    def test_parse_queued_at_from_unix_nanoseconds_with_fraction(self) -> None:
+        queued_at = "1700000000500000000"
+
+        assert RedisStreamConsumer._parse_queued_at(
+            queued_at
+        ) == datetime.fromtimestamp(1700000000.5, tz=timezone.utc)
+
+    def test_parse_queued_at_returns_none_when_missing(self) -> None:
+        assert RedisStreamConsumer._parse_queued_at(None) is None
+        assert RedisStreamConsumer._parse_queued_at("") is None
+
+    def test_parse_queued_at_returns_none_for_invalid_timestamp(self) -> None:
+        assert RedisStreamConsumer._parse_queued_at("not-a-timestamp") is None
+
+    def test_time_since_queued_ms(self) -> None:
+        queued_time = datetime.fromtimestamp(1700000000, tz=timezone.utc)
         consumed_at = datetime.fromtimestamp(1700000001.5, tz=timezone.utc)
 
         assert (
-            RedisStreamConsumer._time_until_consumed_ms(queued_at, now=consumed_at)
+            RedisStreamConsumer._time_since_queued_ms(queued_time, now=consumed_at)
             == 1500.0
         )
 
-    def test_time_until_consumed_ms_from_unix_nanoseconds_with_fraction(self) -> None:
-        queued_at = "1700000000500000000"
-        consumed_at = datetime.fromtimestamp(1700000002.0, tz=timezone.utc)
-
-        assert (
-            RedisStreamConsumer._time_until_consumed_ms(queued_at, now=consumed_at)
-            == 1500.0
-        )
-
-    def test_time_until_consumed_ms_returns_none_when_missing(self) -> None:
-        assert RedisStreamConsumer._time_until_consumed_ms(None) is None
-        assert RedisStreamConsumer._time_until_consumed_ms("") is None
-
-    def test_time_until_consumed_ms_returns_none_for_invalid_timestamp(self) -> None:
-        assert RedisStreamConsumer._time_until_consumed_ms("not-a-timestamp") is None
+    def test_time_since_queued_ms_returns_none_when_queued_time_missing(self) -> None:
+        assert RedisStreamConsumer._time_since_queued_ms(None) is None
 
     @pytest.mark.asyncio
     async def test_handle_message_logs_time_until_consumed(

--- a/port_ocean/tests/consumers/test_redis_stream_utils.py
+++ b/port_ocean/tests/consumers/test_redis_stream_utils.py
@@ -1,0 +1,25 @@
+import pytest
+from redis.exceptions import ResponseError
+
+from port_ocean.consumers.redis_stream_utils import is_missing_stream_or_group_error
+
+
+class TestIsMissingStreamOrGroupError:
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "NOGROUP No such key 'stream' or consumer group 'group'",
+            "nogroup consumer group name does not exist",
+        ],
+    )
+    def test_returns_true_for_missing_stream_or_group(self, message: str) -> None:
+        assert is_missing_stream_or_group_error(ResponseError(message)) is True
+
+    def test_returns_false_for_other_response_errors(self) -> None:
+        assert (
+            is_missing_stream_or_group_error(ResponseError("BUSYGROUP already exists"))
+            is False
+        )
+
+    def test_returns_false_for_non_response_errors(self) -> None:
+        assert is_missing_stream_or_group_error(RuntimeError("boom")) is False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.44.4"
+version = "0.44.5"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

- Add observability to the Redis stream consumer: log time_until_consumed_ms (queue-to-consume) and time_until_acked_ms (queue-to-ack) from the message queuedAt field.

- Include stream_key on Redis stream consumer log lines for easier filtering in production.

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.
