### PR TITLE
[Core] Add integration-level opt-in for Redis live-events stream consumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.44.14 (2026-07-15)
+
+### Improvements
+
+- Added `OCEAN__LIVE_EVENTS__REDIS_STREAM_CONSUMER_ENABLED` (default `false`) as an integration-level opt-in for Redis live-events stream consumption, in addition to the `LIVE_EVENTS_REDIS_STREAM_ENABLED` organization feature flag.
+
 ## 0.44.13 (2026-07-13)
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Improvements
 
-- Added `OCEAN__LIVE_EVENTS__REDIS_STREAM_CONSUMER_ENABLED` (default `false`) as an integration-level opt-in for Redis live-events stream consumption, in addition to the `LIVE_EVENTS_REDIS_STREAM_ENABLED` organization feature flag.
+- Added `OCEAN__LIVE_EVENTS__IS_REDIS_STREAM_CONSUMER_ENABLED` (default `false`) as an integration-level opt-in for Redis live-events stream consumption, in addition to the `LIVE_EVENTS_REDIS_STREAM_ENABLED` organization feature flag.
 
 ## 0.44.13 (2026-07-13)
 

--- a/port_ocean/config/settings.py
+++ b/port_ocean/config/settings.py
@@ -257,7 +257,7 @@ class LiveEventsRedisSettings(BaseOceanModel, extra=Extra.allow):
 
 class LiveEventsSettings(BaseOceanModel, extra=Extra.allow):
     type: LiveEventsConsumerType = LiveEventsConsumerType.REDIS
-    redis_stream_consumer_enabled: bool = False
+    is_redis_stream_consumer_enabled: bool = False
 
 
 class RedisLiveEventsSettings(LiveEventsSettings):

--- a/port_ocean/config/settings.py
+++ b/port_ocean/config/settings.py
@@ -257,6 +257,7 @@ class LiveEventsRedisSettings(BaseOceanModel, extra=Extra.allow):
 
 class LiveEventsSettings(BaseOceanModel, extra=Extra.allow):
     type: LiveEventsConsumerType = LiveEventsConsumerType.REDIS
+    redis_stream_consumer_enabled: bool = False
 
 
 class RedisLiveEventsSettings(LiveEventsSettings):

--- a/port_ocean/core/integrations/mixins/utils.py
+++ b/port_ocean/core/integrations/mixins/utils.py
@@ -151,14 +151,14 @@ async def is_redis_live_events_enabled() -> bool:
     """Check if live events should be consumed from a Redis stream.
 
     Gated by the organization feature flag and the integration-level
-    ``OCEAN__LIVE_EVENTS__REDIS_STREAM_CONSUMER_ENABLED`` setting (default false).
+    ``OCEAN__LIVE_EVENTS__IS_REDIS_STREAM_CONSUMER_ENABLED`` setting (default false).
     Errors are swallowed so this never blocks core flows.
 
     Returns:
         bool: True when Redis stream consumption is enabled, False otherwise.
     """
     try:
-        if not ocean.config.live_events.redis_stream_consumer_enabled:
+        if not ocean.config.live_events.is_redis_stream_consumer_enabled:
             return False
         flags = await ocean.port_client.get_organization_feature_flags()
         return IntegrationFeatureFlag.LIVE_EVENTS_REDIS_STREAM_ENABLED in flags

--- a/port_ocean/core/integrations/mixins/utils.py
+++ b/port_ocean/core/integrations/mixins/utils.py
@@ -150,13 +150,16 @@ async def is_dsp_mode_enabled() -> bool:
 async def is_redis_live_events_enabled() -> bool:
     """Check if live events should be consumed from a Redis stream.
 
-    Gated by the organization feature flag.
+    Gated by the organization feature flag and the integration-level
+    ``OCEAN__LIVE_EVENTS__REDIS_STREAM_CONSUMER_ENABLED`` setting (default false).
     Errors are swallowed so this never blocks core flows.
 
     Returns:
         bool: True when Redis stream consumption is enabled, False otherwise.
     """
     try:
+        if not ocean.config.live_events.redis_stream_consumer_enabled:
+            return False
         flags = await ocean.port_client.get_organization_feature_flags()
         return IntegrationFeatureFlag.LIVE_EVENTS_REDIS_STREAM_ENABLED in flags
     except Exception as e:

