### PR TITLE
[Core] Pass resync_id into kind subprocess for DSP lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.45.1 (2026-07-16)
+
+### Bug Fixes
+
+- Fixed missing DSP KIND lifecycle notifications in multi-process mode by passing the parent resync id into kind subprocesses
+
+
 ## 0.45.0 (2026-07-15)
 
 ### Improvements

--- a/port_ocean/core/integrations/mixins/sync_raw.py
+++ b/port_ocean/core/integrations/mixins/sync_raw.py
@@ -803,12 +803,14 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
         resource: ResourceConfig,
         index: int,
         user_agent_type: UserAgentType,
+        resync_id: str,
     ) -> None:
         logger.info(
             f"process started successfully for {resource.kind} with index {index}"
         )
 
         clear_http_client_context()
+        ocean.metrics.event_id = resync_id
 
         async def process_resource_task() -> None:
 
@@ -965,7 +967,13 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                 }
                 process = ProcessWrapper(
                     target=self.process_resource_in_subprocess,
-                    args=(file_ipc_map, resource, index, user_agent_type),
+                    args=(
+                        file_ipc_map,
+                        resource,
+                        index,
+                        user_agent_type,
+                        ocean.metrics.event_id,
+                    ),
                 )
                 process.start()
                 await process.join_async()

