### PR TITLE
[Integration][Wiz] Convert options models to pydantic

### DIFF
--- a/integrations/wiz/CHANGELOG.md
+++ b/integrations/wiz/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.2.89 (2026-07-14)
+
+
+### Improvements
+
+- Convert TypedDict options to Pydantic models
+
+
 ## 0.2.88 (2026-07-14)
 
 

--- a/integrations/wiz/pyproject.toml
+++ b/integrations/wiz/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "wiz"
-version = "0.2.88"
+version = "0.2.89"
 description = "Wiz Port integration in Ocean"
 authors = ["Albert Luganga <albertluganga@getport.io>"]
 

--- a/integrations/wiz/tests/test_client.py
+++ b/integrations/wiz/tests/test_client.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, AsyncGenerator, List, cast
+from typing import Any, AsyncGenerator, List
 from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from port_ocean.context.ocean import initialize_port_ocean_context
@@ -185,11 +185,11 @@ async def test_get_vulnerability_findings_with_filters(
     mock_wiz_client: WizClient,
 ) -> None:
     """Test that get_vulnerability_findings calls _get_paginated_resources with user overridden params."""
-    options: VulnerabilityFindingOptions = {
-        "status_list": ["OPEN"],
-        "severity_list": ["CRITICAL"],
-        "max_pages": 2,
-    }
+    options = VulnerabilityFindingOptions(
+        status_list=["OPEN"],
+        severity_list=["CRITICAL"],
+        max_pages=2,
+    )
 
     mock_findings = [{"id": "vuln1", "name": "Vulnerability 1"}]
 
@@ -223,7 +223,7 @@ async def test_get_vulnerability_findings_without_filters(
     mock_wiz_client: WizClient,
 ) -> None:
     """Test that get_vulnerability_findings calls _get_paginated_resources with default params."""
-    options = cast(VulnerabilityFindingOptions, {})
+    options = VulnerabilityFindingOptions(max_pages=500)
 
     with patch.object(
         mock_wiz_client,
@@ -242,7 +242,7 @@ async def test_get_vulnerability_findings_without_filters(
                 "first": 100,
                 "filterBy": {},
             },
-            max_pages=None,
+            max_pages=500,
         )
 
 
