### PR TITLE
[Core] Fail unregistered Ocean action runs instead of skipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.44.12 (2026-07-13)
+
+### Improvements
+
+- Fail unregistered Ocean action runs immediately by acknowledging and reporting them as failed instead of skipping them until the claim visibility timeout expires.
+
 ## 0.44.11 (2026-07-13)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
-## 0.44.12 (2026-07-13)
+## 0.44.12 (2026-07-14)
 
 ### Improvements
 
-- Fail unregistered Ocean action runs immediately by acknowledging and reporting them as failed instead of skipping them until the claim visibility timeout expires.
+- Fail unregistered Ocean integration runs immediately by acknowledging and reporting them as failed instead of skipping them until the claim visibility timeout expires.
 
 ## 0.44.11 (2026-07-13)
 

--- a/port_ocean/core/handlers/actions/execution_manager.py
+++ b/port_ocean/core/handlers/actions/execution_manager.py
@@ -209,10 +209,8 @@ class ExecutionManager:
                     try:
                         action_type = run.action_type
                         if action_type not in self._actions_executors:
-                            logger.warning(
-                                "No Executors registered to handle this action, skipping run...",
-                                action_type=action_type,
-                                run_id=run.id,
+                            await self._ack_and_fail_run_without_executor(
+                                run, action_type
                             )
                             continue
 
@@ -255,6 +253,35 @@ class ExecutionManager:
                 )
                 # Backoff to avoid overwhelming the API with requests
                 await asyncio.sleep(self._poll_check_interval_seconds)
+
+    async def _ack_and_fail_run_without_executor(
+        self, run: IntegrationRun, action_type: str
+    ) -> None:
+        logger.warning(
+            "No Executors registered to handle this action, failing run...",
+            action_type=action_type,
+            run_id=run.id,
+        )
+        try:
+            await ocean.port_client.acknowledge_run(run)
+            await ocean.port_client.report_run_completed(
+                run,
+                success=False,
+                message=f"No executor registered for action type '{action_type}'",
+                should_raise=False,
+            )
+        except RunAlreadyAcknowledgedError:
+            logger.warning(
+                "Run already being processed by another worker, skipping",
+                run_id=run.id,
+            )
+        except Exception as e:
+            logger.exception(
+                "Error failing run with no registered executor",
+                run_id=run.id,
+                action_type=action_type,
+                error=str(e),
+            )
 
     async def _get_queues_size(self) -> int:
         """

--- a/port_ocean/core/handlers/actions/execution_manager.py
+++ b/port_ocean/core/handlers/actions/execution_manager.py
@@ -14,7 +14,6 @@ from port_ocean.context.ocean import ocean
 from port_ocean.exceptions.execution_manager import (
     ActionExecutionError,
     DuplicateActionExecutorError,
-    PartitionKeyNotFoundError,
     RunAlreadyAcknowledgedError,
 )
 from port_ocean.utils.signal import SignalHandler
@@ -207,10 +206,9 @@ class ExecutionManager:
                 logger.info(f"Adding {len(runs)} runs to queues", runs_count=len(runs))
                 for run in runs:
                     try:
-                        action_type = run.action_type
-                        if action_type not in self._actions_executors:
+                        if run.action_type not in self._actions_executors:
                             await self._ack_and_fail_run_without_executor(
-                                run, action_type
+                                run, run.action_type
                             )
                             continue
 
@@ -222,27 +220,20 @@ class ExecutionManager:
                             continue
 
                         partition_key = await self._actions_executors[
-                            action_type
+                            run.action_type
                         ]._get_partition_key(run)
 
                         queue_name = (
                             GLOBAL_SOURCE
                             if not partition_key
-                            else f"{action_type}:{partition_key}"
+                            else f"{run.action_type}:{partition_key}"
                         )
                         await self._add_run_to_queue(run, queue_name)
-                    except PartitionKeyNotFoundError as e:
-                        logger.warning(
-                            "Partition key not found in invocation payload, skipping run...",
-                            run_id=run.id,
-                            action_type=action_type,
-                            error=str(e),
-                        )
                     except Exception as e:
                         logger.exception(
                             "Error adding run to queue",
                             run_id=run.id,
-                            action_type=action_type,
+                            action_type=run.action_type,
                             error=str(e),
                         )
 
@@ -264,24 +255,25 @@ class ExecutionManager:
         )
         try:
             await ocean.port_client.acknowledge_run(run)
-            await ocean.port_client.report_run_completed(
-                run,
-                success=False,
-                message=f"No executor registered for action type '{action_type}'",
-                should_raise=False,
-            )
         except RunAlreadyAcknowledgedError:
             logger.warning(
                 "Run already being processed by another worker, skipping",
                 run_id=run.id,
             )
+            return
         except Exception as e:
             logger.exception(
-                "Error failing run with no registered executor",
-                run_id=run.id,
-                action_type=action_type,
+                "Error occurred while trying to acknowledge run",
                 error=str(e),
             )
+            raise
+
+        await ocean.port_client.report_run_completed(
+            run,
+            success=False,
+            message=f"No executor registered for action type '{action_type}'",
+            should_raise=False,
+        )
 
     async def _get_queues_size(self) -> int:
         """

