### PR TITLE
[Core] Fix missing links field in `WorkflowNodeRun` patch on run start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.44.11 (2026-07-13)
+
+### Bug Fixes
+
+- Fixed missing `links` field in `WorkflowNodeRun` patch on run start, so the GitHub Actions run URL now appears as a clickable link on workflow node runs in the Port UI.
+
 ## 0.44.10 (2026-07-12)
 
 ### Improvements

--- a/port_ocean/clients/port/mixins/actions_and_workflow_runs.py
+++ b/port_ocean/clients/port/mixins/actions_and_workflow_runs.py
@@ -148,6 +148,7 @@ class ActionsAndWorkflowRunsClientMixin(ActionsClientMixin, WorkflowNodesClientM
                     "status": WorkflowNodeRunStatus.IN_PROGRESS,
                     "externalRunId": external_id,
                     "output": output,
+                    "links": [link],
                 },
             )
             run.output = output

--- a/port_ocean/tests/clients/port/mixins/test_actions_and_workflow_runs.py
+++ b/port_ocean/tests/clients/port/mixins/test_actions_and_workflow_runs.py
@@ -158,6 +158,7 @@ class TestWorkflowNodeRunOutputPreservation:
                 "status": WorkflowNodeRunStatus.IN_PROGRESS,
                 "externalRunId": EXTERNAL_ID,
                 "output": {"workflowRunUrl": "https://gitlab.example/pipelines/99"},
+                "links": ["https://gitlab.example/pipelines/99"],
             },
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.44.10"
+version = "0.44.11"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What - Pass the `links` field when patching a `WorkflowNodeRun` on run start.

Why - The GitHub Actions run URL was being stored in `output.workflowRunUrl` but never included in the `links` field of the PATCH request, so no clickable link appeared on the workflow node run in the Port UI.

How - Added `"links": [link]` to the `patch_wf_node_run` payload inside `update_run_started`, mirroring the existing behaviour for action runs.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-field addition to an existing Port API patch payload; UI-only impact with no auth or data-model changes.
> 
> **Overview**
> Fixes workflow node runs in the Port UI not showing a clickable external run link when execution starts.
> 
> When a `WorkflowNodeRun` is marked in progress via `update_run_started`, the PATCH now includes **`links`: `[link]`** alongside the existing `output.workflowRunUrl`, so Port can surface the GitHub Actions (or other) run URL the same way action runs already do with `link`.
> 
> Release **0.44.11** with a changelog bug-fix note; no other behavioral changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d42c34d2382f9118a023a47d2b457b77e21bee19. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->