### PR TITLE
[Integration][Github] Revert itemsToParse file deletion changes from #3465

### DIFF
--- a/integrations/github/CHANGELOG.md
+++ b/integrations/github/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 6.2.7 (2026-07-10)
+
+
+### Bug Fixes
+
+- Reverted the file-kind live event deletion changes introduced in 6.2.3 that fetched old file content for `items_to_parse` deletions.
+
+
 ## 6.2.6 (2026-07-08)
 
 

--- a/integrations/github/github/actions/dispatch_workflow_executor.py
+++ b/integrations/github/github/actions/dispatch_workflow_executor.py
@@ -21,7 +21,7 @@ from github.webhook.webhook_processors.workflow_run.dispatch_workflow_webhook_pr
 from github.core.exporters.workflow_runs_exporter import RestWorkflowRunExporter
 from port_ocean.context.ocean import ocean
 
-from port_ocean.core.models import ActionRun, WorkflowNodeRun
+from port_ocean.core.models import IntegrationRun
 from github.actions.abstract_github_executor import (
     AbstractGithubExecutor,
 )
@@ -141,7 +141,7 @@ class DispatchWorkflowExecutor(AbstractGithubExecutor):
                 inputs[key] = json.dumps(value)
         return inputs
 
-    async def execute(self, run: ActionRun | WorkflowNodeRun) -> None:
+    async def execute(self, run: IntegrationRun) -> None:
         """
         Dispatch a GitHub Actions workflow and register the returned run with Port.
 

--- a/integrations/github/github/actions/update_repo_external_properties_executor.py
+++ b/integrations/github/github/actions/update_repo_external_properties_executor.py
@@ -7,7 +7,7 @@ from github.actions.abstract_github_executor import AbstractGithubExecutor
 from github.clients.rate_limiter.utils import is_rate_limit_response
 from github.helpers.exceptions import InvalidActionParametersException
 from port_ocean.context.ocean import ocean
-from port_ocean.core.models import ActionRun, WorkflowNodeRun
+from port_ocean.core.models import IntegrationRun
 from port_ocean.exceptions.execution_manager import ActionExecutionError
 
 
@@ -32,7 +32,7 @@ class UpdateRepoExternalPropertiesExecutor(AbstractGithubExecutor):
     ACTION_NAME = "update_repo_external_properties"
     WEBHOOK_PROCESSOR_CLASS = None
 
-    async def _get_partition_key(self, run: ActionRun | WorkflowNodeRun) -> str | None:
+    async def _get_partition_key(self, run: IntegrationRun) -> str | None:
         """
         Repository update operations should be executed sequentially to avoid conflicts.
         We use the organization and repository as the partition key.
@@ -41,7 +41,7 @@ class UpdateRepoExternalPropertiesExecutor(AbstractGithubExecutor):
         repo = run.execution_properties.get("repo")
         return f"{org}/{repo}"
 
