### PR TITLE
[Integration][GitLab] Add GitLab File Discovery Strategy Selector

### DIFF
--- a/integrations/gitlab-v2/CHANGELOG.md
+++ b/integrations/gitlab-v2/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
-## 0.7.63 (2026-07-16)
+## 0.8.0 (2026-07-16)
 
 
 ### Features

--- a/integrations/gitlab-v2/CHANGELOG.md
+++ b/integrations/gitlab-v2/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
-- Added `discoveryStrategy` to GitLab file selectors, allowing project-level file search to be selected explicitly for broad repository scans.
+- Added `searchStrategy` to GitLab file selectors, allowing project-level file search to be selected explicitly for broad repository scans.
 
 
 ## 0.7.62 (2026-07-16)

--- a/integrations/gitlab-v2/CHANGELOG.md
+++ b/integrations/gitlab-v2/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
-## 0.8.0 (2026-07-16)
+## 0.8.0 (2026-07-19)
 
 
 ### Features

--- a/integrations/gitlab-v2/CHANGELOG.md
+++ b/integrations/gitlab-v2/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.7.63 (2026-07-16)
+
+
+### Features
+
+- Added `discoveryStrategy` to GitLab file selectors, allowing project-level file search to be selected explicitly for broad repository scans.
+
+
 ## 0.7.62 (2026-07-16)
 
 

--- a/integrations/gitlab-v2/integration.py
+++ b/integrations/gitlab-v2/integration.py
@@ -341,10 +341,10 @@ class FilesSelector(BaseModel):
         description="Skip parsing the files and just return the raw file content",
         title="Skip Parsing",
     )
