### PR TITLE
[CI] UT doesn't use local core when there are core changes

### DIFF
--- a/.github/workflows/detect-changes-matrix.yml
+++ b/.github/workflows/detect-changes-matrix.yml
@@ -62,6 +62,7 @@ jobs:
             core_ci_files:
               - '.github/workflows/core-test.yml'
               - '.github/workflows/integration-tests.yml'
+              - '.github/workflows/integrations-unit-test.yml'
               - '.github/workflows/detect-changes-matrix.yml'
               - '.github/workflows/actions/build-docker-image/**'
               - 'scripts/run-smoke-test.sh'

--- a/.github/workflows/integrations-unit-test.yml
+++ b/.github/workflows/integrations-unit-test.yml
@@ -32,7 +32,12 @@ jobs:
       - name: Install dependencies
         working-directory: ${{ format('integrations/{0}', matrix.folder) }}
         run: |
-          make install
+          if [ "${{ needs.detect-changes.outputs.core }}" = "true" ] || \
+             [ "${{ needs.detect-changes.outputs.core_ci_files_changed }}" = "true" ]; then
+            make install/local-core
+          else
+            make install
+          fi
 
       - name: Test
         working-directory: ${{ format('integrations/{0}', matrix.folder) }}


### PR DESCRIPTION
# Description
- Added `integrations-unit-test.yml` to the core CI files in the `detect-changes-matrix.yml` workflow.
- Updated the installation step in `integrations-unit-test.yml` to conditionally run `make install/local-core` based on the outputs from the `detect-changes` job, improving dependency management.

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes; no runtime or application code affected.
> 
> **Overview**
> Integration unit tests now install dependencies against the **in-repo Ocean core** when the PR touches core code or core CI paths, instead of always using `make install`.
> 
> `detect-changes-matrix.yml` treats **`integrations-unit-test.yml`** as a core CI file (alongside `integration-tests.yml`), so edits to that workflow also flip the install path. The install step in **`integrations-unit-test.yml`** mirrors **`integration-tests.yml`**: `make install/local-core` when `core` or `core_ci_files_changed` is true, otherwise `make install`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd9412e259dc3f3db0c7dafe939c41923c4ad600. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->