-    async def execute(self, run: ActionRun | WorkflowNodeRun) -> None:
+    async def execute(self, run: IntegrationRun) -> None:
         org = run.execution_properties.get("org")
         repo = run.execution_properties.get("repo")
         external_properties_mapping = run.execution_properties.get(

--- a/integrations/github/github/core/exporters/file_exporter/file_processor.py
+++ b/integrations/github/github/core/exporters/file_exporter/file_processor.py
@@ -27,7 +27,6 @@ class FileProcessor:
         branch: str,
         content: str,
         metadata: Optional[Dict[str, Any]] = None,
-        should_resolve_references: bool = True,
     ) -> FileObject:
         """
         Common content processor for GraphQL and REST paths.
@@ -51,18 +50,6 @@ class FileProcessor:
             return result
 
         parsed_content = parse_content(content, file_path)
-
-        if not should_resolve_references:
-            return FileObject(
-                organization=organization,
-                content=parsed_content,
-                repository=repository,
-                branch=branch,
-                path=file_path,
-                name=file_name,
-                metadata=result["metadata"],
-                __base_jq=".content",
-            )
 
         logger.info(f"Resolving file references for: {file_path}")
 

--- a/integrations/github/github/core/exporters/file_exporter/utils.py
+++ b/integrations/github/github/core/exporters/file_exporter/utils.py
@@ -1,7 +1,6 @@
 import base64
 import binascii
 from collections import defaultdict
-from enum import StrEnum
 import json
 from pathlib import Path
 import re
@@ -105,12 +104,6 @@ def parse_content(content: str, file_path: str) -> Any:
     return content
 
 
-class FileDiffStatus(StrEnum):
-    ADDED = "added"
-    REMOVED = "removed"
-    RENAMED = "renamed"
-
-
 def group_files_by_status(
     files: List[Dict[str, Any]],
 ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
@@ -118,29 +111,12 @@ def group_files_by_status(
     updated_files: List[Dict[str, Any]] = []
 
     for file in files:
-        if file.get("status") == FileDiffStatus.REMOVED:
+        if file.get("status") == "removed":
             deleted_files.append(file)
         else:
             updated_files.append(file)
 
     return deleted_files, updated_files
-
-
-def split_files_by_content_presence(
-    files: List[Dict[str, Any]],
-) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
-    """Return ``(files_with_new_content, files_with_old_content)`` (not-removed for upserts, not-added for deletions)."""
-    files_with_new_content: List[Dict[str, Any]] = []
-    files_with_old_content: List[Dict[str, Any]] = []
-
-    for file in files:
-        status = file.get("status")
-        if status != FileDiffStatus.REMOVED:
-            files_with_new_content.append(file)
-        if status != FileDiffStatus.ADDED:
-            files_with_old_content.append(file)
-
-    return files_with_new_content, files_with_old_content
 
 
 def is_matching_file(files: List[Dict[str, Any]], filenames: List[str]) -> bool:

--- a/integrations/github/github/webhook/webhook_processors/file_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/file_webhook_processor.py
@@ -1,4 +1,3 @@
-import asyncio
 from pathlib import Path
 from typing import cast, Any
 from github.webhook.webhook_processors.base_repository_webhook_processor import (
@@ -7,9 +6,8 @@ from github.webhook.webhook_processors.base_repository_webhook_processor import 
 from github.clients.client_factory import create_github_client
 from github.core.exporters.file_exporter.core import RestFileExporter
 from github.core.exporters.file_exporter.utils import (
-    FileDiffStatus,
     get_matching_files,
-    split_files_by_content_presence,
+    group_files_by_status,
 )
 from github.core.options import FileContentOptions
 from port_ocean.core.handlers.port_app_config.models import ResourceConfig
@@ -81,8 +79,6 @@ class FileWebhookProcessor(BaseRepositoryWebhookProcessor):
                 updated_raw_results=[], deleted_raw_results=[]
             )
 
-        should_fetch_old_content = bool(resource_config.port.items_to_parse)
-
         updated_raw_results, deleted_raw_results = await self._process_matching_files(
             organization,
             repo_name,
@@ -91,7 +87,6 @@ class FileWebhookProcessor(BaseRepositoryWebhookProcessor):
             matching_patterns,
             repository,
             current_branch,
-            should_fetch_old_content,
         )
 
         if updated_raw_results and selector.included_files:
@@ -156,7 +151,6 @@ class FileWebhookProcessor(BaseRepositoryWebhookProcessor):
         matching_patterns: list["GithubFilePattern"],
         repository: dict[str, Any],
         current_branch: str,
-        should_fetch_old_content: bool,
     ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
         logger.info(
             f"Fetching commit diff for repository {repo_name} of organization: {organization} from {before_sha} to {after_sha}"
@@ -176,115 +170,42 @@ class FileWebhookProcessor(BaseRepositoryWebhookProcessor):
             )
             return [], []
 
-        files_with_new_content, files_with_old_content = (
-            split_files_by_content_presence(matching_files)
-        )
+        deleted_files, updated_files = group_files_by_status(matching_files)
         logger.info(
-            f"Found {len(files_with_new_content)} files with new content and "
-            f"{len(files_with_old_content)} files with old content of organization: {organization}"
+            f"Found {len(deleted_files)} deleted files and {len(updated_files)} updated files of organization: {organization}"
         )
 
-        if not should_fetch_old_content:
-            updated_raw_results = await self._process_files_at_ref(
-                organization,
-                files_with_new_content,
-                exporter,
-                repository,
-                repo_name,
-                current_branch=current_branch,
-            )
-            deleted_raw_results = self._build_metadata_deletions(
-                organization, files_with_old_content, repository, current_branch
-            )
-            return updated_raw_results, deleted_raw_results
-
-        updated_raw_results, deleted_raw_results = await asyncio.gather(
-            self._process_files_at_ref(
-                organization,
-                files_with_new_content,
-                exporter,
-                repository,
-                repo_name,
-                current_branch=current_branch,
-            ),
-            self._process_files_at_ref(
-                organization,
-                files_with_old_content,
-                exporter,
-                repository,
-                repo_name,
-                current_branch=current_branch,
-                content_ref=before_sha,
-                should_resolve_references=False,
-                should_use_previous_filename=True,
-            ),
+        updated_raw_results = await self._process_updated_files(
+            organization, updated_files, exporter, repository, repo_name, current_branch
         )
+
+        deleted_raw_results = [
+            {
+                "organization": organization,
+                "path": file["filename"],
+                "metadata": {"path": file["filename"]},
+                "repository": repository,
+                "branch": current_branch,
+                "name": Path(file["filename"]).name,
+            }
+            for file in deleted_files
+        ]
 
         return updated_raw_results, deleted_raw_results
 
-    def _build_metadata_deletions(
+    async def _process_updated_files(
         self,
         organization: str,
-        files: list[dict[str, Any]],
-        repository: dict[str, Any],
-        branch: str,
-    ) -> list[dict[str, Any]]:
-        """Emit metadata-only deletions for removed files and the old paths of renamed files."""
-        results = []
-        for file_info in files:
-            if file_info.get("status") == FileDiffStatus.REMOVED:
-                deleted_path = file_info["filename"]
-            elif file_info.get("status") == FileDiffStatus.RENAMED:
-                deleted_path = file_info.get("previous_filename")
-                if not deleted_path:
-                    continue
-            else:
-                continue
-
-            results.append(
-                self._build_deletion_metadata_result(
-                    organization, deleted_path, repository, branch
-                )
-            )
-        return results
-
-    def _build_deletion_metadata_result(
-        self,
-        organization: str,
-        file_path: str,
-        repository: dict[str, Any],
-        branch: str,
-    ) -> dict[str, Any]:
-        """Metadata-only deletion entry used when old content cannot be fetched."""
-        return {
-            "organization": organization,
-            "path": file_path,
-            "metadata": {"path": file_path},
-            "repository": repository,
-            "branch": branch,
-            "name": Path(file_path).name,
-        }
-
-    async def _process_files_at_ref(
-        self,
-        organization: str,
-        files: list[dict[str, Any]],
+        updated_files: list[dict[str, Any]],
         exporter: "RestFileExporter",
         repository: dict[str, Any],
         repo_name: str,
         current_branch: str,
-        content_ref: str | None = None,
-        should_resolve_references: bool = True,
-        should_use_previous_filename: bool = False,
     ) -> list[dict[str, Any]]:
-        """Fetch content from ``content_ref`` (defaults to ``current_branch``) but always stamp ``current_branch`` so upsert and delete identifiers match."""
-        content_ref = content_ref or current_branch
         results = []
 
-        for file_info in files:
+        for file_info in updated_files:
             file_path = file_info["filename"]
-            if should_use_previous_filename:
-                file_path = file_info.get("previous_filename") or file_path
             patterns: list["GithubFilePattern"] = file_info["patterns"]
 
             for pattern in patterns:
@@ -294,19 +215,19 @@ class FileWebhookProcessor(BaseRepositoryWebhookProcessor):
                             organization=organization,
                             repo_name=repo_name,
                             file_path=file_path,
-                            branch=content_ref,
+                            branch=current_branch,
                         )
                     )
+                    if not file_content_response:
+                        logger.warning(
+                            f"No response for file {file_path} from {organization}"
+                        )
+                        continue
 
-                    content = (
-                        file_content_response.get("content")
-                        if file_content_response
-                        else None
-                    )
+                    content = file_content_response.get("content")
                     if content is None:
                         logger.warning(
-                            f"File {file_path} has no content or is too large at ref {content_ref} from {organization}; "
-                            "cannot compute sub-entity deletions for this file"
+                            f"File {file_path} has no content or is too large from {organization}"
                         )
                         continue
 
@@ -318,20 +239,19 @@ class FileWebhookProcessor(BaseRepositoryWebhookProcessor):
                         skip_parsing=pattern.skip_parsing,
                         branch=current_branch,
                         metadata=file_content_response,
-                        should_resolve_references=should_resolve_references,
                     )
 
                     results.append(dict(file_obj))
                     logger.debug(
-                        f"Successfully processed file {file_path} with pattern {pattern.path} at ref {content_ref} from {organization}"
+                        f"Successfully processed file {file_path} with pattern {pattern.path} from {organization}"
                     )
 
                 except Exception as e:
                     logger.error(
-                        f"Error processing file {file_path} with pattern {pattern.path} at ref {content_ref}: {e} from {organization}"
+                        f"Error processing file {file_path} with pattern {pattern.path}: {e} from {organization}"
                     )
 
         logger.info(
-            f"Successfully processed {len(results)} file results at ref {content_ref} from {organization}"
+            f"Successfully processed {len(results)} file results from {organization}"
         )
         return results

--- a/integrations/github/pyproject.toml
+++ b/integrations/github/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "github-ocean"
-version = "6.2.6"
+version = "6.2.7"
 description = "This integration ingest data from github"
 authors = ["Chukwuemeka Nwaoma <joelchukks@gmail.com>", "Melody Anyaegbulam <melodyogonna@gmail.com>", "Michael Armah <mikeyarmah@gmail.com>"]
 

--- a/integrations/github/tests/github/actions/test_dispatch_workflow_executor.py
+++ b/integrations/github/tests/github/actions/test_dispatch_workflow_executor.py
@@ -23,6 +23,7 @@ def make_run(execution_properties: dict[str, Any]) -> ActionRun:
     return ActionRun(
         id="run-123",
         status=RunStatus.IN_PROGRESS,
+        action=ActionRun.Action(identifier="dispatch_workflow"),
         payload=IntegrationActionInvocationPayload(
             type="INTEGRATION_ACTION",
             installationId="inst-1",

--- a/integrations/github/tests/github/actions/test_update_repo_external_properties_executor.py
+++ b/integrations/github/tests/github/actions/test_update_repo_external_properties_executor.py
@@ -23,6 +23,7 @@ def make_run(execution_properties: dict[str, Any]) -> ActionRun:
     return ActionRun(
         id="run-123",
         status=RunStatus.IN_PROGRESS,
+        action=ActionRun.Action(identifier="update_repo_external_properties"),
         payload=IntegrationActionInvocationPayload(
             type="INTEGRATION_ACTION",
             installationId="inst-1",

--- a/integrations/github/tests/github/webhook/webhook_processors/test_file_webhook_processor.py
+++ b/integrations/github/tests/github/webhook/webhook_processors/test_file_webhook_processor.py
@@ -1,6 +1,3 @@
-from pathlib import Path
-from typing import Any
-
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 from port_ocean.core.handlers.webhook.webhook_event import (
@@ -56,41 +53,6 @@ def resource_config() -> GithubFileResourceConfig:
                     properties={},
                 )
             )
-        ),
-    )
-
-
-@pytest.fixture
-def resource_config_with_items_to_parse() -> GithubFileResourceConfig:
-    return GithubFileResourceConfig(
-        kind=ObjectKind.FILE,
-        selector=GithubFileSelector(
-            query="true",
-            files=[
-                GithubFilePattern(
-                    organization="test-org",
-                    path="*.yaml",
-                    repos=[RepositoryBranchMapping(name="test-repo", branch="main")],
-                    skipParsing=False,
-                ),
-                GithubFilePattern(
-                    organization="test-org",
-                    path="*.json",
-                    repos=[RepositoryBranchMapping(name="test-repo", branch="main")],
-                    skipParsing=True,
-                ),
-            ],
-        ),
-        port=PortResourceConfig(
-            entity=MappingsConfig(
-                mappings=EntityMapping(
-                    identifier=".item.name",
-                    title=".item.name",
-                    blueprint='"githubFile"',
-                    properties={},
-                )
-            ),
-            itemsToParse=".content.items",
         ),
     )
 
@@ -296,14 +258,15 @@ class TestFileWebhookProcessor:
             mock_exporter.fetch_commit_diff.assert_called_once_with(
                 "test-org", "test-repo", "abc123", "def456"
             )
-            requested_refs = {
-                call.args[0]["branch"]
-                for call in mock_exporter.get_resource.call_args_list
-            }
-            assert requested_refs == {"main"}
-            assert mock_exporter.file_processor.process_file.call_count == 1
-            for call in mock_exporter.file_processor.process_file.call_args_list:
-                assert call.kwargs["branch"] == "main"
+            mock_exporter.get_resource.assert_called_once_with(
+                FileContentOptions(
+                    organization="test-org",
+                    repo_name="test-repo",
+                    file_path="config.yaml",
+                    branch="main",
+                )
+            )
+            mock_exporter.file_processor.process_file.assert_called_once()
 
     async def test_handle_event_with_deleted_files(
         self,
@@ -312,6 +275,7 @@ class TestFileWebhookProcessor:
         payload: EventPayload,
     ) -> None:
 
+        # Mock the exporter to return deleted files
         mock_exporter = AsyncMock()
         mock_exporter.fetch_commit_diff.return_value = {
             "files": [
@@ -331,15 +295,7 @@ class TestFileWebhookProcessor:
             assert isinstance(result, WebhookEventRawResults)
             assert result.updated_raw_results == []
             assert len(result.deleted_raw_results) == 1
-            deleted = result.deleted_raw_results[0]
-            assert deleted["metadata"]["path"] == "config.yaml"
-            assert deleted["path"] == "config.yaml"
-            assert deleted["name"] == "config.yaml"
-            assert deleted["branch"] == "main"
-            assert "content" not in deleted
-
-            mock_exporter.get_resource.assert_not_called()
-            mock_exporter.file_processor.process_file.assert_not_called()
+            assert result.deleted_raw_results[0]["metadata"]["path"] == "config.yaml"
 
     async def test_handle_event_file_without_content(
         self,
@@ -377,291 +333,6 @@ class TestFileWebhookProcessor:
             assert isinstance(result, WebhookEventRawResults)
             assert result.updated_raw_results == []
             assert result.deleted_raw_results == []
-
-    async def test_handle_event_modified_file_carries_old_content_for_deletion(
-        self,
-        file_webhook_processor: FileWebhookProcessor,
-        resource_config_with_items_to_parse: GithubFileResourceConfig,
-        payload: EventPayload,
-    ) -> None:
-        new_content = "items:\n  - a\n  - b\n"
-        old_content = "items:\n  - a\n  - b\n  - c\n"
-
-        def fake_get_resource(options: FileContentOptions) -> dict[str, Any]:
-            content = old_content if options["branch"] == "abc123" else new_content
-            return {
-                "content": content,
-                "name": "config.yaml",
-                "path": "config.yaml",
-                "size": len(content),
-            }
-
-        async def fake_process_file(**kwargs: Any) -> dict[str, Any]:
-            return {
-                "organization": kwargs["organization"],
-                "content": kwargs["content"],
-                "repository": kwargs["repository"],
-                "branch": kwargs["branch"],
-                "path": kwargs["file_path"],
-                "name": Path(kwargs["file_path"]).name,
-                "metadata": kwargs.get("metadata") or {},
-            }
-
-        mock_exporter = AsyncMock()
-        mock_exporter.fetch_commit_diff.return_value = {
-            "files": [{"filename": "config.yaml", "status": "modified"}]
-        }
-        mock_exporter.get_resource.side_effect = fake_get_resource
-        mock_exporter.file_processor.process_file.side_effect = fake_process_file
-
-        with patch(
-            "github.webhook.webhook_processors.file_webhook_processor.RestFileExporter",
-            return_value=mock_exporter,
-        ):
-            result = await file_webhook_processor.handle_event(
-                payload, resource_config_with_items_to_parse
-            )
-
-            assert isinstance(result, WebhookEventRawResults)
-            assert len(result.updated_raw_results) == 1
-            assert len(result.deleted_raw_results) == 1
-            assert result.updated_raw_results[0]["content"] == new_content
-            assert result.deleted_raw_results[0]["content"] == old_content
-            assert result.updated_raw_results[0]["branch"] == "main"
-            assert result.deleted_raw_results[0]["branch"] == "main"
-
-            resolve_by_content = {
-                call.kwargs["content"]: call.kwargs["should_resolve_references"]
-                for call in mock_exporter.file_processor.process_file.call_args_list
-            }
-            assert resolve_by_content == {new_content: True, old_content: False}
-
-    async def test_handle_event_removed_file_without_old_content_yields_no_deletion(
-        self,
-        file_webhook_processor: FileWebhookProcessor,
-        resource_config_with_items_to_parse: GithubFileResourceConfig,
-        payload: EventPayload,
-    ) -> None:
-        mock_exporter = AsyncMock()
-        mock_exporter.fetch_commit_diff.return_value = {
-            "files": [{"filename": "config.yaml", "status": "removed"}]
-        }
-        mock_exporter.get_resource.return_value = {
-            "content": None,
-            "name": "config.yaml",
-            "path": "config.yaml",
-            "size": 1024 * 1024 + 1,
-        }
-
-        with patch(
-            "github.webhook.webhook_processors.file_webhook_processor.RestFileExporter",
-            return_value=mock_exporter,
-        ):
-            result = await file_webhook_processor.handle_event(
-                payload, resource_config_with_items_to_parse
-            )
-
-            assert isinstance(result, WebhookEventRawResults)
-            assert result.updated_raw_results == []
-            assert result.deleted_raw_results == []
-            mock_exporter.file_processor.process_file.assert_not_called()
-
-    async def test_handle_event_modified_file_without_old_content_is_not_deleted(
-        self,
-        file_webhook_processor: FileWebhookProcessor,
-        resource_config: GithubFileResourceConfig,
-        payload: EventPayload,
-    ) -> None:
-        mock_exporter = AsyncMock()
-        mock_exporter.fetch_commit_diff.return_value = {
-            "files": [{"filename": "config.yaml", "status": "modified"}]
-        }
-        mock_exporter.get_resource.return_value = {
-            "content": None,
-            "name": "config.yaml",
-            "path": "config.yaml",
-            "size": 1024 * 1024 + 1,
-        }
-
-        with patch(
-            "github.webhook.webhook_processors.file_webhook_processor.RestFileExporter",
-            return_value=mock_exporter,
-        ):
-            result = await file_webhook_processor.handle_event(payload, resource_config)
-
-            assert isinstance(result, WebhookEventRawResults)
-            assert result.updated_raw_results == []
-            assert result.deleted_raw_results == []
-
-    async def test_handle_event_renamed_file_uses_previous_filename_for_old_content(
-        self,
-        file_webhook_processor: FileWebhookProcessor,
-        resource_config_with_items_to_parse: GithubFileResourceConfig,
-        payload: EventPayload,
-    ) -> None:
-        async def fake_process_file(**kwargs: Any) -> dict[str, Any]:
-            return {
-                "organization": kwargs["organization"],
-                "content": kwargs["content"],
-                "repository": kwargs["repository"],
-                "branch": kwargs["branch"],
-                "path": kwargs["file_path"],
-                "name": Path(kwargs["file_path"]).name,
-                "metadata": kwargs.get("metadata") or {},
-            }
-
-        def fake_get_resource(options: FileContentOptions) -> dict[str, Any]:
-            return {
-                "content": "name: test",
-                "name": Path(options["file_path"]).name,
-                "path": options["file_path"],
-                "size": 9,
-            }
-
-        mock_exporter = AsyncMock()
-        mock_exporter.fetch_commit_diff.return_value = {
-            "files": [
-                {
-                    "filename": "new.yaml",
-                    "previous_filename": "old.yaml",
-                    "status": "renamed",
-                }
-            ]
-        }
-        mock_exporter.get_resource.side_effect = fake_get_resource
-        mock_exporter.file_processor.process_file.side_effect = fake_process_file
-
-        with patch(
-            "github.webhook.webhook_processors.file_webhook_processor.RestFileExporter",
-            return_value=mock_exporter,
-        ):
-            result = await file_webhook_processor.handle_event(
-                payload, resource_config_with_items_to_parse
-            )
-
-            assert isinstance(result, WebhookEventRawResults)
-            assert len(result.updated_raw_results) == 1
-            assert len(result.deleted_raw_results) == 1
-            assert result.updated_raw_results[0]["path"] == "new.yaml"
-            assert result.deleted_raw_results[0]["path"] == "old.yaml"
-
-            fetches = {
-                (call.args[0]["file_path"], call.args[0]["branch"])
-                for call in mock_exporter.get_resource.call_args_list
-            }
-            assert fetches == {("new.yaml", "main"), ("old.yaml", "abc123")}
-
-    async def test_handle_event_renamed_file_without_old_content_yields_no_deletion(
-        self,
-        file_webhook_processor: FileWebhookProcessor,
-        resource_config_with_items_to_parse: GithubFileResourceConfig,
-        payload: EventPayload,
-    ) -> None:
-        def fake_get_resource(options: FileContentOptions) -> dict[str, Any]:
-            content = None if options["branch"] == "abc123" else "items: []"
-            return {
-                "content": content,
-                "name": Path(options["file_path"]).name,
-                "path": options["file_path"],
-                "size": 1024 * 1024 + 1 if content is None else 9,
-            }
-
-        async def fake_process_file(**kwargs: Any) -> dict[str, Any]:
-            return {
-                "organization": kwargs["organization"],
-                "content": kwargs["content"],
-                "repository": kwargs["repository"],
-                "branch": kwargs["branch"],
-                "path": kwargs["file_path"],
-                "name": Path(kwargs["file_path"]).name,
-                "metadata": kwargs.get("metadata") or {},
-            }
-
-        mock_exporter = AsyncMock()
-        mock_exporter.fetch_commit_diff.return_value = {
-            "files": [
-                {
-                    "filename": "new.yaml",
-                    "previous_filename": "old.yaml",
-                    "status": "renamed",
-                }
-            ]
-        }
-        mock_exporter.get_resource.side_effect = fake_get_resource
-        mock_exporter.file_processor.process_file.side_effect = fake_process_file
-
-        with patch(
-            "github.webhook.webhook_processors.file_webhook_processor.RestFileExporter",
-            return_value=mock_exporter,
-        ):
-            result = await file_webhook_processor.handle_event(
-                payload, resource_config_with_items_to_parse
-            )
-
-            assert isinstance(result, WebhookEventRawResults)
-            assert len(result.updated_raw_results) == 1
-            assert result.updated_raw_results[0]["path"] == "new.yaml"
-            assert result.deleted_raw_results == []
-
-    async def test_handle_event_renamed_file_without_items_to_parse_deletes_old_path(
-        self,
-        file_webhook_processor: FileWebhookProcessor,
-        resource_config: GithubFileResourceConfig,
-        payload: EventPayload,
-    ) -> None:
-        async def fake_process_file(**kwargs: Any) -> dict[str, Any]:
-            return {
-                "organization": kwargs["organization"],
-                "content": kwargs["content"],
-                "repository": kwargs["repository"],
-                "branch": kwargs["branch"],
-                "path": kwargs["file_path"],
-                "name": Path(kwargs["file_path"]).name,
-                "metadata": kwargs.get("metadata") or {},
-            }
-
-        def fake_get_resource(options: FileContentOptions) -> dict[str, Any]:
-            return {
-                "content": "name: test",
-                "name": Path(options["file_path"]).name,
-                "path": options["file_path"],
-                "size": 9,
-            }
-
-        mock_exporter = AsyncMock()
-        mock_exporter.fetch_commit_diff.return_value = {
-            "files": [
-                {
-                    "filename": "new.yaml",
-                    "previous_filename": "old.yaml",
-                    "status": "renamed",
-                }
-            ]
-        }
-        mock_exporter.get_resource.side_effect = fake_get_resource
-        mock_exporter.file_processor.process_file.side_effect = fake_process_file
-
-        with patch(
-            "github.webhook.webhook_processors.file_webhook_processor.RestFileExporter",
-            return_value=mock_exporter,
-        ):
-            result = await file_webhook_processor.handle_event(payload, resource_config)
-
-            assert isinstance(result, WebhookEventRawResults)
-            assert len(result.updated_raw_results) == 1
-            assert len(result.deleted_raw_results) == 1
-            assert result.updated_raw_results[0]["path"] == "new.yaml"
-
-            deleted = result.deleted_raw_results[0]
-            assert deleted["metadata"]["path"] == "old.yaml"
-            assert deleted["name"] == "old.yaml"
-            assert "content" not in deleted
-
-            fetches = {
-                (call.args[0]["file_path"], call.args[0]["branch"])
-                for call in mock_exporter.get_resource.call_args_list
-            }
-            assert fetches == {("new.yaml", "main")}
 
     async def test_handle_event_processing_error(
         self,


### PR DESCRIPTION
## Summary
- Reverts the file-kind live event deletion changes introduced in #3465 (released as 6.2.3)
- Restores the pre-6.2.3 file webhook processor behavior for deleted/modified/renamed files
- Bumps GitHub integration version to 6.2.7 with changelog entry

## Test plan
- [ ] Verify file-kind live events for removed files still emit metadata-based deletions
- [ ] Confirm no regression in file upsert handling on push events
- [ ] Run `make test` in `integrations/github`

Made with [Cursor](https://cursor.com)