### PR TITLE
[Integration][Github] Handle situation where we encounter rate-limit errors on GraphQL api with 200 status code

### DIFF
--- a/integrations/github/CHANGELOG.md
+++ b/integrations/github/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 6.2.17 (2026-07-15)
+
+
+### Improvements
+
+- Properly handle GraphQL rate-limit responses with bounded retry logic (max 5 attempts) and sleep-until-reset backoff
+- Detect both primary rate limits (HTTP 200 with exhausted x-ratelimit-* headers) and secondary rate limits (retry-after header)
+
+
 ## 6.2.16 (2026-07-14)
 
 

--- a/integrations/github/github/actions/update_repo_external_custom_properties_executor.py
+++ b/integrations/github/github/actions/update_repo_external_custom_properties_executor.py
@@ -4,7 +4,7 @@ import httpx
 from loguru import logger
 
 from github.actions.abstract_github_executor import AbstractGithubExecutor
-from github.clients.rate_limiter.utils import is_rate_limit_response
+from github.clients.rate_limiter.utils import is_rest_rate_limit_response
 from github.helpers.exceptions import InvalidActionParametersException
 from port_ocean.context.ocean import ocean
 from port_ocean.core.models import IntegrationRun
@@ -76,8 +76,9 @@ class UpdateRepoExternalCustomPropertiesExecutor(AbstractGithubExecutor):
             except Exception as e:
                 error_message = str(e)
                 if isinstance(e, httpx.HTTPStatusError):
