### PR TITLE
GitHub integration: multi-org resync and live events

### DIFF
--- a/integrations/github/CHANGELOG.md
+++ b/integrations/github/CHANGELOG.md
@@ -7,12 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
-## 6.2.7 (2026-07-10)
+## 6.3.0 (2026-07-09)
 
+
+### Improvements
+
+- Added multi-organization auto-discovery for GitHub App authentication.
 
 ### Bug Fixes
 
-- Reverted the file-kind live event deletion changes introduced in 6.2.3 that fetched old file content for `items_to_parse` deletions.
+- Fixed action executors to use per-organization GitHub clients after the auth refactor.
+- Fixed `get_authenticated_actor` to prefer PAT credentials when both PAT and app credentials are configured.
 
 
 ## 6.2.6 (2026-07-08)

--- a/integrations/github/github/clients/client_factory.py
+++ b/integrations/github/github/clients/client_factory.py
@@ -1,6 +1,6 @@
 import os
 from dataclasses import dataclass
-from typing import Dict, Literal, Optional, Type, overload
+from typing import Dict, Literal, Type, overload
 
 from loguru import logger
 from port_ocean.context.ocean import ocean
@@ -139,45 +139,3 @@ def create_github_client_for_org(
     return _client_for(
         _authenticator_for_org(organization), client_type or GithubClientType.REST
     )
-
-
-class GitHubAuthenticatorFactory:
-    """Backward-compatible factory for webhook setup until main.py is migrated."""
-
-    @staticmethod
-    def create(
-        github_host: str,
-        organization: Optional[str] = None,
-        token: Optional[str] = None,
-        app_id: Optional[str] = None,
-        installation_id: Optional[str] = None,
-        private_key: Optional[str] = None,
-    ) -> AbstractGitHubAuthenticator:
-        del github_host, token, app_id, installation_id, private_key
-        return _authenticator_for_org(organization)
-
-
-@overload
-def create_github_client(
-    client_type: Literal[GithubClientType.REST],
-) -> GithubRestClient: ...
-
-
-@overload
-def create_github_client(client_type: None = None) -> GithubRestClient: ...
-
-
-@overload
-def create_github_client(
-    client_type: Literal[GithubClientType.GRAPHQL],
-) -> GithubGraphQLClient: ...
-
-
-def create_github_client(
-    client_type: GithubClientType | None = None,
-) -> AbstractGithubClient:
-    organization = ocean.integration_config.get("github_organization")
-    resolved = client_type or GithubClientType.REST
-    if resolved == GithubClientType.GRAPHQL:
-        return create_github_client_for_org(organization, GithubClientType.GRAPHQL)
-    return create_github_client_for_org(organization, GithubClientType.REST)

--- a/integrations/github/main.py
+++ b/integrations/github/main.py
@@ -1,11 +1,11 @@
-from typing import Any, cast
+from typing import Any, AsyncGenerator, cast
 
 from loguru import logger
 
 from github.actions.registry import register_actions_executors
 from port_ocean.context.event import event
 from port_ocean.context.ocean import ocean
-from port_ocean.core.ocean_types import ASYNC_GENERATOR_RESYNC_TYPE
+from port_ocean.core.ocean_types import ASYNC_GENERATOR_RESYNC_TYPE, RAW_ITEM
 from port_ocean.utils.async_iterators import (
     stream_async_iterators_tasks,
     stream_independent_async_iterators,
@@ -19,14 +19,13 @@ from github.core.exporters.user_exporter import GraphQLUserExporter
 from github.webhook.registry import register_live_events_webhooks
 from github.core.exporters.file_exporter.utils import FilePatternMappingBuilder
 from github.clients.client_factory import (
-    GitHubAuthenticatorFactory,
-    create_github_client,
+    GithubClientScope,
+    create_github_client_for_org,
+    create_github_clients,
 )
 from github.webhook.clients.client_factory import GithubWebhookClientFactory
 from github.core.exporters.workflow_runs_exporter import RestWorkflowRunExporter
-from github.clients.utils import (
-    get_github_organizations,
-)
+from github.clients.utils import get_github_organizations
 from github.core.exporters.abstract_exporter import AbstractGithubExporter
 from github.core.exporters.branch_exporter import RestBranchExporter
 from github.core.exporters.deployment_exporter import RestDeploymentExporter
@@ -119,17 +118,9 @@ MAX_CONCURRENT_REPOS = 10
 
 
 async def _create_webhooks_for_organization(org_name: str, base_url: str) -> None:
-    github_host = ocean.integration_config["github_host"]
     webhook_secret = ocean.integration_config["webhook_secret"]
     skip_patching = ocean.integration_config["skip_webhook_patching"]
-    authenticator = GitHubAuthenticatorFactory.create(
-        github_host=github_host,
-        organization=org_name,
-        token=ocean.integration_config.get("github_token"),
-        app_id=ocean.integration_config.get("github_app_id"),
-        installation_id=ocean.integration_config.get("github_app_installation_id"),
-        private_key=ocean.integration_config.get("github_app_private_key"),
-    )
+    authenticator = create_github_client_for_org(org_name).authenticator
 
     client = await GithubWebhookClientFactory.create(
         authenticator=authenticator,
@@ -140,6 +131,16 @@ async def _create_webhooks_for_organization(org_name: str, base_url: str) -> Non
 
     logger.info(f"Subscribing to GitHub webhooks for organization: {org_name}")
     await client.upsert_webhook(base_url)
+
+
+async def _iter_resync_organization_batches(
+    scope: GithubClientScope,
+) -> AsyncGenerator[list[RAW_ITEM], None]:
+    org_exporter = RestOrganizationExporter(scope.get_client(GithubClientType.REST))
+    async for organizations in org_exporter.get_paginated_resources(
+        get_github_organizations(scope.organization)
+    ):
+        yield organizations
 
 
 @ocean.on_start()
@@ -155,22 +156,14 @@ async def on_start() -> None:
     if not base_url:
         return
 
-    github_organization = ocean.integration_config.get("github_organization")
-    if github_organization:
-        await _create_webhooks_for_organization(github_organization, base_url)
-        return
-
-    org_exporter = RestOrganizationExporter(create_github_client())
     await ocean.integration.port_app_config_handler.get_port_app_config()
-    async for organizations in org_exporter.get_paginated_resources(
-        get_github_organizations()
-    ):
-        logger.info(
-            f"Subscribing to GitHub webhooks for {len(organizations)} organizations"
-        )
-
-        for org in organizations:
-            await _create_webhooks_for_organization(org["login"], base_url)
+    for scope in await create_github_clients():
+        async for organizations in _iter_resync_organization_batches(scope):
+            logger.info(
+                f"Subscribing to GitHub webhooks for {len(organizations)} organizations"
+            )
+            for org in organizations:
+                await _create_webhooks_for_organization(org["login"], base_url)
 
 
 @ocean.on_resync(ObjectKind.ORGANIZATION)
@@ -178,14 +171,10 @@ async def resync_organizations(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     """Resync all organizations the Personal Access Token user is a member of."""
     logger.info(f"Starting resync for kind: {kind}")
 
-    rest_client = create_github_client()
-    exporter = RestOrganizationExporter(rest_client)
-
-    async for organizations in exporter.get_paginated_resources(
-        get_github_organizations()
-    ):
-        logger.info(f"Received {len(organizations)} batch {kind}s")
-        yield organizations
+    for scope in await create_github_clients():
+        async for organizations in _iter_resync_organization_batches(scope):
+            logger.info(f"Received {len(organizations)} batch {kind}s")
+            yield organizations
 
 
 @ocean.on_resync(ObjectKind.REPOSITORY)
@@ -193,40 +182,41 @@ async def resync_repositories(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     """Resync all repositories across organizations."""
     logger.info(f"Starting resync for kind: {kind}")
 
-    rest_client = create_github_client()
-    org_exporter = RestOrganizationExporter(rest_client)
     port_app_config = cast(GithubPortAppConfig, event.port_app_config)
     repo_config = cast(GithubRepositoryConfig, event.resource_config)
     included_relations = repo_config.selector.normalized_relations
     included_files = repo_config.selector.included_files or []
-    included_files_enricher = (
-        IncludedFilesEnricher(
-            client=rest_client,
-            strategy=RepositoryIncludedFilesStrategy(included_files=included_files),
-        )
-        if included_files
-        else None
-    )
 
-    async for organizations in org_exporter.get_paginated_resources(
-        get_github_organizations()
-    ):
-        tasks = (
-            RestRepositoryExporter(rest_client).get_paginated_resources(
-                options=ListRepositoryOptions(
-                    organization=org["login"],
-                    organization_type=org["type"],
-                    type=port_app_config.repository_type,
-                    included_relations=included_relations,
-                    search_params=repo_config.selector.repo_search,
-                )
+    for scope in await create_github_clients():
+        rest_client = scope.get_client(GithubClientType.REST)
+        included_files_enricher = (
+            IncludedFilesEnricher(
+                client=rest_client,
+                strategy=RepositoryIncludedFilesStrategy(included_files=included_files),
             )
-            for org in organizations
+            if included_files
+            else None
         )
-        async for repositories in stream_async_iterators_tasks(*tasks):
-            if included_files_enricher:
-                repositories = await included_files_enricher.enrich_batch(repositories)
-            yield repositories
+
+        async for organizations in _iter_resync_organization_batches(scope):
+            tasks = (
+                RestRepositoryExporter(rest_client).get_paginated_resources(
+                    options=ListRepositoryOptions(
+                        organization=org["login"],
+                        organization_type=org["type"],
+                        type=port_app_config.repository_type,
+                        included_relations=included_relations,
+                        search_params=repo_config.selector.repo_search,
+                    )
+                )
+                for org in organizations
+            )
+            async for repositories in stream_async_iterators_tasks(*tasks):
+                if included_files_enricher:
+                    repositories = await included_files_enricher.enrich_batch(
+                        repositories
+                    )
+                yield repositories
 
 
 @ocean.on_resync(ObjectKind.USER)
@@ -234,35 +224,34 @@ async def resync_users(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     """Resync all users across organizations."""
     logger.info(f"Starting resync for kind: {kind}")
 
-    rest_client = create_github_client()
-    graphql_client = create_github_client(GithubClientType.GRAPHQL)
-    org_exporter = RestOrganizationExporter(rest_client)
-    exporter = GraphQLUserExporter(graphql_client)
     config = cast(GithubUserConfig, event.resource_config)
 
-    async for organizations in org_exporter.get_paginated_resources(
-        get_github_organizations()
-    ):
-        tasks = []
-        for org in organizations:
-            if org["type"] == "Organization":
-                tasks.append(
-                    exporter.get_paginated_resources(
-                        options=ListUserOptions(
-                            organization=org["login"],
-                            include_saml_email=config.selector.include_saml_email,
+    for scope in await create_github_clients():
+        rest_client = scope.get_client(GithubClientType.REST)
+        graphql_client = scope.get_client(GithubClientType.GRAPHQL)
+        exporter = GraphQLUserExporter(graphql_client)
+
+        async for organizations in _iter_resync_organization_batches(scope):
+            tasks = []
+            for org in organizations:
+                if org["type"] == "Organization":
+                    tasks.append(
+                        exporter.get_paginated_resources(
+                            options=ListUserOptions(
+                                organization=org["login"],
+                                include_saml_email=config.selector.include_saml_email,
+                            )
                         )
                     )
-                )
-                continue
+                    continue
 
-            if not org.get("email"):
-                org = await enrich_user_with_primary_email(rest_client, org)
-            yield [org]
+                if not org.get("email"):
+                    org = await enrich_user_with_primary_email(rest_client, org)
+                yield [org]
 
-        if tasks:
-            async for users in stream_async_iterators_tasks(*tasks):
-                yield users
+            if tasks:
+                async for users in stream_async_iterators_tasks(*tasks):
+                    yield users
 
 
 @ocean.on_resync(ObjectKind.TEAM)
@@ -270,45 +259,44 @@ async def resync_teams(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     """Resync all teams across organizations."""
     logger.info(f"Starting resync for kind: {kind}")
 
-    rest_client = create_github_client()
-    graphql_client = create_github_client(GithubClientType.GRAPHQL)
-
-    org_exporter = RestOrganizationExporter(rest_client)
-
     config = cast(GithubTeamConfig, event.resource_config)
     selector = config.selector
 
-    async for organizations in org_exporter.get_paginated_resources(
-        get_github_organizations()
-    ):
-        tasks = []
-        for org in organizations:
-            if org["type"] == "Organization":
-                org_name = org["login"]
-                rest_exporter = RestTeamExporter(rest_client)
+    for scope in await create_github_clients():
+        rest_client = scope.get_client(GithubClientType.REST)
+        graphql_client = scope.get_client(GithubClientType.GRAPHQL)
 
-                tasks.append(
-                    tag_batch_with_org(
-                        org_name,
-                        rest_exporter.get_paginated_resources(
-                            ListTeamOptions(organization=org_name)
-                        ),
-                    )
-                )
+        async for organizations in _iter_resync_organization_batches(scope):
+            tasks = []
+            for org in organizations:
+                if org["type"] == "Organization":
+                    org_name = org["login"]
+                    rest_exporter = RestTeamExporter(rest_client)
 
-        if tasks:
-            async for org_name, teams in stream_async_iterators_tasks(*tasks):
-                if selector.members:
-                    graphql_exporter = GraphQLTeamWithMembersExporter(graphql_client)
-                    teams = await graphql_exporter._enrich_team_with_extras(
-                        teams,
-                        ListTeamOptions(
-                            organization=org_name,
-                            include_saml_email=selector.include_saml_email,
-                        ),
+                    tasks.append(
+                        tag_batch_with_org(
+                            org_name,
+                            rest_exporter.get_paginated_resources(
+                                ListTeamOptions(organization=org_name)
+                            ),
+                        )
                     )
 
-                yield teams
+            if tasks:
+                async for org_name, teams in stream_async_iterators_tasks(*tasks):
+                    if selector.members:
+                        graphql_exporter = GraphQLTeamWithMembersExporter(
+                            graphql_client
+                        )
+                        teams = await graphql_exporter._enrich_team_with_extras(
+                            teams,
+                            ListTeamOptions(
+                                organization=org_name,
+                                include_saml_email=selector.include_saml_email,
+                            ),
+                        )
+
+                    yield teams
 
 
 @ocean.on_resync(ObjectKind.WORKFLOW)
@@ -316,41 +304,40 @@ async def resync_workflows(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     """Resync all workflows for specified Github repositories"""
     logger.info(f"Starting resync for kind: {kind}")
 
-    rest_client = create_github_client()
-    org_exporter = RestOrganizationExporter(rest_client)
     port_app_config = cast(GithubPortAppConfig, event.port_app_config)
     config = cast(GithubWorkflowConfig, event.resource_config)
 
-    async for organizations in org_exporter.get_paginated_resources(
-        get_github_organizations()
-    ):
-        for org in organizations:
-            org_name = org["login"]
-            repo_exporter = RestRepositoryExporter(rest_client)
-            workflow_exporter = RestWorkflowExporter(rest_client)
+    for scope in await create_github_clients():
+        rest_client = scope.get_client(GithubClientType.REST)
 
-            repo_options = ListRepositoryOptions(
-                organization=org_name,
-                organization_type=org["type"],
-                type=port_app_config.repository_type,
-                search_params=config.selector.repo_search,
-            )
+        async for organizations in _iter_resync_organization_batches(scope):
+            for org in organizations:
+                org_name = org["login"]
+                repo_exporter = RestRepositoryExporter(rest_client)
+                workflow_exporter = RestWorkflowExporter(rest_client)
 
-            async for repositories in repo_exporter.get_paginated_resources(
-                options=repo_options
-            ):
-                tasks = []
-                for repo in repositories:
-                    tasks.append(
-                        workflow_exporter.get_paginated_resources(
-                            options=ListWorkflowOptions(
-                                organization=org_name, repo_name=repo["name"]
+                repo_options = ListRepositoryOptions(
+                    organization=org_name,
+                    organization_type=org["type"],
+                    type=port_app_config.repository_type,
+                    search_params=config.selector.repo_search,
+                )
+
+                async for repositories in repo_exporter.get_paginated_resources(
+                    options=repo_options
+                ):
+                    tasks = []
+                    for repo in repositories:
+                        tasks.append(
+                            workflow_exporter.get_paginated_resources(
+                                options=ListWorkflowOptions(
+                                    organization=org_name, repo_name=repo["name"]
+                                )
                             )
                         )
-                    )
 
-                async for workflows in stream_async_iterators_tasks(*tasks):
-                    yield workflows
+                    async for workflows in stream_async_iterators_tasks(*tasks):
+                        yield workflows
 
 
 @ocean.on_resync(ObjectKind.WORKFLOW_RUN)
@@ -358,70 +345,70 @@ async def resync_workflow_runs(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     """Resync all workflow runs for specified Github repositories"""
     logger.info(f"Starting resync for kind: {kind}")
 
-    rest_client = create_github_client()
-    org_exporter = RestOrganizationExporter(rest_client)
-    repo_exporter = RestRepositoryExporter(rest_client)
-    workflow_exporter = RestWorkflowExporter(rest_client)
-    workflow_run_exporter = RestWorkflowRunExporter(rest_client)
-
     port_app_config = cast(GithubPortAppConfig, event.port_app_config)
     config = cast(GithubWorkflowRunConfig, event.resource_config)
 
-    async for organizations in org_exporter.get_paginated_resources(
-        get_github_organizations()
-    ):
-        for org in organizations:
-            org_name = org["login"]
-            repo_options = ListRepositoryOptions(
-                organization=org_name,
-                organization_type=org["type"],
-                type=port_app_config.repository_type,
-                search_params=config.selector.repo_search,
-            )
+    for scope in await create_github_clients():
+        rest_client = scope.get_client(GithubClientType.REST)
+        repo_exporter = RestRepositoryExporter(rest_client)
+        workflow_exporter = RestWorkflowExporter(rest_client)
+        workflow_run_exporter = RestWorkflowRunExporter(rest_client)
 
-            async for repositories in repo_exporter.get_paginated_resources(
-                options=repo_options
-            ):
-                tasks = []
-                for repo in repositories:
-                    repo_name = repo["name"]
-                    workflow_options = ListWorkflowOptions(
-                        organization=org_name, repo_name=repo_name
-                    )
-                    async for workflows in workflow_exporter.get_paginated_resources(
-                        workflow_options
-                    ):
-                        if config.selector.statuses:
-                            tasks = [
-                                workflow_run_exporter.get_paginated_resources(
-                                    ListWorkflowRunOptions(
-                                        organization=org_name,
-                                        repo_name=repo_name,
-                                        workflow_id=workflow["id"],
-                                        max_runs=100,
-                                        status=status,
-                                        created=config.selector.created_after,
-                                    )
-                                )
-                                for workflow in workflows
-                                for status in config.selector.statuses
-                            ]
-                        else:
-                            tasks = [
-                                workflow_run_exporter.get_paginated_resources(
-                                    ListWorkflowRunOptions(
-                                        organization=org_name,
-                                        repo_name=repo_name,
-                                        workflow_id=workflow["id"],
-                                        max_runs=100,
-                                        created=config.selector.created_after,
-                                    )
-                                )
-                                for workflow in workflows
-                            ]
+        async for organizations in _iter_resync_organization_batches(scope):
+            for org in organizations:
+                org_name = org["login"]
+                repo_options = ListRepositoryOptions(
+                    organization=org_name,
+                    organization_type=org["type"],
+                    type=port_app_config.repository_type,
+                    search_params=config.selector.repo_search,
+                )
 
-                    async for runs in stream_async_iterators_tasks(*tasks):
-                        yield runs
+                async for repositories in repo_exporter.get_paginated_resources(
+                    options=repo_options
+                ):
+                    tasks = []
+                    for repo in repositories:
+                        repo_name = repo["name"]
+                        workflow_options = ListWorkflowOptions(
+                            organization=org_name, repo_name=repo_name
+                        )
+                        async for (
+                            workflows
+                        ) in workflow_exporter.get_paginated_resources(
+                            workflow_options
+                        ):
+                            if config.selector.statuses:
+                                tasks = [
+                                    workflow_run_exporter.get_paginated_resources(
+                                        ListWorkflowRunOptions(
+                                            organization=org_name,
+                                            repo_name=repo_name,
+                                            workflow_id=workflow["id"],
+                                            max_runs=100,
+                                            status=status,
+                                            created=config.selector.created_after,
+                                        )
+                                    )
+                                    for workflow in workflows
+                                    for status in config.selector.statuses
+                                ]
+                            else:
+                                tasks = [
+                                    workflow_run_exporter.get_paginated_resources(
+                                        ListWorkflowRunOptions(
+                                            organization=org_name,
+                                            repo_name=repo_name,
+                                            workflow_id=workflow["id"],
+                                            max_runs=100,
+                                            created=config.selector.created_after,
+                                        )
+                                    )
+                                    for workflow in workflows
+                                ]
+
+                        async for runs in stream_async_iterators_tasks(*tasks):
+                            yield runs
 
 
 @ocean.on_resync(ObjectKind.PULL_REQUEST)
@@ -429,71 +416,68 @@ async def resync_pull_requests(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     """Resync all pull requests in the organization's repositories."""
     logger.info(f"Starting resync for kind: {kind}")
 
-    rest_client = create_github_client()
-    graphql_client = create_github_client(GithubClientType.GRAPHQL)
-    org_exporter = RestOrganizationExporter(rest_client)
-    repository_exporter = RestRepositoryExporter(rest_client)
     port_app_config = cast(GithubPortAppConfig, event.port_app_config)
     config = cast(GithubPullRequestConfig, event.resource_config)
-
     is_graphql_api = config.selector.api == GithubClientType.GRAPHQL
-    pull_request_exporter: AbstractGithubExporter[Any] = (
-        GraphQLPullRequestExporter(graphql_client)
-        if is_graphql_api
-        else RestPullRequestExporter(rest_client)
-    )
-
     fetch_errors: list[Exception] = []
 
-    async for organizations in org_exporter.get_paginated_resources(
-        get_github_organizations()
-    ):
-        for org in organizations:
-            org_name = org["login"]
-            repo_options = ListRepositoryOptions(
-                organization=org_name,
-                organization_type=org["type"],
-                type=port_app_config.repository_type,
-                search_params=config.selector.repo_search,
-            )
+    for scope in await create_github_clients():
+        rest_client = scope.get_client(GithubClientType.REST)
+        graphql_client = scope.get_client(GithubClientType.GRAPHQL)
+        repository_exporter = RestRepositoryExporter(rest_client)
+        pull_request_exporter: AbstractGithubExporter[Any] = (
+            GraphQLPullRequestExporter(graphql_client)
+            if is_graphql_api
+            else RestPullRequestExporter(rest_client)
+        )
 
-            async for repos in repository_exporter.get_paginated_resources(
-                options=repo_options
-            ):
-                tasks = []
-                for repo in repos:
-                    tasks.append(
-                        pull_request_exporter.get_paginated_resources(
-                            ListPullRequestOptions(
-                                organization=org_name,
-                                repo_name=repo["name"],
-                                states=list(config.selector.states),
-                                max_results=config.selector.effective_max_results,
-                                updated_after=config.selector.updated_after,
-                                closed_after=config.selector.closed_after,
-                                enrich_with_first_commit=config.selector.enrich_with_first_commit,
-                                repo=repo if is_graphql_api else None,
-                                exclude_graphql_fields=config.selector.exclude_graphql_fields,
+        async for organizations in _iter_resync_organization_batches(scope):
+            for org in organizations:
+                org_name = org["login"]
+                repo_options = ListRepositoryOptions(
+                    organization=org_name,
+                    organization_type=org["type"],
+                    type=port_app_config.repository_type,
+                    search_params=config.selector.repo_search,
+                )
+
+                async for repos in repository_exporter.get_paginated_resources(
+                    options=repo_options
+                ):
+                    tasks = []
+                    for repo in repos:
+                        tasks.append(
+                            pull_request_exporter.get_paginated_resources(
+                                ListPullRequestOptions(
+                                    organization=org_name,
+                                    repo_name=repo["name"],
+                                    states=list(config.selector.states),
+                                    max_results=config.selector.effective_max_results,
+                                    updated_after=config.selector.updated_after,
+                                    closed_after=config.selector.closed_after,
+                                    enrich_with_first_commit=config.selector.enrich_with_first_commit,
+                                    repo=repo if is_graphql_api else None,
+                                    exclude_graphql_fields=config.selector.exclude_graphql_fields,
+                                )
                             )
                         )
-                    )
 
-                try:
-                    async for pull_requests in stream_independent_async_iterators(
-                        *tasks, context=kind
-                    ):
-                        yield pull_requests
-                except ExceptionGroup as page_errors:
-                    fetch_errors.extend(page_errors.exceptions)
-                    logger.error(
-                        f"{len(page_errors.exceptions)} repo(s) failed fetching pull requests "
-                        f"in org {org_name} (batch of {len(repos)}), continuing with remaining pages",
-                        extra={
-                            "failed_repos": [
-                                str(error) for error in page_errors.exceptions
-                            ],
-                        },
-                    )
+                    try:
+                        async for pull_requests in stream_independent_async_iterators(
+                            *tasks, context=kind
+                        ):
+                            yield pull_requests
+                    except ExceptionGroup as page_errors:
+                        fetch_errors.extend(page_errors.exceptions)
+                        logger.error(
+                            f"{len(page_errors.exceptions)} repo(s) failed fetching pull requests "
+                            f"in org {org_name} (batch of {len(repos)}), continuing with remaining pages",
+                            extra={
+                                "failed_repos": [
+                                    str(error) for error in page_errors.exceptions
+                                ],
+                            },
+                        )
 
     if fetch_errors:
         raise ExceptionGroup(
@@ -507,44 +491,42 @@ async def resync_issues(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     """Resync all issues from repositories."""
     logger.info(f"Starting resync for kind {kind}")
 
-    rest_client = create_github_client()
-    org_exporter = RestOrganizationExporter(rest_client)
-    repository_exporter = RestRepositoryExporter(rest_client)
-    issue_exporter = RestIssueExporter(rest_client)
-
     port_app_config = cast(GithubPortAppConfig, event.port_app_config)
     config = cast(GithubIssueConfig, event.resource_config)
 
-    async for organizations in org_exporter.get_paginated_resources(
-        get_github_organizations()
-    ):
-        for org in organizations:
-            org_name = org["login"]
-            repo_options = ListRepositoryOptions(
-                organization=org_name,
-                organization_type=org["type"],
-                type=port_app_config.repository_type,
-                search_params=config.selector.repo_search,
-            )
+    for scope in await create_github_clients():
+        rest_client = scope.get_client(GithubClientType.REST)
+        repository_exporter = RestRepositoryExporter(rest_client)
+        issue_exporter = RestIssueExporter(rest_client)
 
-            async for repos in repository_exporter.get_paginated_resources(
-                options=repo_options
-            ):
-                tasks = []
-                for repo in repos:
-                    tasks.append(
-                        issue_exporter.get_paginated_resources(
-                            ListIssueOptions(
-                                organization=org_name,
-                                repo_name=repo["name"],
-                                state=config.selector.state,
-                                labels=config.selector.labels_str,
+        async for organizations in _iter_resync_organization_batches(scope):
+            for org in organizations:
+                org_name = org["login"]
+                repo_options = ListRepositoryOptions(
+                    organization=org_name,
+                    organization_type=org["type"],
+                    type=port_app_config.repository_type,
+                    search_params=config.selector.repo_search,
+                )
+
+                async for repos in repository_exporter.get_paginated_resources(
+                    options=repo_options
+                ):
+                    tasks = []
+                    for repo in repos:
+                        tasks.append(
+                            issue_exporter.get_paginated_resources(
+                                ListIssueOptions(
+                                    organization=org_name,
+                                    repo_name=repo["name"],
+                                    state=config.selector.state,
+                                    labels=config.selector.labels_str,
+                                )
                             )
                         )
-                    )
 
-                async for issues in stream_async_iterators_tasks(*tasks):
-                    yield issues
+                    async for issues in stream_async_iterators_tasks(*tasks):
+                        yield issues
 
 
 @ocean.on_resync(ObjectKind.RELEASE)
@@ -552,41 +534,39 @@ async def resync_releases(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     """Resync all releases in the organization's repositories."""
     logger.info(f"Starting resync for kind: {kind}")
 
-    rest_client = create_github_client()
-    org_exporter = RestOrganizationExporter(rest_client)
-    repository_exporter = RestRepositoryExporter(rest_client)
-    release_exporter = RestReleaseExporter(rest_client)
-
     port_app_config = cast(GithubPortAppConfig, event.port_app_config)
     config = cast(GithubReleaseConfig, event.resource_config)
 
-    async for organizations in org_exporter.get_paginated_resources(
-        get_github_organizations()
-    ):
-        for org in organizations:
-            org_name = org["login"]
-            repo_options = ListRepositoryOptions(
-                organization=org_name,
-                organization_type=org["type"],
-                type=port_app_config.repository_type,
-                search_params=config.selector.repo_search,
-            )
+    for scope in await create_github_clients():
+        rest_client = scope.get_client(GithubClientType.REST)
+        repository_exporter = RestRepositoryExporter(rest_client)
+        release_exporter = RestReleaseExporter(rest_client)
 
-            async for repositories in repository_exporter.get_paginated_resources(
-                repo_options
-            ):
-                tasks = []
-                for repo in repositories:
-                    tasks.append(
-                        release_exporter.get_paginated_resources(
-                            ListReleaseOptions(
-                                organization=org_name, repo_name=repo["name"]
+        async for organizations in _iter_resync_organization_batches(scope):
+            for org in organizations:
+                org_name = org["login"]
+                repo_options = ListRepositoryOptions(
+                    organization=org_name,
+                    organization_type=org["type"],
+                    type=port_app_config.repository_type,
+                    search_params=config.selector.repo_search,
+                )
+
+                async for repositories in repository_exporter.get_paginated_resources(
+                    repo_options
+                ):
+                    tasks = []
+                    for repo in repositories:
+                        tasks.append(
+                            release_exporter.get_paginated_resources(
+                                ListReleaseOptions(
+                                    organization=org_name, repo_name=repo["name"]
+                                )
                             )
                         )
-                    )
 
-                async for releases in stream_async_iterators_tasks(*tasks):
-                    yield releases
+                    async for releases in stream_async_iterators_tasks(*tasks):
+                        yield releases
 
 
 @ocean.on_resync(ObjectKind.TAG)
@@ -594,41 +574,41 @@ async def resync_tags(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     """Resync all tags in the organization's repositories."""
     logger.info(f"Starting resync for kind: {kind}")
 
-    rest_client = create_github_client()
-    org_exporter = RestOrganizationExporter(rest_client)
-    repository_exporter = RestRepositoryExporter(rest_client)
-    tag_exporter = RestTagExporter(rest_client)
-
     port_app_config = cast(GithubPortAppConfig, event.port_app_config)
     config = cast(GithubTagConfig, event.resource_config)
 
-    async for organizations in org_exporter.get_paginated_resources(
-        get_github_organizations()
-    ):
-        for org in organizations:
-            org_name = org["login"]
-            repo_options = ListRepositoryOptions(
-                organization=org_name,
-                organization_type=org["type"],
-                type=port_app_config.repository_type,
-                search_params=config.selector.repo_search,
-            )
+    for scope in await create_github_clients():
+        rest_client = scope.get_client(GithubClientType.REST)
+        repository_exporter = RestRepositoryExporter(rest_client)
+        tag_exporter = RestTagExporter(rest_client)
 
-            async for repositories in repository_exporter.get_paginated_resources(
-                repo_options
-            ):
-                tasks = []
-                for repo in repositories:
-                    tasks.append(
-                        tag_exporter.get_paginated_resources(
-                            ListTagOptions(
-                                organization=org_name, repo_name=repo["name"], repo=repo
+        async for organizations in _iter_resync_organization_batches(scope):
+            for org in organizations:
+                org_name = org["login"]
+                repo_options = ListRepositoryOptions(
+                    organization=org_name,
+                    organization_type=org["type"],
+                    type=port_app_config.repository_type,
+                    search_params=config.selector.repo_search,
+                )
+
+                async for repositories in repository_exporter.get_paginated_resources(
+                    repo_options
+                ):
+                    tasks = []
+                    for repo in repositories:
+                        tasks.append(
+                            tag_exporter.get_paginated_resources(
+                                ListTagOptions(
+                                    organization=org_name,
+                                    repo_name=repo["name"],
+                                    repo=repo,
+                                )
                             )
                         )
-                    )
 
-                async for tags in stream_async_iterators_tasks(*tasks):
-                    yield tags
+                    async for tags in stream_async_iterators_tasks(*tasks):
+                        yield tags
 
 
 @ocean.on_resync(ObjectKind.BRANCH)
@@ -636,53 +616,51 @@ async def resync_branches(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     """Resync all branches in the organization's repositories."""
     logger.info(f"Starting resync for kind: {kind}")
 
-    rest_client = create_github_client()
-    org_exporter = RestOrganizationExporter(rest_client)
-    repository_exporter = RestRepositoryExporter(rest_client)
-    branch_exporter = RestBranchExporter(rest_client)
-
     port_app_config = cast(GithubPortAppConfig, event.port_app_config)
     selector = cast(GithubBranchConfig, event.resource_config).selector
 
-    async for organizations in org_exporter.get_paginated_resources(
-        get_github_organizations()
-    ):
-        for org in organizations:
-            org_name = org["login"]
-            repo_options = ListRepositoryOptions(
-                organization=org_name,
-                organization_type=org["type"],
-                type=port_app_config.repository_type,
-                search_params=selector.repo_search,
-            )
+    for scope in await create_github_clients():
+        rest_client = scope.get_client(GithubClientType.REST)
+        repository_exporter = RestRepositoryExporter(rest_client)
+        branch_exporter = RestBranchExporter(rest_client)
 
-            async for repositories in repository_exporter.get_paginated_resources(
-                repo_options
-            ):
-                tasks = []
-                for repo in repositories:
-                    tasks.append(
-                        branch_exporter.get_paginated_resources(
-                            ListBranchOptions(
-                                organization=org_name,
-                                repo_name=repo["name"],
-                                protection_rules=selector.protection_rules,
-                                detailed=selector.detailed,
-                                branch_names=selector.branch_names,
-                                default_branch_only=selector.default_branch_only,
-                                repo=repo,
+        async for organizations in _iter_resync_organization_batches(scope):
+            for org in organizations:
+                org_name = org["login"]
+                repo_options = ListRepositoryOptions(
+                    organization=org_name,
+                    organization_type=org["type"],
+                    type=port_app_config.repository_type,
+                    search_params=selector.repo_search,
+                )
+
+                async for repositories in repository_exporter.get_paginated_resources(
+                    repo_options
+                ):
+                    tasks = []
+                    for repo in repositories:
+                        tasks.append(
+                            branch_exporter.get_paginated_resources(
+                                ListBranchOptions(
+                                    organization=org_name,
+                                    repo_name=repo["name"],
+                                    protection_rules=selector.protection_rules,
+                                    detailed=selector.detailed,
+                                    branch_names=selector.branch_names,
+                                    default_branch_only=selector.default_branch_only,
+                                    repo=repo,
+                                )
                             )
                         )
-                    )
 
-                    if len(tasks) == MAX_CONCURRENT_REPOS:
+                        if len(tasks) == MAX_CONCURRENT_REPOS:
+                            async for branches in stream_async_iterators_tasks(*tasks):
+                                yield branches
+                            tasks.clear()
+
+                    if tasks:
                         async for branches in stream_async_iterators_tasks(*tasks):
                             yield branches
-                        tasks.clear()
-
-                if tasks:
-                    async for branches in stream_async_iterators_tasks(*tasks):
-                        yield branches
 
 
 @ocean.on_resync(ObjectKind.ENVIRONMENT)
@@ -690,42 +668,40 @@ async def resync_environments(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     """Resync all environments in the organization."""
     logger.info(f"Starting resync for kind {kind}")
 
-    rest_client = create_github_client()
-    org_exporter = RestOrganizationExporter(rest_client)
-    repository_exporter = RestRepositoryExporter(rest_client)
-    environment_exporter = RestEnvironmentExporter(rest_client)
-
     port_app_config = cast(GithubPortAppConfig, event.port_app_config)
     config = cast(GithubEnvironmentConfig, event.resource_config)
 
-    async for organizations in org_exporter.get_paginated_resources(
-        get_github_organizations()
-    ):
-        for org in organizations:
-            org_name = org["login"]
-            repo_options = ListRepositoryOptions(
-                organization=org_name,
-                organization_type=org["type"],
-                type=port_app_config.repository_type,
-                search_params=config.selector.repo_search,
-            )
+    for scope in await create_github_clients():
+        rest_client = scope.get_client(GithubClientType.REST)
+        repository_exporter = RestRepositoryExporter(rest_client)
+        environment_exporter = RestEnvironmentExporter(rest_client)
 
-            async for repositories in repository_exporter.get_paginated_resources(
-                repo_options
-            ):
-                tasks = []
-                for repo in repositories:
-                    tasks.append(
-                        environment_exporter.get_paginated_resources(
-                            ListEnvironmentsOptions(
-                                organization=org_name,
-                                repo_name=repo["name"],
+        async for organizations in _iter_resync_organization_batches(scope):
+            for org in organizations:
+                org_name = org["login"]
+                repo_options = ListRepositoryOptions(
+                    organization=org_name,
+                    organization_type=org["type"],
+                    type=port_app_config.repository_type,
+                    search_params=config.selector.repo_search,
+                )
+
+                async for repositories in repository_exporter.get_paginated_resources(
+                    repo_options
+                ):
+                    tasks = []
+                    for repo in repositories:
+                        tasks.append(
+                            environment_exporter.get_paginated_resources(
+                                ListEnvironmentsOptions(
+                                    organization=org_name,
+                                    repo_name=repo["name"],
+                                )
                             )
                         )
-                    )
 
-                async for environments in stream_async_iterators_tasks(*tasks):
-                    yield environments
+                    async for environments in stream_async_iterators_tasks(*tasks):
+                        yield environments
 
 
 @ocean.on_resync(ObjectKind.DEPLOYMENT)
@@ -733,17 +709,15 @@ async def resync_deployments(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     """Resync all deployments in the organization."""
     logger.info(f"Starting resync for kind {kind}")
 
-    rest_client = create_github_client()
-    org_exporter = RestOrganizationExporter(rest_client)
-    repository_exporter = RestRepositoryExporter(rest_client)
-    deployment_exporter = RestDeploymentExporter(rest_client)
-
     port_app_config = cast(GithubPortAppConfig, event.port_app_config)
     config = cast(GithubDeploymentConfig, event.resource_config)
 
-    async for organizations in org_exporter.get_paginated_resources(
-        get_github_organizations()
-    ):
+    for scope in await create_github_clients():
+        rest_client = scope.get_client(GithubClientType.REST)
+        repository_exporter = RestRepositoryExporter(rest_client)
+        deployment_exporter = RestDeploymentExporter(rest_client)
+
+    async for organizations in _iter_resync_organization_batches(scope):
         for org in organizations:
             org_name = org["login"]
             repo_options = ListRepositoryOptions(
@@ -779,12 +753,6 @@ async def resync_deployment_statuses(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     """Resync all deployment statuses in the organization."""
     logger.info(f"Starting resync for kind {kind}")
 
-    rest_client = create_github_client()
-    org_exporter = RestOrganizationExporter(rest_client)
-    repository_exporter = RestRepositoryExporter(rest_client)
-    deployment_exporter = RestDeploymentExporter(rest_client)
-    deployment_status_exporter = RestDeploymentStatusExporter(rest_client)
-
     port_app_config = cast(GithubPortAppConfig, event.port_app_config)
     config = cast(GithubDeploymentStatusConfig, event.resource_config)
 
@@ -793,61 +761,65 @@ async def resync_deployment_statuses(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
         f"task={config.selector.task}, environment={config.selector.environment}"
     )
 
-    async for organizations in org_exporter.get_paginated_resources(
-        get_github_organizations()
-    ):
-        for org in organizations:
-            org_name = org["login"]
-            org_type = org["type"]
-            logger.debug(f"Processing organization: {org_name} (type={org_type})")
+    for scope in await create_github_clients():
+        rest_client = scope.get_client(GithubClientType.REST)
+        repository_exporter = RestRepositoryExporter(rest_client)
+        deployment_exporter = RestDeploymentExporter(rest_client)
+        deployment_status_exporter = RestDeploymentStatusExporter(rest_client)
 
-            repo_options = ListRepositoryOptions(
-                organization=org_name,
-                organization_type=org_type,
-                type=port_app_config.repository_type,
-                search_params=config.selector.repo_search,
-            )
+        async for organizations in _iter_resync_organization_batches(scope):
+            for org in organizations:
+                org_name = org["login"]
+                org_type = org["type"]
+                logger.debug(f"Processing organization: {org_name} (type={org_type})")
 
-            async for repositories in repository_exporter.get_paginated_resources(
-                repo_options
-            ):
-                for repo in repositories:
-                    repo_name = repo["name"]
-                    logger.debug(f"Fetching deployments for {org_name}/{repo_name}")
-                    deployment_options = ListDeploymentsOptions(
-                        organization=org_name,
-                        repo_name=repo_name,
-                        task=config.selector.task,
-                        environment=config.selector.environment,
-                    )
+                repo_options = ListRepositoryOptions(
+                    organization=org_name,
+                    organization_type=org_type,
+                    type=port_app_config.repository_type,
+                    search_params=config.selector.repo_search,
+                )
 
-                    async for (
-                        deployments
-                    ) in deployment_exporter.get_paginated_resources(
-                        deployment_options
-                    ):
-                        logger.debug(
-                            f"Found {len(deployments)} deployments in {org_name}/{repo_name}"
+                async for repositories in repository_exporter.get_paginated_resources(
+                    repo_options
+                ):
+                    for repo in repositories:
+                        repo_name = repo["name"]
+                        logger.debug(f"Fetching deployments for {org_name}/{repo_name}")
+                        deployment_options = ListDeploymentsOptions(
+                            organization=org_name,
+                            repo_name=repo_name,
+                            task=config.selector.task,
+                            environment=config.selector.environment,
                         )
-                        tasks = []
-                        for deployment in deployments:
-                            deployment_id = str(deployment["id"])
+
+                        async for (
+                            deployments
+                        ) in deployment_exporter.get_paginated_resources(
+                            deployment_options
+                        ):
                             logger.debug(
-                                f"Fetching statuses for deployment {deployment_id} "
-                                f"(task={deployment['task']}, env={deployment['environment']})"
+                                f"Found {len(deployments)} deployments in {org_name}/{repo_name}"
                             )
-                            tasks.append(
-                                deployment_status_exporter.get_paginated_resources(
-                                    ListDeploymentStatusesOptions(
-                                        organization=org_name,
-                                        repo_name=repo_name,
-                                        deployment_id=deployment_id,
+                            tasks = []
+                            for deployment in deployments:
+                                deployment_id = str(deployment["id"])
+                                logger.debug(
+                                    f"Fetching statuses for deployment {deployment_id} "
+                                    f"(task={deployment['task']}, env={deployment['environment']})"
+                                )
+                                tasks.append(
+                                    deployment_status_exporter.get_paginated_resources(
+                                        ListDeploymentStatusesOptions(
+                                            organization=org_name,
+                                            repo_name=repo_name,
+                                            deployment_id=deployment_id,
+                                        )
                                     )
                                 )
-                            )
 
-                        async for statuses in stream_async_iterators_tasks(*tasks):
-                            yield statuses
+                            async for statuses in stream_async_iterators_tasks(*tasks):
+                                yield statuses
 
 
 @ocean.on_resync(ObjectKind.DEPENDABOT_ALERT)
@@ -855,46 +827,44 @@ async def resync_dependabot_alerts(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     """Resync all Dependabot alerts in the organization's repositories."""
     logger.info(f"Starting resync for kind: {kind}")
 
-    rest_client = create_github_client()
-    org_exporter = RestOrganizationExporter(rest_client)
-    repository_exporter = RestRepositoryExporter(rest_client)
-    dependabot_alert_exporter = RestDependabotAlertExporter(rest_client)
-
     port_app_config = cast(GithubPortAppConfig, event.port_app_config)
     config = cast(GithubDependabotAlertConfig, event.resource_config)
 
-    async for organizations in org_exporter.get_paginated_resources(
-        get_github_organizations()
-    ):
-        for org in organizations:
-            org_name = org["login"]
+    for scope in await create_github_clients():
+        rest_client = scope.get_client(GithubClientType.REST)
+        repository_exporter = RestRepositoryExporter(rest_client)
+        dependabot_alert_exporter = RestDependabotAlertExporter(rest_client)
 
-            repo_options = ListRepositoryOptions(
-                organization=org_name,
-                organization_type=org["type"],
-                type=port_app_config.repository_type,
-                search_params=config.selector.repo_search,
-            )
+        async for organizations in _iter_resync_organization_batches(scope):
+            for org in organizations:
+                org_name = org["login"]
 
-            async for repositories in repository_exporter.get_paginated_resources(
-                repo_options
-            ):
-                tasks = []
-                for repo in repositories:
-                    tasks.append(
-                        dependabot_alert_exporter.get_paginated_resources(
-                            ListDependabotAlertOptions(
-                                organization=org_name,
-                                repo_name=repo["name"],
-                                state=list(config.selector.states),
-                                severity=config.selector.severity_str,
-                                ecosystem=config.selector.ecosystems_str,
+                repo_options = ListRepositoryOptions(
+                    organization=org_name,
+                    organization_type=org["type"],
+                    type=port_app_config.repository_type,
+                    search_params=config.selector.repo_search,
+                )
+
+                async for repositories in repository_exporter.get_paginated_resources(
+                    repo_options
+                ):
+                    tasks = []
+                    for repo in repositories:
+                        tasks.append(
+                            dependabot_alert_exporter.get_paginated_resources(
+                                ListDependabotAlertOptions(
+                                    organization=org_name,
+                                    repo_name=repo["name"],
+                                    state=list(config.selector.states),
+                                    severity=config.selector.severity_str,
+                                    ecosystem=config.selector.ecosystems_str,
+                                )
                             )
                         )
-                    )
 
-                async for alerts in stream_async_iterators_tasks(*tasks):
-                    yield alerts
+                    async for alerts in stream_async_iterators_tasks(*tasks):
+                        yield alerts
 
 
 @ocean.on_resync(ObjectKind.CODE_SCANNING_ALERT)
@@ -902,53 +872,48 @@ async def resync_code_scanning_alerts(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     """Resync all code scanning alerts in the organization's repositories."""
     logger.info(f"Starting resync for kind: {kind}")
 
-    rest_client = create_github_client()
-    org_exporter = RestOrganizationExporter(rest_client)
-    repository_exporter = RestRepositoryExporter(rest_client)
-    code_scanning_alert_exporter = RestCodeScanningAlertExporter(rest_client)
-
     port_app_config = cast(GithubPortAppConfig, event.port_app_config)
     config = cast(GithubCodeScanningAlertConfig, event.resource_config)
 
-    async for organizations in org_exporter.get_paginated_resources(
-        get_github_organizations()
-    ):
-        for org in organizations:
-            org_name = org["login"]
-            repo_options = ListRepositoryOptions(
-                organization=org_name,
-                organization_type=org["type"],
-                type=port_app_config.repository_type,
-                search_params=config.selector.repo_search,
-            )
+    for scope in await create_github_clients():
+        rest_client = scope.get_client(GithubClientType.REST)
+        repository_exporter = RestRepositoryExporter(rest_client)
+        code_scanning_alert_exporter = RestCodeScanningAlertExporter(rest_client)
 
-            async for repositories in repository_exporter.get_paginated_resources(
-                repo_options
-            ):
-                tasks = []
-                for repo in repositories:
-                    tasks.append(
-                        code_scanning_alert_exporter.get_paginated_resources(
-                            ListCodeScanningAlertOptions(
-                                organization=org_name,
-                                repo_name=repo["name"],
-                                state=config.selector.state,
-                                severity=config.selector.severity,
+        async for organizations in _iter_resync_organization_batches(scope):
+            for org in organizations:
+                org_name = org["login"]
+                repo_options = ListRepositoryOptions(
+                    organization=org_name,
+                    organization_type=org["type"],
+                    type=port_app_config.repository_type,
+                    search_params=config.selector.repo_search,
+                )
+
+                async for repositories in repository_exporter.get_paginated_resources(
+                    repo_options
+                ):
+                    tasks = []
+                    for repo in repositories:
+                        tasks.append(
+                            code_scanning_alert_exporter.get_paginated_resources(
+                                ListCodeScanningAlertOptions(
+                                    organization=org_name,
+                                    repo_name=repo["name"],
+                                    state=config.selector.state,
+                                    severity=config.selector.severity,
+                                )
                             )
                         )
-                    )
 
-                async for alerts in stream_async_iterators_tasks(*tasks):
-                    yield alerts
+                    async for alerts in stream_async_iterators_tasks(*tasks):
+                        yield alerts
 
 
 @ocean.on_resync(ObjectKind.FOLDER)
 async def resync_folders(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     """Resync all folders in specified repositories."""
     logger.info(f"Starting resync for kind: {kind}")
-
-    rest_client = create_github_client()
-    folder_exporter = RestFolderExporter(rest_client)
 
     selector = cast(GithubFolderResourceConfig, event.resource_config).selector
     should_enrich_with_included_files = any(
@@ -957,33 +922,35 @@ async def resync_folders(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     should_enrich_with_included_files = should_enrich_with_included_files or bool(
         selector.included_files
     )
-    included_files_enricher = (
-        IncludedFilesEnricher(
-            client=rest_client,
-            strategy=FolderIncludedFilesStrategy(
-                folder_selectors=selector.folders,
-                global_included_files=selector.included_files,
-            ),
-        )
-        if should_enrich_with_included_files
-        else None
-    )
-
-    org_exporter = RestOrganizationExporter(rest_client)
-    repo_exporter = RestRepositoryExporter(rest_client)
     app_config = cast(GithubPortAppConfig, event.port_app_config)
 
-    pattern_builder = FolderPatternMappingBuilder(
-        org_exporter=org_exporter,
-        repo_exporter=repo_exporter,
-        repo_type=app_config.repository_type,
-    )
-    repo_path_map = await pattern_builder.build(selector.folders)
+    for scope in await create_github_clients():
+        rest_client = scope.get_client(GithubClientType.REST)
+        folder_exporter = RestFolderExporter(rest_client)
+        included_files_enricher = (
+            IncludedFilesEnricher(
+                client=rest_client,
+                strategy=FolderIncludedFilesStrategy(
+                    folder_selectors=selector.folders,
+                    global_included_files=selector.included_files,
+                ),
+            )
+            if should_enrich_with_included_files
+            else None
+        )
+        org_exporter = RestOrganizationExporter(rest_client)
+        repo_exporter = RestRepositoryExporter(rest_client)
+        pattern_builder = FolderPatternMappingBuilder(
+            org_exporter=org_exporter,
+            repo_exporter=repo_exporter,
+            repo_type=app_config.repository_type,
+        )
+        repo_path_map = await pattern_builder.build(selector.folders)
 
-    async for folders in folder_exporter.get_paginated_resources(repo_path_map):
-        if included_files_enricher:
-            folders = await included_files_enricher.enrich_batch(folders)
-        yield folders
+        async for folders in folder_exporter.get_paginated_resources(repo_path_map):
+            if included_files_enricher:
+                folders = await included_files_enricher.enrich_batch(folders)
+            yield folders
 
 
 @ocean.on_resync(ObjectKind.FILE)
@@ -991,36 +958,36 @@ async def resync_files(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     """Resync files based on configuration using the file exporter."""
     logger.info(f"Starting resync for kind: {kind}")
 
-    rest_client = create_github_client()
-    org_exporter = RestOrganizationExporter(rest_client)
-    file_exporter = RestFileExporter(rest_client)
-    repo_exporter = RestRepositoryExporter(rest_client)
-
     config = cast(GithubFileResourceConfig, event.resource_config)
     app_config = cast(GithubPortAppConfig, event.port_app_config)
     should_enrich_with_included_files = bool(config.selector.included_files)
-    included_files_enricher = (
-        IncludedFilesEnricher(
-            client=rest_client,
-            strategy=FileIncludedFilesStrategy(
-                included_files=config.selector.included_files,
-            ),
+
+    for scope in await create_github_clients():
+        rest_client = scope.get_client(GithubClientType.REST)
+        included_files_enricher = (
+            IncludedFilesEnricher(
+                client=rest_client,
+                strategy=FileIncludedFilesStrategy(
+                    included_files=config.selector.included_files,
+                ),
+            )
+            if should_enrich_with_included_files
+            else None
         )
-        if should_enrich_with_included_files
-        else None
-    )
+        org_exporter = RestOrganizationExporter(rest_client)
+        file_exporter = RestFileExporter(rest_client)
+        repo_exporter = RestRepositoryExporter(rest_client)
+        pattern_builder = FilePatternMappingBuilder(
+            org_exporter=org_exporter,
+            repo_exporter=repo_exporter,
+            repo_type=app_config.repository_type,
+        )
+        repo_path_map = await pattern_builder.build(config.selector.files)
 
-    pattern_builder = FilePatternMappingBuilder(
-        org_exporter=org_exporter,
-        repo_exporter=repo_exporter,
-        repo_type=app_config.repository_type,
-    )
-    repo_path_map = await pattern_builder.build(config.selector.files)
-
-    async for file_results in file_exporter.get_paginated_resources(repo_path_map):
-        if included_files_enricher:
-            file_results = await included_files_enricher.enrich_batch(file_results)
-        yield file_results
+        async for file_results in file_exporter.get_paginated_resources(repo_path_map):
+            if included_files_enricher:
+                file_results = await included_files_enricher.enrich_batch(file_results)
+            yield file_results
 
 
 @ocean.on_resync(ObjectKind.COLLABORATOR)
@@ -1028,43 +995,41 @@ async def resync_collaborators(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     """Resync all collaborators in the organization's repositories."""
     logger.info(f"Starting resync for kind: {kind}")
 
-    rest_client = create_github_client()
-    org_exporter = RestOrganizationExporter(rest_client)
-    repository_exporter = RestRepositoryExporter(rest_client)
-    collaborator_exporter = RestCollaboratorExporter(rest_client)
-
     port_app_config = cast(GithubPortAppConfig, event.port_app_config)
     config = cast(GithubCollaboratorConfig, event.resource_config)
 
-    async for organizations in org_exporter.get_paginated_resources(
-        get_github_organizations()
-    ):
-        for org in organizations:
-            org_name = org["login"]
-            repo_options = ListRepositoryOptions(
-                organization=org_name,
-                organization_type=org["type"],
-                type=port_app_config.repository_type,
-                search_params=config.selector.repo_search,
-            )
+    for scope in await create_github_clients():
+        rest_client = scope.get_client(GithubClientType.REST)
+        repository_exporter = RestRepositoryExporter(rest_client)
+        collaborator_exporter = RestCollaboratorExporter(rest_client)
 
-            async for repositories in repository_exporter.get_paginated_resources(
-                repo_options
-            ):
-                tasks = []
-                for repo in repositories:
-                    tasks.append(
-                        collaborator_exporter.get_paginated_resources(
-                            ListCollaboratorOptions(
-                                organization=org_name,
-                                repo_name=repo["name"],
-                                affiliation=config.selector.affiliation,
+        async for organizations in _iter_resync_organization_batches(scope):
+            for org in organizations:
+                org_name = org["login"]
+                repo_options = ListRepositoryOptions(
+                    organization=org_name,
+                    organization_type=org["type"],
+                    type=port_app_config.repository_type,
+                    search_params=config.selector.repo_search,
+                )
+
+                async for repositories in repository_exporter.get_paginated_resources(
+                    repo_options
+                ):
+                    tasks = []
+                    for repo in repositories:
+                        tasks.append(
+                            collaborator_exporter.get_paginated_resources(
+                                ListCollaboratorOptions(
+                                    organization=org_name,
+                                    repo_name=repo["name"],
+                                    affiliation=config.selector.affiliation,
+                                )
                             )
                         )
-                    )
 
-                async for collaborators in stream_async_iterators_tasks(*tasks):
-                    yield collaborators
+                    async for collaborators in stream_async_iterators_tasks(*tasks):
+                        yield collaborators
 
 
 @ocean.on_resync(ObjectKind.SECRET_SCANNING_ALERT)
@@ -1072,44 +1037,42 @@ async def resync_secret_scanning_alerts(kind: str) -> ASYNC_GENERATOR_RESYNC_TYP
     """Resync all secret scanning alerts in the organization's repositories."""
     logger.info(f"Starting resync for kind: {kind}")
 
-    rest_client = create_github_client()
-    org_exporter = RestOrganizationExporter(rest_client)
-    repository_exporter = RestRepositoryExporter(rest_client)
-    secret_scanning_alert_exporter = RestSecretScanningAlertExporter(rest_client)
-
     port_app_config = cast(GithubPortAppConfig, event.port_app_config)
     config = cast(GithubSecretScanningAlertConfig, event.resource_config)
 
-    async for organizations in org_exporter.get_paginated_resources(
-        get_github_organizations()
-    ):
-        for org in organizations:
-            org_name = org["login"]
-            repo_options = ListRepositoryOptions(
-                organization=org_name,
-                organization_type=org["type"],
-                type=port_app_config.repository_type,
-                search_params=config.selector.repo_search,
-            )
+    for scope in await create_github_clients():
+        rest_client = scope.get_client(GithubClientType.REST)
+        repository_exporter = RestRepositoryExporter(rest_client)
+        secret_scanning_alert_exporter = RestSecretScanningAlertExporter(rest_client)
 
-            async for repositories in repository_exporter.get_paginated_resources(
-                repo_options
-            ):
-                tasks = []
-                for repo in repositories:
-                    tasks.append(
-                        secret_scanning_alert_exporter.get_paginated_resources(
-                            ListSecretScanningAlertOptions(
-                                organization=org_name,
-                                repo_name=repo["name"],
-                                state=config.selector.state,
-                                hide_secret=config.selector.hide_secret,
+        async for organizations in _iter_resync_organization_batches(scope):
+            for org in organizations:
+                org_name = org["login"]
+                repo_options = ListRepositoryOptions(
+                    organization=org_name,
+                    organization_type=org["type"],
+                    type=port_app_config.repository_type,
+                    search_params=config.selector.repo_search,
+                )
+
+                async for repositories in repository_exporter.get_paginated_resources(
+                    repo_options
+                ):
+                    tasks = []
+                    for repo in repositories:
+                        tasks.append(
+                            secret_scanning_alert_exporter.get_paginated_resources(
+                                ListSecretScanningAlertOptions(
+                                    organization=org_name,
+                                    repo_name=repo["name"],
+                                    state=config.selector.state,
+                                    hide_secret=config.selector.hide_secret,
+                                )
                             )
                         )
-                    )
 
-                async for alerts in stream_async_iterators_tasks(*tasks):
-                    yield alerts
+                    async for alerts in stream_async_iterators_tasks(*tasks):
+                        yield alerts
 
 
 # Register webhook processors

--- a/integrations/github/pyproject.toml
+++ b/integrations/github/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "github-ocean"
-version = "6.2.7"
+version = "6.3.0"
 description = "This integration ingest data from github"
 authors = ["Chukwuemeka Nwaoma <joelchukks@gmail.com>", "Melody Anyaegbulam <melodyogonna@gmail.com>", "Michael Armah <mikeyarmah@gmail.com>"]
 

--- a/integrations/github/tests/github/webhook/webhook_processors/test_file_webhook_processor.py
+++ b/integrations/github/tests/github/webhook/webhook_processors/test_file_webhook_processor.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+from typing import Any
+
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 from port_ocean.core.handlers.webhook.webhook_event import (
@@ -53,6 +56,41 @@ def resource_config() -> GithubFileResourceConfig:
                     properties={},
                 )
             )
+        ),
+    )
+
+
+@pytest.fixture
+def resource_config_with_items_to_parse() -> GithubFileResourceConfig:
+    return GithubFileResourceConfig(
+        kind=ObjectKind.FILE,
+        selector=GithubFileSelector(
+            query="true",
+            files=[
+                GithubFilePattern(
+                    organization="test-org",
+                    path="*.yaml",
+                    repos=[RepositoryBranchMapping(name="test-repo", branch="main")],
+                    skipParsing=False,
+                ),
+                GithubFilePattern(
+                    organization="test-org",
+                    path="*.json",
+                    repos=[RepositoryBranchMapping(name="test-repo", branch="main")],
+                    skipParsing=True,
+                ),
+            ],
+        ),
+        port=PortResourceConfig(
+            entity=MappingsConfig(
+                mappings=EntityMapping(
+                    identifier=".item.name",
+                    title=".item.name",
+                    blueprint='"githubFile"',
+                    properties={},
+                )
+            ),
+            itemsToParse=".content.items",
         ),
     )
 
@@ -258,15 +296,14 @@ class TestFileWebhookProcessor:
             mock_exporter.fetch_commit_diff.assert_called_once_with(
                 "test-org", "test-repo", "abc123", "def456"
             )
-            mock_exporter.get_resource.assert_called_once_with(
-                FileContentOptions(
-                    organization="test-org",
-                    repo_name="test-repo",
-                    file_path="config.yaml",
-                    branch="main",
-                )
-            )
-            mock_exporter.file_processor.process_file.assert_called_once()
+            requested_refs = {
+                call.args[0]["branch"]
+                for call in mock_exporter.get_resource.call_args_list
+            }
+            assert requested_refs == {"main"}
+            assert mock_exporter.file_processor.process_file.call_count == 1
+            for call in mock_exporter.file_processor.process_file.call_args_list:
+                assert call.kwargs["branch"] == "main"
 
     async def test_handle_event_with_deleted_files(
         self,
@@ -275,7 +312,6 @@ class TestFileWebhookProcessor:
         payload: EventPayload,
     ) -> None:
 
-        # Mock the exporter to return deleted files
         mock_exporter = AsyncMock()
         mock_exporter.fetch_commit_diff.return_value = {
             "files": [
@@ -295,7 +331,15 @@ class TestFileWebhookProcessor:
             assert isinstance(result, WebhookEventRawResults)
             assert result.updated_raw_results == []
             assert len(result.deleted_raw_results) == 1
-            assert result.deleted_raw_results[0]["metadata"]["path"] == "config.yaml"
+            deleted = result.deleted_raw_results[0]
+            assert deleted["metadata"]["path"] == "config.yaml"
+            assert deleted["path"] == "config.yaml"
+            assert deleted["name"] == "config.yaml"
+            assert deleted["branch"] == "main"
+            assert "content" not in deleted
+
+            mock_exporter.get_resource.assert_not_called()
+            mock_exporter.file_processor.process_file.assert_not_called()
 
     async def test_handle_event_file_without_content(
         self,
@@ -333,6 +377,291 @@ class TestFileWebhookProcessor:
             assert isinstance(result, WebhookEventRawResults)
             assert result.updated_raw_results == []
             assert result.deleted_raw_results == []
+
+    async def test_handle_event_modified_file_carries_old_content_for_deletion(
+        self,
+        file_webhook_processor: FileWebhookProcessor,
+        resource_config_with_items_to_parse: GithubFileResourceConfig,
+        payload: EventPayload,
+    ) -> None:
+        new_content = "items:\n  - a\n  - b\n"
+        old_content = "items:\n  - a\n  - b\n  - c\n"
+
+        def fake_get_resource(options: FileContentOptions) -> dict[str, Any]:
+            content = old_content if options["branch"] == "abc123" else new_content
+            return {
+                "content": content,
+                "name": "config.yaml",
+                "path": "config.yaml",
+                "size": len(content),
+            }
+
+        async def fake_process_file(**kwargs: Any) -> dict[str, Any]:
+            return {
+                "organization": kwargs["organization"],
+                "content": kwargs["content"],
+                "repository": kwargs["repository"],
+                "branch": kwargs["branch"],
+                "path": kwargs["file_path"],
+                "name": Path(kwargs["file_path"]).name,
+                "metadata": kwargs.get("metadata") or {},
+            }
+
+        mock_exporter = AsyncMock()
+        mock_exporter.fetch_commit_diff.return_value = {
+            "files": [{"filename": "config.yaml", "status": "modified"}]
+        }
+        mock_exporter.get_resource.side_effect = fake_get_resource
+        mock_exporter.file_processor.process_file.side_effect = fake_process_file
+
+        with patch(
+            "github.webhook.webhook_processors.file_webhook_processor.RestFileExporter",
+            return_value=mock_exporter,
+        ):
+            result = await file_webhook_processor.handle_event(
+                payload, resource_config_with_items_to_parse
+            )
+
+            assert isinstance(result, WebhookEventRawResults)
+            assert len(result.updated_raw_results) == 1
+            assert len(result.deleted_raw_results) == 1
+            assert result.updated_raw_results[0]["content"] == new_content
+            assert result.deleted_raw_results[0]["content"] == old_content
+            assert result.updated_raw_results[0]["branch"] == "main"
+            assert result.deleted_raw_results[0]["branch"] == "main"
+
+            resolve_by_content = {
+                call.kwargs["content"]: call.kwargs["should_resolve_references"]
+                for call in mock_exporter.file_processor.process_file.call_args_list
+            }
+            assert resolve_by_content == {new_content: True, old_content: False}
+
+    async def test_handle_event_removed_file_without_old_content_yields_no_deletion(
+        self,
+        file_webhook_processor: FileWebhookProcessor,
+        resource_config_with_items_to_parse: GithubFileResourceConfig,
+        payload: EventPayload,
+    ) -> None:
+        mock_exporter = AsyncMock()
+        mock_exporter.fetch_commit_diff.return_value = {
+            "files": [{"filename": "config.yaml", "status": "removed"}]
+        }
+        mock_exporter.get_resource.return_value = {
+            "content": None,
+            "name": "config.yaml",
+            "path": "config.yaml",
+            "size": 1024 * 1024 + 1,
+        }
+
+        with patch(
+            "github.webhook.webhook_processors.file_webhook_processor.RestFileExporter",
+            return_value=mock_exporter,
+        ):
+            result = await file_webhook_processor.handle_event(
+                payload, resource_config_with_items_to_parse
+            )
+
+            assert isinstance(result, WebhookEventRawResults)
+            assert result.updated_raw_results == []
+            assert result.deleted_raw_results == []
+            mock_exporter.file_processor.process_file.assert_not_called()
+
+    async def test_handle_event_modified_file_without_old_content_is_not_deleted(
+        self,
+        file_webhook_processor: FileWebhookProcessor,
+        resource_config: GithubFileResourceConfig,
+        payload: EventPayload,
+    ) -> None:
+        mock_exporter = AsyncMock()
+        mock_exporter.fetch_commit_diff.return_value = {
+            "files": [{"filename": "config.yaml", "status": "modified"}]
+        }
+        mock_exporter.get_resource.return_value = {
+            "content": None,
+            "name": "config.yaml",
+            "path": "config.yaml",
+            "size": 1024 * 1024 + 1,
+        }
+
+        with patch(
+            "github.webhook.webhook_processors.file_webhook_processor.RestFileExporter",
+            return_value=mock_exporter,
+        ):
+            result = await file_webhook_processor.handle_event(payload, resource_config)
+
+            assert isinstance(result, WebhookEventRawResults)
+            assert result.updated_raw_results == []
+            assert result.deleted_raw_results == []
+
+    async def test_handle_event_renamed_file_uses_previous_filename_for_old_content(
+        self,
+        file_webhook_processor: FileWebhookProcessor,
+        resource_config_with_items_to_parse: GithubFileResourceConfig,
+        payload: EventPayload,
+    ) -> None:
+        async def fake_process_file(**kwargs: Any) -> dict[str, Any]:
+            return {
+                "organization": kwargs["organization"],
+                "content": kwargs["content"],
+                "repository": kwargs["repository"],
+                "branch": kwargs["branch"],
+                "path": kwargs["file_path"],
+                "name": Path(kwargs["file_path"]).name,
+                "metadata": kwargs.get("metadata") or {},
+            }
+
+        def fake_get_resource(options: FileContentOptions) -> dict[str, Any]:
+            return {
+                "content": "name: test",
+                "name": Path(options["file_path"]).name,
+                "path": options["file_path"],
+                "size": 9,
+            }
+
+        mock_exporter = AsyncMock()
+        mock_exporter.fetch_commit_diff.return_value = {
+            "files": [
+                {
+                    "filename": "new.yaml",
+                    "previous_filename": "old.yaml",
+                    "status": "renamed",
+                }
+            ]
+        }
+        mock_exporter.get_resource.side_effect = fake_get_resource
+        mock_exporter.file_processor.process_file.side_effect = fake_process_file
+
+        with patch(
+            "github.webhook.webhook_processors.file_webhook_processor.RestFileExporter",
+            return_value=mock_exporter,
+        ):
+            result = await file_webhook_processor.handle_event(
+                payload, resource_config_with_items_to_parse
+            )
+
+            assert isinstance(result, WebhookEventRawResults)
+            assert len(result.updated_raw_results) == 1
+            assert len(result.deleted_raw_results) == 1
+            assert result.updated_raw_results[0]["path"] == "new.yaml"
+            assert result.deleted_raw_results[0]["path"] == "old.yaml"
+
+            fetches = {
+                (call.args[0]["file_path"], call.args[0]["branch"])
+                for call in mock_exporter.get_resource.call_args_list
+            }
+            assert fetches == {("new.yaml", "main"), ("old.yaml", "abc123")}
+
+    async def test_handle_event_renamed_file_without_old_content_yields_no_deletion(
+        self,
+        file_webhook_processor: FileWebhookProcessor,
+        resource_config_with_items_to_parse: GithubFileResourceConfig,
+        payload: EventPayload,
+    ) -> None:
+        def fake_get_resource(options: FileContentOptions) -> dict[str, Any]:
+            content = None if options["branch"] == "abc123" else "items: []"
+            return {
+                "content": content,
+                "name": Path(options["file_path"]).name,
+                "path": options["file_path"],
+                "size": 1024 * 1024 + 1 if content is None else 9,
+            }
+
+        async def fake_process_file(**kwargs: Any) -> dict[str, Any]:
+            return {
+                "organization": kwargs["organization"],
+                "content": kwargs["content"],
+                "repository": kwargs["repository"],
+                "branch": kwargs["branch"],
+                "path": kwargs["file_path"],
+                "name": Path(kwargs["file_path"]).name,
+                "metadata": kwargs.get("metadata") or {},
+            }
+
+        mock_exporter = AsyncMock()
+        mock_exporter.fetch_commit_diff.return_value = {
+            "files": [
+                {
+                    "filename": "new.yaml",
+                    "previous_filename": "old.yaml",
+                    "status": "renamed",
+                }
+            ]
+        }
+        mock_exporter.get_resource.side_effect = fake_get_resource
+        mock_exporter.file_processor.process_file.side_effect = fake_process_file
+
+        with patch(
+            "github.webhook.webhook_processors.file_webhook_processor.RestFileExporter",
+            return_value=mock_exporter,
+        ):
+            result = await file_webhook_processor.handle_event(
+                payload, resource_config_with_items_to_parse
+            )
+
+            assert isinstance(result, WebhookEventRawResults)
+            assert len(result.updated_raw_results) == 1
+            assert result.updated_raw_results[0]["path"] == "new.yaml"
+            assert result.deleted_raw_results == []
+
+    async def test_handle_event_renamed_file_without_items_to_parse_deletes_old_path(
+        self,
+        file_webhook_processor: FileWebhookProcessor,
+        resource_config: GithubFileResourceConfig,
+        payload: EventPayload,
+    ) -> None:
+        async def fake_process_file(**kwargs: Any) -> dict[str, Any]:
+            return {
+                "organization": kwargs["organization"],
+                "content": kwargs["content"],
+                "repository": kwargs["repository"],
+                "branch": kwargs["branch"],
+                "path": kwargs["file_path"],
+                "name": Path(kwargs["file_path"]).name,
+                "metadata": kwargs.get("metadata") or {},
+            }
+
+        def fake_get_resource(options: FileContentOptions) -> dict[str, Any]:
+            return {
+                "content": "name: test",
+                "name": Path(options["file_path"]).name,
+                "path": options["file_path"],
+                "size": 9,
+            }
+
+        mock_exporter = AsyncMock()
+        mock_exporter.fetch_commit_diff.return_value = {
+            "files": [
+                {
+                    "filename": "new.yaml",
+                    "previous_filename": "old.yaml",
+                    "status": "renamed",
+                }
+            ]
+        }
+        mock_exporter.get_resource.side_effect = fake_get_resource
+        mock_exporter.file_processor.process_file.side_effect = fake_process_file
+
+        with patch(
+            "github.webhook.webhook_processors.file_webhook_processor.RestFileExporter",
+            return_value=mock_exporter,
+        ):
+            result = await file_webhook_processor.handle_event(payload, resource_config)
+
+            assert isinstance(result, WebhookEventRawResults)
+            assert len(result.updated_raw_results) == 1
+            assert len(result.deleted_raw_results) == 1
+            assert result.updated_raw_results[0]["path"] == "new.yaml"
+
+            deleted = result.deleted_raw_results[0]
+            assert deleted["metadata"]["path"] == "old.yaml"
+            assert deleted["name"] == "old.yaml"
+            assert "content" not in deleted
+
+            fetches = {
+                (call.args[0]["file_path"], call.args[0]["branch"])
+                for call in mock_exporter.get_resource.call_args_list
+            }
+            assert fetches == {("new.yaml", "main")}
 
     async def test_handle_event_processing_error(
         self,


### PR DESCRIPTION
## Summary
- Multi-org resync and webhook registration via `create_github_clients` / `GithubClientScope`.
- Version bump and changelog.
- Remove `create_github_client` and `GitHubAuthenticatorFactory` shims from `client_factory.py`.
- Align `test_file_webhook_processor.py` with the source branch (file webhook test updates not in the original 66-file list).

Fixes [PORT-17895](https://getport.atlassian.net/browse/PORT-17895) — GitHub Ocean live events for personal accounts.

Port task: [task_ti1spg](https://app.getport.io/taskEntity?identifier=task_ti1spg)

## Test plan
- [x] `make lint` in `integrations/github`
- [x] `make test` in `integrations/github`
- [x] Combined diff for `integrations/github` matches `task_tgtuzt/github_app_multi_org_support_in_ocean`

[PORT-17895]: https://getport.atlassian.net/browse/PORT-17895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