### PR TITLE
[Integration][Aikido] Increased issues page size to 1000 and added issue selector filters

### DIFF
--- a/integrations/aikido/CHANGELOG.md
+++ b/integrations/aikido/CHANGELOG.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Improvements
 
-- Added `IssueSelector` to the issues kind configuration, exposing three server-side filter fields: `filterStatus` (open/ignored/snoozed/closed/all), `filterSeverities` (critical/high/medium/low, multi-select), and `filterIssueType` (open_source, sast, iac, and others). Users can set these in their Port integration config to sync only the issues they care about.
-- Increased `ISSUES_PAGE_SIZE` from 100 to 1000, reducing the number of API requests for a 350k-issue resync from ~3,500 to ~350 and cutting expected sync time from ~9 hours to ~23 minutes.
+- Added `IssueSelector` to the issues kind configuration, exposing three server-side filter fields: `filterStatus`, `filterSeverities`, and `filterIssueType`. Users can set these in their Port integration config to sync only the issues they care about.
+- Increased `ISSUES_PAGE_SIZE` from 100 to 1000, reducing the number of API requests and sync time.
 
 
 ## 0.2.21 (2026-07-16)

--- a/integrations/aikido/CHANGELOG.md
+++ b/integrations/aikido/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.3.0 (2026-07-14)
+
+
+### Improvements
+
+- Added `IssueSelector` to the issues kind configuration, exposing three server-side filter fields: `filterStatus` (open/ignored/snoozed/closed/all), `filterSeverities` (critical/high/medium/low, multi-select), and `filterIssueType` (open_source, sast, iac, and others). Users can set these in their Port integration config to sync only the issues they care about.
+- Increased `ISSUES_PAGE_SIZE` from 100 to 1000, reducing the number of API requests for a 350k-issue resync from ~3,500 to ~350 and cutting expected sync time from ~9 hours to ~23 minutes.
+
+
 ## 0.2.17 (2026-07-14)
 
 

--- a/integrations/aikido/clients/aikido_client.py
+++ b/integrations/aikido/clients/aikido_client.py
@@ -2,7 +2,11 @@ from typing import Any, AsyncGenerator, List, Dict, Optional
 from httpx import HTTPStatusError, AsyncClient, Response
 from aiolimiter import AsyncLimiter
 from clients.auth_client import AikidoAuth
-from clients.options import ListRepositoriesOptions, ListContainersOptions
+from clients.options import (
+    ListRepositoriesOptions,
+    ListContainersOptions,
+    IssuesOptions,
+)
 from helpers.utils import IgnoredError
 from loguru import logger
 from port_ocean.utils import http_async_client
@@ -11,7 +15,7 @@ API_VERSION = "v1"
 FIRST_PAGE = 0
 PAGE_SIZE = 20
 REPOSITORIES_PAGE_SIZE = 100
-ISSUES_PAGE_SIZE = 100
+ISSUES_PAGE_SIZE = 1000
 REQUESTS_PER_MINUTE = 15
 
 ISSUES_ENDPOINT = f"api/public/{API_VERSION}/issues/export"
@@ -174,13 +178,19 @@ class AikidoClient:
         ):
             yield repositories
 
-    async def get_issues(self) -> AsyncGenerator[List[Dict[str, Any]], None]:
+    async def get_issues(
+        self, options: Optional[IssuesOptions] = None
+    ) -> AsyncGenerator[List[Dict[str, Any]], None]:
+        base_params: Dict[str, Any] = {
+            "format": "json",
+            **(options.model_dump(exclude_none=True) if options else {}),
+        }
         async for issues in self.get_paginated_resource(
             endpoint=ISSUES_ENDPOINT,
             resource_name="issues",
             first_page=FIRST_PAGE,
             page_size=ISSUES_PAGE_SIZE,
-            base_params={"format": "json"},
+            base_params=base_params,
         ):
             yield issues
 

--- a/integrations/aikido/clients/literals.py
+++ b/integrations/aikido/clients/literals.py
@@ -1,0 +1,21 @@
+from typing import Literal
+
+IssueStatusLiteral = Literal["all", "open", "ignored", "snoozed", "closed"]
+IssueSeverityLiteral = Literal["critical", "high", "medium", "low"]
+IssueTypeLiteral = Literal[
+    "open_source",
+    "leaked_secret",
+    "cloud",
+    "sast",
+    "iac",
+    "docker_container",
+    "cloud_instance",
+    "surface_monitoring",
+    "malware",
+    "eol",
+    "mobile",
+    "scm_security",
+    "ai_pentest",
+    "license",
+    "app_level_open_source",
+]