-    discovery_strategy: Literal["groupSearch", "projectSearch"] = Field(
+    search_strategy: Literal["groupSearch", "projectSearch"] = Field(
         default="groupSearch",
-        alias="discoveryStrategy",
-        title="Discovery Strategy",
+        alias="searchStrategy",
+        title="Search Strategy",
         description=(
             "Controls how files are discovered when repositories are not explicitly configured. "
             "Use groupSearch to search through GitLab groups, or projectSearch to enumerate "

--- a/integrations/gitlab-v2/integration.py
+++ b/integrations/gitlab-v2/integration.py
@@ -341,6 +341,16 @@ class FilesSelector(BaseModel):
         description="Skip parsing the files and just return the raw file content",
         title="Skip Parsing",
     )
+    discovery_strategy: Literal["groupSearch", "projectSearch"] = Field(
+        default="groupSearch",
+        alias="discoveryStrategy",
+        title="Discovery Strategy",
+        description=(
+            "Controls how files are discovered when repositories are not explicitly configured. "
+            "Use groupSearch to search through GitLab groups, or projectSearch to enumerate "
+            "projects and search each project directly."
+        ),
+    )
 
 
 class GitLabFilesSelector(GroupSelector):

--- a/integrations/gitlab-v2/main.py
+++ b/integrations/gitlab-v2/main.py
@@ -496,11 +496,11 @@ async def on_resync_files(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
         )
     else:
         level = (
-            f"repository-level ... across {len(repositories)} configured repositories"
+            f"repository-level file search across {len(repositories)} configured repositories"
             if repositories
-            else "group-level"
+            else "group-level file search"
         )
-        logger.info(f"Using {level} file search for path pattern '{search_path}'.")
+        logger.info(f"Using {level} for path pattern '{search_path}'.")
         search_iter = client.search_files(
             scope,
             search_path,

--- a/integrations/gitlab-v2/main.py
+++ b/integrations/gitlab-v2/main.py
@@ -451,7 +451,7 @@ async def on_resync_files(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     search_path = selector.files.path
     scope = "blobs"
     skip_parsing = selector.files.skip_parsing
-    discovery_strategy = selector.files.discovery_strategy
+    search_strategy = selector.files.search_strategy
 
     repositories = (
         selector.files.repos
@@ -477,16 +477,16 @@ async def on_resync_files(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
                 file_entity["__includedFiles"] = files_cache[repo_key]
         return enriched_batch
 
-    use_project_search = discovery_strategy == "projectSearch" and not repositories
+    should_use_project_search = search_strategy == "projectSearch" and not repositories
 
-    if use_project_search:
+    if should_use_project_search:
         logger.info(
             f"Using project-level file search for path pattern '{search_path}' "
-            "based on selector discoveryStrategy."
+            "based on selector searchStrategy."
         )
         logger.info(
-            "Project-level file search scans every accessible project because "
-            "no file repositories were explicitly configured."
+            "Project-level file search scans accessible projects according to "
+            "the file selector filters because no file repositories were explicitly configured."
         )
         params = build_project_params(
             include_only_active_projects=include_only_active_groups
@@ -515,7 +515,7 @@ async def on_resync_files(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
             found_any_files = True
             yield enriched_batch
 
-    if not use_project_search and not found_any_files and not repositories:
+    if not should_use_project_search and not found_any_files and not repositories:
         logger.info(
             "Group-level file search returned no results. "
             "Falling back to project-level file search."

--- a/integrations/gitlab-v2/main.py
+++ b/integrations/gitlab-v2/main.py
@@ -451,6 +451,7 @@ async def on_resync_files(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     search_path = selector.files.path
     scope = "blobs"
     skip_parsing = selector.files.skip_parsing
+    discovery_strategy = selector.files.discovery_strategy
 
     repositories = (
         selector.files.repos
@@ -476,24 +477,49 @@ async def on_resync_files(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
                 file_entity["__includedFiles"] = files_cache[repo_key]
         return enriched_batch
 
-    async for files_batch in client.search_files(
-        scope,
-        search_path,
-        repositories,
-        skip_parsing,
-        build_group_params(include_only_active_groups=include_only_active_groups),
-    ):
+    use_project_search = discovery_strategy == "projectSearch" and not repositories
+
+    if use_project_search:
+        logger.info(
+            f"Using project-level file search for path pattern '{search_path}' "
+            "based on selector discoveryStrategy."
+        )
+        logger.info(
+            "Project-level file search scans every accessible project because "
+            "no file repositories were explicitly configured."
+        )
+        params = build_project_params(
+            include_only_active_projects=include_only_active_groups
+        )
+        search_iter = client.search_files_in_projects(
+            scope, search_path, skip_parsing, params
+        )
+    else:
+        level = (
+            f"repository-level ... across {len(repositories)} configured repositories"
+            if repositories
+            else "group-level"
+        )
+        logger.info(f"Using {level} file search for path pattern '{search_path}'.")
+        search_iter = client.search_files(
+            scope,
+            search_path,
+            repositories,
+            skip_parsing,
+            build_group_params(include_only_active_groups=include_only_active_groups),
+        )
+
+    async for files_batch in search_iter:
         enriched_batch = await _enrich_and_yield(files_batch)
         if enriched_batch:
             found_any_files = True
             yield enriched_batch
 
-    if not found_any_files and not repositories:
+    if not use_project_search and not found_any_files and not repositories:
         logger.info(
             "Group-level file search returned no results. "
             "Falling back to project-level file search."
         )
-        # control project filtering using group selector to avoid adding a new selector
         params = build_project_params(
             include_only_active_projects=include_only_active_groups
         )

--- a/integrations/gitlab-v2/pyproject.toml
+++ b/integrations/gitlab-v2/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gitlab-v2"
-version = "0.7.62"
+version = "0.7.63"
 description = "Gitlab"
 authors = ["Shariff <mohammed.s@getport.io>"]
 

--- a/integrations/gitlab-v2/pyproject.toml
+++ b/integrations/gitlab-v2/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gitlab-v2"
-version = "0.7.63"
+version = "0.8.0"
 description = "Gitlab"
 authors = ["Shariff <mohammed.s@getport.io>"]
 

--- a/integrations/gitlab-v2/tests/integration/test_integration.py
+++ b/integrations/gitlab-v2/tests/integration/test_integration.py
@@ -136,9 +136,11 @@ def test_files_selector_accepts_project_search_discovery_strategy() -> None:
 
 def test_files_selector_rejects_unknown_discovery_strategy() -> None:
     with pytest.raises(ValidationError):
-        FilesSelector(
-            path="**/skills/**/*",
-            discoveryStrategy="tree",
+        FilesSelector.parse_obj(
+            {
+                "path": "**/skills/**/*",
+                "discoveryStrategy": "tree",
+            }
         )
 
 

--- a/integrations/gitlab-v2/tests/integration/test_integration.py
+++ b/integrations/gitlab-v2/tests/integration/test_integration.py
@@ -19,6 +19,7 @@ from integration import (
     PipelineQueryParams,
     GitlabDeploymentQueryParams,
     GitlabDeploymentSelector,
+    FilesSelector,
 )
 
 
@@ -116,6 +117,29 @@ def test_gitlab_port_app_config_schema_generation_includes_all_resource_kinds() 
 
     missing_kinds = {kind for kind in expected_kinds if kind not in schema_str}
     assert not missing_kinds, f"Missing resource kinds in schema: {missing_kinds}"
+
+
+def test_files_selector_defaults_to_group_search_discovery_strategy() -> None:
+    selector = FilesSelector(path="**/skills/**/*")
+
+    assert selector.discovery_strategy == "groupSearch"
+
+
+def test_files_selector_accepts_project_search_discovery_strategy() -> None:
+    selector = FilesSelector(
+        path="**/skills/**/*",
+        discoveryStrategy="projectSearch",
+    )
+
+    assert selector.discovery_strategy == "projectSearch"
+
+
+def test_files_selector_rejects_unknown_discovery_strategy() -> None:
+    with pytest.raises(ValidationError):
+        FilesSelector(
+            path="**/skills/**/*",
+            discoveryStrategy="tree",
+        )
 
 
 def test_generate_query_params_excludes_unset_fields() -> None:

--- a/integrations/gitlab-v2/tests/integration/test_integration.py
+++ b/integrations/gitlab-v2/tests/integration/test_integration.py
@@ -119,27 +119,27 @@ def test_gitlab_port_app_config_schema_generation_includes_all_resource_kinds() 
     assert not missing_kinds, f"Missing resource kinds in schema: {missing_kinds}"
 
 
-def test_files_selector_defaults_to_group_search_discovery_strategy() -> None:
+def test_files_selector_defaults_to_group_search_strategy() -> None:
     selector = FilesSelector(path="**/skills/**/*")
 
-    assert selector.discovery_strategy == "groupSearch"
+    assert selector.search_strategy == "groupSearch"
 
 
-def test_files_selector_accepts_project_search_discovery_strategy() -> None:
+def test_files_selector_accepts_project_search_strategy() -> None:
     selector = FilesSelector(
         path="**/skills/**/*",
-        discoveryStrategy="projectSearch",
+        searchStrategy="projectSearch",
     )
 
-    assert selector.discovery_strategy == "projectSearch"
+    assert selector.search_strategy == "projectSearch"
 
 
-def test_files_selector_rejects_unknown_discovery_strategy() -> None:
+def test_files_selector_rejects_unknown_search_strategy() -> None:
     with pytest.raises(ValidationError):
         FilesSelector.parse_obj(
             {
                 "path": "**/skills/**/*",
-                "discoveryStrategy": "tree",
+                "searchStrategy": "tree",
             }
         )
 


### PR DESCRIPTION
# Description

What - Added a `discoveryStrategy` option to GitLab v2 file selectors so users can explicitly choose project-level file search for broad file scans.

Why - Broad group-level GitLab file search can return unstable or partial results in some environments, causing file entities to be considered missing during reconciliation. Project-level search gives customers an opt-in path with a smaller search blast radius while preserving existing behavior by default.

How - Added `discoveryStrategy` with `groupSearch` as the default and `projectSearch` as the opt-in value. File resync now routes to project-level search when `projectSearch` is selected and no explicit `files.repos` are configured. Added selector validation tests and a GitLab v2 changelog entry.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [x] Integration able to create all default resources from scratch
- [x] Resync finishes successfully
- [x] Resync able to create entities
- [x] Resync able to update entities
- [x] Resync able to detect and delete entities
- [x] Scheduled resync able to abort existing resync and start a new one
- [x] Tested with at least 2 integrations from scratch
- [x] Tested with Kafka and Polling event listeners
- [x] Tested deletion of entities that don't pass the selector

### Integration testing checklist

- [x] Integration able to create all default resources from scratch
- [x] Completed a full resync from a freshly installed integration and it completed successfully
- [x] Resync able to create entities
- [x] Resync able to update entities
- [x] Resync able to detect and delete entities
- [x] Resync finishes successfully
- [x] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [x] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [x] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes file ingestion paths and API load (project-wide scans) for customers who opt in; default behavior and explicit repo lists are unchanged.
> 
> **Overview**
> Adds **`discoveryStrategy`** on GitLab v2 file selectors (`groupSearch` by default, **`projectSearch`** opt-in) so customers can choose how files are discovered when **`files.repos`** is not set.
> 
> **File resync** in `on_resync_files` now branches on that setting: with **`projectSearch`** and no explicit repos, it uses **`search_files_in_projects`** up front (with logging) instead of group-level **`search_files`**. Explicit **`files.repos`** still use repository/group search as before. The existing **group → project fallback** when group search finds nothing runs only when project search was not already selected.
> 
> Includes **Pydantic validation tests** for defaults, accepted values, and invalid strategies, plus a **0.7.63 changelog** entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dd38cfea2469b92b6c8d2dc9cc009f3966f72b1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->