### PR TITLE
[Integration][Mend] Add community provider badge to spec

### DIFF
--- a/integrations/mend/.port/spec.yaml
+++ b/integrations/mend/.port/spec.yaml
@@ -19,3 +19,5 @@ configurations:
     type: integer
     default: 720
     description: Interval in minutes between forced full resyncs. Between forced full resyncs, the integration only fetches findings whose project changed since the last sync. A forced full resync bypasses that delta filter so findings updated independently of their project (status changes, suppressions, etc.) are picked up. Set 0 to always perform a full resync.
+provider:
+  type: community

--- a/integrations/mend/CHANGELOG.md
+++ b/integrations/mend/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.10 (2026-07-12)
+
+
+### Improvements
+
+- Added `provider.type: community` to integration spec - displays the Community badge on the integration card in the Port data sources page
+
+
 ## 0.1.9 (2026-07-08)
 
 

--- a/integrations/mend/pyproject.toml
+++ b/integrations/mend/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mend"
-version = "0.1.9"
+version = "0.1.10"
 description = "An integration for Mend.io project and scan results types"
 authors = ["Het Saliya <het.saliya@crestdata.ai>"]
 


### PR DESCRIPTION
## Summary
- Add `provider.type: community` to Mend integration spec so the Port data sources page shows the Community badge
- Bump Mend integration version to `0.1.10` and add changelog entry

## Test plan
- [ ] Verify Mend integration card shows Community badge in Port data sources UI after spec publish
- [ ] Confirm version bump in `pyproject.toml` and changelog entry


Made with [Cursor](https://cursor.com)