### PR TITLE
[Integration][GitHub] Add legacyDispatchWorkflowTracking config for dispatch workflow action (task_ti20mi)

### DIFF
--- a/integrations/github/.port/spec.yaml
+++ b/integrations/github/.port/spec.yaml
@@ -75,7 +75,7 @@ configurations:
     type: boolean
     required: false
     default: false
-    description: When enabled, the dispatch_workflow action polls GitHub for the triggered workflow run and serializes dispatches per organization/repository/workflow instead of using the workflow run ID returned on dispatch.
+    description: Enable for GitHub Enterprise Server versions older than 3.21 that do not support `return_run_details` on workflow dispatch (see https://github.com/github/roadmap/issues/1188). Polls GitHub for the triggered workflow run and serializes dispatches per organization/repository/workflow.
 saas:
   enabled: true
   liveEvents:

--- a/integrations/github/.port/spec.yaml
+++ b/integrations/github/.port/spec.yaml
@@ -71,6 +71,11 @@ configurations:
     required: false
     default: 95
     description: GitHub REST rate-limit utilization percentage (0-100) at which resync processes pause to reserve quota for webhooks. Does not throttle webhooks or actions.
+  - name: legacyDispatchWorkflowTracking
+    type: boolean
+    required: false
+    default: false
+    description: When enabled, the dispatch_workflow action polls GitHub for the triggered workflow run and serializes dispatches per organization/repository/workflow instead of using the workflow run ID returned on dispatch.
 saas:
   enabled: true
   liveEvents:

--- a/integrations/github/CHANGELOG.md
+++ b/integrations/github/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
-- Added `legacyDispatchWorkflowTracking` configuration to restore pre-6.2.4 dispatch workflow tracking behavior that polls GitHub for workflow runs and serializes dispatches per organization/repository/workflow.
+- Added `legacyDispatchWorkflowTracking` configuration for GitHub Enterprise Server versions older than 3.21 that do not support `return_run_details` on workflow dispatch. When enabled, the dispatch_workflow action polls GitHub for workflow runs and serializes dispatches per organization/repository/workflow.
 
 
 ## 6.2.7 (2026-07-10)

--- a/integrations/github/CHANGELOG.md
+++ b/integrations/github/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 6.2.8 (2026-07-12)
+
+
+### Improvements
+
+- Added `legacyDispatchWorkflowTracking` configuration to restore pre-6.2.4 dispatch workflow tracking behavior that polls GitHub for workflow runs and serializes dispatches per organization/repository/workflow.
+
+
 ## 6.2.7 (2026-07-10)
 
 

--- a/integrations/github/github/actions/dispatch_workflow_executor.py
+++ b/integrations/github/github/actions/dispatch_workflow_executor.py
@@ -1,9 +1,12 @@
+import asyncio
+from datetime import datetime, timezone
 import json
 from typing import Any
 
 import httpx
 from loguru import logger
 from github.actions.utils import build_external_id
+from github.context.auth import get_authenticated_actor
 from github.core.exporters.repository_exporter import (
     RestRepositoryExporter,
 )
@@ -13,6 +16,7 @@ from github.webhook.registry import (
 )
 from github.helpers.exceptions import (
     InvalidActionParametersException,
+    NoWorkflowRunsFoundException,
     RepositoryDefaultBranchNotFoundException,
 )
 from github.webhook.webhook_processors.workflow_run.dispatch_workflow_webhook_processor import (
@@ -28,61 +32,21 @@ from github.actions.abstract_github_executor import (
 from port_ocean.exceptions.execution_manager import ActionExecutionError
 
 
+MAX_WORKFLOW_POLL_ATTEMPTS = 30
+WORKFLOW_POLL_DELAY_SECONDS = 2
+
+
 class DispatchWorkflowExecutor(AbstractGithubExecutor):
     """
     Executor for dispatching GitHub workflow runs and tracking their execution.
 
-    This executor implements the Port action for triggering GitHub Actions workflows.
-    It supports:
-    - Dispatching workflows with custom inputs
-    - Tracking workflow execution status via the returned workflow run ID
-    - Reporting workflow completion back to Port
-    - Rate limit handling for GitHub API
-    - Webhook processing for async status updates
-
-    On dispatch, GitHub returns a workflow run ID when `return_run_details` is set.
+    By default, GitHub returns a workflow run ID when `return_run_details` is set.
     The executor fetches that run and builds a unique external ID from it, so
-    multiple dispatches of the same workflow can run concurrently without collision.
+    multiple dispatches of the same workflow can run concurrently.
 
-    Attributes:
-        ACTION_NAME (str): The name of this action in Port's spec ("dispatch_workflow")
-        WEBHOOK_PROCESSOR_CLASS (Type[AbstractWebhookProcessor]): Processor for workflow_run events
-        WEBHOOK_PATH (str): Path for receiving GitHub webhook events
-        _default_ref_cache (dict[str, str]): Cache of repository default branch names
-        _workflow_run_exporter (RestWorkflowRunExporter): Fetches dispatched workflow runs by ID
-
-    Example Usage in Port:
-        ```yaml
-        actions:
-          dispatch_workflow:
-            displayName: Trigger Workflow
-            trigger: PORT
-            inputs:
-              repo:
-                type: string
-                description: Repository name
-              workflow:
-                type: string
-                description: Workflow file name or ID
-              workflowInputs:
-                type: object
-                description: Optional workflow inputs
-        ```
-
-    Example API Usage:
-        ```python
-        executor = DispatchWorkflowExecutor()
-        await executor.execute(ActionRun(
-            payload=IntegrationActionInvocationPayload(
-                actionType="dispatch_workflow",
-                integrationActionExecutionProperties={
-                    "repo": "my-repo",
-                    "workflow": "deploy.yml",
-                    "workflowInputs": {"environment": "prod"}
-                }
-            )
-        ))
-        ```
+    When `legacyDispatchWorkflowTracking` is enabled, the executor polls GitHub
+    for the dispatched workflow run and uses `{organization}/{repo}/{workflow}` as
+    the partition key to serialize dispatches of the same workflow.
     """
 
     ACTION_NAME = "dispatch_workflow"
@@ -95,10 +59,24 @@ class DispatchWorkflowExecutor(AbstractGithubExecutor):
         super().__init__()
         self._workflow_run_exporter = RestWorkflowRunExporter(self.rest_client)
 
+    def _use_legacy_dispatch_workflow_tracking(self) -> bool:
+        return bool(
+            ocean.integration_config.get("legacy_dispatch_workflow_tracking", False)
+        )
+
+    async def _get_partition_key(self, run: IntegrationRun) -> str | None:
+        if not self._use_legacy_dispatch_workflow_tracking():
+            return None
+
+        organization = run.execution_properties.get("org")
+        repo = run.execution_properties.get("repo")
+        workflow = run.execution_properties.get("workflow")
+        if not (organization and repo and workflow):
+            return None
+
+        return f"{organization}/{repo}/{workflow}"
+
     async def _get_default_ref(self, organization: str, repo_name: str) -> str:
-        """
-        Get the default branch name for a repository, using cache when available.
-        """
         key = f"{organization}:{repo_name}"
         if key in self._default_ref_cache:
             logger.info(
@@ -132,6 +110,44 @@ class DispatchWorkflowExecutor(AbstractGithubExecutor):
         self._default_ref_cache[key] = repo["default_branch"]
         return self._default_ref_cache[key]
 
+    async def _get_workflow_run(
+        self, organization: str, repo: str, ref: str, iso_date: str
+    ) -> dict[str, Any]:
+        workflow_runs: list[dict[str, Any]] = []
+        actor = await get_authenticated_actor()
+        attempts_made = 0
+        while len(workflow_runs) == 0 and attempts_made < MAX_WORKFLOW_POLL_ATTEMPTS:
+            response = await self.rest_client.send_api_request(
+                f"{self.rest_client.base_url}/repos/{organization}/{repo}/actions/runs",
+                params={
+                    "actor": actor,
+                    "event": "workflow_dispatch",
+                    "created": f">={iso_date}",
+                    "exclude_pull_requests": True,
+                    "branch": ref,
+                },
+                method="GET",
+                ignore_default_errors=False,
+            )
+            workflow_runs = response.get("workflow_runs", [])
+            if len(workflow_runs) == 0:
+                logger.warning(
+                    f"Couldn't find the triggered workflow run, waiting for {WORKFLOW_POLL_DELAY_SECONDS} seconds",
+                    attempts_made=attempts_made,
+                )
+                await asyncio.sleep(WORKFLOW_POLL_DELAY_SECONDS)
+                attempts_made += 1
+
+        if len(workflow_runs) == 0:
+            raise NoWorkflowRunsFoundException(
+                "Workflow dispatched successfully but due to a delay in GitHub we were unable to track it's progress"
+            )
+
+        logger.info(
+            f"Found workflow run for {organization}/{repo} with ref {ref}: {workflow_runs[0]['id']}",
+        )
+        return workflow_runs[0]
+
     def _parse_inputs(self, raw_inputs: dict[str, Any]) -> dict[str, Any]:
         inputs: dict[str, str] = {}
         for key, value in raw_inputs.items():
@@ -141,13 +157,30 @@ class DispatchWorkflowExecutor(AbstractGithubExecutor):
                 inputs[key] = json.dumps(value)
         return inputs
 
-    async def execute(self, run: IntegrationRun) -> None:
-        """
-        Dispatch a GitHub Actions workflow and register the returned run with Port.
+    async def _dispatch_workflow(
+        self,
+        organization: str,
+        repo: str,
+        workflow: str,
+        ref: str,
+        inputs: dict[str, str],
+    ) -> dict[str, Any]:
+        dispatch_payload: dict[str, Any] = {
+            "ref": ref,
+            "inputs": inputs,
+        }
+        if not self._use_legacy_dispatch_workflow_tracking():
+            dispatch_payload["return_run_details"] = True
 
-        Requests `return_run_details` from GitHub, fetches the workflow run by ID,
-        and calls `update_run_started` with its URL and external ID.
-        """
+        response = await self.rest_client.make_request(
+            f"{self.rest_client.base_url}/repos/{organization}/{repo}/actions/workflows/{workflow}/dispatches",
+            method="POST",
+            json_data=dispatch_payload,
+            ignore_default_errors=False,
+        )
+        return response.json()
+
+    async def execute(self, run: IntegrationRun) -> None:
         logger.info(f"Dispatching workflow for action run {run.id}", run_id=run.id)
         organization = run.execution_properties.get("org")
         repo = run.execution_properties.get("repo")
@@ -165,31 +198,34 @@ class DispatchWorkflowExecutor(AbstractGithubExecutor):
         if not ref:
             ref = await self._get_default_ref(organization, repo)
         try:
-            response = await self.rest_client.make_request(
-                f"{self.rest_client.base_url}/repos/{organization}/{repo}/actions/workflows/{workflow}/dispatches",
-                method="POST",
-                json_data={
-                    "ref": ref,
-                    "inputs": inputs,
-                    "return_run_details": True,
-                },
-                ignore_default_errors=False,
-            )
-            workflow_run_id = response.json().get("workflow_run_id")
-            if not workflow_run_id:
-                raise ActionExecutionError("Workflow run ID not found")
+            if self._use_legacy_dispatch_workflow_tracking():
+                iso_date = datetime.now(timezone.utc).isoformat()
+                await self._dispatch_workflow(organization, repo, workflow, ref, inputs)
+                workflow_run = await self._get_workflow_run(
+                    organization, repo, ref, iso_date
+                )
+                workflow_run_id = workflow_run["id"]
+            else:
+                dispatch_response = await self._dispatch_workflow(
+                    organization, repo, workflow, ref, inputs
+                )
+                workflow_run_id = dispatch_response.get("workflow_run_id")
+                if not workflow_run_id:
+                    raise ActionExecutionError("Workflow run ID not found")
 
-            workflow_run = await self._workflow_run_exporter.get_resource(
-                SingleWorkflowRunOptions(
-                    organization=organization,
-                    repo_name=repo,
-                    run_id=workflow_run_id,
+                fetched_workflow_run = await self._workflow_run_exporter.get_resource(
+                    SingleWorkflowRunOptions(
+                        organization=organization,
+                        repo_name=repo,
+                        run_id=workflow_run_id,
+                    )
                 )
-            )
-            if not workflow_run:
-                raise ActionExecutionError(
-                    f"Workflow run {workflow_run_id} not found in {organization}/{repo}"
-                )
+                if not fetched_workflow_run:
+                    raise ActionExecutionError(
+                        f"Workflow run {workflow_run_id} not found in {organization}/{repo}"
+                    )
+                workflow_run = fetched_workflow_run
+
             external_id = build_external_id(workflow_run)
 
             await ocean.port_client.update_run_started(

--- a/integrations/github/github/actions/dispatch_workflow_executor.py
+++ b/integrations/github/github/actions/dispatch_workflow_executor.py
@@ -267,7 +267,9 @@ class DispatchWorkflowExecutor(AbstractGithubExecutor):
         try:
             if self._use_legacy_dispatch_workflow_tracking():
                 iso_date = datetime.now(timezone.utc).isoformat()
-                await self._dispatch_workflow_legacy(organization, repo, workflow, ref, inputs)
+                await self._dispatch_workflow_legacy(
+                    organization, repo, workflow, ref, inputs
+                )
                 workflow_run = await self._get_workflow_run(
                     organization, repo, workflow, ref, iso_date
                 )

--- a/integrations/github/github/actions/dispatch_workflow_executor.py
+++ b/integrations/github/github/actions/dispatch_workflow_executor.py
@@ -46,7 +46,9 @@ class DispatchWorkflowExecutor(AbstractGithubExecutor):
 
     When `legacyDispatchWorkflowTracking` is enabled, the executor polls GitHub
     for the dispatched workflow run and uses `{organization}/{repo}/{workflow}` as
-    the partition key to serialize dispatches of the same workflow.
+    the partition key to serialize dispatches of the same workflow. Use this for
+    GitHub Enterprise Server versions older than 3.21 that do not support
+    `return_run_details` on workflow dispatch.
     """
 
     ACTION_NAME = "dispatch_workflow"

--- a/integrations/github/github/actions/dispatch_workflow_executor.py
+++ b/integrations/github/github/actions/dispatch_workflow_executor.py
@@ -40,15 +40,63 @@ class DispatchWorkflowExecutor(AbstractGithubExecutor):
     """
     Executor for dispatching GitHub workflow runs and tracking their execution.
 
+    This executor implements the Port action for triggering GitHub Actions workflows.
+    It supports:
+    - Dispatching workflows with custom inputs
+    - Tracking workflow execution status via the returned workflow run ID
+    - Reporting workflow completion back to Port
+    - Rate limit handling for GitHub API
+    - Webhook processing for async status updates
+
     By default, GitHub returns a workflow run ID when `return_run_details` is set.
     The executor fetches that run and builds a unique external ID from it, so
-    multiple dispatches of the same workflow can run concurrently.
+    multiple dispatches of the same workflow can run concurrently without collision.
 
-    When `legacyDispatchWorkflowTracking` is enabled, the executor polls GitHub
-    for the dispatched workflow run and uses `{organization}/{repo}/{workflow}` as
-    the partition key to serialize dispatches of the same workflow. Use this for
-    GitHub Enterprise Server versions older than 3.21 that do not support
-    `return_run_details` on workflow dispatch.
+    When `legacyDispatchWorkflowTracking` is enabled (for GitHub Enterprise Server
+    versions older than 3.21 that do not support `return_run_details` on workflow
+    dispatch), the executor polls GitHub for the dispatched workflow run and uses
+    `{organization}/{repo}/{workflow}` as the partition key to serialize dispatches
+    of the same workflow.
+
+    Attributes:
+        ACTION_NAME (str): The name of this action in Port's spec ("dispatch_workflow")
+        WEBHOOK_PROCESSOR_CLASS (Type[AbstractWebhookProcessor]): Processor for workflow_run events
+        WEBHOOK_PATH (str): Path for receiving GitHub webhook events
+        _default_ref_cache (dict[str, str]): Cache of repository default branch names
+        _workflow_run_exporter (RestWorkflowRunExporter): Fetches dispatched workflow runs by ID
+
+    Example Usage in Port:
+        ```yaml
+        actions:
+          dispatch_workflow:
+            displayName: Trigger Workflow
+            trigger: PORT
+            inputs:
+              repo:
+                type: string
+                description: Repository name
+              workflow:
+                type: string
+                description: Workflow file name or ID
+              workflowInputs:
+                type: object
+                description: Optional workflow inputs
+        ```
+
+    Example API Usage:
+        ```python
+        executor = DispatchWorkflowExecutor()
+        await executor.execute(ActionRun(
+            payload=IntegrationActionInvocationPayload(
+                actionType="dispatch_workflow",
+                integrationActionExecutionProperties={
+                    "repo": "my-repo",
+                    "workflow": "deploy.yml",
+                    "workflowInputs": {"environment": "prod"}
+                }
+            )
+        ))
+        ```
     """
 
     ACTION_NAME = "dispatch_workflow"
@@ -113,14 +161,14 @@ class DispatchWorkflowExecutor(AbstractGithubExecutor):
         return self._default_ref_cache[key]
 
     async def _get_workflow_run(
-        self, organization: str, repo: str, ref: str, iso_date: str
+        self, organization: str, repo: str, workflow: str, ref: str, iso_date: str
     ) -> dict[str, Any]:
         workflow_runs: list[dict[str, Any]] = []
         actor = await get_authenticated_actor()
         attempts_made = 0
         while len(workflow_runs) == 0 and attempts_made < MAX_WORKFLOW_POLL_ATTEMPTS:
             response = await self.rest_client.send_api_request(
-                f"{self.rest_client.base_url}/repos/{organization}/{repo}/actions/runs",
+                f"{self.rest_client.base_url}/repos/{organization}/{repo}/actions/workflows/{workflow}/runs",
                 params={
                     "actor": actor,
                     "event": "workflow_dispatch",
@@ -159,6 +207,24 @@ class DispatchWorkflowExecutor(AbstractGithubExecutor):
                 inputs[key] = json.dumps(value)
         return inputs
 
+    async def _dispatch_workflow_legacy(
+        self,
+        organization: str,
+        repo: str,
+        workflow: str,
+        ref: str,
+        inputs: dict[str, str],
+    ) -> None:
+        await self.rest_client.make_request(
+            f"{self.rest_client.base_url}/repos/{organization}/{repo}/actions/workflows/{workflow}/dispatches",
+            method="POST",
+            json_data={
+                "ref": ref,
+                "inputs": inputs,
+            },
+            ignore_default_errors=False,
+        )
+
     async def _dispatch_workflow(
         self,
         organization: str,
@@ -170,9 +236,8 @@ class DispatchWorkflowExecutor(AbstractGithubExecutor):
         dispatch_payload: dict[str, Any] = {
             "ref": ref,
             "inputs": inputs,
+            "return_run_details": True,
         }
-        if not self._use_legacy_dispatch_workflow_tracking():
-            dispatch_payload["return_run_details"] = True
 
         response = await self.rest_client.make_request(
             f"{self.rest_client.base_url}/repos/{organization}/{repo}/actions/workflows/{workflow}/dispatches",
@@ -202,9 +267,9 @@ class DispatchWorkflowExecutor(AbstractGithubExecutor):
         try:
             if self._use_legacy_dispatch_workflow_tracking():
                 iso_date = datetime.now(timezone.utc).isoformat()
-                await self._dispatch_workflow(organization, repo, workflow, ref, inputs)
+                await self._dispatch_workflow_legacy(organization, repo, workflow, ref, inputs)
                 workflow_run = await self._get_workflow_run(
-                    organization, repo, ref, iso_date
+                    organization, repo, workflow, ref, iso_date
                 )
                 workflow_run_id = workflow_run["id"]
             else:

--- a/integrations/github/github/helpers/exceptions.py
+++ b/integrations/github/github/helpers/exceptions.py
@@ -45,3 +45,7 @@ class RepositoryDefaultBranchNotFoundException(Exception):
 
 class InvalidActionParametersException(Exception):
     """Exception for invalid action parameters."""
+
+
+class NoWorkflowRunsFoundException(Exception):
+    """Exception for workflow runs not found after dispatch."""

--- a/integrations/github/pyproject.toml
+++ b/integrations/github/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "github-ocean"
-version = "6.2.7"
+version = "6.2.8"
 description = "This integration ingest data from github"
 authors = ["Chukwuemeka Nwaoma <joelchukks@gmail.com>", "Melody Anyaegbulam <melodyogonna@gmail.com>", "Michael Armah <mikeyarmah@gmail.com>"]
 

--- a/integrations/github/tests/github/actions/test_dispatch_workflow_executor.py
+++ b/integrations/github/tests/github/actions/test_dispatch_workflow_executor.py
@@ -1,10 +1,11 @@
 """Tests for DispatchWorkflowExecutor."""
 
-from typing import Any
+from typing import Any, Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+from port_ocean.context.ocean import ocean
 
 from github.actions.dispatch_workflow_executor import DispatchWorkflowExecutor
 from github.helpers.exceptions import (
@@ -43,29 +44,43 @@ WORKFLOW_RUN = {
 }
 
 
+@pytest.fixture(autouse=True)
+def patched_ocean() -> Generator[MagicMock, None, None]:
+    mock_client = MagicMock()
+    mock_client.update_run_started = AsyncMock()
+    with patch("github.actions.dispatch_workflow_executor.ocean") as mock_ocean:
+        mock_ocean.port_client = mock_client
+        mock_ocean.integration_config = {
+            **ocean.integration_config,
+            "legacy_dispatch_workflow_tracking": False,
+        }
+        yield mock_ocean
+
+
+@pytest.fixture
+def mock_port_client(patched_ocean: MagicMock) -> MagicMock:
+    return patched_ocean.port_client
+
+
 @pytest.fixture
 def mock_rest_client() -> MagicMock:
     client = MagicMock()
     client.base_url = "https://api.github.com"
     client.make_request = AsyncMock()
+    client.send_api_request = AsyncMock()
     client.get_rate_limit_status = MagicMock(return_value=None)
     return client
 
 
 @pytest.fixture
-def mock_port_client() -> MagicMock:
-    pc = MagicMock()
-    pc.update_run_started = AsyncMock()
-    return pc
-
-
-@pytest.fixture
-def executor(mock_rest_client: MagicMock) -> DispatchWorkflowExecutor:
+def executor(
+    mock_rest_client: MagicMock,
+) -> Generator[DispatchWorkflowExecutor, None, None]:
     with patch(
         "github.actions.abstract_github_executor.create_github_client",
         return_value=mock_rest_client,
     ):
-        return DispatchWorkflowExecutor()
+        yield DispatchWorkflowExecutor()
 
 
 class TestDispatchWorkflowExecutor:
@@ -98,9 +113,7 @@ class TestDispatchWorkflowExecutor:
                 "get_resource",
                 get_resource_mock,
             ),
-            patch("github.actions.dispatch_workflow_executor.ocean") as mock_ocean,
         ):
-            mock_ocean.port_client = mock_port_client
             await executor.execute(run)
 
         mock_rest_client.make_request.assert_awaited_once()
@@ -144,15 +157,11 @@ class TestDispatchWorkflowExecutor:
         dispatch_response.json.return_value = {"workflow_run_id": 12345}
         mock_rest_client.make_request.return_value = dispatch_response
 
-        with (
-            patch.object(
-                executor._workflow_run_exporter,
-                "get_resource",
-                AsyncMock(return_value=WORKFLOW_RUN),
-            ),
-            patch("github.actions.dispatch_workflow_executor.ocean") as mock_ocean,
+        with patch.object(
+            executor._workflow_run_exporter,
+            "get_resource",
+            AsyncMock(return_value=WORKFLOW_RUN),
         ):
-            mock_ocean.port_client = mock_port_client
             await executor.execute(run)
 
         json_data = mock_rest_client.make_request.call_args.kwargs["json_data"]
@@ -196,9 +205,7 @@ class TestDispatchWorkflowExecutor:
 
         with (
             patch.object(executor, "_get_default_ref", AsyncMock(return_value="main")),
-            patch("github.actions.dispatch_workflow_executor.ocean") as mock_ocean,
         ):
-            mock_ocean.port_client = mock_port_client
             with pytest.raises(ActionExecutionError, match="Workflow run ID not found"):
                 await executor.execute(run)
 
@@ -228,11 +235,7 @@ class TestDispatchWorkflowExecutor:
             "422", request=request, response=response
         )
 
-        with (
-            patch.object(executor, "_get_default_ref", AsyncMock(return_value="main")),
-            patch("github.actions.dispatch_workflow_executor.ocean") as mock_ocean,
-        ):
-            mock_ocean.port_client = mock_port_client
+        with patch.object(executor, "_get_default_ref", AsyncMock(return_value="main")):
             with pytest.raises(
                 ActionExecutionError,
                 match="Error dispatching workflow: Workflow not found",
@@ -276,3 +279,130 @@ class TestDispatchWorkflowExecutor:
 
     def test_action_name(self, executor: DispatchWorkflowExecutor) -> None:
         assert executor.ACTION_NAME == "dispatch_workflow"
+
+    @pytest.mark.asyncio
+    async def test_partition_key_disabled_by_default(
+        self, executor: DispatchWorkflowExecutor
+    ) -> None:
+        run = make_run(
+            {
+                "org": "port-labs",
+                "repo": "ocean",
+                "workflow": "deploy.yml",
+            }
+        )
+        assert await executor._get_partition_key(run) is None
+
+    @pytest.mark.asyncio
+    async def test_partition_key_when_legacy_tracking_enabled(
+        self, executor: DispatchWorkflowExecutor, patched_ocean: MagicMock
+    ) -> None:
+        patched_ocean.integration_config["legacy_dispatch_workflow_tracking"] = True
+        run = make_run(
+            {
+                "org": "port-labs",
+                "repo": "ocean",
+                "workflow": "deploy.yml",
+            }
+        )
+        assert await executor._get_partition_key(run) == "port-labs/ocean/deploy.yml"
+
+
+class TestLegacyDispatchWorkflowExecutor:
+    @pytest.mark.asyncio
+    async def test_happy_path(
+        self,
+        mock_rest_client: MagicMock,
+        mock_port_client: MagicMock,
+        patched_ocean: MagicMock,
+    ) -> None:
+        run = make_run(
+            {
+                "org": "port-labs",
+                "repo": "ocean",
+                "workflow": "deploy.yml",
+                "workflowInputs": {"environment": "prod"},
+            }
+        )
+
+        mock_rest_client.send_api_request.return_value = {
+            "workflow_runs": [WORKFLOW_RUN]
+        }
+        patched_ocean.integration_config["legacy_dispatch_workflow_tracking"] = True
+
+        with (
+            patch(
+                "github.actions.abstract_github_executor.create_github_client",
+                return_value=mock_rest_client,
+            ),
+            patch(
+                "github.actions.dispatch_workflow_executor.get_authenticated_actor",
+                AsyncMock(return_value="port-bot[bot]"),
+            ),
+            patch.object(
+                DispatchWorkflowExecutor,
+                "_get_default_ref",
+                AsyncMock(return_value="main"),
+            ),
+        ):
+            executor = DispatchWorkflowExecutor()
+            await executor.execute(run)
+
+        call_kwargs = mock_rest_client.make_request.call_args
+        assert call_kwargs.kwargs["json_data"] == {
+            "ref": "main",
+            "inputs": {"environment": "prod"},
+        }
+        assert "return_run_details" not in call_kwargs.kwargs["json_data"]
+
+        mock_rest_client.send_api_request.assert_awaited_once()
+        mock_port_client.update_run_started.assert_awaited_once_with(
+            run,
+            WORKFLOW_RUN["html_url"],
+            "gh_1_99_12345",
+            extra_output={"workflowRunId": 12345},
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_workflow_runs_found_raises(
+        self,
+        mock_rest_client: MagicMock,
+        mock_port_client: MagicMock,
+        patched_ocean: MagicMock,
+    ) -> None:
+        run = make_run(
+            {
+                "org": "port-labs",
+                "repo": "ocean",
+                "workflow": "deploy.yml",
+            }
+        )
+
+        mock_rest_client.send_api_request.return_value = {"workflow_runs": []}
+        patched_ocean.integration_config["legacy_dispatch_workflow_tracking"] = True
+
+        with (
+            patch(
+                "github.actions.abstract_github_executor.create_github_client",
+                return_value=mock_rest_client,
+            ),
+            patch(
+                "github.actions.dispatch_workflow_executor.get_authenticated_actor",
+                AsyncMock(return_value="port-bot[bot]"),
+            ),
+            patch(
+                "github.actions.dispatch_workflow_executor.asyncio.sleep",
+                AsyncMock(),
+            ),
+            patch.object(
+                DispatchWorkflowExecutor,
+                "_get_default_ref",
+                AsyncMock(return_value="main"),
+            ),
+        ):
+            executor = DispatchWorkflowExecutor()
+            with pytest.raises(
+                ActionExecutionError,
+                match="unable to track it's progress",
+            ):
+                await executor.execute(run)


### PR DESCRIPTION
## Summary
- Add `legacyDispatchWorkflowTracking` integration config (default: `false`) for **GitHub Enterprise Server versions older than 3.21** that do not support `return_run_details` on workflow dispatch ([github/roadmap#1188](https://github.com/github/roadmap/issues/1188), shipped in GHES 3.21)
- When enabled, `dispatch_workflow` polls GitHub for the triggered workflow run and uses partition key `{organization}/{repo}/{workflow}` to serialize dispatches
- Default behavior remains unchanged on GitHub.com and GHES 3.21+: use `return_run_details` and track runs by workflow run ID for concurrent dispatches

## Test plan
- [x] `poetry run pytest tests/github/actions/test_dispatch_workflow_executor.py -n 0`
- [x] `make lint` in `integrations/github`
- [ ] Enable `legacyDispatchWorkflowTracking: true` on a GHES < 3.21 integration and verify dispatch workflow action polls and serializes per org/repo/workflow
- [ ] Verify default config still supports concurrent dispatches on GitHub.com / GHES 3.21+