### PR TITLE
[Integration][ServiceNow] Use simple string literals as object kind in integration py configuration

### DIFF
--- a/integrations/servicenow/CHANGELOG.md
+++ b/integrations/servicenow/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.3.97 (2026-07-01)
+
+
+### Bug Fixes
+
+- Use simple string literals in kind names to prevent Loguru from crashing in multi-process mode
+
+
 ## 0.3.96 (2026-06-30)
 
 

--- a/integrations/servicenow/integration.py
+++ b/integrations/servicenow/integration.py
@@ -74,7 +74,7 @@ class IncidentResourceConfig(ResourceConfig):
         title="Incident Selector",
         description="Selector for filtering ServiceNow incident records",
     )
-    kind: Literal[ObjectKind.INCIDENT] = Field(
+    kind: Literal["incident"] = Field(
         title="ServiceNow Incident",
         description="A ServiceNow incident record from the incident table",
     )
@@ -85,7 +85,7 @@ class UserGroupResourceConfig(ResourceConfig):
         title="User Group Selector",
         description="Selector for filtering ServiceNow user group records",
     )
-    kind: Literal[ObjectKind.USER_GROUP] = Field(
+    kind: Literal["sys_user_group"] = Field(
         title="ServiceNow User Group",
         description="A ServiceNow user group from the sys_user_group table",
     )
@@ -96,7 +96,7 @@ class ServiceCatalogResourceConfig(ResourceConfig):
         title="Service Catalog Selector",
         description="Selector for filtering ServiceNow service catalog records",
     )
-    kind: Literal[ObjectKind.SERVICE_CATALOG] = Field(
+    kind: Literal["sc_catalog"] = Field(
         title="ServiceNow Service Catalog",
         description="A ServiceNow service catalog from the sc_catalog table",
     )
@@ -107,7 +107,7 @@ class VulnerabilityResourceConfig(ResourceConfig):
         title="Vulnerability Selector",
         description="Selector for filtering ServiceNow vulnerable item records",
     )
-    kind: Literal[ObjectKind.VULNERABILITY] = Field(
+    kind: Literal["sn_vul_vulnerable_item"] = Field(
         title="ServiceNow Vulnerability",
         description="A ServiceNow vulnerable item from the sn_vul_vulnerable_item table",
     )
@@ -118,7 +118,7 @@ class ReleaseProjectResourceConfig(ResourceConfig):
         title="Release Project Selector",
         description="Selector for filtering ServiceNow release project records",
     )
-    kind: Literal[ObjectKind.RELEASE_PROJECT] = Field(
+    kind: Literal["release_project"] = Field(
         title="ServiceNow Release Project",
         description="A ServiceNow release project from the release_project table",
     )

--- a/integrations/servicenow/pyproject.toml
+++ b/integrations/servicenow/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "servicenow"
-version = "0.3.96"
+version = "0.3.97"
 description = "ServiceNow Ocean Integration"
 authors = ["Isaac Coffie <isaac@getport.io>"]
 


### PR DESCRIPTION
# Description

What - Use simple string literals in kind names rather than the enum value.

Why - Loguru has issues pickling the enum value in multi-process mode.

How - Use the string values directly and compare generated schema.

## Type of change

Please leave one option from the following and delete the rest:

- [ x ] Bug fix (non-breaking change which fixes an issue)

## Screenshots

Both generate exactly the same ui schema.

<img width="1745" height="696" alt="Screenshot 2026-07-01 at 15 13 25" src="https://github.com/user-attachments/assets/1cfd3494-0c7e-4bef-972a-c25749b4e6ed" />


## API Documentation

Provide links to the API documentation used for this integration.