--- a/integrations/aikido/clients/options.py
+++ b/integrations/aikido/clients/options.py
@@ -1,4 +1,8 @@
-from typing import Literal, TypedDict
+from typing import Literal, Optional, TypedDict
+
+from pydantic import BaseModel
+
+from clients.literals import IssueStatusLiteral, IssueTypeLiteral
 
 
 class ListRepositoriesOptions(TypedDict):
@@ -7,3 +11,9 @@ class ListRepositoriesOptions(TypedDict):
 
 class ListContainersOptions(TypedDict):
     filter_status: Literal["all", "active", "inactive"]
+
+
+class IssuesOptions(BaseModel):
+    filter_status: Optional[IssueStatusLiteral] = None
+    filter_severities: Optional[str] = None  # comma-joined list e.g. "critical,high"
+    filter_issue_type: Optional[IssueTypeLiteral] = None

--- a/integrations/aikido/integration.py
+++ b/integrations/aikido/integration.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import List, Literal, Optional
 
 from pydantic.v1 import Field
 from port_ocean.core.integrations.base import BaseIntegration
@@ -8,6 +8,7 @@ from port_ocean.core.handlers.port_app_config.models import (
     ResourceConfig,
     Selector,
 )
+from clients.literals import IssueStatusLiteral, IssueSeverityLiteral, IssueTypeLiteral
 
 
 class ObjectKind:
@@ -58,10 +59,35 @@ class ContainerResourceConfig(ResourceConfig):
     )
 
 
+class IssueSelector(Selector):
+    filter_status: IssueStatusLiteral = Field(
+        default="all",
+        alias="filterStatus",
+        title="Status",
+        description="Filter issues by status.",
+    )
+    filter_severities: Optional[List[IssueSeverityLiteral]] = Field(
+        default=None,
+        alias="filterSeverities",
+        title="Severities",
+        description="Filter issues by one or more severities. Multiple values are combined with OR.",
+    )
+    filter_issue_type: Optional[IssueTypeLiteral] = Field(
+        default=None,
+        alias="filterIssueType",
+        title="Issue type",
+        description="Filter issues by type.",
+    )
+
+
 class IssueResourceConfig(ResourceConfig):
     kind: Literal["issues"] = Field(
         title="Aikido Issue",
         description="Aikido issue resource kind.",
+    )
+    selector: IssueSelector = Field(
+        title="Issue Selector",
+        description="Selector for the Aikido issue resource.",
     )
 
 

--- a/integrations/aikido/main.py
+++ b/integrations/aikido/main.py
@@ -5,10 +5,15 @@ from port_ocean.context.ocean import ocean
 from port_ocean.context.event import event
 from port_ocean.helpers.retry import RetryConfig, register_retry_config_callback
 