--- a/port_ocean/tests/config/test_live_events_redis_settings.py
+++ b/port_ocean/tests/config/test_live_events_redis_settings.py
@@ -12,12 +12,14 @@ class TestLiveEventsRedisSettingsValidation:
         assert settings.pel_requeue_worker_enabled is True
         assert settings.stream_ttl_seconds == 3600
 
-    def test_redis_stream_consumer_enabled_from_env(
+    def test_is_redis_stream_consumer_enabled_from_env(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         from port_ocean.config.settings import IntegrationConfiguration
 
-        monkeypatch.setenv("OCEAN__LIVE_EVENTS__REDIS_STREAM_CONSUMER_ENABLED", "true")
+        monkeypatch.setenv(
+            "OCEAN__LIVE_EVENTS__IS_REDIS_STREAM_CONSUMER_ENABLED", "true"
+        )
         monkeypatch.setenv("OCEAN__PORT__CLIENT_ID", "test-client-id")
         monkeypatch.setenv("OCEAN__PORT__CLIENT_SECRET", "test-client-secret")
         monkeypatch.setenv("OCEAN__INTEGRATION__TYPE", "test")
@@ -25,7 +27,7 @@ class TestLiveEventsRedisSettingsValidation:
 
         config = IntegrationConfiguration()
 
-        assert config.live_events.redis_stream_consumer_enabled is True
+        assert config.live_events.is_redis_stream_consumer_enabled is True
 
     def test_pel_requeue_worker_enabled_from_env(
         self, monkeypatch: pytest.MonkeyPatch

--- a/port_ocean/tests/config/test_live_events_redis_settings.py
+++ b/port_ocean/tests/config/test_live_events_redis_settings.py
@@ -12,6 +12,21 @@ class TestLiveEventsRedisSettingsValidation:
         assert settings.pel_requeue_worker_enabled is True
         assert settings.stream_ttl_seconds == 3600
 
+    def test_redis_stream_consumer_enabled_from_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from port_ocean.config.settings import IntegrationConfiguration
+
+        monkeypatch.setenv("OCEAN__LIVE_EVENTS__REDIS_STREAM_CONSUMER_ENABLED", "true")
+        monkeypatch.setenv("OCEAN__PORT__CLIENT_ID", "test-client-id")
+        monkeypatch.setenv("OCEAN__PORT__CLIENT_SECRET", "test-client-secret")
+        monkeypatch.setenv("OCEAN__INTEGRATION__TYPE", "test")
+        monkeypatch.setenv("OCEAN__INTEGRATION__IDENTIFIER", "test-id")
+
+        config = IntegrationConfiguration()
+
+        assert config.live_events.redis_stream_consumer_enabled is True
+
     def test_pel_requeue_worker_enabled_from_env(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/port_ocean/tests/core/integrations/mixins/test_integration_utils.py
+++ b/port_ocean/tests/core/integrations/mixins/test_integration_utils.py
@@ -955,6 +955,7 @@ class TestProcessingModes:
     @pytest.mark.asyncio
     async def test_is_redis_live_events_enabled_when_flag_on(self) -> None:
         with patch("port_ocean.core.integrations.mixins.utils.ocean") as mock_ocean_context:
+            mock_ocean_context.config.live_events.redis_stream_consumer_enabled = True
             mock_ocean_context.port_client.get_organization_feature_flags = AsyncMock(
                 return_value=[IntegrationFeatureFlag.LIVE_EVENTS_REDIS_STREAM_ENABLED]
             )
@@ -962,6 +963,19 @@ class TestProcessingModes:
             result = await is_redis_live_events_enabled()
 
         assert result is True
+
+    @pytest.mark.asyncio
+    async def test_is_redis_live_events_disabled_when_env_opt_in_off(self) -> None:
+        with patch("port_ocean.core.integrations.mixins.utils.ocean") as mock_ocean_context:
+            mock_ocean_context.config.live_events.redis_stream_consumer_enabled = False
+            mock_ocean_context.port_client.get_organization_feature_flags = AsyncMock(
+                return_value=[IntegrationFeatureFlag.LIVE_EVENTS_REDIS_STREAM_ENABLED]
+            )
+
+            result = await is_redis_live_events_enabled()
+
+        assert result is False
+        mock_ocean_context.port_client.get_organization_feature_flags.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_is_redis_live_events_disabled_when_flag_off(self) -> None:

--- a/port_ocean/tests/core/integrations/mixins/test_integration_utils.py
+++ b/port_ocean/tests/core/integrations/mixins/test_integration_utils.py
@@ -955,7 +955,7 @@ class TestProcessingModes:
     @pytest.mark.asyncio
     async def test_is_redis_live_events_enabled_when_flag_on(self) -> None:
         with patch("port_ocean.core.integrations.mixins.utils.ocean") as mock_ocean_context:
-            mock_ocean_context.config.live_events.redis_stream_consumer_enabled = True
+            mock_ocean_context.config.live_events.is_redis_stream_consumer_enabled = True
             mock_ocean_context.port_client.get_organization_feature_flags = AsyncMock(
                 return_value=[IntegrationFeatureFlag.LIVE_EVENTS_REDIS_STREAM_ENABLED]
             )
@@ -967,7 +967,7 @@ class TestProcessingModes:
     @pytest.mark.asyncio
     async def test_is_redis_live_events_disabled_when_env_opt_in_off(self) -> None:
         with patch("port_ocean.core.integrations.mixins.utils.ocean") as mock_ocean_context:
-            mock_ocean_context.config.live_events.redis_stream_consumer_enabled = False
+            mock_ocean_context.config.live_events.is_redis_stream_consumer_enabled = False
             mock_ocean_context.port_client.get_organization_feature_flags = AsyncMock(
                 return_value=[IntegrationFeatureFlag.LIVE_EVENTS_REDIS_STREAM_ENABLED]
             )

--- a/port_ocean/tests/core/integrations/mixins/test_integration_utils.py
+++ b/port_ocean/tests/core/integrations/mixins/test_integration_utils.py
@@ -963,6 +963,7 @@ class TestProcessingModes:
             result = await is_redis_live_events_enabled()
 
         assert result is True
+        mock_ocean_context.port_client.get_organization_feature_flags.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_is_redis_live_events_disabled_when_env_opt_in_off(self) -> None:
@@ -980,6 +981,7 @@ class TestProcessingModes:
     @pytest.mark.asyncio
     async def test_is_redis_live_events_disabled_when_flag_off(self) -> None:
         with patch("port_ocean.core.integrations.mixins.utils.ocean") as mock_ocean_context:
+            mock_ocean_context.config.live_events.is_redis_stream_consumer_enabled = True
             mock_ocean_context.port_client.get_organization_feature_flags = AsyncMock(
                 return_value=[]
             )
@@ -987,6 +989,7 @@ class TestProcessingModes:
             result = await is_redis_live_events_enabled()
 
         assert result is False
+        mock_ocean_context.port_client.get_organization_feature_flags.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_is_redis_live_events_enabled_uses_local_only_warning_on_exception(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.44.13"
+version = "0.44.14"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

**This env var is for setting the old infra as the default and override the env in saas for using the new infra.**

- Adds `OCEAN__LIVE_EVENTS__REDIS_STREAM_CONSUMER_ENABLED` (default `false`) as an integration-level opt-in for the Redis live-events stream consumer.
- Updates `is_redis_live_events_enabled()` so Redis stream consumption requires both the new env setting and the existing `LIVE_EVENTS_REDIS_STREAM_ENABLED` organization feature flag.

This lets integrations opt in to the new live-events Redis infra explicitly, instead of being enabled solely by the org feature flag. Existing behavior is unchanged when the env var is unset or `false`.


## Type of change

Please leave one option from the following and delete the rest:
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)


<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Default-off integration gate preserves prior behavior for unset env; only affects live-events transport selection when explicitly enabled alongside the org flag.
> 
> **Overview**
> Adds **`OCEAN__LIVE_EVENTS__REDIS_STREAM_CONSUMER_ENABLED`** (default **`false`**) on `LiveEventsSettings` so each integration must explicitly opt in before Redis stream consumption is considered.
> 
> **`is_redis_live_events_enabled()`** now returns **`false`** when that setting is off **without** calling Port for org feature flags; when it is on, behavior is unchanged—**`LIVE_EVENTS_REDIS_STREAM_ENABLED`** must still be present. Existing deployments stay on the local HTTP webhook queue unless they set the env var to **`true`**.
> 
> Release **0.44.14** with changelog and tests for env binding and the early-exit path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c1ac63f75bbc8773eaeb99766df6f56bda2db92. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->