### PR TITLE
GitHub integration: per-org clients in webhook processors

### DIFF
--- a/integrations/github/github/core/exporters/file_exporter/file_processor.py
+++ b/integrations/github/github/core/exporters/file_exporter/file_processor.py
@@ -27,6 +27,7 @@ class FileProcessor:
         branch: str,
         content: str,
         metadata: Optional[Dict[str, Any]] = None,
+        should_resolve_references: bool = True,
     ) -> FileObject:
         """
         Common content processor for GraphQL and REST paths.
@@ -50,6 +51,18 @@ class FileProcessor:
             return result
 
         parsed_content = parse_content(content, file_path)
+
+        if not should_resolve_references:
+            return FileObject(
+                organization=organization,
+                content=parsed_content,
+                repository=repository,
+                branch=branch,
+                path=file_path,
+                name=file_name,
+                metadata=result["metadata"],
+                __base_jq=".content",
+            )
 
         logger.info(f"Resolving file references for: {file_path}")
 

--- a/integrations/github/github/core/exporters/file_exporter/utils.py
+++ b/integrations/github/github/core/exporters/file_exporter/utils.py
@@ -1,6 +1,7 @@
 import base64
 import binascii
 from collections import defaultdict
+from enum import StrEnum
 import json
 from pathlib import Path
 import re
@@ -104,6 +105,12 @@ def parse_content(content: str, file_path: str) -> Any:
     return content
 
 
+class FileDiffStatus(StrEnum):
+    ADDED = "added"
+    REMOVED = "removed"
+    RENAMED = "renamed"
+
+
 def group_files_by_status(
     files: List[Dict[str, Any]],
 ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
@@ -111,12 +118,29 @@ def group_files_by_status(
     updated_files: List[Dict[str, Any]] = []
 
     for file in files:
-        if file.get("status") == "removed":
+        if file.get("status") == FileDiffStatus.REMOVED:
             deleted_files.append(file)
         else:
             updated_files.append(file)
 
     return deleted_files, updated_files
+
+
+def split_files_by_content_presence(
+    files: List[Dict[str, Any]],
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    """Return ``(files_with_new_content, files_with_old_content)`` (not-removed for upserts, not-added for deletions)."""
+    files_with_new_content: List[Dict[str, Any]] = []
+    files_with_old_content: List[Dict[str, Any]] = []
+
+    for file in files:
+        status = file.get("status")
+        if status != FileDiffStatus.REMOVED:
+            files_with_new_content.append(file)
+        if status != FileDiffStatus.ADDED:
+            files_with_old_content.append(file)
+
+    return files_with_new_content, files_with_old_content
 
 
 def is_matching_file(files: List[Dict[str, Any]], filenames: List[str]) -> bool:

--- a/integrations/github/github/webhook/webhook_processors/base_repository_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/base_repository_webhook_processor.py
@@ -4,7 +4,7 @@ from github.webhook.events import COLLABORATOR_EVENTS, TEAM_COLLABORATOR_EVENTS
 from port_ocean.core.handlers.port_app_config.models import ResourceConfig
 from port_ocean.core.handlers.webhook.webhook_event import EventPayload, WebhookEvent
 from port_ocean.context.event import event
-from github.clients.client_factory import create_github_client
+from github.clients.client_factory import create_github_client_for_org
 from github.core.exporters.repository_exporter import RestRepositoryExporter
 from github.core.options import ListRepositoryOptions
 from github.helpers.models import RepoSearchParams
@@ -78,7 +78,7 @@ class BaseRepositoryWebhookProcessor(_GithubAbstractWebhookProcessor):
             organization_type="Organization",
             search_params=RepoSearchParams(query=targeted_query),
         )
-        rest_client = create_github_client()
+        rest_client = create_github_client_for_org(organization_login)
         exporter = RestRepositoryExporter(rest_client)
         async for search_results in exporter.get_paginated_resources(search_options):
             for repository in search_results:

--- a/integrations/github/github/webhook/webhook_processors/branch_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/branch_webhook_processor.py
@@ -5,7 +5,7 @@ from github.helpers.utils import (
     enrich_with_organization,
     enrich_with_repository,
 )
-from github.clients.client_factory import create_github_client
+from github.clients.client_factory import create_github_client_for_org
 from github.webhook.webhook_processors.base_repository_webhook_processor import (
     BaseRepositoryWebhookProcessor,
 )
@@ -88,7 +88,7 @@ class BranchWebhookProcessor(BaseRepositoryWebhookProcessor):
                 updated_raw_results=[], deleted_raw_results=[data_to_delete]
             )
 
-        rest_client = create_github_client()
+        rest_client = create_github_client_for_org(organization)
         exporter = RestBranchExporter(rest_client)
 
         data_to_upsert = await exporter.get_resource(

--- a/integrations/github/github/webhook/webhook_processors/check_runs/check_runs_validator_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/check_runs/check_runs_validator_webhook_processor.py
@@ -1,7 +1,7 @@
 import asyncio
 from typing import List, cast
 from loguru import logger
-from github.clients.client_factory import create_github_client
+from github.clients.client_factory import create_github_client_for_org
 from github.webhook.webhook_processors.check_runs.file_validation import (
     get_file_validation_mappings,
     ResourceConfigToPatternMapping,
@@ -96,7 +96,7 @@ class CheckRunValidatorWebhookProcessor(PullRequestWebhookProcessor):
             f"Fetching commit diff for repository {repo_name} of organization: {organization} from {base_sha} to {head_sha}"
         )
 
-        rest_client = create_github_client()
+        rest_client = create_github_client_for_org(organization)
         file_exporter = RestFileExporter(rest_client)
         diff_data = await file_exporter.fetch_commit_diff(
             organization, repo_name, base_sha, head_sha

--- a/integrations/github/github/webhook/webhook_processors/check_runs/file_validation.py
+++ b/integrations/github/github/webhook/webhook_processors/check_runs/file_validation.py
@@ -5,12 +5,13 @@ from github.core.exporters.file_exporter.utils import (
     FileObject,
 )
 from integration import GithubFileResourceConfig, GithubFilePattern, GithubPortAppConfig
+from github.clients.http.rest_client import GithubRestClient
 from port_ocean.clients.port.types import RequestOptions
 from port_ocean.context.ocean import ocean
 from port_ocean.core.models import Entity
 from port_ocean.core.handlers.entity_processor import JQEntityProcessor
 from datetime import datetime, timezone
-from github.clients.client_factory import create_github_client
+from github.clients.client_factory import create_github_client_for_org
 from github.helpers.exceptions import CheckRunsException
 
 
@@ -32,17 +33,18 @@ class MatchedFile:
     file_info: Dict[str, Any]
 
 
-class CheckRuns:
+class _CheckRuns:
     """Handles GitHub check run operations for file validation."""
 
-    def __init__(self) -> None:
-        self.client = create_github_client()
+    def __init__(self, organization: str, client: GithubRestClient) -> None:
+        self.organization = organization
+        self.client = client
 
-    async def create_validation_check(
-        self, organization: str, repo_name: str, head_sha: str
-    ) -> str:
+    async def create_validation_check(self, repo_name: str, head_sha: str) -> str:
         """Create a new check run for validation."""
-        endpoint = f"{self.client.base_url}/repos/{organization}/{repo_name}/check-runs"
+        endpoint = (
+            f"{self.client.base_url}/repos/{self.organization}/{repo_name}/check-runs"
+        )
 
         payload = {
             "name": "File Kind validation",
@@ -58,21 +60,20 @@ class CheckRuns:
             endpoint, method="POST", json_data=payload
         )
         if not response:
-            log_message = f"Failed to create check run for {repo_name} of organization: {organization}"
+            log_message = f"Failed to create check run for {repo_name} of organization: {self.organization}"
             logger.error(log_message)
             raise CheckRunsException(log_message)
 
         check_run_id = response["id"]
 
         logger.info(
-            f"Created check run {check_run_id} for {repo_name} of organization: {organization}"
+            f"Created check run {check_run_id} for {repo_name} of organization: {self.organization}"
         )
 
         return str(check_run_id)
 
     async def update_check_run(
         self,
-        organization: str,
         repo_name: str,
         check_run_id: str,
         status: str,
@@ -82,7 +83,7 @@ class CheckRuns:
         details: str,
     ) -> None:
         """Update check run with results."""
-        endpoint = f"{self.client.base_url}/repos/{organization}/{repo_name}/check-runs/{check_run_id}"
+        endpoint = f"{self.client.base_url}/repos/{self.organization}/{repo_name}/check-runs/{check_run_id}"
 
         payload = {
             "status": status,
@@ -94,7 +95,7 @@ class CheckRuns:
         await self.client.send_api_request(endpoint, method="PATCH", json_data=payload)
 
         logger.info(
-            f"Updated check run {check_run_id} for {repo_name} with {conclusion} status of organization: {organization}"
+            f"Updated check run {check_run_id} for {repo_name} with {conclusion} status of organization: {self.organization}"
         )
 
 
@@ -103,7 +104,8 @@ class FileValidationService:
 
     def __init__(self, organization: str) -> None:
         self.organization = organization
-        self.check_runs = CheckRuns()
+        self.client = create_github_client_for_org(organization)
+        self.check_runs = _CheckRuns(organization, self.client)
 
     async def validate_pull_request_files(
         self,
@@ -129,7 +131,7 @@ class FileValidationService:
 
         try:
             check_run_id = await self.check_runs.create_validation_check(
-                organization=self.organization, repo_name=repo_name, head_sha=head_sha
+                repo_name=repo_name, head_sha=head_sha
             )
         except Exception as e:
             logger.error(
@@ -169,7 +171,6 @@ class FileValidationService:
             validation_check_details = str(e)
 
         await self.check_runs.update_check_run(
-            self.organization,
             repo_name,
             check_run_id,
             validation_check_status,

--- a/integrations/github/github/webhook/webhook_processors/code_scanning_alert_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/code_scanning_alert_webhook_processor.py
@@ -8,7 +8,7 @@ from github.helpers.utils import (
     enrich_with_repository,
     enrich_with_organization,
 )
-from github.clients.client_factory import create_github_client
+from github.clients.client_factory import create_github_client_for_org
 from integration import GithubCodeScanningAlertConfig, GithubCodeScanningAlertSelector
 from github.webhook.webhook_processors.base_repository_webhook_processor import (
     BaseRepositoryWebhookProcessor,
@@ -86,7 +86,7 @@ class CodeScanningAlertWebhookProcessor(BaseRepositoryWebhookProcessor):
                 updated_raw_results=[], deleted_raw_results=[alert]
             )
 
-        rest_client = create_github_client()
+        rest_client = create_github_client_for_org(organization)
         exporter = RestCodeScanningAlertExporter(rest_client)
 
         data_to_upsert = await exporter.get_resource(

--- a/integrations/github/github/webhook/webhook_processors/collaborator_webhook_processor/member_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/collaborator_webhook_processor/member_webhook_processor.py
@@ -1,6 +1,6 @@
 from loguru import logger
 
-from github.clients.client_factory import create_github_client
+from github.clients.client_factory import create_github_client_for_org
 from github.core.exporters.collaborator_exporter import RestCollaboratorExporter
 from github.core.options import SingleCollaboratorOptions
 from github.helpers.utils import (
@@ -77,7 +77,7 @@ class CollaboratorMemberWebhookProcessor(
         logger.info(
             f"Creating REST client and exporter for collaborator {username} of organization: {organization}"
         )
-        rest_client = create_github_client()
+        rest_client = create_github_client_for_org(organization)
         exporter = RestCollaboratorExporter(rest_client)
 
         data_to_upsert = await exporter.get_resource(

--- a/integrations/github/github/webhook/webhook_processors/collaborator_webhook_processor/membership_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/collaborator_webhook_processor/membership_webhook_processor.py
@@ -2,7 +2,7 @@ from typing import Any, Dict, List
 
 from loguru import logger
 
-from github.clients.client_factory import create_github_client
+from github.clients.client_factory import create_github_client_for_org
 from github.core.exporters.team_exporter import (
     RestTeamExporter,
 )
@@ -74,7 +74,7 @@ class CollaboratorMembershipWebhookProcessor(
                 updated_raw_results=[], deleted_raw_results=[]
             )
 
-        rest_client = create_github_client()
+        rest_client = create_github_client_for_org(organization)
         team_exporter = RestTeamExporter(rest_client)
 
         repositories = []

--- a/integrations/github/github/webhook/webhook_processors/collaborator_webhook_processor/team_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/collaborator_webhook_processor/team_webhook_processor.py
@@ -1,7 +1,7 @@
 from typing import Any
 from loguru import logger
 
-from github.clients.client_factory import create_github_client
+from github.clients.client_factory import create_github_client_for_org
 from github.core.exporters.team_exporter import RestTeamExporter
 from github.helpers.utils import (
     ObjectKind,
@@ -66,7 +66,7 @@ class CollaboratorTeamWebhookProcessor(
                 updated_raw_results=[], deleted_raw_results=[]
             )
 
-        rest_client = create_github_client()
+        rest_client = create_github_client_for_org(organization)
         team_exporter = RestTeamExporter(rest_client)
         members: list[dict[str, Any]] = []
         async for batch in team_exporter.get_team_members_by_slug(

--- a/integrations/github/github/webhook/webhook_processors/dependabot_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/dependabot_webhook_processor.py
@@ -6,7 +6,7 @@ from github.helpers.utils import (
     enrich_with_repository,
     enrich_with_organization,
 )
-from github.clients.client_factory import create_github_client
+from github.clients.client_factory import create_github_client_for_org
 from port_ocean.core.handlers.port_app_config.models import ResourceConfig
 from port_ocean.core.handlers.webhook.webhook_event import (
     EventPayload,
@@ -70,7 +70,7 @@ class DependabotAlertWebhookProcessor(BaseRepositoryWebhookProcessor):
                 updated_raw_results=[], deleted_raw_results=[alert]
             )
 
-        rest_client = create_github_client()
+        rest_client = create_github_client_for_org(organization)
         exporter = RestDependabotAlertExporter(rest_client)
 
         data_to_upsert = await exporter.get_resource(

--- a/integrations/github/github/webhook/webhook_processors/deployment_status_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/deployment_status_webhook_processor.py
@@ -1,6 +1,6 @@
 from loguru import logger
 from github.helpers.utils import ObjectKind
-from github.clients.client_factory import create_github_client
+from github.clients.client_factory import create_github_client_for_org
 
 from github.core.options import SingleDeploymentStatusOptions
 from port_ocean.core.handlers.port_app_config.models import ResourceConfig
@@ -64,7 +64,7 @@ class DeploymentStatusWebhookProcessor(BaseRepositoryWebhookProcessor):
                 updated_raw_results=[], deleted_raw_results=[]
             )
 
-        client = create_github_client()
+        client = create_github_client_for_org(organization)
         deployment_status_exporter = RestDeploymentStatusExporter(client)
         data_to_upsert = await deployment_status_exporter.get_resource(
             SingleDeploymentStatusOptions(

--- a/integrations/github/github/webhook/webhook_processors/deployment_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/deployment_webhook_processor.py
@@ -1,6 +1,6 @@
 from loguru import logger
 from github.helpers.utils import ObjectKind
-from github.clients.client_factory import create_github_client
+from github.clients.client_factory import create_github_client_for_org
 
 from github.core.options import SingleDeploymentOptions
 from port_ocean.core.handlers.port_app_config.models import ResourceConfig
@@ -51,7 +51,7 @@ class DeploymentWebhookProcessor(BaseDeploymentWebhookProcessor):
                 updated_raw_results=[], deleted_raw_results=[]
             )
 
-        client = create_github_client()
+        client = create_github_client_for_org(organization)
         deployment_exporter = RestDeploymentExporter(client)
         data_to_upsert = await deployment_exporter.get_resource(
             SingleDeploymentOptions(

--- a/integrations/github/github/webhook/webhook_processors/environment_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/environment_webhook_processor.py
@@ -1,6 +1,6 @@
 from loguru import logger
 from github.helpers.utils import ObjectKind
-from github.clients.client_factory import create_github_client
+from github.clients.client_factory import create_github_client_for_org
 
 from github.core.options import SingleEnvironmentOptions
 from port_ocean.core.handlers.port_app_config.models import ResourceConfig
@@ -38,7 +38,7 @@ class EnvironmentWebhookProcessor(BaseDeploymentWebhookProcessor):
                 updated_raw_results=[], deleted_raw_results=[]
             )
 
-        client = create_github_client()
+        client = create_github_client_for_org(organization)
         environment_exporter = RestEnvironmentExporter(client)
         data_to_upsert = await environment_exporter.get_resource(
             SingleEnvironmentOptions(

--- a/integrations/github/github/webhook/webhook_processors/file_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/file_webhook_processor.py
@@ -1,13 +1,15 @@
+import asyncio
 from pathlib import Path
 from typing import cast, Any
 from github.webhook.webhook_processors.base_repository_webhook_processor import (
     BaseRepositoryWebhookProcessor,
 )
-from github.clients.client_factory import create_github_client
+from github.clients.client_factory import create_github_client_for_org
 from github.core.exporters.file_exporter.core import RestFileExporter
 from github.core.exporters.file_exporter.utils import (
+    FileDiffStatus,
     get_matching_files,
-    group_files_by_status,
+    split_files_by_content_presence,
 )
 from github.core.options import FileContentOptions
 from port_ocean.core.handlers.port_app_config.models import ResourceConfig
@@ -79,6 +81,8 @@ class FileWebhookProcessor(BaseRepositoryWebhookProcessor):
                 updated_raw_results=[], deleted_raw_results=[]
             )
 
+        should_fetch_old_content = bool(resource_config.port.items_to_parse)
+
         updated_raw_results, deleted_raw_results = await self._process_matching_files(
             organization,
             repo_name,
@@ -87,10 +91,11 @@ class FileWebhookProcessor(BaseRepositoryWebhookProcessor):
             matching_patterns,
             repository,
             current_branch,
+            should_fetch_old_content,
         )
 
         if updated_raw_results and selector.included_files:
-            rest_client = create_github_client()
+            rest_client = create_github_client_for_org(organization)
             enricher = IncludedFilesEnricher(
                 client=rest_client,
                 strategy=FileIncludedFilesStrategy(
@@ -151,11 +156,12 @@ class FileWebhookProcessor(BaseRepositoryWebhookProcessor):
         matching_patterns: list["GithubFilePattern"],
         repository: dict[str, Any],
         current_branch: str,
+        should_fetch_old_content: bool,
     ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
         logger.info(
             f"Fetching commit diff for repository {repo_name} of organization: {organization} from {before_sha} to {after_sha}"
         )
-        rest_client = create_github_client()
+        rest_client = create_github_client_for_org(organization)
         exporter = RestFileExporter(rest_client)
 
         diff_data = await exporter.fetch_commit_diff(
@@ -170,42 +176,115 @@ class FileWebhookProcessor(BaseRepositoryWebhookProcessor):
             )
             return [], []
 
-        deleted_files, updated_files = group_files_by_status(matching_files)
+        files_with_new_content, files_with_old_content = (
+            split_files_by_content_presence(matching_files)
+        )
         logger.info(
-            f"Found {len(deleted_files)} deleted files and {len(updated_files)} updated files of organization: {organization}"
+            f"Found {len(files_with_new_content)} files with new content and "
+            f"{len(files_with_old_content)} files with old content of organization: {organization}"
         )
 
-        updated_raw_results = await self._process_updated_files(
-            organization, updated_files, exporter, repository, repo_name, current_branch
-        )
+        if not should_fetch_old_content:
+            updated_raw_results = await self._process_files_at_ref(
+                organization,
+                files_with_new_content,
+                exporter,
+                repository,
+                repo_name,
+                current_branch=current_branch,
+            )
+            deleted_raw_results = self._build_metadata_deletions(
+                organization, files_with_old_content, repository, current_branch
+            )
+            return updated_raw_results, deleted_raw_results
 
-        deleted_raw_results = [
-            {
-                "organization": organization,
-                "path": file["filename"],
-                "metadata": {"path": file["filename"]},
-                "repository": repository,
-                "branch": current_branch,
-                "name": Path(file["filename"]).name,
-            }
-            for file in deleted_files
-        ]
+        updated_raw_results, deleted_raw_results = await asyncio.gather(
+            self._process_files_at_ref(
+                organization,
+                files_with_new_content,
+                exporter,
+                repository,
+                repo_name,
+                current_branch=current_branch,
+            ),
+            self._process_files_at_ref(
+                organization,
+                files_with_old_content,
+                exporter,
+                repository,
+                repo_name,
+                current_branch=current_branch,
+                content_ref=before_sha,
+                should_resolve_references=False,
+                should_use_previous_filename=True,
+            ),
+        )
 
         return updated_raw_results, deleted_raw_results
 
-    async def _process_updated_files(
+    def _build_metadata_deletions(
         self,
         organization: str,
-        updated_files: list[dict[str, Any]],
+        files: list[dict[str, Any]],
+        repository: dict[str, Any],
+        branch: str,
+    ) -> list[dict[str, Any]]:
+        """Emit metadata-only deletions for removed files and the old paths of renamed files."""
+        results = []
+        for file_info in files:
+            if file_info.get("status") == FileDiffStatus.REMOVED:
+                deleted_path = file_info["filename"]
+            elif file_info.get("status") == FileDiffStatus.RENAMED:
+                deleted_path = file_info.get("previous_filename")
+                if not deleted_path:
+                    continue
+            else:
+                continue
+
+            results.append(
+                self._build_deletion_metadata_result(
+                    organization, deleted_path, repository, branch
+                )
+            )
+        return results
+
+    def _build_deletion_metadata_result(
+        self,
+        organization: str,
+        file_path: str,
+        repository: dict[str, Any],
+        branch: str,
+    ) -> dict[str, Any]:
+        """Metadata-only deletion entry used when old content cannot be fetched."""
+        return {
+            "organization": organization,
+            "path": file_path,
+            "metadata": {"path": file_path},
+            "repository": repository,
+            "branch": branch,
+            "name": Path(file_path).name,
+        }
+
+    async def _process_files_at_ref(
+        self,
+        organization: str,
+        files: list[dict[str, Any]],
         exporter: "RestFileExporter",
         repository: dict[str, Any],
         repo_name: str,
         current_branch: str,
+        content_ref: str | None = None,
+        should_resolve_references: bool = True,
+        should_use_previous_filename: bool = False,
     ) -> list[dict[str, Any]]:
+        """Fetch content from ``content_ref`` (defaults to ``current_branch``) but always stamp ``current_branch`` so upsert and delete identifiers match."""
+        content_ref = content_ref or current_branch
         results = []
 
-        for file_info in updated_files:
+        for file_info in files:
             file_path = file_info["filename"]
+            if should_use_previous_filename:
+                file_path = file_info.get("previous_filename") or file_path
             patterns: list["GithubFilePattern"] = file_info["patterns"]
 
             for pattern in patterns:
@@ -215,19 +294,19 @@ class FileWebhookProcessor(BaseRepositoryWebhookProcessor):
                             organization=organization,
                             repo_name=repo_name,
                             file_path=file_path,
-                            branch=current_branch,
+                            branch=content_ref,
                         )
                     )
-                    if not file_content_response:
-                        logger.warning(
-                            f"No response for file {file_path} from {organization}"
-                        )
-                        continue
 
-                    content = file_content_response.get("content")
+                    content = (
+                        file_content_response.get("content")
+                        if file_content_response
+                        else None
+                    )
                     if content is None:
                         logger.warning(
-                            f"File {file_path} has no content or is too large from {organization}"
+                            f"File {file_path} has no content or is too large at ref {content_ref} from {organization}; "
+                            "cannot compute sub-entity deletions for this file"
                         )
                         continue
 
@@ -239,19 +318,20 @@ class FileWebhookProcessor(BaseRepositoryWebhookProcessor):
                         skip_parsing=pattern.skip_parsing,
                         branch=current_branch,
                         metadata=file_content_response,
+                        should_resolve_references=should_resolve_references,
                     )
 
                     results.append(dict(file_obj))
                     logger.debug(
-                        f"Successfully processed file {file_path} with pattern {pattern.path} from {organization}"
+                        f"Successfully processed file {file_path} with pattern {pattern.path} at ref {content_ref} from {organization}"
                     )
 
                 except Exception as e:
                     logger.error(
-                        f"Error processing file {file_path} with pattern {pattern.path}: {e} from {organization}"
+                        f"Error processing file {file_path} with pattern {pattern.path} at ref {content_ref}: {e} from {organization}"
                     )
 
         logger.info(
-            f"Successfully processed {len(results)} file results from {organization}"
+            f"Successfully processed {len(results)} file results at ref {content_ref} from {organization}"
         )
         return results

--- a/integrations/github/github/webhook/webhook_processors/folder_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/folder_webhook_processor.py
@@ -2,7 +2,7 @@ from typing import Any, cast
 
 from loguru import logger
 
-from github.clients.client_factory import create_github_client
+from github.clients.client_factory import create_github_client_for_org
 from github.core.exporters.folder_exporter import RestFolderExporter
 from github.core.options import (
     FolderSearchOptions,
@@ -62,7 +62,7 @@ class FolderWebhookProcessor(_GithubAbstractWebhookProcessor):
             if config.selector.included_files or any(
                 sel.included_files for sel in config.selector.folders
             ):
-                client = create_github_client()
+                client = create_github_client_for_org(organization)
                 enricher = IncludedFilesEnricher(
                     client=client,
                     strategy=FolderIncludedFilesStrategy(
@@ -128,8 +128,8 @@ class FolderWebhookProcessor(_GithubAbstractWebhookProcessor):
         branch: str,
         event_payload: EventPayload,
     ) -> list[dict[str, Any]]:
-        client = create_github_client()
         organization = self.get_webhook_payload_organization(event_payload)["login"]
+        client = create_github_client_for_org(organization)
 
         commit_diff = await fetch_commit_diff(
             client,

--- a/integrations/github/github/webhook/webhook_processors/issue_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/issue_webhook_processor.py
@@ -15,7 +15,7 @@ from github.webhook.events import ISSUE_DELETE_EVENTS, ISSUE_EVENTS
 from github.core.exporters.issue_exporter import RestIssueExporter
 from github.core.options import SingleIssueOptions
 from integration import GithubIssueConfig, GithubIssueSelector
-from github.clients.client_factory import create_github_client
+from github.clients.client_factory import create_github_client_for_org
 from github.webhook.webhook_processors.base_repository_webhook_processor import (
     BaseRepositoryWebhookProcessor,
 )
@@ -73,7 +73,7 @@ class IssueWebhookProcessor(BaseRepositoryWebhookProcessor):
                 updated_raw_results=[],
                 deleted_raw_results=[data_to_delete],
             )
-        exporter = RestIssueExporter(create_github_client())
+        exporter = RestIssueExporter(create_github_client_for_org(organization))
         data_to_upsert = await exporter.get_resource(
             SingleIssueOptions(
                 organization=organization,

--- a/integrations/github/github/webhook/webhook_processors/port_app_config_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/port_app_config_webhook_processor.py
@@ -19,7 +19,7 @@ from github.webhook.webhook_processors.github_abstract_webhook_processor import 
 from github.core.exporters.file_exporter.utils import group_files_by_status
 from github.helpers.port_app_config import is_repo_managed_mapping
 from github.core.exporters.file_exporter.core import RestFileExporter
-from github.clients.client_factory import create_github_client
+from github.clients.client_factory import create_github_client_for_org
 from github.helpers.port_app_config import ORG_CONFIG_FILE, ORG_CONFIG_REPO
 
 
@@ -91,7 +91,7 @@ class PortAppConfigWebhookProcessor(
                 updated_raw_results=[], deleted_raw_results=[]
             )
 
-        rest_client = create_github_client()
+        rest_client = create_github_client_for_org(organization)
         exporter = RestFileExporter(rest_client)
 
         diff_data = await exporter.fetch_commit_diff(

--- a/integrations/github/github/webhook/webhook_processors/pull_request_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/pull_request_webhook_processor.py
@@ -7,7 +7,7 @@ from github.helpers.utils import (
     enrich_with_organization,
     enrich_with_repository,
 )
-from github.clients.client_factory import create_github_client
+from github.clients.client_factory import create_github_client_for_org
 from github.core.exporters.abstract_exporter import AbstractGithubExporter
 from port_ocean.core.handlers.port_app_config.models import ResourceConfig
 from port_ocean.core.handlers.webhook.webhook_event import (
@@ -74,9 +74,11 @@ class PullRequestWebhookProcessor(BaseRepositoryWebhookProcessor):
 
         is_graphql_api = config.selector.api == GithubClientType.GRAPHQL
         exporter: AbstractGithubExporter[Any] = (
-            GraphQLPullRequestExporter(create_github_client(GithubClientType.GRAPHQL))
+            GraphQLPullRequestExporter(
+                create_github_client_for_org(organization, GithubClientType.GRAPHQL)
+            )
             if is_graphql_api
-            else RestPullRequestExporter(create_github_client())
+            else RestPullRequestExporter(create_github_client_for_org(organization))
         )
         data_to_upsert = await exporter.get_resource(
             SinglePullRequestOptions(

--- a/integrations/github/github/webhook/webhook_processors/release_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/release_webhook_processor.py
@@ -5,7 +5,7 @@ from github.helpers.utils import (
     enrich_with_organization,
     enrich_with_repository,
 )
-from github.clients.client_factory import create_github_client
+from github.clients.client_factory import create_github_client_for_org
 from github.webhook.webhook_processors.base_repository_webhook_processor import (
     BaseRepositoryWebhookProcessor,
 )
@@ -56,7 +56,7 @@ class ReleaseWebhookProcessor(BaseRepositoryWebhookProcessor):
                 updated_raw_results=[], deleted_raw_results=[data_to_delete]
             )
 
-        rest_client = create_github_client()
+        rest_client = create_github_client_for_org(organization)
         exporter = RestReleaseExporter(rest_client)
 
         data_to_upsert = await exporter.get_resource(

--- a/integrations/github/github/webhook/webhook_processors/repository_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/repository_webhook_processor.py
@@ -7,7 +7,7 @@ from github.webhook.events import (
     TEAM_COLLABORATOR_EVENTS,
 )
 from github.helpers.utils import ObjectKind
-from github.clients.client_factory import create_github_client
+from github.clients.client_factory import create_github_client_for_org
 from github.webhook.webhook_processors.base_repository_webhook_processor import (
     BaseRepositoryWebhookProcessor,
     CollaboratorEventValidator,
@@ -97,7 +97,7 @@ class RepositoryWebhookProcessor(
                 updated_raw_results=[], deleted_raw_results=[repo]
             )
 
-        rest_client = create_github_client()
+        rest_client = create_github_client_for_org(organization)
         exporter = RestRepositoryExporter(rest_client)
         included_relations = resource_config.selector.normalized_relations
 

--- a/integrations/github/github/webhook/webhook_processors/secret_scanning_alert_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/secret_scanning_alert_webhook_processor.py
@@ -5,7 +5,7 @@ from github.helpers.utils import (
     enrich_with_repository,
     enrich_with_organization,
 )
-from github.clients.client_factory import create_github_client
+from github.clients.client_factory import create_github_client_for_org
 from port_ocean.core.handlers.port_app_config.models import ResourceConfig
 from port_ocean.core.handlers.webhook.webhook_event import (
     EventPayload,
@@ -84,7 +84,7 @@ class SecretScanningAlertWebhookProcessor(BaseRepositoryWebhookProcessor):
             f"The action {action} is allowed for secret scanning alert {alert_number} in {repo_name} from {organization}. Updating resource."
         )
 
-        rest_client = create_github_client()
+        rest_client = create_github_client_for_org(organization)
         exporter = RestSecretScanningAlertExporter(rest_client)
 
         data_to_upsert = await exporter.get_resource(

--- a/integrations/github/github/webhook/webhook_processors/tag_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/tag_webhook_processor.py
@@ -4,7 +4,7 @@ from github.helpers.utils import (
     enrich_with_organization,
     enrich_with_repository,
 )
-from github.clients.client_factory import create_github_client
+from github.clients.client_factory import create_github_client_for_org
 from github.webhook.webhook_processors.base_repository_webhook_processor import (
     BaseRepositoryWebhookProcessor,
 )
@@ -62,7 +62,7 @@ class TagWebhookProcessor(BaseRepositoryWebhookProcessor):
                 updated_raw_results=[], deleted_raw_results=[data_to_delete]
             )
 
-        rest_client = create_github_client()
+        rest_client = create_github_client_for_org(organization)
         exporter = RestTagExporter(rest_client)
 
         data_to_upsert = await exporter.get_resource(

--- a/integrations/github/github/webhook/webhook_processors/team_member_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/team_member_webhook_processor.py
@@ -9,7 +9,7 @@ from github.webhook.events import (
     TEAM_MEMBERSHIP_EVENTS,
 )
 from github.helpers.utils import GithubClientType, ObjectKind
-from github.clients.client_factory import create_github_client
+from github.clients.client_factory import create_github_client_for_org
 from github.webhook.webhook_processors.github_abstract_webhook_processor import (
     _GithubAbstractWebhookProcessor,
 )
@@ -72,7 +72,9 @@ class TeamMemberWebhookProcessor(_GithubAbstractWebhookProcessor):
                 deleted_raw_results=[],
             )
 
-        graphql_client = create_github_client(GithubClientType.GRAPHQL)
+        graphql_client = create_github_client_for_org(
+            organization, GithubClientType.GRAPHQL
+        )
         exporter = GraphQLTeamWithMembersExporter(graphql_client)
 
         data_to_upsert = await exporter.get_resource(

--- a/integrations/github/github/webhook/webhook_processors/team_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/team_webhook_processor.py
@@ -7,7 +7,7 @@ from github.core.exporters.team_exporter import (
 from github.core.options import ListTeamOptions, SingleTeamOptions
 from github.webhook.events import TEAM_DELETE_EVENTS, TEAM_EVENTS
 from github.helpers.utils import GithubClientType, ObjectKind
-from github.clients.client_factory import create_github_client
+from github.clients.client_factory import create_github_client_for_org
 from github.webhook.webhook_processors.github_abstract_webhook_processor import (
     _GithubAbstractWebhookProcessor,
 )
@@ -57,7 +57,7 @@ class TeamWebhookProcessor(_GithubAbstractWebhookProcessor):
                 updated_raw_results=[], deleted_raw_results=[team]
             )
 
-        rest_client = create_github_client(GithubClientType.REST)
+        rest_client = create_github_client_for_org(organization, GithubClientType.REST)
         exporter = RestTeamExporter(rest_client)
 
         data_to_upsert = await exporter.get_resource(
@@ -74,7 +74,7 @@ class TeamWebhookProcessor(_GithubAbstractWebhookProcessor):
 
         if selector.members:
             graphql_exporter = GraphQLTeamWithMembersExporter(
-                create_github_client(GithubClientType.GRAPHQL)
+                create_github_client_for_org(organization, GithubClientType.GRAPHQL)
             )
             extras_result = await graphql_exporter._enrich_team_with_extras(
                 [data_to_upsert],

--- a/integrations/github/github/webhook/webhook_processors/user_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/user_webhook_processor.py
@@ -6,7 +6,7 @@ from github.webhook.events import (
     USER_UPSERT_EVENTS,
 )
 from github.helpers.utils import GithubClientType, ObjectKind
-from github.clients.client_factory import create_github_client
+from github.clients.client_factory import create_github_client_for_org
 from github.webhook.webhook_processors.github_abstract_webhook_processor import (
     _GithubAbstractWebhookProcessor,
 )
@@ -51,7 +51,7 @@ class UserWebhookProcessor(_GithubAbstractWebhookProcessor):
                 updated_raw_results=[], deleted_raw_results=[user]
             )
 
-        client = create_github_client(GithubClientType.GRAPHQL)
+        client = create_github_client_for_org(organization, GithubClientType.GRAPHQL)
         exporter = GraphQLUserExporter(client)
         selector = cast(GithubUserConfig, resource_config).selector
 

--- a/integrations/github/github/webhook/webhook_processors/workflow_run/workflow_run_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/workflow_run/workflow_run_webhook_processor.py
@@ -2,7 +2,7 @@ from typing import cast
 from loguru import logger
 from github.core.exporters.workflow_runs_exporter import RestWorkflowRunExporter
 from github.core.options import SingleWorkflowRunOptions
-from github.clients.client_factory import create_github_client
+from github.clients.client_factory import create_github_client_for_org
 from github.webhook.webhook_processors.workflow_run.base_workflow_run_webhook_processor import (
     BaseWorkflowRunWebhookProcessor,
 )
@@ -56,7 +56,7 @@ class WorkflowRunWebhookProcessor(BaseWorkflowRunWebhookProcessor):
                         )
                     ],
                 )
-        exporter = RestWorkflowRunExporter(create_github_client())
+        exporter = RestWorkflowRunExporter(create_github_client_for_org(organization))
         options = SingleWorkflowRunOptions(
             organization=organization, repo_name=repo["name"], run_id=workflow_run["id"]
         )

--- a/integrations/github/github/webhook/webhook_processors/workflow_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/workflow_webhook_processor.py
@@ -2,7 +2,7 @@ from loguru import logger
 from github.core.exporters.workflows_exporter import RestWorkflowExporter
 from github.core.options import SingleWorkflowOptions
 from github.helpers.utils import ObjectKind
-from github.clients.client_factory import create_github_client
+from github.clients.client_factory import create_github_client_for_org
 from github.webhook.webhook_processors.base_repository_webhook_processor import (
     BaseRepositoryWebhookProcessor,
 )
@@ -57,7 +57,7 @@ class WorkflowWebhookProcessor(BaseRepositoryWebhookProcessor):
                 updated_raw_results=[], deleted_raw_results=[]
             )
 
-        rest_client = create_github_client()
+        rest_client = create_github_client_for_org(organization)
         commit_diff = await fetch_commit_diff(
             rest_client, organization, repo_name, payload["before"], payload["after"]
         )

--- a/integrations/github/tests/github/webhook/webhook_processors/check_runs/test_check_run_validator_webhook_processor.py
+++ b/integrations/github/tests/github/webhook/webhook_processors/check_runs/test_check_run_validator_webhook_processor.py
@@ -179,18 +179,18 @@ class TestCheckRunValidatorWebhookProcessor:
                 ),
             ),
             patch(
-                "github.webhook.webhook_processors.check_runs.check_runs_validator_webhook_processor.create_github_client",
+                "github.webhook.webhook_processors.check_runs.check_runs_validator_webhook_processor.create_github_client_for_org",
                 return_value=(lambda: None)(),
             ),
             patch(
                 "github.webhook.webhook_processors.check_runs.check_runs_validator_webhook_processor.RestFileExporter",
             ) as mock_file_exporter_class,
         ):
-            # Configure create_github_client to return a client with async send_api_request
+            # Configure create_github_client_for_org to return a client with async send_api_request
             client_mock = MagicMock()
             client_mock.send_api_request = AsyncMock(return_value={"login": "test-org"})
             patcher = patch(
-                "github.webhook.webhook_processors.check_runs.check_runs_validator_webhook_processor.create_github_client",
+                "github.webhook.webhook_processors.check_runs.check_runs_validator_webhook_processor.create_github_client_for_org",
                 return_value=client_mock,
             )
             patcher.start()
@@ -240,7 +240,7 @@ class TestCheckRunValidatorWebhookProcessor:
                 ),
             ),
             patch(
-                "github.webhook.webhook_processors.check_runs.check_runs_validator_webhook_processor.create_github_client",
+                "github.webhook.webhook_processors.check_runs.check_runs_validator_webhook_processor.create_github_client_for_org",
                 return_value=(lambda: None)(),
             ),
             patch(
@@ -250,11 +250,11 @@ class TestCheckRunValidatorWebhookProcessor:
                 "github.webhook.webhook_processors.check_runs.check_runs_validator_webhook_processor.FileValidationService",
             ) as mock_validation_service_class,
         ):
-            # Configure create_github_client to return a client with async send_api_request
+            # Configure create_github_client_for_org to return a client with async send_api_request
             client_mock = MagicMock()
             client_mock.send_api_request = AsyncMock(return_value={"login": "test-org"})
             patcher = patch(
-                "github.webhook.webhook_processors.check_runs.check_runs_validator_webhook_processor.create_github_client",
+                "github.webhook.webhook_processors.check_runs.check_runs_validator_webhook_processor.create_github_client_for_org",
                 return_value=client_mock,
             )
             patcher.start()

--- a/integrations/github/tests/github/webhook/webhook_processors/check_runs/test_file_validation.py
+++ b/integrations/github/tests/github/webhook/webhook_processors/check_runs/test_file_validation.py
@@ -168,7 +168,7 @@ class TestFileValidation:
             )
 
             mock_create_check.assert_called_once_with(
-                organization="test-org", repo_name="test-repo", head_sha="head-sha-456"
+                repo_name="test-repo", head_sha="head-sha-456"
             )
             mock_update_check.assert_called_once()
 
@@ -213,7 +213,7 @@ class TestFileValidation:
             )
 
             mock_create_check.assert_called_once_with(
-                organization="test-org", repo_name="test-repo", head_sha="head-sha-456"
+                repo_name="test-repo", head_sha="head-sha-456"
             )
             mock_update_check.assert_called_once()
 

--- a/integrations/github/tests/github/webhook/webhook_processors/test_code_scanning_alert_webhook_processor.py
+++ b/integrations/github/tests/github/webhook/webhook_processors/test_code_scanning_alert_webhook_processor.py
@@ -196,7 +196,7 @@ class TestCodeScanningAlertWebhookProcessor:
 
         with (
             patch(
-                "github.webhook.webhook_processors.code_scanning_alert_webhook_processor.create_github_client"
+                "github.webhook.webhook_processors.code_scanning_alert_webhook_processor.create_github_client_for_org"
             ) as mock_create_client,
             patch(
                 "github.webhook.webhook_processors.code_scanning_alert_webhook_processor.RestCodeScanningAlertExporter",

--- a/integrations/github/tests/github/webhook/webhook_processors/test_collaborator_webhook_processor/test_member_webhook_processor.py
+++ b/integrations/github/tests/github/webhook/webhook_processors/test_collaborator_webhook_processor/test_member_webhook_processor.py
@@ -162,7 +162,7 @@ class TestCollaboratorMemberWebhookProcessor:
         }
 
         with patch(
-            "github.webhook.webhook_processors.collaborator_webhook_processor.member_webhook_processor.create_github_client"
+            "github.webhook.webhook_processors.collaborator_webhook_processor.member_webhook_processor.create_github_client_for_org"
         ) as mock_create_client:
             mock_client = MagicMock()
             mock_create_client.return_value = mock_client
@@ -219,7 +219,7 @@ class TestCollaboratorMemberWebhookProcessor:
 
         with (
             patch(
-                "github.webhook.webhook_processors.collaborator_webhook_processor.member_webhook_processor.create_github_client"
+                "github.webhook.webhook_processors.collaborator_webhook_processor.member_webhook_processor.create_github_client_for_org"
             ) as mock_create_client,
             patch(
                 "github.webhook.webhook_processors.collaborator_webhook_processor.member_webhook_processor.RestCollaboratorExporter"

--- a/integrations/github/tests/github/webhook/webhook_processors/test_collaborator_webhook_processor/test_membership_webhook_processor.py
+++ b/integrations/github/tests/github/webhook/webhook_processors/test_collaborator_webhook_processor/test_membership_webhook_processor.py
@@ -192,7 +192,7 @@ class TestCollaboratorMembershipWebhookProcessor:
         ]
 
         with patch(
-            "github.webhook.webhook_processors.collaborator_webhook_processor.membership_webhook_processor.create_github_client"
+            "github.webhook.webhook_processors.collaborator_webhook_processor.membership_webhook_processor.create_github_client_for_org"
         ) as mock_create_client:
             mock_client = MagicMock()
             mock_create_client.return_value = mock_client
@@ -256,7 +256,7 @@ class TestCollaboratorMembershipWebhookProcessor:
         resource_config.selector.affiliation = "outside"
 
         with patch(
-            "github.webhook.webhook_processors.collaborator_webhook_processor.membership_webhook_processor.create_github_client"
+            "github.webhook.webhook_processors.collaborator_webhook_processor.membership_webhook_processor.create_github_client_for_org"
         ) as mock_create_client:
             async with event_context("test_event") as event_context_obj:
                 event_context_obj.port_app_config = mock_port_app_config

--- a/integrations/github/tests/github/webhook/webhook_processors/test_collaborator_webhook_processor/test_team_webhook_processor.py
+++ b/integrations/github/tests/github/webhook/webhook_processors/test_collaborator_webhook_processor/test_team_webhook_processor.py
@@ -189,7 +189,7 @@ class TestCollaboratorTeamWebhookProcessor:
         ]
 
         with patch(
-            "github.webhook.webhook_processors.collaborator_webhook_processor.team_webhook_processor.create_github_client"
+            "github.webhook.webhook_processors.collaborator_webhook_processor.team_webhook_processor.create_github_client_for_org"
         ) as mock_create_client:
             mock_client = MagicMock()
             mock_create_client.return_value = mock_client
@@ -221,7 +221,7 @@ class TestCollaboratorTeamWebhookProcessor:
                 ]
                 assert result.updated_raw_results == expected_team_data
 
-                mock_create_client.assert_called_once_with()
+                mock_create_client.assert_called_once_with("test-org")
             else:
                 # For unsupported events, no exporters should be called
                 mock_create_client.assert_not_called()
@@ -238,7 +238,7 @@ class TestCollaboratorTeamWebhookProcessor:
         resource_config.selector.affiliation = "direct"
 
         with patch(
-            "github.webhook.webhook_processors.collaborator_webhook_processor.team_webhook_processor.create_github_client"
+            "github.webhook.webhook_processors.collaborator_webhook_processor.team_webhook_processor.create_github_client_for_org"
         ) as mock_create_client:
             result = await team_webhook_processor.handle_event(payload, resource_config)
 
@@ -257,7 +257,7 @@ class TestCollaboratorTeamWebhookProcessor:
         payload["action"] = "added_to_repository"
 
         with patch(
-            "github.webhook.webhook_processors.collaborator_webhook_processor.team_webhook_processor.create_github_client"
+            "github.webhook.webhook_processors.collaborator_webhook_processor.team_webhook_processor.create_github_client_for_org"
         ) as mock_create_client:
             mock_client = MagicMock()
             mock_create_client.return_value = mock_client
@@ -276,4 +276,4 @@ class TestCollaboratorTeamWebhookProcessor:
             assert result.updated_raw_results == []
             assert result.deleted_raw_results == []
 
-            mock_create_client.assert_called_once_with()
+            mock_create_client.assert_called_once_with("test-org")

--- a/integrations/github/tests/github/webhook/webhook_processors/test_dependabot_webhook_processor.py
+++ b/integrations/github/tests/github/webhook/webhook_processors/test_dependabot_webhook_processor.py
@@ -174,7 +174,7 @@ class TestDependabotAlertWebhookProcessor:
 
         with (
             patch(
-                "github.webhook.webhook_processors.dependabot_webhook_processor.create_github_client"
+                "github.webhook.webhook_processors.dependabot_webhook_processor.create_github_client_for_org"
             ) as mock_create_client,
             patch(
                 "github.webhook.webhook_processors.dependabot_webhook_processor.RestDependabotAlertExporter",

--- a/integrations/github/tests/github/webhook/webhook_processors/test_folder_webhook_processor.py
+++ b/integrations/github/tests/github/webhook/webhook_processors/test_folder_webhook_processor.py
@@ -123,7 +123,7 @@ class TestFolderWebhookProcessor:
         assert ObjectKind.FOLDER in kinds
 
     @patch(
-        "github.webhook.webhook_processors.folder_webhook_processor.create_github_client"
+        "github.webhook.webhook_processors.folder_webhook_processor.create_github_client_for_org"
     )
     @patch(
         "github.webhook.webhook_processors.folder_webhook_processor.fetch_commit_diff",
@@ -229,7 +229,7 @@ class TestFolderWebhookProcessor:
         assert mock_exporter_instance.get_paginated_resources.call_count >= 1
 
     @patch(
-        "github.webhook.webhook_processors.folder_webhook_processor.create_github_client"
+        "github.webhook.webhook_processors.folder_webhook_processor.create_github_client_for_org"
     )
     @patch(
         "github.webhook.webhook_processors.folder_webhook_processor.fetch_commit_diff",

--- a/integrations/github/tests/github/webhook/webhook_processors/test_included_files_enrichment.py
+++ b/integrations/github/tests/github/webhook/webhook_processors/test_included_files_enrichment.py
@@ -213,7 +213,7 @@ class TestGithubIncludedFilesEnrichment:
                 new=AsyncMock(return_value=True),
             ),
             patch(
-                "github.webhook.webhook_processors.repository_webhook_processor.create_github_client",
+                "github.webhook.webhook_processors.repository_webhook_processor.create_github_client_for_org",
                 return_value=MagicMock(),
             ),
             patch(

--- a/integrations/github/tests/github/webhook/webhook_processors/test_secret_scanning_alert_webhook_processor.py
+++ b/integrations/github/tests/github/webhook/webhook_processors/test_secret_scanning_alert_webhook_processor.py
@@ -196,7 +196,7 @@ class TestSecretScanningAlertWebhookProcessor:
 
         with (
             patch(
-                "github.webhook.webhook_processors.secret_scanning_alert_webhook_processor.create_github_client"
+                "github.webhook.webhook_processors.secret_scanning_alert_webhook_processor.create_github_client_for_org"
             ) as mock_create_client,
             patch(
                 "github.webhook.webhook_processors.secret_scanning_alert_webhook_processor.RestSecretScanningAlertExporter",

--- a/integrations/github/tests/github/webhook/webhook_processors/test_team_member_webhook_processor.py
+++ b/integrations/github/tests/github/webhook/webhook_processors/test_team_member_webhook_processor.py
@@ -159,7 +159,7 @@ class TestTeamMemberWebhookProcessor:
         if api_call_for_team_upsert_expected:
             mock_exporter_instance.get_resource.return_value = full_team_export_data
             exporter_class_path = "github.webhook.webhook_processors.team_member_webhook_processor.GraphQLTeamWithMembersExporter"
-            create_client_path = "github.webhook.webhook_processors.team_member_webhook_processor.create_github_client"
+            create_client_path = "github.webhook.webhook_processors.team_member_webhook_processor.create_github_client_for_org"
 
             with (
                 patch(
@@ -173,7 +173,9 @@ class TestTeamMemberWebhookProcessor:
                     payload, resource_config
                 )
 
-                mock_create_client.assert_called_once_with(GithubClientType.GRAPHQL)
+                mock_create_client.assert_called_once_with(
+                    "test-org", GithubClientType.GRAPHQL
+                )
                 mock_exporter_class_constructor.assert_called_once_with(
                     mock_graphql_client
                 )
@@ -298,7 +300,7 @@ class TestTeamMemberWebhookProcessor:
         mock_exporter_instance = AsyncMock()
 
         exporter_class_path = "github.webhook.webhook_processors.team_member_webhook_processor.GraphQLTeamWithMembersExporter"
-        create_client_path = "github.webhook.webhook_processors.team_member_webhook_processor.create_github_client"
+        create_client_path = "github.webhook.webhook_processors.team_member_webhook_processor.create_github_client_for_org"
 
         with (
             patch(

--- a/integrations/github/tests/github/webhook/webhook_processors/test_team_webhook_processor.py
+++ b/integrations/github/tests/github/webhook/webhook_processors/test_team_webhook_processor.py
@@ -132,7 +132,9 @@ class TestTeamWebhookProcessor:
             mock_rest_client = AsyncMock()
             mock_graphql_client = AsyncMock()
 
-            def create_client_side_effect(client_type: GithubClientType) -> AsyncMock:
+            def create_client_side_effect(
+                organization: str, client_type: GithubClientType
+            ) -> AsyncMock:
                 return (
                     mock_graphql_client
                     if client_type == GithubClientType.GRAPHQL
@@ -141,7 +143,7 @@ class TestTeamWebhookProcessor:
 
             with (
                 patch(
-                    "github.webhook.webhook_processors.team_webhook_processor.create_github_client"
+                    "github.webhook.webhook_processors.team_webhook_processor.create_github_client_for_org"
                 ) as mock_create_client,
                 patch(
                     "github.webhook.webhook_processors.team_webhook_processor.RestTeamExporter.get_resource",
@@ -167,8 +169,8 @@ class TestTeamWebhookProcessor:
 
                 if include_members:
                     assert mock_create_client.call_args_list == [
-                        call(GithubClientType.REST),
-                        call(GithubClientType.GRAPHQL),
+                        call("test-org", GithubClientType.REST),
+                        call("test-org", GithubClientType.GRAPHQL),
                     ]
                     mock_graphql_get_resource.assert_awaited_once_with(
                         SingleTeamOptions(
@@ -178,7 +180,9 @@ class TestTeamWebhookProcessor:
                         )
                     )
                 else:
-                    mock_create_client.assert_called_once_with(GithubClientType.REST)
+                    mock_create_client.assert_called_once_with(
+                        "test-org", GithubClientType.REST
+                    )
                     mock_graphql_get_resource.assert_not_awaited()
 
         assert isinstance(result, WebhookEventRawResults)

--- a/integrations/github/tests/github/webhook/webhook_processors/test_workflow_webhook_processor.py
+++ b/integrations/github/tests/github/webhook/webhook_processors/test_workflow_webhook_processor.py
@@ -235,7 +235,7 @@ class TestWorkflowWebhookProcessor:
 
         with (
             patch(
-                "github.webhook.webhook_processors.workflow_webhook_processor.create_github_client",
+                "github.webhook.webhook_processors.workflow_webhook_processor.create_github_client_for_org",
                 return_value=mock_rest_client,
             ),
             patch(


### PR DESCRIPTION
## Summary
- Use per-organization GitHub clients across webhook processors and related tests.
- Include `file_exporter/utils.py` and `file_exporter/file_processor.py` from the source branch (required by `file_webhook_processor` but omitted from the original 66-file diff vs `main`).

Port task: task_thwvv0

## Test plan
- [x] `make lint` in `integrations/github`
- [x] `make test` in `integrations/github`


Made with [Cursor](https://cursor.com)