-from clients.options import ListRepositoriesOptions, ListContainersOptions
+from clients.options import (
+    ListRepositoriesOptions,
+    ListContainersOptions,
+    IssuesOptions,
+)
 from initialize_client import init_aikido_client
 from integration import (
     ObjectKind,
+    IssueResourceConfig,
     RepositoryResourceConfig,
     ContainerResourceConfig,
     IssueGroupResourceConfig,
@@ -47,8 +52,16 @@ async def on_repositories_resync(
 @ocean.on_resync(ObjectKind.ISSUES)
 async def on_issues_resync(kind: str) -> AsyncGenerator[list[dict[str, Any]], None]:
     client = init_aikido_client()
+    selector = cast(IssueResourceConfig, event.resource_config).selector
+    options = IssuesOptions(
+        filter_status=selector.filter_status,
+        filter_severities=(
+            ",".join(selector.filter_severities) if selector.filter_severities else None
+        ),
+        filter_issue_type=selector.filter_issue_type,
+    )
     logger.info("Fetching all issues from Aikido API")
-    async for issue_batch in client.get_issues():
+    async for issue_batch in client.get_issues(options=options):
         logger.info(f"Yielding issues batch of size: {len(issue_batch)}")
         yield issue_batch
 

--- a/integrations/aikido/pyproject.toml
+++ b/integrations/aikido/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aikido"
-version = "0.2.17"
+version = "0.3.0"
 description = "Aikido Ocean Integation"
 authors = ["Habib Nuhu <habib.nuhu@getport.io>"]
 

--- a/integrations/aikido/tests/clients/test_aikido_client.py
+++ b/integrations/aikido/tests/clients/test_aikido_client.py
@@ -16,7 +16,11 @@ from clients.aikido_client import (
     TEAMS_ENDPOINT,
     CONTAINERS_ENDPOINT,
 )
-from clients.options import ListRepositoriesOptions, ListContainersOptions
+from clients.options import (
+    ListRepositoriesOptions,
+    ListContainersOptions,
+    IssuesOptions,
+)
 from helpers.exceptions import (
     MissingIntegrationCredentialException,
 )
@@ -570,6 +574,73 @@ async def test_get_issues_paginates(aikido_client: AikidoClient) -> None:
     assert captured_kwargs["endpoint"] == ISSUES_ENDPOINT
     assert captured_kwargs["page_size"] == ISSUES_PAGE_SIZE
     assert captured_kwargs["base_params"] == {"format": "json"}
+
+
+@pytest.mark.asyncio
+async def test_get_issues_passes_filter_status(aikido_client: AikidoClient) -> None:
+    captured_kwargs: dict[str, Any] = {}
+
+    async def _mock_paginated(**kwargs: Any) -> Any:
+        captured_kwargs.update(kwargs)
+        yield [{"id": "1"}]
+
+    with patch.object(aikido_client, "get_paginated_resource", new=_mock_paginated):
+        async for _ in aikido_client.get_issues(
+            options=IssuesOptions(filter_status="open")
+        ):
+            pass
+
+    assert captured_kwargs["base_params"] == {"format": "json", "filter_status": "open"}
+
+
+@pytest.mark.asyncio
+async def test_get_issues_passes_multiple_severities(
+    aikido_client: AikidoClient,
+) -> None:
+    captured_kwargs: dict[str, Any] = {}
+
+    async def _mock_paginated(**kwargs: Any) -> Any:
+        captured_kwargs.update(kwargs)
+        yield [{"id": "1"}]
+
+    with patch.object(aikido_client, "get_paginated_resource", new=_mock_paginated):
+        async for _ in aikido_client.get_issues(
+            options=IssuesOptions(filter_severities="critical,high")
+        ):
+            pass
+
+    assert captured_kwargs["base_params"] == {
+        "format": "json",
+        "filter_severities": "critical,high",
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_issues_passes_combined_filters(
+    aikido_client: AikidoClient,
+) -> None:
+    captured_kwargs: dict[str, Any] = {}
+
+    async def _mock_paginated(**kwargs: Any) -> Any:
+        captured_kwargs.update(kwargs)
+        yield [{"id": "1"}]
+
+    with patch.object(aikido_client, "get_paginated_resource", new=_mock_paginated):
+        async for _ in aikido_client.get_issues(
+            options=IssuesOptions(
+                filter_status="open",
+                filter_severities="critical,high",
+                filter_issue_type="sast",
+            )
+        ):
+            pass
+
+    assert captured_kwargs["base_params"] == {
+        "format": "json",
+        "filter_status": "open",
+        "filter_severities": "critical,high",
+        "filter_issue_type": "sast",
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description

What - Increased `ISSUES_PAGE_SIZE` from 100 to 1000 and added `IssueSelector` to the issues kind, exposing `filterStatus`, `filterSeverities`, and `filterIssueType` as server-side filter options.

Why - A full resync of issues takes long due to large API requests at page size 100. Raising the page size to 1000 brings this down. The selector filters let users narrow what gets synced, further reducing request count and ingested entity volume.

How - Added `IssueSelector` (Pydantic model) to `integration.py` with three optional filter fields wired through `IssuesOptions` in the client. The `on_issues_resync` handler reads the selector and passes the built options into `get_issues()`. Shared literal types are extracted to `clients/literals.py`.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

## API Documentation

https://developer.aikido.dev/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Narrowing issue filters changes which entities are synced and can cause reconciliation to drop Port entities that no longer match the export scope; larger pages also increase per-request payload size.
> 
> **Overview**
> **Aikido issues resync** is faster and configurable: `ISSUES_PAGE_SIZE` goes from **100 to 1000**, and the issues kind gets an **`IssueSelector`** so Port config can pass **server-side** filters into `issues/export`.
> 
> Users can set **`filterStatus`**, multi-select **`filterSeverities`** (joined as a comma list for the API), and **`filterIssueType`** in the integration resource config. **`on_issues_resync`** reads the selector, builds **`IssuesOptions`**, and **`get_issues()`** merges those params with `format=json` for pagination. Shared filter literals live in **`clients/literals.py`**.
> 
> Release **0.3.0** and changelog/tests cover the new query params and the larger page size.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bb0cf843f635f3b93660ccaffcfd4ad4efbcb9d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->