-                    if e.response.status_code == 403 and not is_rate_limit_response(
-                        e.response
+                    if (
+                        e.response.status_code == 403
+                        and not is_rest_rate_limit_response(e.response)
                     ):
                         raise ActionExecutionError(
                             "Missing external custom properties write permission on the organization. "

--- a/integrations/github/github/clients/auth/abstract_authenticator.py
+++ b/integrations/github/github/clients/auth/abstract_authenticator.py
@@ -68,7 +68,10 @@ class AbstractGitHubAuthenticator(ABC):
         return (await self.get_headers()).as_dict()
 
     def _make_client(
-        self, extra_retryable_methods: frozenset[str] = frozenset()
+        self,
+        *,
+        extra_retryable_methods: frozenset[str] = frozenset(),
+        extra_retryable_status: frozenset[int] = frozenset(),
     ) -> httpx.AsyncClient:
         default_methods = frozenset(
             ["HEAD", "GET", "PUT", "DELETE", "OPTIONS", "TRACE"]
@@ -79,7 +82,8 @@ class AbstractGitHubAuthenticator(ABC):
                 "X-RateLimit-Reset",
             ],
             retryable_methods=default_methods | extra_retryable_methods,
-            additional_retry_status_codes=[HTTPStatus.INTERNAL_SERVER_ERROR, 499],
+            additional_retry_status_codes={HTTPStatus.INTERNAL_SERVER_ERROR, 499}
+            | extra_retryable_status,
             ignore_retry_after_status_codes=[
                 HTTPStatus.INTERNAL_SERVER_ERROR,
                 HTTPStatus.BAD_GATEWAY,

--- a/integrations/github/github/clients/auth/retry_transport.py
+++ b/integrations/github/github/clients/auth/retry_transport.py
@@ -7,7 +7,7 @@ from loguru import logger
 
 from port_ocean.helpers.retry import RetryConfig, RetryTransport
 from github.clients.constants import GRAPHQL_SENT_VARIABLES_EXTENSION
-from github.clients.rate_limiter.utils import is_rate_limit_response
+from github.clients.rate_limiter.utils import is_rest_rate_limit_response
 
 
 # Gateway errors that signal a query exceeded GitHub's GraphQL execution budget:
@@ -190,7 +190,7 @@ class GitHubRetryTransport(RetryTransport):
         response: httpx.Response,
         attempt: int,
     ) -> None:
-        if is_rate_limit_response(response) and self._rate_limit_notifier:
+        if is_rest_rate_limit_response(response) and self._rate_limit_notifier:
             await self._rate_limit_notifier(response)
 
         if self._is_graphql_request(request):
@@ -205,7 +205,7 @@ class GitHubRetryTransport(RetryTransport):
         response: Optional[httpx.Response],
         error: Optional[Exception],
     ) -> None:
-        if response and is_rate_limit_response(response):
+        if response and is_rest_rate_limit_response(response):
             logger.bind(
                 remaining=response.headers.get("x-ratelimit-remaining"),
                 limit=response.headers.get("x-ratelimit-limit"),
@@ -285,11 +285,11 @@ class GitHubRetryTransport(RetryTransport):
     async def _should_retry_async(self, response: httpx.Response) -> bool:
         if self._page_reduction_exhausted(response):
             return False
-        return await super()._should_retry_async(response) or is_rate_limit_response(
+        return await super()._should_retry_async(
             response
-        )
+        ) or is_rest_rate_limit_response(response)
 
     def _should_retry(self, response: httpx.Response) -> bool:
         if self._page_reduction_exhausted(response):
             return False
-        return super()._should_retry(response) or is_rate_limit_response(response)
+        return super()._should_retry(response) or is_rest_rate_limit_response(response)

--- a/integrations/github/github/clients/http/graphql_client.py
+++ b/integrations/github/github/clients/http/graphql_client.py
@@ -20,8 +20,7 @@ from github.helpers.exceptions import (
 from github.helpers.utils import IgnoredError
 from github.clients.rate_limiter.utils import (
     GitHubRateLimiterConfig,
-    is_graphql_rate_limit_response,
-    RateLimitInfo,
+    extract_graphql_rate_limit_info,
 )
 from urllib.parse import urlparse, urlunparse
 
@@ -75,13 +74,8 @@ class GithubGraphQLClient(AbstractGithubClient):
         query_path: Optional[str] = None,
         query_params: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
-        if is_graphql_rate_limit_response(response):
-            limit = int(response.headers.get("x-ratelimit-limit", 0))
-            remaining = int(response.headers.get("x-ratelimit-remaining", 0))
-            reset_time = int(response.headers.get("x-ratelimit-reset", 0))
-            rate_limit_info = RateLimitInfo(
-                remaining=remaining, reset_time=reset_time, limit=limit
-            )
+        rate_limit_info = extract_graphql_rate_limit_info(response)
+        if rate_limit_info is not None:
             raise RateLimitException(rate_limit_info)
 
         try:

--- a/integrations/github/github/clients/http/graphql_client.py
+++ b/integrations/github/github/clients/http/graphql_client.py
@@ -1,3 +1,5 @@
+import asyncio
+from json import JSONDecodeError
 from typing import Any, AsyncGenerator, Dict, List, Optional
 
 import httpx
@@ -9,9 +11,17 @@ from github.clients.auth.retry_transport import (
 )
 from github.clients.constants import GRAPHQL_SENT_VARIABLES_EXTENSION
 from github.clients.http.base_client import AbstractGithubClient
-from github.helpers.exceptions import GraphQLClientError, GraphQLErrorGroup
+from github.helpers.exceptions import (
+    GraphQLClientError,
+    GraphQLErrorGroup,
+    RateLimitException,
+)
 from github.helpers.utils import IgnoredError
-from github.clients.rate_limiter.utils import GitHubRateLimiterConfig
+from github.clients.rate_limiter.utils import (
+    GitHubRateLimiterConfig,
+    is_graphql_rate_limit_response,
+    RateLimitInfo,
+)
 from urllib.parse import urlparse, urlunparse
 
 PAGE_SIZE = 25
@@ -61,7 +71,25 @@ class GithubGraphQLClient(AbstractGithubClient):
         query_path: Optional[str] = None,
         query_params: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
-        body = response.json()
+        if is_graphql_rate_limit_response(response):
+            limit = int(response.headers.get("x-ratelimit-limit", 0))
+            remaining = int(response.headers.get("x-ratelimit-remaining", 0))
+            reset_time = int(response.headers.get("x-ratelimit-reset", 0))
+            rate_limit_info = RateLimitInfo(
+                remaining=remaining, reset_time=reset_time, limit=limit
+            )
+            raise RateLimitException(rate_limit_info)
+
+        try:
+            body = response.json()
+        except JSONDecodeError:
+            # Empty/non-JSON 2xx response; treat as no data instead of failing
+            logger.warning(
+                f"[GraphQL] Empty or non-JSON response body (status "
+                f"{response.status_code}) for path {query_path}; treating as no data"
+            )
+            return {}
+
         if "errors" not in body:
             return body
 
@@ -116,21 +144,30 @@ class GithubGraphQLClient(AbstractGithubClient):
         query_path: Optional[str] = None,
         query_params: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
-        response = await self.make_request(
-            resource=resource,
-            params=params,
-            method=method,
-            json_data=json_data,
-            ignored_errors=ignored_errors,
-            ignore_default_errors=ignore_default_errors,
-            authenticator_headers_params=authenticator_headers_params,
-        )
-        return self._handle_graphql_errors(
-            response,
-            ignored_errors,
-            query_path=query_path,
-            query_params=query_params,
-        )
+        while True:
+            response = await self.make_request(
+                resource=resource,
+                params=params,
+                method=method,
+                json_data=json_data,
+                ignored_errors=ignored_errors,
+                ignore_default_errors=ignore_default_errors,
+                authenticator_headers_params=authenticator_headers_params,
+            )
+            try:
+                return self._handle_graphql_errors(
+                    response,
+                    ignored_errors,
+                    query_path=query_path,
+                    query_params=query_params,
+                )
+            except RateLimitException as exc:
+                sleep_time = exc.rate_limit_info.seconds_until_reset
+                logger.warning(
+                    f"[GraphQL] Rate limit exceeded for path {query_path}. "
+                    f"Sleeping for {sleep_time} seconds until {exc.rate_limit_info.reset_time}"
+                )
+                await asyncio.sleep(sleep_time)
 
     def build_graphql_payload(
         self,

--- a/integrations/github/github/clients/http/graphql_client.py
+++ b/integrations/github/github/clients/http/graphql_client.py
@@ -1,4 +1,5 @@
 import asyncio
+from http import HTTPStatus
 from json import JSONDecodeError
 from typing import Any, AsyncGenerator, Dict, List, Optional
 
@@ -50,7 +51,10 @@ class GithubGraphQLClient(AbstractGithubClient):
     @property
     def client(self) -> httpx.AsyncClient:
         if self._graphql_client is None:
-            self._graphql_client = self.authenticator._make_client(frozenset({"POST"}))
+            self._graphql_client = self.authenticator._make_client(
+                extra_retryable_methods=frozenset({"POST"}),
+                extra_retryable_status=frozenset({HTTPStatus.FORBIDDEN}),
+            )
         return self._graphql_client
 
     @property

--- a/integrations/github/github/clients/http/graphql_client.py
+++ b/integrations/github/github/clients/http/graphql_client.py
@@ -142,7 +142,9 @@ class GithubGraphQLClient(AbstractGithubClient):
         query_path: Optional[str] = None,
         query_params: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
-        while True:
+        max_retries = 5
+        retry_count = 0
+        while retry_count < max_retries:
             response = await self.make_request(
                 resource=resource,
                 params=params,
@@ -160,12 +162,23 @@ class GithubGraphQLClient(AbstractGithubClient):
                     query_params=query_params,
                 )
             except RateLimitException as exc:
+                retry_count += 1
+                if retry_count >= max_retries:
+                    logger.error(
+                        f"[GraphQL] Max retries ({max_retries}) exceeded for path {query_path}. "
+                        f"Rate limit reset at {exc.rate_limit_info.reset_time}"
+                    )
+                    raise
+
                 sleep_time = exc.rate_limit_info.seconds_until_reset
                 logger.warning(
-                    f"[GraphQL] Rate limit exceeded for path {query_path}. "
+                    f"[GraphQL] Rate limit exceeded for path {query_path} (attempt {retry_count}/{max_retries}). "
                     f"Sleeping for {sleep_time} seconds until {exc.rate_limit_info.reset_time}"
                 )
                 await asyncio.sleep(sleep_time)
+
+        # Unreachable: raised before loop exits
+        raise AssertionError("Rate limit retry loop should not exit normally")
 
     def build_graphql_payload(
         self,

--- a/integrations/github/github/clients/rate_limiter/limiter.py
+++ b/integrations/github/github/clients/rate_limiter/limiter.py
@@ -21,23 +21,17 @@ _DEFAULT_RATE_LIMIT_RESYNC_USAGE_THRESHOLD: float = 95.0
 class GitHubRateLimiter:
     def __init__(self, config: GitHubRateLimiterConfig) -> None:
         self.api_type = config.api_type
-        self._semaphore = asyncio.Semaphore(config.max_concurrent)
+        self._semaphore = asyncio.BoundedSemaphore(config.max_concurrent)
         self.rate_limit_info: Optional[RateLimitInfo] = None
         self._lock = asyncio.Lock()
         self._initialized: bool = False
 
     async def __aenter__(self) -> "GitHubRateLimiter":
+        # Enforce rate limit BEFORE acquiring semaphore so sleep doesn't hold up the permit
+        async with self._lock:
+            await self._enforce_rate_limit()
+
         await self._semaphore.acquire()
-        try:
-            async with self._lock:
-                await self._enforce_rate_limit()
-        except BaseException as ctx_error:
-            logger.debug(
-                "github:clients:rate_limiter:GitHubRateLimiter::Error occurred while enforcing rate limit: {error}",
-                error=ctx_error,
-            )
-            self._semaphore.release()
-            raise
         return self
 
     async def __aexit__(

--- a/integrations/github/github/clients/rate_limiter/limiter.py
+++ b/integrations/github/github/clients/rate_limiter/limiter.py
@@ -11,7 +11,8 @@ from github.clients.rate_limiter.utils import (
     GitHubRateLimiterConfig,
     RateLimitInfo,
     RateLimiterRequiredHeaders,
-    is_rate_limit_response,
+    is_graphql_rate_limit_response,
+    is_rest_rate_limit_response,
 )
 
 _DEFAULT_RATE_LIMIT_RESYNC_USAGE_THRESHOLD: float = 95.0
@@ -130,7 +131,11 @@ class GitHubRateLimiter:
         self._initialized = False
 
     def is_rate_limit_response(self, response: httpx.Response) -> bool:
-        return is_rate_limit_response(response)
+        match self.api_type:
+            case "graphql":
+                return is_graphql_rate_limit_response(response)
+            case _:
+                return is_rest_rate_limit_response(response)
 
     def _parse_rate_limit_headers(
         self, headers: RateLimiterRequiredHeaders

--- a/integrations/github/github/clients/rate_limiter/utils.py
+++ b/integrations/github/github/clients/rate_limiter/utils.py
@@ -1,4 +1,6 @@
 import time
+import calendar
+from datetime import datetime
 from typing import Optional, Dict, Literal
 from dataclasses import dataclass
 from pydantic.v1 import BaseModel, Field
@@ -67,3 +69,48 @@ class RateLimiterRequiredHeaders(BaseModel):
 
     def as_dict(self) -> Dict[str, str]:
         return self.dict(by_alias=True)
+
+
+def extract_graphql_rate_limit_info(
+    response: httpx.Response,
+) -> Optional[RateLimitInfo]:
+    """
+    Extract GraphQL rate-limit info from response headers.
+
+    Handles both primary rate limits (HTTP 200 with exhausted x-ratelimit-* headers)
+    and secondary rate limits (retry-after header on any response).
+    Returns RateLimitInfo if rate-limited, None otherwise.
+    """
+    # Check primary rate limit (exhausted headers)
+    if is_graphql_rate_limit_response(response):
+        limit = int(response.headers.get("x-ratelimit-limit", 0))
+        remaining = int(response.headers.get("x-ratelimit-remaining", 0))
+        reset_time = int(response.headers.get("x-ratelimit-reset", 0))
+        return RateLimitInfo(remaining=remaining, reset_time=reset_time, limit=limit)
+
+    # Check secondary rate limit (retry-after header)
+    retry_after = response.headers.get("retry-after")
+    if retry_after is not None:
+        retry_after_seconds = None
+        try:
+            retry_after_seconds = int(retry_after)
+        except ValueError:
+            try:
+                date_part = (
+                    retry_after.rsplit(" ", 1)[0] if " " in retry_after else retry_after
+                )
+                retry_time = datetime.strptime(date_part, "%a, %d %b %Y %H:%M:%S")
+                utc_timestamp = calendar.timegm(retry_time.timetuple())
+                retry_after_seconds = int(utc_timestamp - time.time())
+            except (ValueError, AttributeError, IndexError):
+                pass
+
+        if retry_after_seconds is not None and retry_after_seconds > 0:
+            reset_time = int(time.time()) + retry_after_seconds
+            return RateLimitInfo(
+                remaining=0,
+                reset_time=reset_time,
+                limit=1,
+            )
+
+    return None

--- a/integrations/github/github/clients/rate_limiter/utils.py
+++ b/integrations/github/github/clients/rate_limiter/utils.py
@@ -6,15 +6,22 @@ import httpx
 
 from github.helpers.utils import has_exhausted_rate_limit_headers
 
-RATE_LIMIT_STATUS_CODES = {403, 429}
+REST_RATE_LIMIT_STATUS_CODES = {403, 429}
+GRAPHQL_RATE_LIMIT_STATUS_CODES = REST_RATE_LIMIT_STATUS_CODES | {200}
 
 
-def is_rate_limit_response(response: httpx.Response) -> bool:
-    if response.status_code not in RATE_LIMIT_STATUS_CODES:
+def is_rest_rate_limit_response(response: httpx.Response) -> bool:
+    if response.status_code not in REST_RATE_LIMIT_STATUS_CODES:
         return False
     return response.status_code == 429 or has_exhausted_rate_limit_headers(
         response.headers
     )
+
+
+def is_graphql_rate_limit_response(response: httpx.Response) -> bool:
+    if response.status_code not in GRAPHQL_RATE_LIMIT_STATUS_CODES:
+        return False
+    return has_exhausted_rate_limit_headers(response.headers)
 
 
 @dataclass

--- a/integrations/github/github/helpers/exceptions.py
+++ b/integrations/github/github/helpers/exceptions.py
@@ -1,5 +1,8 @@
-from typing import List
+from typing import List, TYPE_CHECKING
 from port_ocean.exceptions.core import OceanAbortException
+
+if TYPE_CHECKING:
+    from github.clients.rate_limiter.utils import RateLimitInfo
 
 
 class AuthenticationException(OceanAbortException):
@@ -49,3 +52,14 @@ class InvalidActionParametersException(Exception):
 
 class NoWorkflowRunsFoundException(Exception):
     """Exception for workflow runs not found after dispatch."""
+
+
+class RateLimitException(Exception):
+    """Raised when GitHub API rate limit is exceeded."""
+
+    def __init__(self, rate_limit_info: "RateLimitInfo"):
+        self.rate_limit_info = rate_limit_info
+        super().__init__(
+            f"Rate limit exceeded. Reset at {rate_limit_info.reset_time}. "
+            f"Remaining: {rate_limit_info.remaining}/{rate_limit_info.limit}"
+        )

--- a/integrations/github/pyproject.toml
+++ b/integrations/github/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "github-ocean"
-version = "6.2.16"
+version = "6.2.17"
 description = "This integration ingest data from github"
 authors = ["Chukwuemeka Nwaoma <joelchukks@gmail.com>", "Melody Anyaegbulam <melodyogonna@gmail.com>", "Michael Armah <mikeyarmah@gmail.com>"]
 

--- a/integrations/github/tests/github/clients/http/test_graphql_client.py
+++ b/integrations/github/tests/github/clients/http/test_graphql_client.py
@@ -597,6 +597,42 @@ class TestGithubGraphQLClient:
                     assert "Rate limit exceeded" in warning_msg
                     assert "test.query" in warning_msg
 
+    @pytest.mark.asyncio
+    async def test_send_api_request_bounded_retry_loop(
+        self, authenticator: AbstractGitHubAuthenticator
+    ) -> None:
+        """Test that send_api_request retries max 5 times on rate limit before raising."""
+        client = GithubGraphQLClient(
+            organization="test-org",
+            github_host="https://api.github.com",
+            authenticator=authenticator,
+        )
+
+        # Always return rate-limited response
+        rate_limit_response = MagicMock(spec=httpx.Response)
+        rate_limit_response.status_code = 200
+        rate_limit_response.headers = {
+            "x-ratelimit-limit": "5000",
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": "1700000000",
+        }
+        rate_limit_response.extensions = {}
+
+        make_request_mock = AsyncMock(return_value=rate_limit_response)
+
+        with patch.object(client, "make_request", make_request_mock):
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                with pytest.raises(RateLimitException):
+                    await client.send_api_request(
+                        client.base_url,
+                        method="POST",
+                        json_data={},
+                        query_path="test.query",
+                    )
+
+                # Verify make_request was called 5 times (max retries)
+                assert make_request_mock.call_count == 5
+
 
 class TestGithubGraphQLClientRetryConfig:
     """Tests for client property override — POST retryability and caching."""

--- a/integrations/github/tests/github/clients/http/test_graphql_client.py
+++ b/integrations/github/tests/github/clients/http/test_graphql_client.py
@@ -8,7 +8,11 @@ from github.clients.auth.retry_transport import (
     MIN_GRAPHQL_PAGE_SIZE,
 )
 from github.clients.http.graphql_client import GithubGraphQLClient, PAGE_SIZE
-from github.helpers.exceptions import GraphQLClientError, GraphQLErrorGroup
+from github.helpers.exceptions import (
+    GraphQLClientError,
+    GraphQLErrorGroup,
+    RateLimitException,
+)
 
 _GQL_HOST = "https://api.github.com"
 _GQL_ORG = "test-org"
@@ -464,6 +468,134 @@ class TestGithubGraphQLClient:
                 _gateway_error(status)
             )
         assert not GithubGraphQLClient._is_query_too_expensive(GraphQLErrorGroup([]))
+
+    @pytest.mark.asyncio
+    async def test_handle_graphql_errors_detects_rate_limit_response(
+        self, authenticator: AbstractGitHubAuthenticator
+    ) -> None:
+        """Test that _handle_graphql_errors raises RateLimitException for rate-limited responses."""
+        client = GithubGraphQLClient(
+            organization="test-org",
+            github_host="https://api.github.com",
+            authenticator=authenticator,
+        )
+
+        # Mock rate-limit response (HTTP 200 with exhausted headers)
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.headers = {
+            "x-ratelimit-limit": "5000",
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": "1700000000",
+        }
+        mock_response.extensions = {}
+
+        with pytest.raises(RateLimitException) as exc_info:
+            client._handle_graphql_errors(mock_response)
+
+        assert exc_info.value.rate_limit_info.limit == 5000
+        assert exc_info.value.rate_limit_info.remaining == 0
+        assert exc_info.value.rate_limit_info.reset_time == 1700000000
+
+    @pytest.mark.asyncio
+    async def test_send_api_request_retries_on_rate_limit(
+        self, authenticator: AbstractGitHubAuthenticator
+    ) -> None:
+        """Test that send_api_request retries after catching RateLimitException."""
+        client = GithubGraphQLClient(
+            organization="test-org",
+            github_host="https://api.github.com",
+            authenticator=authenticator,
+        )
+
+        # First response: rate-limited
+        rate_limit_response = MagicMock(spec=httpx.Response)
+        rate_limit_response.status_code = 200
+        rate_limit_response.headers = {
+            "x-ratelimit-limit": "5000",
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": "1700000000",
+        }
+        rate_limit_response.extensions = {}
+
+        # Second response: success
+        success_response = MagicMock(spec=httpx.Response)
+        success_response.status_code = 200
+        success_response.headers = {}
+        success_response.extensions = {}
+        success_response.json.return_value = {
+            "data": {"organization": {"repositories": {"nodes": []}}}
+        }
+
+        make_request_mock = AsyncMock(
+            side_effect=[rate_limit_response, success_response]
+        )
+
+        with patch.object(client, "make_request", make_request_mock):
+            with patch("asyncio.sleep", new_callable=AsyncMock) as sleep_mock:
+                result = await client.send_api_request(
+                    client.base_url, method="POST", json_data={}
+                )
+
+                # Verify retry happened
+                assert make_request_mock.call_count == 2
+                # Verify sleep was called with the correct duration
+                sleep_mock.assert_called_once()
+                sleep_duration = sleep_mock.call_args[0][0]
+                # Sleep duration should be non-negative (reset_time - current_time)
+                assert sleep_duration >= 0
+                # Verify the result is from the successful response
+                assert result == {
+                    "data": {"organization": {"repositories": {"nodes": []}}}
+                }
+
+    @pytest.mark.asyncio
+    async def test_send_api_request_rate_limit_logs_warning(
+        self, authenticator: AbstractGitHubAuthenticator
+    ) -> None:
+        """Test that rate-limit retry logs a warning message."""
+        client = GithubGraphQLClient(
+            organization="test-org",
+            github_host="https://api.github.com",
+            authenticator=authenticator,
+        )
+
+        # First response: rate-limited
+        rate_limit_response = MagicMock(spec=httpx.Response)
+        rate_limit_response.status_code = 200
+        rate_limit_response.headers = {
+            "x-ratelimit-limit": "5000",
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": "1700000000",
+        }
+        rate_limit_response.extensions = {}
+
+        # Second response: success
+        success_response = MagicMock(spec=httpx.Response)
+        success_response.status_code = 200
+        success_response.headers = {}
+        success_response.extensions = {}
+        success_response.json.return_value = {"data": {}}
+
+        make_request_mock = AsyncMock(
+            side_effect=[rate_limit_response, success_response]
+        )
+
+        with patch.object(client, "make_request", make_request_mock):
+            with patch("asyncio.sleep", new_callable=AsyncMock):
+                with patch("github.clients.http.graphql_client.logger") as logger_mock:
+                    await client.send_api_request(
+                        client.base_url,
+                        method="POST",
+                        json_data={},
+                        query_path="test.query",
+                    )
+
+                    # Verify warning was logged
+                    logger_mock.warning.assert_called_once()
+                    warning_msg = logger_mock.warning.call_args[0][0]
+                    assert "Rate limit exceeded" in warning_msg
+                    assert "test.query" in warning_msg
 
 
 class TestGithubGraphQLClientRetryConfig:

--- a/integrations/github/tests/github/clients/test_rate_limiter.py
+++ b/integrations/github/tests/github/clients/test_rate_limiter.py
@@ -11,7 +11,11 @@ import httpx
 
 from github.clients.auth.abstract_authenticator import AbstractGitHubAuthenticator
 from github.clients.http.base_client import AbstractGithubClient
-from github.clients.rate_limiter.utils import GitHubRateLimiterConfig, RateLimitInfo
+from github.clients.rate_limiter.utils import (
+    GitHubRateLimiterConfig,
+    RateLimitInfo,
+    extract_graphql_rate_limit_info,
+)
 from github.clients.rate_limiter.registry import GitHubRateLimiterRegistry
 
 
@@ -890,6 +894,122 @@ class TestRateLimiterSemaphorePermitLeak:
         assert len(acquired_permits) == max_concurrent_slots
         for _ in acquired_permits:
             limiter._semaphore.release()
+
+
+class TestExtractGraphQLRateLimitInfo:
+    """Tests for the extract_graphql_rate_limit_info utility function."""
+
+    def test_extract_primary_rate_limit_exhausted_headers(self) -> None:
+        """Extract primary rate limit from exhausted x-ratelimit headers."""
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.headers = {
+            "x-ratelimit-limit": "5000",
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": str(int(time.time()) + 3600),
+        }
+
+        info = extract_graphql_rate_limit_info(mock_response)
+
+        assert info is not None
+        assert info.limit == 5000
+        assert info.remaining == 0
+        assert info.reset_time == int(time.time()) + 3600
+
+    def test_extract_secondary_rate_limit_numeric_retry_after(self) -> None:
+        """Extract secondary rate limit from numeric retry-after header."""
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.headers = {"retry-after": "60"}
+
+        info = extract_graphql_rate_limit_info(mock_response)
+
+        assert info is not None
+        assert info.remaining == 0
+        assert info.limit == 1  # Secondary limits don't have a limit
+        assert 59 <= (info.reset_time - int(time.time())) <= 61  # Allow 1s timing skew
+
+    def test_extract_secondary_rate_limit_date_retry_after(self) -> None:
+        """Extract secondary rate limit from date-format retry-after header."""
+        future_time = int(time.time()) + 120
+        from datetime import datetime as dt, timezone
+
+        future_datetime = dt.fromtimestamp(future_time, tz=timezone.utc)
+        date_str = future_datetime.strftime("%a, %d %b %Y %H:%M:%S GMT")
+
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.headers = {"retry-after": date_str}
+
+        info = extract_graphql_rate_limit_info(mock_response)
+
+        assert info is not None
+        assert info.remaining == 0
+        assert info.limit == 1
+        # Allow 2s timing skew for slow tests
+        assert 118 <= (info.reset_time - int(time.time())) <= 122
+
+    def test_extract_ignores_invalid_retry_after_format(self) -> None:
+        """Invalid retry-after format returns None."""
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.headers = {"retry-after": "invalid-date-format"}
+
+        info = extract_graphql_rate_limit_info(mock_response)
+
+        assert info is None
+
+    def test_extract_ignores_zero_retry_after(self) -> None:
+        """Zero or negative retry-after is ignored."""
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.headers = {"retry-after": "0"}
+
+        info = extract_graphql_rate_limit_info(mock_response)
+
+        assert info is None
+
+    def test_extract_ignores_negative_retry_after(self) -> None:
+        """Negative retry-after is ignored."""
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.headers = {"retry-after": "-10"}
+
+        info = extract_graphql_rate_limit_info(mock_response)
+
+        assert info is None
+
+    def test_extract_primary_takes_precedence_over_secondary(self) -> None:
+        """Primary rate limit (exhausted headers) takes precedence over retry-after."""
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.headers = {
+            "x-ratelimit-limit": "5000",
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": str(int(time.time()) + 3600),
+            "retry-after": "60",
+        }
+
+        info = extract_graphql_rate_limit_info(mock_response)
+
+        assert info is not None
+        # Should use primary rate limit, not retry-after
+        assert info.limit == 5000
+        assert info.reset_time == int(time.time()) + 3600
+
+    def test_extract_returns_none_for_normal_response(self) -> None:
+        """Normal response without rate-limit indicators returns None."""
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.headers = {
+            "x-ratelimit-limit": "5000",
+            "x-ratelimit-remaining": "100",
+            "x-ratelimit-reset": str(int(time.time()) + 3600),
+        }
+
+        info = extract_graphql_rate_limit_info(mock_response)
+
+        assert info is None
 
     @pytest.mark.asyncio
     async def test_non_cancelled_exception_during_aenter_also_releases_acquired_semaphore_permit(

--- a/integrations/github/tests/github/clients/test_rate_limiter.py
+++ b/integrations/github/tests/github/clients/test_rate_limiter.py
@@ -429,46 +429,54 @@ class TestRateLimiterOnResponse:
 
     @pytest.mark.asyncio
     async def test_handle_rate_limit_response_retry_after_only(
-        self, client_config: GitHubRateLimiterConfig, github_host: str, mock_sleep: Mock
+        self, github_host: str, mock_sleep: Mock
     ) -> None:
-        """When only retry-after is present (no x-ratelimit headers), a fallback RateLimitInfo is created."""
-        client = MockGitHubClient(github_host, client_config)
-        retry_after_seconds = 30
+        """When only retry-after is present (no x-ratelimit headers), a fallback RateLimitInfo is created (REST/Search only)."""
+        # Only test REST and Search APIs — GraphQL uses HTTP 200 for rate-limiting, not 429
+        for api_type in ("rest", "search"):
+            config = GitHubRateLimiterConfig(api_type=api_type, max_concurrent=5)
+            GitHubRateLimiterRegistry._instances.clear()
+            client = MockGitHubClient(github_host, config)
+            retry_after_seconds = 30
 
-        mock_response = Mock()
-        mock_response.status_code = 429
-        mock_response.headers = {"retry-after": str(retry_after_seconds)}
-        await client.rate_limiter.on_response(mock_response, "/search")
+            mock_response = Mock()
+            mock_response.status_code = 429
+            mock_response.headers = {"retry-after": str(retry_after_seconds)}
+            await client.rate_limiter.on_response(mock_response, "/search")
 
-        assert client.rate_limiter._initialized is True
-        info = client.rate_limiter.rate_limit_info
-        assert info is not None
-        assert info.remaining == 0
-        assert info.seconds_until_reset >= retry_after_seconds - 2
+            assert client.rate_limiter._initialized is True
+            info = client.rate_limiter.rate_limit_info
+            assert info is not None
+            assert info.remaining == 0
+            assert info.seconds_until_reset >= retry_after_seconds - 2
 
     @pytest.mark.asyncio
     async def test_handle_rate_limit_response_retry_after_overrides_x_ratelimit_reset(
-        self, client_config: GitHubRateLimiterConfig, github_host: str, mock_sleep: Mock
+        self, github_host: str, mock_sleep: Mock
     ) -> None:
-        """When both x-ratelimit-reset and retry-after are present, retry-after wins."""
-        client = MockGitHubClient(github_host, client_config)
-        retry_after_seconds = 60
+        """When both x-ratelimit-reset and retry-after are present, retry-after wins (REST/Search only)."""
+        # Only test REST and Search APIs — GraphQL uses HTTP 200 for rate-limiting, not 429
+        for api_type in ("rest", "search"):
+            config = GitHubRateLimiterConfig(api_type=api_type, max_concurrent=5)
+            GitHubRateLimiterRegistry._instances.clear()
+            client = MockGitHubClient(github_host, config)
+            retry_after_seconds = 60
 
-        mock_response = Mock()
-        mock_response.status_code = 429
-        mock_response.headers = {
-            "x-ratelimit-limit": "1000",
-            "x-ratelimit-remaining": "0",
-            "x-ratelimit-reset": str(int(time.time()) + 3600),
-            "retry-after": str(retry_after_seconds),
-        }
-        await client.rate_limiter.on_response(mock_response, "/repos")
+            mock_response = Mock()
+            mock_response.status_code = 429
+            mock_response.headers = {
+                "x-ratelimit-limit": "1000",
+                "x-ratelimit-remaining": "0",
+                "x-ratelimit-reset": str(int(time.time()) + 3600),
+                "retry-after": str(retry_after_seconds),
+            }
+            await client.rate_limiter.on_response(mock_response, "/repos")
 
-        info = client.rate_limiter.rate_limit_info
-        assert info is not None
-        assert info.remaining == 0
-        # reset_time must reflect retry-after (≈60s), not x-ratelimit-reset (≈3600s)
-        assert info.seconds_until_reset <= retry_after_seconds + 2
+            info = client.rate_limiter.rate_limit_info
+            assert info is not None
+            assert info.remaining == 0
+            # reset_time must reflect retry-after (≈60s), not x-ratelimit-reset (≈3600s)
+            assert info.seconds_until_reset <= retry_after_seconds + 2
 
 
 class TestRateLimiterLogging:
@@ -939,3 +947,125 @@ class TestRateLimiterSemaphorePermitLeak:
         assert len(acquired_permits) == client_config.max_concurrent
         for _ in acquired_permits:
             client.rate_limiter._semaphore.release()
+
+
+class TestIsRateLimitResponseDispatch:
+    """Tests for is_rate_limit_response routing to the correct check function."""
+
+    def test_graphql_uses_graphql_rate_limit_check(
+        self, github_host: str, mock_sleep: Mock
+    ) -> None:
+        """GraphQL API type should use is_graphql_rate_limit_response."""
+        config = GitHubRateLimiterConfig(api_type="graphql", max_concurrent=5)
+        limiter = GitHubRateLimiterRegistry.get_limiter(github_host, config)
+
+        # GraphQL rate-limit: HTTP 200 with exhausted headers
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.headers = {
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": str(int(time.time()) + 3600),
+        }
+
+        assert limiter.is_rate_limit_response(mock_response) is True
+
+    def test_graphql_ignores_429_without_exhausted_headers(
+        self, github_host: str, mock_sleep: Mock
+    ) -> None:
+        """GraphQL API should not treat 429 as rate-limited without exhausted headers."""
+        config = GitHubRateLimiterConfig(api_type="graphql", max_concurrent=5)
+        limiter = GitHubRateLimiterRegistry.get_limiter(github_host, config)
+
+        # 429 without exhausted headers should not be treated as rate-limited by GraphQL check
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.status_code = 429
+        mock_response.headers = {}
+
+        assert limiter.is_rate_limit_response(mock_response) is False
+
+    def test_rest_uses_rest_rate_limit_check(
+        self, github_host: str, mock_sleep: Mock
+    ) -> None:
+        """REST API type should use is_rest_rate_limit_response."""
+        config = GitHubRateLimiterConfig(api_type="rest", max_concurrent=5)
+        limiter = GitHubRateLimiterRegistry.get_limiter(github_host, config)
+
+        # REST rate-limit: HTTP 429
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.status_code = 429
+        mock_response.headers = {}
+
+        assert limiter.is_rate_limit_response(mock_response) is True
+
+    def test_rest_rate_limit_403_with_exhausted_headers(
+        self, github_host: str, mock_sleep: Mock
+    ) -> None:
+        """REST API should treat 403 with exhausted headers as rate-limited."""
+        config = GitHubRateLimiterConfig(api_type="rest", max_concurrent=5)
+        limiter = GitHubRateLimiterRegistry.get_limiter(github_host, config)
+
+        # REST rate-limit: HTTP 403 with exhausted headers
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.status_code = 403
+        mock_response.headers = {
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": str(int(time.time()) + 3600),
+        }
+
+        assert limiter.is_rate_limit_response(mock_response) is True
+
+    def test_search_uses_rest_rate_limit_check(
+        self, github_host: str, mock_sleep: Mock
+    ) -> None:
+        """Search API type should use is_rest_rate_limit_response (falls to default case)."""
+        config = GitHubRateLimiterConfig(api_type="search", max_concurrent=5)
+        limiter = GitHubRateLimiterRegistry.get_limiter(github_host, config)
+
+        # Search API should use REST check: treat 429 as rate-limited
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.status_code = 429
+        mock_response.headers = {}
+
+        assert limiter.is_rate_limit_response(mock_response) is True
+
+    def test_graphql_http_200_without_exhausted_headers_not_rate_limited(
+        self, github_host: str, mock_sleep: Mock
+    ) -> None:
+        """GraphQL HTTP 200 without exhausted headers should not be treated as rate-limited."""
+        config = GitHubRateLimiterConfig(api_type="graphql", max_concurrent=5)
+        limiter = GitHubRateLimiterRegistry.get_limiter(github_host, config)
+
+        # Normal successful response
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.headers = {
+            "x-ratelimit-remaining": "500",
+            "x-ratelimit-reset": str(int(time.time()) + 3600),
+        }
+
+        assert limiter.is_rate_limit_response(mock_response) is False
+
+    @pytest.mark.asyncio
+    async def test_graphql_rate_limit_response_handled_by_on_response(
+        self, github_host: str, mock_sleep: Mock
+    ) -> None:
+        """Verify that GraphQL rate-limit responses (HTTP 200 with exhausted headers) are handled."""
+        config = GitHubRateLimiterConfig(api_type="graphql", max_concurrent=5)
+        client = MockGitHubClient(github_host, config)
+
+        # Simulate a GraphQL rate-limit response
+        mock_response = Mock(spec=httpx.Response)
+        mock_response.status_code = 200
+        mock_response.headers = {
+            "x-ratelimit-limit": "5000",
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-reset": str(int(time.time()) + 3600),
+        }
+
+        await client.rate_limiter.on_response(mock_response, "/graphql")
+
+        # Verify the limiter recognized it as rate-limited and updated state
+        assert client.rate_limiter._initialized is True
+        assert client.rate_limiter.rate_limit_info is not None
+        assert client.rate_limiter.rate_limit_info.remaining == 0
+        assert client.rate_limiter.rate_limit_info.limit == 5000


### PR DESCRIPTION
status code

# Description

What - Handle situation where we encounter rate-limit errors on GraphQL api with 200 status code

Why - Per Github docs: if you exceed your primary rate limit, the response status will still be 200, but you will receive an error message, and the value of the x-ratelimit-remaining header will be 0. You should not retry your request until after the time specified by the x-ratelimit-reset header.

How - Extend the existing rate-limiter response handler to also check 200 status codes on GraphQL requests. Extend the GraphQL client to retry rate-limited requests rather than fail.

## Type of change

Please leave one option from the following and delete the rest:

- [ x ] Bug fix (non-breaking change which fixes an issue)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared GitHub HTTP/rate-limit and GraphQL request paths used during resync; behavior changes under quota exhaustion but aligns with GitHub docs and is covered by new tests.
> 
> **Overview**
> Fixes GitHub GraphQL **primary rate limit** handling when GitHub returns **HTTP 200** with `x-ratelimit-remaining: 0` (per GitHub’s documented behavior).
> 
> **Rate-limit detection** is split into REST vs GraphQL helpers: REST keeps **403/429** semantics; GraphQL also treats **200 + exhausted rate-limit headers** as limited. The shared limiter picks the right check by `api_type`, while the HTTP retry transport only applies REST-style rate-limit retries (so GraphQL **200** limits are not mis-handled there).
> 
> The **GraphQL client** raises a new `RateLimitException` from `_handle_graphql_errors`, and **`send_api_request`** sleeps until `x-ratelimit-reset` and retries in a loop. Empty or non-JSON **2xx** bodies are treated as no data instead of failing JSON parse.
> 
> REST call sites (e.g. custom properties action **403** handling) use the renamed REST helper so permission errors stay distinct from quota exhaustion. Tests cover GraphQL detection, retry/sleep, and limiter dispatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53135a68e20707f301214fbebac77925cf91fe8b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->