--- a/port_ocean/exceptions/execution_manager.py
+++ b/port_ocean/exceptions/execution_manager.py
@@ -14,14 +14,6 @@ class RunAlreadyAcknowledgedError(Exception):
     pass
 
 
-class PartitionKeyNotFoundError(Exception):
-    """
-    Raised when attempting to extract a partition key that is not found in the invocation payload.
-    """
-
-    pass
-
-
 class ActionExecutionError(Exception):
     """
     Raised by integration executors for expected action failures such as invalid

--- a/port_ocean/tests/core/handlers/actions/test_execution_manager.py
+++ b/port_ocean/tests/core/handlers/actions/test_execution_manager.py
@@ -573,15 +573,28 @@ class TestExecutionManager:
         )
 
     @pytest.mark.asyncio
-    async def test_poll_action_runs_should_skip_unregistered_actions(
+    async def test_poll_action_runs_should_ack_and_fail_unregistered_actions(
         self, execution_manager: ExecutionManager, mock_port_client: MagicMock
     ) -> None:
         # Arrange
         execution_manager._high_watermark = 10
         execution_manager._poll_check_interval_seconds = 0
-        mock_port_client.claim_pending_runs.side_effect = lambda limit, visibility_timeout_ms, exclude_action_identifiers=None, exclude_wf_nodes_uid=None: [
-            generate_mock_action_run(action_type="unregistered_action")
-        ]
+        unregistered_run = generate_mock_action_run(action_type="unregistered_action")
+        claim_count = 0
+
+        async def claim_runs_once(
+            limit: int,
+            visibility_timeout_ms: int,
+            exclude_action_identifiers: list[str] | None = None,
+            exclude_wf_nodes_uid: list[str] | None = None,
+        ) -> list[ActionRun]:
+            nonlocal claim_count
+            claim_count += 1
+            if claim_count == 1:
+                return [unregistered_run]
+            return []
+
+        mock_port_client.claim_pending_runs.side_effect = claim_runs_once
 
         # Act
         polling_task: asyncio.Task[None] = asyncio.create_task(
@@ -592,6 +605,13 @@ class TestExecutionManager:
 
         # Assert
         assert await execution_manager._get_queues_size() == 0
+        mock_port_client.acknowledge_run.assert_called_once_with(unregistered_run)
+        mock_port_client.report_run_completed.assert_called_once_with(
+            unregistered_run,
+            success=False,
+            message="No executor registered for action type 'unregistered_action'",
+            should_raise=False,
+        )
 
     @pytest.mark.asyncio
     async def test_shutdown_should_cancel_polling_and_waits_for_workers(

--- a/port_ocean/tests/core/handlers/actions/test_execution_manager.py
+++ b/port_ocean/tests/core/handlers/actions/test_execution_manager.py
@@ -572,14 +572,22 @@ class TestExecutionManager:
             == execution_manager._high_watermark
         )
 
+    @pytest.mark.parametrize(
+        "generate_run",
+        [generate_mock_action_run, generate_mock_wf_node_run],
+        ids=["action_run", "workflow_node_run"],
+    )
     @pytest.mark.asyncio
     async def test_poll_action_runs_should_ack_and_fail_unregistered_actions(
-        self, execution_manager: ExecutionManager, mock_port_client: MagicMock
+        self,
+        execution_manager: ExecutionManager,
+        mock_port_client: MagicMock,
+        generate_run: Any,
     ) -> None:
         # Arrange
         execution_manager._high_watermark = 10
         execution_manager._poll_check_interval_seconds = 0
-        unregistered_run = generate_mock_action_run(action_type="unregistered_action")
+        unregistered_run = generate_run(action_type="unregistered_action")
         claim_count = 0
 
         async def claim_runs_once(
@@ -587,7 +595,7 @@ class TestExecutionManager:
             visibility_timeout_ms: int,
             exclude_action_identifiers: list[str] | None = None,
             exclude_wf_nodes_uid: list[str] | None = None,
-        ) -> list[ActionRun]:
+        ) -> list[ActionRun | WorkflowNodeRun]:
             nonlocal claim_count
             claim_count += 1
             if claim_count == 1:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.44.11"
+version = "0.44.12"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
## Summary
- When `ExecutionManager` claims a run for an action type with no registered executor, acknowledge it and report it as failed instead of skipping until the visibility timeout expires
- Extract `_ack_and_fail_run_without_executor` helper and update unit test coverage

Port task: https://app.getport.io/taskEntity?identifier=task_ti3va0

## Test plan
- [x] `poetry run pytest port_ocean/tests/core/handlers/actions/test_execution_manager.py::TestExecutionManager::test_poll_action_runs_should_ack_and_fail_unregistered_actions`
- [ ] Verify an integration with a missing executor fails the run in Port with a clear error message


Made with [Cursor](https://cursor.com)