### PR TITLE
[Core] Reduce datasource-entities API page size to 5,000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.45.2 (2026-07-16)
+
+### Improvements
+
+- Reduced datasource-entities reconciliation page size to 5,000 to lower per-request payload and memory usage
+
+
 ## 0.45.1 (2026-07-16)
 
 ### Bug Fixes

--- a/port_ocean/clients/port/mixins/entities.py
+++ b/port_ocean/clients/port/mixins/entities.py
@@ -27,6 +27,7 @@ ENTITIES_BULK_ESTIMATED_SIZE_MULTIPLIER = 1.5
 ENTITIES_BULK_MINIMUM_BATCH_SIZE = 1
 ENTITIES_BULK_UPSERT_CONCURRENCY = 5
 ENTITIES_BULK_DELETE_MAX_BATCH_SIZE = 100
+DATASOURCE_ENTITIES_PAGE_SIZE = 5000
 
 
 class EntityClientMixin:
@@ -633,6 +634,7 @@ class EntityClientMixin:
             request_body: dict[str, Any] = {
                 "datasource_prefix": datasource_prefix,
                 "datasource_suffix": datasource_suffix,
+                "limit": DATASOURCE_ENTITIES_PAGE_SIZE,
             }
 
             if before is not None:

--- a/port_ocean/tests/clients/port/mixins/test_entities.py
+++ b/port_ocean/tests/clients/port/mixins/test_entities.py
@@ -232,6 +232,7 @@ async def test_search_entities_uses_datasource_route_when_query_is_none(
     sent_json = call_args[1]["json"]
     assert sent_json["datasource_prefix"] == "port-ocean/test-integration/"
     assert sent_json["datasource_suffix"] == "/test-identifier/sync"
+    assert sent_json["limit"] == 5000
 
 
 async def test_search_entities_passes_before_to_datasource_route(
@@ -322,6 +323,7 @@ async def test_search_entities_uses_datasource_route_when_query_is_none_two_page
     first_sent_json = first_call_args[1]["json"]
     assert first_sent_json["datasource_prefix"] == "port-ocean/test-integration/"
     assert first_sent_json["datasource_suffix"] == "/test-identifier/sync"
+    assert first_sent_json["limit"] == 5000
 
     # Check second call
     second_call_args = entity_client.client.post.call_args_list[1]
@@ -332,6 +334,7 @@ async def test_search_entities_uses_datasource_route_when_query_is_none_two_page
     second_sent_json = second_call_args[1]["json"]
     assert second_sent_json["datasource_prefix"] == "port-ocean/test-integration/"
     assert second_sent_json["datasource_suffix"] == "/test-identifier/sync"
+    assert second_sent_json["limit"] == 5000
 
 
 async def test_upsert_entities_in_batches_with_dictionary_identifier(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.45.1"
+version = "0.45.2"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
## Summary
- Pass `limit: 5000` when Ocean calls `POST /v1/blueprints/entities/datasource-entities` during reconciliation
- Adds `DATASOURCE_ENTITIES_PAGE_SIZE` constant and test coverage for the request payload

## Test plan
- [x] `poetry run pytest port_ocean/tests/clients/port/mixins/test_entities.py`
- [ ] Verify reconciliation on an integration with >5k entities paginates correctly

Related Port task: https://app.getport.io/taskEntity?identifier=task_ti9nny

Made with [Cursor](https://cursor.com)