@@ -359,10 +359,10 @@ async def test_build_sbom_artifact_resource_filter_maps_supported_fields(
 async def test_get_sbom_artifacts_filters_groups_without_capping_max_pages(
     mock_wiz_client: WizClient,
 ) -> None:
-    options: SbomArtifactOptions = {
-        "group_list": ["CODE_LIBRARY"],
-        "max_pages": 999,
-    }
+    options = SbomArtifactOptions(
+        group_list=["CODE_LIBRARY"],
+        max_pages=999,
+    )
     grouped_nodes = [
         {
             "id": "group-1",
@@ -496,10 +496,10 @@ async def test_get_sbom_artifacts_for_grouped_name_adds_resource_filter(
 async def test_get_sbom_artifacts_wraps_group_fetches_with_semaphore(
     mock_wiz_client: WizClient,
 ) -> None:
-    options: SbomArtifactOptions = {
-        "group_list": ["CODE_LIBRARY"],
-        "max_pages": 1,
-    }
+    options = SbomArtifactOptions(
+        group_list=["CODE_LIBRARY"],
+        max_pages=1,
+    )
     grouped_nodes = [
         {
             "id": "group-1",

--- a/integrations/wiz/wiz/client.py
+++ b/integrations/wiz/wiz/client.py
@@ -210,7 +210,7 @@ class WizClient:
         variables.update(self._enrich_variables_with_issue_options(variables, options))
 
         async for issues in self._get_paginated_resources(
-            resource="issues", variables=variables, max_pages=options["max_pages"]
+            resource="issues", variables=variables, max_pages=options.max_pages
         ):
             yield issues
 
@@ -229,11 +229,11 @@ class WizClient:
             "filterBy": {},
         }
 
-        if options["include_archived"]:
-            variables["filterBy"]["includeArchived"] = options["include_archived"]
+        if options.include_archived:
+            variables["filterBy"]["includeArchived"] = options.include_archived
 
-        if options["impact"]:
-            variables["filterBy"]["impact"] = options["impact"]
+        if options.impact:
+            variables["filterBy"]["impact"] = options.impact
 
         async for projects in self._get_paginated_resources(
             resource="projects", variables=variables
@@ -266,13 +266,13 @@ class WizClient:
         if "filterBy" not in variables:
             variables["filterBy"] = {}
 
-        variables["filterBy"]["status"] = options["status_list"]
+        variables["filterBy"]["status"] = options.status_list
 
-        if options["severity_list"]:
-            variables["filterBy"]["severity"] = options["severity_list"]
+        if options.severity_list:
+            variables["filterBy"]["severity"] = options.severity_list
 
-        if options["type_list"]:
-            variables["filterBy"]["type"] = options["type_list"]
+        if options.type_list:
+            variables["filterBy"]["type"] = options.type_list
 
         return variables
 
@@ -286,16 +286,16 @@ class WizClient:
             "filterBy": {},
         }
 
-        if options.get("status_list"):
-            variables["filterBy"]["status"] = options["status_list"]
+        if options.status_list:
+            variables["filterBy"]["status"] = options.status_list
 
-        if options.get("severity_list"):
-            variables["filterBy"]["severity"] = options["severity_list"]
+        if options.severity_list:
+            variables["filterBy"]["severity"] = options.severity_list
 
         async for findings in self._get_paginated_resources(
             resource="vulnerabilityFindings",
             variables=variables,
-            max_pages=options.get("max_pages"),
+            max_pages=options.max_pages,
         ):
             yield findings
 
@@ -455,10 +455,10 @@ class WizClient:
         options: SbomArtifactOptions,
         page_size: int = PAGE_SIZE,
     ) -> AsyncGenerator[list[dict[str, Any]], None]:
-        max_pages = options.get("max_pages", 500)
-        selected_groups = set(options.get("group_list") or [])
+        max_pages = options.max_pages
+        selected_groups = set(options.group_list or [])
         resource_filter = self._build_sbom_artifact_resource_filter(
-            options.get("resource_filter")
+            options.resource_filter
         )
         allow_all_groups = not selected_groups
 

--- a/integrations/wiz/wiz/options.py
+++ b/integrations/wiz/wiz/options.py
@@ -1,6 +1,6 @@
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 
 class IssueOptions(BaseModel):

--- a/integrations/wiz/wiz/options.py
+++ b/integrations/wiz/wiz/options.py
@@ -22,8 +22,8 @@ class ProjectOptions(BaseModel):
 
 class VulnerabilityFindingOptions(BaseModel):
     max_pages: int
-    status_list: list[Literal["OPEN", "IN_PROGRESS", "RESOLVED", "REJECTED"]] = Field(
-        default=None,  # type: ignore[arg-type]
+    status_list: list[Literal["OPEN", "IN_PROGRESS", "RESOLVED", "REJECTED"]] | None = (
+        None
     )
     severity_list: list[Literal["LOW", "MEDIUM", "HIGH", "CRITICAL", "NONE"]] | None = (
         None

--- a/integrations/wiz/wiz/options.py
+++ b/integrations/wiz/wiz/options.py
@@ -1,49 +1,47 @@
-from typing import Any, List, Literal, TypedDict, Required, NotRequired, Optional
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
 
 
-class IssueOptions(TypedDict):
-    max_pages: Required[int]
-    status_list: Required[List[Literal["OPEN", "IN_PROGRESS", "RESOLVED", "REJECTED"]]]
-    severity_list: NotRequired[
-        Optional[List[Literal["LOW", "MEDIUM", "HIGH", "CRITICAL", "INFORMATIONAL"]]]
-    ]
-    type_list: NotRequired[
-        Optional[
-            List[
-                Literal["TOXIC_COMBINATION", "THREAT_DETECTION", "CLOUD_CONFIGURATION"]
+class IssueOptions(BaseModel):
+    max_pages: int
+    status_list: list[Literal["OPEN", "IN_PROGRESS", "RESOLVED", "REJECTED"]]
+    severity_list: (
+        list[Literal["LOW", "MEDIUM", "HIGH", "CRITICAL", "INFORMATIONAL"]] | None
+    ) = None
+    type_list: (
+        list[Literal["TOXIC_COMBINATION", "THREAT_DETECTION", "CLOUD_CONFIGURATION"]]
+        | None
+    ) = None
+
+
+class ProjectOptions(BaseModel):
+    include_archived: bool | None = None
+    impact: Literal["LBI", "MBI", "HBI"] | None = None
+
+
+class VulnerabilityFindingOptions(BaseModel):
+    max_pages: int
+    status_list: list[Literal["OPEN", "IN_PROGRESS", "RESOLVED", "REJECTED"]] = Field(
+        default=None,  # type: ignore[arg-type]
+    )
+    severity_list: list[Literal["LOW", "MEDIUM", "HIGH", "CRITICAL", "NONE"]] | None = (
+        None
+    )
+
+
+class SbomArtifactOptions(BaseModel):
+    max_pages: int
+    group_list: (
+        list[
+            Literal[
+                "CODE_LIBRARY",
+                "OS_PACKAGE",
+                "PLUGIN",
+                "CUSTOM",
+                "CI_COMPONENT",
             ]
         ]
-    ]
-
-
-class ProjectOptions(TypedDict):
-    include_archived: NotRequired[Optional[bool]]
-    impact: NotRequired[Optional[Literal["LBI", "MBI", "HBI"]]]
-
-
-class VulnerabilityFindingOptions(TypedDict):
-    max_pages: Required[int]
-    status_list: NotRequired[
-        List[Literal["OPEN", "IN_PROGRESS", "RESOLVED", "REJECTED"]]
-    ]
-    severity_list: NotRequired[
-        Optional[List[Literal["LOW", "MEDIUM", "HIGH", "CRITICAL", "NONE"]]]
-    ]
-
-
-class SbomArtifactOptions(TypedDict):
-    max_pages: Required[int]
-    group_list: NotRequired[
-        Optional[
-            List[
-                Literal[
-                    "CODE_LIBRARY",
-                    "OS_PACKAGE",
-                    "PLUGIN",
-                    "CUSTOM",
-                    "CI_COMPONENT",
-                ]
-            ]
-        ]
-    ]
-    resource_filter: NotRequired[Optional[dict[str, Any]]]
+        | None
+    ) = None
+    resource_filter: dict[str, Any] | None = None


### PR DESCRIPTION
# Description

What -

Why -

How -

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all Wiz API fetch paths that build GraphQL variables from options; optional fields and `max_pages` handling changed slightly (no SBOM default of 500 in the client), so misconfigured resync selectors could behave differently until validated at construction time.
> 
> **Overview**
> Replaces Wiz resync/client **option bags** (`IssueOptions`, `ProjectOptions`, `VulnerabilityFindingOptions`, `SbomArtifactOptions`) from `TypedDict` with **Pydantic `BaseModel`** classes in `options.py`, keeping the same fields and literal unions.
> 
> **`WizClient`** now reads options via attributes (e.g. `options.max_pages`, `options.status_list`) instead of dict keys/`.get()`, including issues, projects, vulnerability findings, and SBOM artifact flows. SBOM pagination no longer applies an in-client default of `500` for `max_pages`—it uses the value on the model (call sites like resync already pass `max_pages`).
> 
> Tests construct options with model constructors and assert pagination args accordingly (e.g. vulnerability findings with empty filters expect `max_pages=500` when that is what the model is built with).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a076b7e75045b64dfef30c7874a597a953c27cfc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->