### PR TITLE
[Integration][GitHub] Use workflow run ID on dispatch for concurrent action runs

### DIFF
--- a/integrations/github/CHANGELOG.md
+++ b/integrations/github/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
-- Use GitHub workflow run ID returned on dispatch to track workflow runs, enabling concurrent dispatch workflow action executions. (thsmib)
+- Use GitHub workflow run ID returned on dispatch to track workflow runs, enabling concurrent dispatch workflow action executions.
 
 
 ## 6.2.2 (2026-07-02)

--- a/integrations/github/CHANGELOG.md
+++ b/integrations/github/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 6.2.3 (2026-07-07)
+
+
+### Improvements
+
+- Use GitHub workflow run ID returned on dispatch to track workflow runs, enabling concurrent dispatch workflow action executions. (thsmib)
+
+
 ## 6.2.2 (2026-07-02)
 
 

--- a/integrations/github/github/actions/dispatch_workflow_executor.py
+++ b/integrations/github/github/actions/dispatch_workflow_executor.py
@@ -35,22 +35,21 @@ class DispatchWorkflowExecutor(AbstractGithubExecutor):
     This executor implements the Port action for triggering GitHub Actions workflows.
     It supports:
     - Dispatching workflows with custom inputs
-    - Tracking workflow execution status
+    - Tracking workflow execution status via the returned workflow run ID
     - Reporting workflow completion back to Port
     - Rate limit handling for GitHub API
     - Webhook processing for async status updates
 
-    The executor uses workflow names as partition keys to ensure sequential
-    execution of the same workflow, which is necessary for proper run tracking.
-    It identifies workflow runs by finding the one closest to the trigger time
-    and recording its ID.
+    On dispatch, GitHub returns a workflow run ID when `return_run_details` is set.
+    The executor fetches that run and builds a unique external ID from it, so
+    multiple dispatches of the same workflow can run concurrently without collision.
 
     Attributes:
         ACTION_NAME (str): The name of this action in Port's spec ("dispatch_workflow")
-        PARTITION_KEY (str): The key for partitioning runs ("workflow")
         WEBHOOK_PROCESSOR_CLASS (Type[AbstractWebhookProcessor]): Processor for workflow_run events
         WEBHOOK_PATH (str): Path for receiving GitHub webhook events
         _default_ref_cache (dict[str, str]): Cache of repository default branch names