--- a/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
+++ b/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
@@ -1708,6 +1708,20 @@ async def test_process_resource_passes_resync_id_to_subprocess(
     process.start = MagicMock()
     process.join_async = AsyncMock()
 
+    process_resource_ipc = MagicMock()
+    process_resource_ipc.load.return_value = ([], [])
+    topological_entities_ipc = MagicMock()
+    topological_entities_ipc.load.return_value = []
+
+    def file_ipc_factory(
+        _process_id: str, name: str, _default: Any = None
+    ) -> MagicMock:
+        if name == "process_resource":
+            return process_resource_ipc
+        if name == "topological_entities":
+            return topological_entities_ipc
+        raise AssertionError(f"Unexpected FileIPC channel: {name}")
+
     with (
         patch(
             "port_ocean.core.integrations.mixins.sync_raw.ProcessWrapper",
@@ -1715,18 +1729,15 @@ async def test_process_resource_passes_resync_id_to_subprocess(
         ) as process_cls,
         patch(
             "port_ocean.core.integrations.mixins.sync_raw.FileIPC",
-        ) as file_ipc_cls,
+            side_effect=file_ipc_factory,
+        ),
     ):
-        ipc_instance = MagicMock()
-        ipc_instance.load.return_value = ([], [])
-        file_ipc_cls.return_value = ipc_instance
-
         async with event_context(
             EventType.RESYNC,
             trigger_type="machine",
             attributes={"resync_start_time": datetime.now(timezone.utc)},
         ):
-            await mock_sync_raw_mixin.process_resource(
+            result = await mock_sync_raw_mixin.process_resource(
                 mock_resource_config,
                 index=0,
                 user_agent_type=UserAgentType.exporter,
@@ -1735,6 +1746,9 @@ async def test_process_resource_passes_resync_id_to_subprocess(
     process_cls.assert_called_once()
     assert process_cls.call_args.kwargs["args"][4] == "resync-from-parent"
     process.start.assert_called_once()
+    process_resource_ipc.load.assert_called_once()
+    topological_entities_ipc.load.assert_called_once()
+    assert result == ([], [])
 
 
 def test_process_resource_in_subprocess_sets_metrics_event_id(

--- a/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
+++ b/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
@@ -24,7 +24,7 @@ from port_ocean.core.handlers.entities_state_applier.port.applier import (
 from port_ocean.core.handlers.entity_processor.jq_entity_processor import (
     JQEntityProcessor,
 )
-from port_ocean.core.models import Entity
+from port_ocean.core.models import Entity, ProcessExecutionMode
 from port_ocean.core.ocean_types import ETLPhase
 from port_ocean.context.event import event_context, EventType
 from port_ocean.clients.port.types import UserAgentType
@@ -1693,3 +1693,71 @@ async def test_process_resource_dsp_notifies_lifecycle_kind_boundaries(
     )
     lifecycle_client.notify_failed.assert_not_awaited()
     lifecycle_client.notify_aborted.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_process_resource_passes_resync_id_to_subprocess(
+    mock_sync_raw_mixin: SyncRawMixin,
+    mock_resource_config: ResourceConfig,
+    mock_ocean: Ocean,
+) -> None:
+    mock_ocean.process_execution_mode = ProcessExecutionMode.multi_process
+    mock_ocean.metrics.event_id = "resync-from-parent"
+
+    process = MagicMock()
+    process.start = MagicMock()
+    process.join_async = AsyncMock()
+
+    with (
+        patch(
+            "port_ocean.core.integrations.mixins.sync_raw.ProcessWrapper",
+            return_value=process,
+        ) as process_cls,
+        patch(
+            "port_ocean.core.integrations.mixins.sync_raw.FileIPC",
+        ) as file_ipc_cls,
+    ):
+        ipc_instance = MagicMock()
+        ipc_instance.load.return_value = ([], [])
+        file_ipc_cls.return_value = ipc_instance
+
+        async with event_context(
+            EventType.RESYNC,
+            trigger_type="machine",
+            attributes={"resync_start_time": datetime.now(timezone.utc)},
+        ):
+            await mock_sync_raw_mixin.process_resource(
+                mock_resource_config,
+                index=0,
+                user_agent_type=UserAgentType.exporter,
+            )
+
+    process_cls.assert_called_once()
+    assert process_cls.call_args.kwargs["args"][4] == "resync-from-parent"
+    process.start.assert_called_once()
+
+
+def test_process_resource_in_subprocess_sets_metrics_event_id(
+    mock_sync_raw_mixin: SyncRawMixin,
+    mock_resource_config: ResourceConfig,
+    mock_ocean: Ocean,
+) -> None:
+    mock_ocean.metrics.event_id = ""
+
+    def assert_event_id_set_before_run(coro: Any) -> None:
+        assert mock_ocean.metrics.event_id == "resync-from-parent"
+        coro.close()
+
+    with patch(
+        "port_ocean.core.integrations.mixins.sync_raw.asyncio.run",
+        side_effect=assert_event_id_set_before_run,
+    ):
+        mock_sync_raw_mixin.process_resource_in_subprocess(
+            {},
+            mock_resource_config,
+            index=0,
+            user_agent_type=UserAgentType.exporter,
+            resync_id="resync-from-parent",
+        )
+
+    assert mock_ocean.metrics.event_id == "resync-from-parent"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.45.0"
+version = "0.45.1"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description
- In `multi_process` mode, KIND lifecycle notifies depend on `ocean.metrics.event_id`, which was only set in the parent
- With spawn, the child starts with an empty `Metrics` instance, so kind started/finished/failed/aborted notifies were skipped - leaving kinds stuck in Pending in Sync status while the resync could still finish.
- Pass the parent's `metrics.event_id` into `process_resource_in_subprocess` and set it on the child before kind work runs

## Type of change
Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow bug fix in subprocess bootstrap for metrics/event correlation; behavior unchanged outside multi_process DSP kind lifecycle paths.
> 
> **Overview**
> Fixes **DSP per-kind lifecycle notifications** in `multi_process` mode when workers are started with **spawn**, where the child’s `ocean.metrics.event_id` was empty even though the parent had set it during `sync_raw_all`.
> 
> `process_resource` now passes the parent’s `ocean.metrics.event_id` into `process_resource_in_subprocess`, which assigns it on the child **before** kind processing runs so `notify_started` / `notify_finished` / `notify_failed` / `notify_aborted` at `GranularityType.KIND` use the correct resync id. Unit tests cover the subprocess argument wiring and that the child sets `metrics.event_id` before work starts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 040f3ffa95cdcad3af335e3f235c756cb1271e3a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->