### PR TITLE
[CI] fix lint doesn't use local core

### DIFF
--- a/.github/workflows/detect-changes-matrix.yml
+++ b/.github/workflows/detect-changes-matrix.yml
@@ -62,6 +62,7 @@ jobs:
             core_ci_files:
               - '.github/workflows/core-test.yml'
               - '.github/workflows/integration-tests.yml'
+              - '.github/workflows/lint.yml'
               - '.github/workflows/detect-changes-matrix.yml'
               - '.github/workflows/actions/build-docker-image/**'
               - 'scripts/run-smoke-test.sh'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,10 +31,9 @@ jobs:
       - name: Install dependencies
         working-directory: ${{ matrix.folder != '.' && format('integrations/{0}', matrix.folder) || '.' }}
         run: |
-          if [ "${{ matrix.folder }}" = "." ]; then
-            make install
-          elif [ "${{ needs.detect-changes.outputs.core }}" = "true" ] || \
-               [ "${{ needs.detect-changes.outputs.core_ci_files_changed }}" = "true" ]; then
+          if [ "${{ matrix.folder }}" != "." ] && \
+             ([ "${{ needs.detect-changes.outputs.core }}" = "true" ] || \
+              [ "${{ needs.detect-changes.outputs.core_ci_files_changed }}" = "true" ]); then
             make install/local-core
           else
             make install

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,14 @@ jobs:
       - name: Install dependencies
         working-directory: ${{ matrix.folder != '.' && format('integrations/{0}', matrix.folder) || '.' }}
         run: |
-          make install
+          if [ "${{ matrix.folder }}" = "." ]; then
+            make install
+          elif [ "${{ needs.detect-changes.outputs.core }}" = "true" ] || \
+               [ "${{ needs.detect-changes.outputs.core_ci_files_changed }}" = "true" ]; then
+            make install/local-core
+          else
+            make install
+          fi
 
       - name: Lint
         working-directory: ${{ matrix.folder != '.' && format('integrations/{0}', matrix.folder) || '.' }}


### PR DESCRIPTION
# Description

What -

Why -

How -

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes with no runtime or application logic impact.
> 
> **Overview**
> Fixes the **lint** workflow so integration jobs install against the **in-repo Ocean core** when a PR changes core code or relevant CI config, instead of always using `make install`.
> 
> The install step now mirrors **integration-tests** and **integrations-unit-test**: Ocean Core (`.`) still runs `make install`; integration folders use `make install/local-core` when `detect-changes` reports `core` or `core_ci_files_changed`, otherwise `make install`.
> 
> **detect-changes-matrix** now treats **`.github/workflows/lint.yml`** as a `core_ci_files` path so edits to the lint workflow participate in that same “core CI changed” signal and matrix behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61a85edfdce49fac7429b52c01b1e51338239a17. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->