+        _workflow_run_exporter (RestWorkflowRunExporter): Fetches dispatched workflow runs by ID
 
     Example Usage in Port:
         ```yaml
@@ -87,12 +86,6 @@ class DispatchWorkflowExecutor(AbstractGithubExecutor):
     """
 
     ACTION_NAME = "dispatch_workflow"
-
-    """
-    We use the workflow name as the partition key because we track workflow executions
-    by locating the workflow run closest to the trigger time and record its ID.
-    Triggering the same workflow concurrently would prevent us from uniquely tracking each instance.
-    """
 
     WEBHOOK_PROCESSOR_CLASS = DispatchWorkflowWebhookProcessor
     WEBHOOK_PATH = DISPATCH_WEBHOOK_PATH
@@ -150,7 +143,10 @@ class DispatchWorkflowExecutor(AbstractGithubExecutor):
 
     async def execute(self, run: ActionRun | WorkflowNodeRun) -> None:
         """
-        Execute a workflow dispatch action by triggering a GitHub Actions workflow.
+        Dispatch a GitHub Actions workflow and register the returned run with Port.
+
+        Requests `return_run_details` from GitHub, fetches the workflow run by ID,
+        and calls `update_run_started` with its URL and external ID.
         """
         logger.info(f"Dispatching workflow for action run {run.id}", run_id=run.id)
         organization = run.execution_properties.get("org")

--- a/integrations/github/github/actions/dispatch_workflow_executor.py
+++ b/integrations/github/github/actions/dispatch_workflow_executor.py
@@ -1,39 +1,31 @@
-import asyncio
-from datetime import datetime, timezone
 import json
 from typing import Any
 
 import httpx
 from loguru import logger
 from github.actions.utils import build_external_id
-from github.context.auth import (
-    get_authenticated_actor,
-)
 from github.core.exporters.repository_exporter import (
     RestRepositoryExporter,
 )
-from github.core.options import SingleRepositoryOptions
+from github.core.options import SingleRepositoryOptions, SingleWorkflowRunOptions
 from github.webhook.registry import (
     WEBHOOK_PATH as DISPATCH_WEBHOOK_PATH,
 )
 from github.helpers.exceptions import (
     InvalidActionParametersException,
-    NoWorkflowRunsFoundException,
     RepositoryDefaultBranchNotFoundException,
 )
 from github.webhook.webhook_processors.workflow_run.dispatch_workflow_webhook_processor import (
     DispatchWorkflowWebhookProcessor,
 )
+from github.core.exporters.workflow_runs_exporter import RestWorkflowRunExporter
 from port_ocean.context.ocean import ocean
 
 from port_ocean.core.models import ActionRun, WorkflowNodeRun
 from github.actions.abstract_github_executor import (
     AbstractGithubExecutor,
 )
-
-
-MAX_WORKFLOW_POLL_ATTEMPTS = 30
-WORKFLOW_POLL_DELAY_SECONDS = 2
+from port_ocean.exceptions.execution_manager import ActionExecutionError
 
 
 class DispatchWorkflowExecutor(AbstractGithubExecutor):
@@ -106,11 +98,9 @@ class DispatchWorkflowExecutor(AbstractGithubExecutor):
     WEBHOOK_PATH = DISPATCH_WEBHOOK_PATH
     _default_ref_cache: dict[str, str] = {}
 
-    async def _get_partition_key(self, run: ActionRun | WorkflowNodeRun) -> str | None:
-        """
-        Get the workflow name as the partition key.
-        """
-        return run.execution_properties.get("workflow")
+    def __init__(self) -> None:
+        super().__init__()
+        self._workflow_run_exporter = RestWorkflowRunExporter(self.rest_client)
 
     async def _get_default_ref(self, organization: str, repo_name: str) -> str:
         """
@@ -149,47 +139,6 @@ class DispatchWorkflowExecutor(AbstractGithubExecutor):
         self._default_ref_cache[key] = repo["default_branch"]
         return self._default_ref_cache[key]
 
-    async def _get_workflow_run(
-        self, organization: str, repo: str, ref: str, isoDate: str
-    ) -> dict[str, Any]:
-        """
-        Get the workflow run for a given workflow.
-        """
-        workflow_runs: list[dict[str, Any]] = []
-        actor = await get_authenticated_actor()
-        attempts_made = 0
-        while len(workflow_runs) == 0 and attempts_made < MAX_WORKFLOW_POLL_ATTEMPTS:
-            response = await self.rest_client.send_api_request(
-                f"{self.rest_client.base_url}/repos/{organization}/{repo}/actions/runs",
-                params={
-                    "actor": actor,
-                    "event": "workflow_dispatch",
-                    "created": f">={isoDate}",
-                    "exclude_pull_requests": True,
-                    "branch": ref,
-                },
-                method="GET",
-                ignore_default_errors=False,
-            )
-            workflow_runs = response.get("workflow_runs", [])
-            if len(workflow_runs) == 0:
-                logger.warning(
-                    f"Couldn't find the triggered workflow run, waiting for {WORKFLOW_POLL_DELAY_SECONDS} seconds",
-                    attempts_made=attempts_made,
-                )
-                await asyncio.sleep(WORKFLOW_POLL_DELAY_SECONDS)
-                attempts_made += 1
-
-        if len(workflow_runs) == 0:
-            raise NoWorkflowRunsFoundException(
-                "Workflow dispatched successfully but due to a delay in GitHub we were unable to track it's progress"
-            )
-
-        logger.info(
-            f"Found workflow run for {organization}/{repo} with ref {ref}: {workflow_runs[0]['id']}",
-        )
-        return workflow_runs[0]
-
     def _parse_inputs(self, raw_inputs: dict[str, Any]) -> dict[str, Any]:
         inputs: dict[str, str] = {}
         for key, value in raw_inputs.items():
@@ -220,30 +169,41 @@ class DispatchWorkflowExecutor(AbstractGithubExecutor):
         if not ref:
             ref = await self._get_default_ref(organization, repo)
         try:
-            isoDate = datetime.now(timezone.utc).isoformat()
-            await self.rest_client.make_request(
+            response = await self.rest_client.make_request(
                 f"{self.rest_client.base_url}/repos/{organization}/{repo}/actions/workflows/{workflow}/dispatches",
                 method="POST",
                 json_data={
                     "ref": ref,
                     "inputs": inputs,
+                    "return_run_details": True,
                 },
                 ignore_default_errors=False,
             )
+            workflow_run_id = response.json().get("workflow_run_id")
+            if not workflow_run_id:
+                raise ActionExecutionError("Workflow run ID not found")
 
-            workflow_run = await self._get_workflow_run(
-                organization, repo, ref, isoDate
+            workflow_run = await self._workflow_run_exporter.get_resource(
+                SingleWorkflowRunOptions(
+                    organization=organization,
+                    repo_name=repo,
+                    run_id=workflow_run_id,
+                )
             )
+            if not workflow_run:
+                raise ActionExecutionError(
+                    f"Workflow run {workflow_run_id} not found in {organization}/{repo}"
+                )
             external_id = build_external_id(workflow_run)
 
             await ocean.port_client.update_run_started(
                 run,
                 workflow_run["html_url"],
                 external_id,
-                extra_output={"workflowRunId": workflow_run["id"]},
+                extra_output={"workflowRunId": workflow_run_id},
             )
         except Exception as e:
             error_message = str(e)
             if isinstance(e, httpx.HTTPStatusError):
                 error_message = json.loads(e.response.text).get("message", str(e))
-            raise Exception(f"Error dispatching workflow: {error_message}")
+            raise ActionExecutionError(f"Error dispatching workflow: {error_message}")

--- a/integrations/github/github/helpers/exceptions.py
+++ b/integrations/github/github/helpers/exceptions.py
@@ -45,7 +45,3 @@ class RepositoryDefaultBranchNotFoundException(Exception):
 
 class InvalidActionParametersException(Exception):
     """Exception for invalid action parameters."""
-
-
-class NoWorkflowRunsFoundException(Exception):
-    """Exception for no workflow runs found."""

--- a/integrations/github/pyproject.toml
+++ b/integrations/github/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "github-ocean"
-version = "6.2.2"
+version = "6.2.3"
 description = "This integration ingest data from github"
 authors = ["Chukwuemeka Nwaoma <joelchukks@gmail.com>", "Melody Anyaegbulam <melodyogonna@gmail.com>", "Michael Armah <mikeyarmah@gmail.com>"]
 

--- a/integrations/github/pyproject.toml
+++ b/integrations/github/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "github-ocean"
-version = "6.2.3"
+version = "6.2.4"
 description = "This integration ingest data from github"
 authors = ["Chukwuemeka Nwaoma <joelchukks@gmail.com>", "Melody Anyaegbulam <melodyogonna@gmail.com>", "Michael Armah <mikeyarmah@gmail.com>"]
 

--- a/integrations/github/tests/github/actions/test_dispatch_workflow_executor.py
+++ b/integrations/github/tests/github/actions/test_dispatch_workflow_executor.py
@@ -91,9 +91,7 @@ class TestDispatchWorkflowExecutor:
         get_resource_mock = AsyncMock(return_value=WORKFLOW_RUN)
 
         with (
-            patch.object(
-                executor, "_get_default_ref", AsyncMock(return_value="main")
-            ),
+            patch.object(executor, "_get_default_ref", AsyncMock(return_value="main")),
             patch.object(
                 executor._workflow_run_exporter,
                 "get_resource",
@@ -196,9 +194,7 @@ class TestDispatchWorkflowExecutor:
         mock_rest_client.make_request.return_value = dispatch_response
 
         with (
-            patch.object(
-                executor, "_get_default_ref", AsyncMock(return_value="main")
-            ),
+            patch.object(executor, "_get_default_ref", AsyncMock(return_value="main")),
             patch("github.actions.dispatch_workflow_executor.ocean") as mock_ocean,
         ):
             mock_ocean.port_client = mock_port_client
@@ -232,9 +228,7 @@ class TestDispatchWorkflowExecutor:
         )
 
         with (
-            patch.object(
-                executor, "_get_default_ref", AsyncMock(return_value="main")
-            ),
+            patch.object(executor, "_get_default_ref", AsyncMock(return_value="main")),
             patch("github.actions.dispatch_workflow_executor.ocean") as mock_ocean,
         ):
             mock_ocean.port_client = mock_port_client

--- a/integrations/github/tests/github/actions/test_dispatch_workflow_executor.py
+++ b/integrations/github/tests/github/actions/test_dispatch_workflow_executor.py
@@ -1,0 +1,283 @@
+"""Tests for DispatchWorkflowExecutor."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from github.actions.dispatch_workflow_executor import DispatchWorkflowExecutor
+from github.helpers.exceptions import (
+    InvalidActionParametersException,
+    RepositoryDefaultBranchNotFoundException,
+)
+from port_ocean.core.models import (
+    ActionRun,
+    IntegrationActionInvocationPayload,
+    RunStatus,
+)
+from port_ocean.exceptions.execution_manager import ActionExecutionError
+
+
+def make_run(execution_properties: dict[str, Any]) -> ActionRun:
+    return ActionRun(
+        id="run-123",
+        status=RunStatus.IN_PROGRESS,
+        payload=IntegrationActionInvocationPayload(
+            type="INTEGRATION_ACTION",
+            installationId="inst-1",
+            integrationActionType="dispatch_workflow",
+            integrationActionExecutionProperties=execution_properties,
+        ),
+    )
+
+
+WORKFLOW_RUN = {
+    "id": 12345,
+    "html_url": "https://github.com/port-labs/ocean/actions/runs/12345",
+    "repository": {
+        "id": 99,
+        "owner": {"id": 1},
+    },
+}
+
+
+@pytest.fixture
+def mock_rest_client() -> MagicMock:
+    client = MagicMock()
+    client.base_url = "https://api.github.com"
+    client.make_request = AsyncMock()
+    client.get_rate_limit_status = MagicMock(return_value=None)
+    return client
+
+
+@pytest.fixture
+def mock_port_client() -> MagicMock:
+    pc = MagicMock()
+    pc.update_run_started = AsyncMock()
+    return pc
+
+
+@pytest.fixture
+def executor(mock_rest_client: MagicMock) -> DispatchWorkflowExecutor:
+    with patch(
+        "github.actions.abstract_github_executor.create_github_client",
+        return_value=mock_rest_client,
+    ):
+        return DispatchWorkflowExecutor()
+
+
+class TestDispatchWorkflowExecutor:
+    @pytest.mark.asyncio
+    async def test_happy_path(
+        self,
+        executor: DispatchWorkflowExecutor,
+        mock_rest_client: MagicMock,
+        mock_port_client: MagicMock,
+    ) -> None:
+        run = make_run(
+            {
+                "org": "port-labs",
+                "repo": "ocean",
+                "workflow": "deploy.yml",
+                "workflowInputs": {"environment": "prod"},
+            }
+        )
+
+        dispatch_response = MagicMock()
+        dispatch_response.json.return_value = {"workflow_run_id": 12345}
+        mock_rest_client.make_request.return_value = dispatch_response
+
+        get_resource_mock = AsyncMock(return_value=WORKFLOW_RUN)
+
+        with (
+            patch.object(
+                executor, "_get_default_ref", AsyncMock(return_value="main")
+            ),
+            patch.object(
+                executor._workflow_run_exporter,
+                "get_resource",
+                get_resource_mock,
+            ),
+            patch("github.actions.dispatch_workflow_executor.ocean") as mock_ocean,
+        ):
+            mock_ocean.port_client = mock_port_client
+            await executor.execute(run)
+
+        mock_rest_client.make_request.assert_awaited_once()
+        call_kwargs = mock_rest_client.make_request.call_args
+        assert (
+            "repos/port-labs/ocean/actions/workflows/deploy.yml/dispatches"
+            in call_kwargs.args[0]
+        )
+        assert call_kwargs.kwargs["method"] == "POST"
+        assert call_kwargs.kwargs["json_data"] == {
+            "ref": "main",
+            "inputs": {"environment": "prod"},
+            "return_run_details": True,
+        }
+
+        get_resource_mock.assert_awaited_once()
+        mock_port_client.update_run_started.assert_awaited_once_with(
+            run,
+            WORKFLOW_RUN["html_url"],
+            "gh_1_99_12345",
+            extra_output={"workflowRunId": 12345},
+        )
+
+    @pytest.mark.asyncio
+    async def test_uses_ref_from_workflow_inputs(
+        self,
+        executor: DispatchWorkflowExecutor,
+        mock_rest_client: MagicMock,
+        mock_port_client: MagicMock,
+    ) -> None:
+        run = make_run(
+            {
+                "org": "port-labs",
+                "repo": "ocean",
+                "workflow": "deploy.yml",
+                "workflowInputs": {"ref": "feature-branch"},
+            }
+        )
+
+        dispatch_response = MagicMock()
+        dispatch_response.json.return_value = {"workflow_run_id": 12345}
+        mock_rest_client.make_request.return_value = dispatch_response
+
+        with (
+            patch.object(
+                executor._workflow_run_exporter,
+                "get_resource",
+                AsyncMock(return_value=WORKFLOW_RUN),
+            ),
+            patch("github.actions.dispatch_workflow_executor.ocean") as mock_ocean,
+        ):
+            mock_ocean.port_client = mock_port_client
+            await executor.execute(run)
+
+        json_data = mock_rest_client.make_request.call_args.kwargs["json_data"]
+        assert json_data["ref"] == "feature-branch"
+        assert "ref" not in json_data["inputs"]
+
+    @pytest.mark.asyncio
+    async def test_missing_required_params_fails(
+        self,
+        executor: DispatchWorkflowExecutor,
+        mock_rest_client: MagicMock,
+    ) -> None:
+        run = make_run({"org": "port-labs", "repo": "ocean"})
+
+        with pytest.raises(
+            InvalidActionParametersException,
+            match="organization, repo and workflow are required",
+        ):
+            await executor.execute(run)
+
+        mock_rest_client.make_request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_workflow_run_id_raises(
+        self,
+        executor: DispatchWorkflowExecutor,
+        mock_rest_client: MagicMock,
+        mock_port_client: MagicMock,
+    ) -> None:
+        run = make_run(
+            {
+                "org": "port-labs",
+                "repo": "ocean",
+                "workflow": "deploy.yml",
+            }
+        )
+
+        dispatch_response = MagicMock()
+        dispatch_response.json.return_value = {}
+        mock_rest_client.make_request.return_value = dispatch_response
+
+        with (
+            patch.object(
+                executor, "_get_default_ref", AsyncMock(return_value="main")
+            ),
+            patch("github.actions.dispatch_workflow_executor.ocean") as mock_ocean,
+        ):
+            mock_ocean.port_client = mock_port_client
+            with pytest.raises(ActionExecutionError, match="Workflow run ID not found"):
+                await executor.execute(run)
+
+    @pytest.mark.asyncio
+    async def test_github_http_error_raises(
+        self,
+        executor: DispatchWorkflowExecutor,
+        mock_rest_client: MagicMock,
+        mock_port_client: MagicMock,
+    ) -> None:
+        run = make_run(
+            {
+                "org": "port-labs",
+                "repo": "ocean",
+                "workflow": "deploy.yml",
+            }
+        )
+
+        request = httpx.Request(
+            "POST",
+            "https://api.github.com/repos/port-labs/ocean/actions/workflows/deploy.yml/dispatches",
+        )
+        response = httpx.Response(
+            422, json={"message": "Workflow not found"}, request=request
+        )
+        mock_rest_client.make_request.side_effect = httpx.HTTPStatusError(
+            "422", request=request, response=response
+        )
+
+        with (
+            patch.object(
+                executor, "_get_default_ref", AsyncMock(return_value="main")
+            ),
+            patch("github.actions.dispatch_workflow_executor.ocean") as mock_ocean,
+        ):
+            mock_ocean.port_client = mock_port_client
+            with pytest.raises(
+                ActionExecutionError,
+                match="Error dispatching workflow: Workflow not found",
+            ):
+                await executor.execute(run)
+
+    @pytest.mark.asyncio
+    async def test_default_branch_not_found_raises(
+        self,
+        executor: DispatchWorkflowExecutor,
+        mock_rest_client: MagicMock,
+    ) -> None:
+        run = make_run(
+            {
+                "org": "port-labs",
+                "repo": "ocean",
+                "workflow": "deploy.yml",
+            }
+        )
+
+        with patch.object(
+            executor,
+            "_get_default_ref",
+            AsyncMock(
+                side_effect=RepositoryDefaultBranchNotFoundException(
+                    "Default branch not found for repository port-labs/ocean"
+                )
+            ),
+        ):
+            with pytest.raises(
+                RepositoryDefaultBranchNotFoundException,
+                match="Default branch not found for repository port-labs/ocean",
+            ):
+                await executor.execute(run)
+
+        mock_rest_client.make_request.assert_not_awaited()
+
+    def test_parse_inputs(self, executor: DispatchWorkflowExecutor) -> None:
+        assert executor._parse_inputs({"env": "prod"}) == {"env": "prod"}
+        assert executor._parse_inputs({"count": 3}) == {"count": "3"}
+
+    def test_action_name(self, executor: DispatchWorkflowExecutor) -> None:
+        assert executor.ACTION_NAME == "dispatch_workflow"


### PR DESCRIPTION
## Summary
- Use GitHub's `return_run_details` dispatch API to get the `workflow_run_id` directly instead of polling the workflow runs list
- Fetch the dispatched run via `RestWorkflowRunExporter` and track it with a unique external ID, enabling concurrent `dispatch_workflow` action executions
- Remove workflow-based partition key and polling logic; raise `ActionExecutionError` for expected failures
- Bump GitHub integration to `6.2.3` and add unit tests for `DispatchWorkflowExecutor`

## Test plan
- [x] `poetry run pytest tests/github/actions/test_dispatch_workflow_executor.py -n 0`
- [ ] Trigger multiple concurrent `dispatch_workflow` actions against the same workflow and verify each Port run tracks the correct GitHub workflow run
- [ ] Verify webhook completion still updates the correct Port action run via external ID


Made with [Cursor](https://cursor.com)