### PR TITLE
[Integration][Azure-DevOps] Add trigger_pipeline integration action

### DIFF
--- a/integrations/azure-devops/.port/spec.yaml
+++ b/integrations/azure-devops/.port/spec.yaml
@@ -103,6 +103,39 @@ configurations:
     description: A list of tags used to exclude projects and resources that belong to them from syncing.
     type: array
     required: false
+actionsProcessingEnabled: true
+actions:
+  - name: trigger_pipeline
+    icon: AzureDevops
+    description: Trigger an Azure DevOps pipeline run
+    inputs:
+      - name: project
+        title: Project
+        type: string
+        description: The name or ID of the Azure DevOps project that contains the target pipeline
+        required: true
+      - name: pipelineId
+        title: Pipeline ID
+        type: string
+        description: The numeric ID of the pipeline to run. It can be found in the pipeline URL, for example - "12" for https://dev.azure.com/org/project/_build?definitionId=12
+        required: true
+      - name: branch
+        title: Branch
+        type: string
+        description: The branch (ref) to run the pipeline on, for example - "main". When omitted, the pipeline's default branch is used.
+      - name: reportPipelineStatus
+        title: Report pipeline status
+        type: boolean
+        description: Whether to report the pipeline run status back to Port once it completes
+        default: true
+      - name: templateParameters
+        title: Template parameters
+        type: jqObject
+        description: 'Runtime template parameters declared in the pipeline YAML. You can use JQ to reference the action trigger data by writing double brackets, for example: {{ .trigger.by.user.email }}. <a href="https://docs.port.io/actions-and-automations/create-self-service-experiences/setup-the-backend/#define-the-actions-payload" target="_blank">Learn more</a>'
+      - name: variables
+        title: Variables
+        type: jqObject
+        description: 'Queue-time variables to pass to the pipeline run. Each value is sent as { "value": <value> }.'
 deploymentMethodOverride:
   - type: helm
 saas:

--- a/integrations/azure-devops/CHANGELOG.md
+++ b/integrations/azure-devops/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.10.34 (2026-07-23)
+
+
+### Features
+
+- Added a `trigger_pipeline` integration action that runs an Azure DevOps pipeline and reports its completion status back to Port via the pipeline run-state-changed service hook (Single Account mode). Queue-time variables are wrapped in the Azure DevOps API `{ "value": <value> }` format, and `reportPipelineStatus` defaults to enabled when the input is omitted.
+
+
 ## 0.10.33 (2026-07-23)
 
 

--- a/integrations/azure-devops/azure_devops/actions/abstract_ado_executor.py
+++ b/integrations/azure-devops/azure_devops/actions/abstract_ado_executor.py
@@ -1,0 +1,46 @@
+from typing import Optional
+
+from loguru import logger
+
+from azure_devops.actions.exceptions import MultipleOrganizationsNotSupportedError
+from azure_devops.client.azure_devops_client import AzureDevopsClient
+from azure_devops.client.client_manager import AzureDevopsClientManager
+from port_ocean.core.handlers.actions.abstract_executor import AbstractExecutor
+from port_ocean.core.models import IntegrationRun
+
+
+class AbstractAzureDevopsExecutor(AbstractExecutor):
+    def __init__(self) -> None:
+        self._client: Optional[AzureDevopsClient] = None
+
+    @property
+    def client(self) -> AzureDevopsClient:
+        """Resolve the single configured Azure DevOps client lazily.
+
+        Actions currently support Single Account mode only. The client is built
+        on first use (not at registration time) so the integration still starts
+        when actions are disabled or multiple organizations are configured.
+        """
+        if self._client is None:
+            manager = AzureDevopsClientManager.create_from_ocean_config_no_cache()
+            clients = manager.get_clients()
+            if len(clients) != 1:
+                logger.error(
+                    "Azure DevOps actions currently support a single organization "
+                    f"(Single Account mode); found {len(clients)} configured clients.",
+                    configured_clients=len(clients),
+                )
+                raise MultipleOrganizationsNotSupportedError(
+                    "Azure DevOps actions currently support a single organization "
+                    f"(Single Account mode); found {len(clients)} configured clients."
+                )
+            self._client = clients[0]
+        return self._client
+
+    async def is_close_to_rate_limit(self, run: IntegrationRun) -> bool:
+        return self.client.is_close_to_rate_limit()
+
+    async def get_remaining_seconds_until_rate_limit(
+        self, run: IntegrationRun
+    ) -> float:
+        return self.client.seconds_until_rate_limit_reset()

--- a/integrations/azure-devops/azure_devops/actions/exceptions.py
+++ b/integrations/azure-devops/azure_devops/actions/exceptions.py
@@ -1,0 +1,36 @@
+import json
+
+import httpx
+
+
+class InvalidActionParametersError(Exception):
+    """Raised when an action run is missing required parameters."""
+
+
+class MultipleOrganizationsNotSupportedError(Exception):
+    """Raised when actions are invoked while multiple organizations are configured."""
+
+
+class TriggerPipelineError(Exception):
+    """Raised when the Azure DevOps API returns an error while triggering a pipeline."""
+
+    @classmethod
+    def from_response(
+        cls, response: httpx.Response, prefix: str
+    ) -> "TriggerPipelineError":
+        return cls(f"{prefix}: {cls._response_detail(response)}")
+
+    @staticmethod
+    def _response_detail(response: httpx.Response) -> str:
+        try:
+            body = response.json()
+        except Exception:
+            body = None
+
+        if isinstance(body, dict):
+            message = body.get("message")
+            if message is not None:
+                return message if isinstance(message, str) else json.dumps(message)
+
+        text = response.text.strip()
+        return text or f"HTTP {response.status_code}"

--- a/integrations/azure-devops/azure_devops/actions/registry.py
+++ b/integrations/azure-devops/azure_devops/actions/registry.py
@@ -1,0 +1,8 @@
+from port_ocean.context.ocean import ocean
+
+from azure_devops.actions.trigger_pipeline_executor import TriggerPipelineExecutor
+
+
+def register_actions_executors() -> None:
+    """Register all Azure DevOps action executors."""
+    ocean.register_action_executor(TriggerPipelineExecutor())

--- a/integrations/azure-devops/azure_devops/actions/trigger_pipeline_executor.py
+++ b/integrations/azure-devops/azure_devops/actions/trigger_pipeline_executor.py
@@ -1,0 +1,109 @@
+import httpx
+from loguru import logger
+
+from azure_devops.actions.abstract_ado_executor import AbstractAzureDevopsExecutor
+from azure_devops.actions.exceptions import (
+    InvalidActionParametersError,
+    TriggerPipelineError,
+)
+from azure_devops.actions.utils import build_external_id
+from azure_devops.client.azure_devops_client import RunPipelineOptions
+from azure_devops.webhooks.webhook_processors.pipeline_run_action_webhook_processor import (
+    PipelineRunActionWebhookProcessor,
+)
+from port_ocean.context.ocean import ocean
+from port_ocean.core.models import IntegrationRun
+
+
+class TriggerPipelineExecutor(AbstractAzureDevopsExecutor):
+    """Executor for triggering Azure DevOps pipeline runs and tracking them.
+
+    Azure DevOps' Run Pipeline API returns the created run synchronously, so the
+    run is marked as started immediately (no polling). Completion is reported
+    asynchronously by ``PipelineRunActionWebhookProcessor`` via the pipeline
+    run-state-changed service hook.
+    """
+
+    ACTION_NAME = "trigger_pipeline"
+    WEBHOOK_PROCESSOR_CLASS = PipelineRunActionWebhookProcessor
+    WEBHOOK_PATH = "/webhook"
+
+    async def execute(self, run: IntegrationRun) -> None:
+        logger.info(f"Triggering pipeline for action run {run.id}", run_id=run.id)
+        project_input = run.execution_properties.get("project")
+        pipeline_id = run.execution_properties.get("pipelineId")
+        if not (project_input and pipeline_id):
+            logger.warning(
+                f"Missing required parameters for action run {run.id}",
+                run_id=run.id,
+                project=project_input,
+                pipeline_id=pipeline_id,
+            )
+            raise InvalidActionParametersError("project and pipelineId are required")
+
+        options = RunPipelineOptions(
+            branch=run.execution_properties.get("branch"),
+            template_parameters=run.execution_properties.get("templateParameters"),
+            variables=run.execution_properties.get("variables"),
+        )
+        project = await self.client.get_single_project(str(project_input))
+        if not project:
+            logger.warning(
+                f"Project '{project_input}' was not found for action run {run.id}",
+                run_id=run.id,
+                project=project_input,
+            )
+            raise InvalidActionParametersError(
+                f"Project '{project_input}' was not found"
+            )
+        project_id = project["id"]
+
+        logger.info(
+            f"Running pipeline {pipeline_id} in project '{project_input}' for action run {run.id}",
+            run_id=run.id,
+            project_id=project_id,
+            pipeline_id=pipeline_id,
+            branch=options.branch,
+        )
+        await ocean.port_client.post_run_log(
+            run, f"Triggering pipeline {pipeline_id} in project '{project_input}'"
+        )
+        try:
+            pipeline_run = await self.client.run_pipeline(
+                project_id, str(pipeline_id), options
+            )
+        except httpx.HTTPStatusError as e:
+            logger.error(
+                f"Azure DevOps rejected pipeline {pipeline_id} run for action run {run.id}: "
+                f"HTTP {e.response.status_code}",
+                run_id=run.id,
+                project_id=project_id,
+                pipeline_id=pipeline_id,
+                status_code=e.response.status_code,
+            )
+            raise TriggerPipelineError.from_response(
+                e.response,
+                f"Error triggering pipeline {pipeline_id} in project '{project_input}'",
+            )
+
+        external_id = build_external_id(
+            project_id, str(pipeline_id), str(pipeline_run["id"])
+        )
+        link = pipeline_run.get("_links", {}).get("web", {}).get("href", "")
+        logger.info(
+            f"Pipeline run {pipeline_run['id']} started for action run {run.id}",
+            run_id=run.id,
+            external_id=external_id,
+            pipeline_run_id=pipeline_run["id"],
+            link=link,
+        )
+        run_started_message = (
+            f"Pipeline run started: {link}" if link else "Pipeline run started"
+        )
+        await ocean.port_client.post_run_log(run, run_started_message)
+        await ocean.port_client.update_run_started(
+            run,
+            link,
+            external_id,
+            extra_output={"pipelineRunId": pipeline_run["id"]},
+        )

--- a/integrations/azure-devops/azure_devops/actions/utils.py
+++ b/integrations/azure-devops/azure_devops/actions/utils.py
@@ -1,0 +1,2 @@
+def build_external_id(project_id: str, pipeline_id: str, run_id: str) -> str:
+    return f"ado_{project_id}_{pipeline_id}_{run_id}"

--- a/integrations/azure-devops/azure_devops/client/azure_devops_client.py
+++ b/integrations/azure-devops/azure_devops/client/azure_devops_client.py
@@ -6,6 +6,7 @@ import re
 import httpx
 from collections import defaultdict
 from datetime import datetime, timezone
+from dataclasses import dataclass
 from itertools import batched
 from typing import Any, AsyncGenerator, Awaitable, Optional, Callable, Iterable
 from httpx import HTTPStatusError, ReadTimeout
@@ -196,6 +197,15 @@ def _flatten_area_path_tree(
     for child in node.get("children", []):
         result.extend(_flatten_area_path_tree(child, project, node.get("identifier")))
     return result
+
+
+@dataclass
+class RunPipelineOptions:
+    """Optional inputs for triggering a pipeline run."""
+
+    branch: Optional[str] = None
+    template_parameters: Optional[dict[str, Any]] = None
+    variables: Optional[dict[str, Any]] = None
 
 
 class AzureDevopsClient(HTTPBaseClient):
@@ -1716,6 +1726,83 @@ class AzureDevopsClient(HTTPBaseClient):
             return None
         pipeline_run_data = response.json()
         return pipeline_run_data
+
+    async def run_pipeline(
+        self,
+        project_id: str,
+        pipeline_id: str,
+        options: RunPipelineOptions,
+    ) -> dict[str, Any]:
+        """Trigger a pipeline run and return the created run.
+
+        API: POST {org}/{project}/_apis/pipelines/{pipelineId}/runs
+        https://learn.microsoft.com/en-us/rest/api/azure/devops/pipelines/runs/run-pipeline
+        """
+        run_pipeline_url = (
+            f"{self._organization_base_url}/{project_id}/{API_URL_PREFIX}"
+            f"/pipelines/{pipeline_id}/runs"
+        )
+        body: dict[str, Any] = {}
+        if options.branch:
+            ref_name = (
+                options.branch
+                if options.branch.startswith("refs/")
+                else f"refs/heads/{options.branch}"
+            )
+            body["resources"] = {"repositories": {"self": {"refName": ref_name}}}
+        if options.template_parameters:
+            body["templateParameters"] = options.template_parameters
+        if options.variables:
+            # The Run Pipeline API expects each variable as { "value": <value> }.
+            # Values already in that shape are passed through to allow advanced
+            # inputs (e.g. { "value": x, "isSecret": true }).
+            body["variables"] = {
+                name: (
+                    value
+                    if isinstance(value, dict) and "value" in value
+                    else {"value": value}
+                )
+                for name, value in options.variables.items()
+            }
+
+        logger.info(
+            f"Sending Run Pipeline request for pipeline {pipeline_id} in project {project_id}",
+            project_id=project_id,
+            pipeline_id=pipeline_id,
+            url=run_pipeline_url,
+        )
+        response = await self.send_request(
+            "POST",
+            run_pipeline_url,
+            data=json.dumps(body),
+            headers={"Content-Type": "application/json"},
+            params=API_PARAMS,
+            raise_on_404=True,
+        )
+        if not response:
+            logger.error(
+                f"Failed to trigger pipeline {pipeline_id} in project {project_id}: no response from Azure DevOps",
+                project_id=project_id,
+                pipeline_id=pipeline_id,
+            )
+            raise RuntimeError(
+                f"Failed to trigger pipeline {pipeline_id} in project {project_id}"
+            )
+        run = response.json()
+        logger.info(
+            f"Run Pipeline request succeeded for pipeline {pipeline_id} in project {project_id}: run {run.get('id')}",
+            project_id=project_id,
+            pipeline_id=pipeline_id,
+            run_id=run.get("id"),
+            state=run.get("state"),
+        )
+        return run
+
+    def is_close_to_rate_limit(self) -> bool:
+        return self._rate_limiter.is_close_to_limit
+
+    def seconds_until_rate_limit_reset(self) -> float:
+        return self._rate_limiter.seconds_until_reset
 
     async def get_pipeline_stage(
         self, project: dict[str, Any], pipeline_id: str, run_id: str, stage_id: str

--- a/integrations/azure-devops/azure_devops/client/base_client.py
+++ b/integrations/azure-devops/azure_devops/client/base_client.py
@@ -53,6 +53,7 @@ class HTTPBaseClient:
         data: Optional[Any] = None,
         params: Optional[dict[str, Any]] = None,
         headers: Optional[dict[str, Any]] = None,
+        raise_on_404: bool = False,
     ) -> Response | None:
         auth_headers = await self._auth_provider.get_auth_headers()
         headers = {**(headers or {}), **auth_headers}
@@ -69,7 +70,7 @@ class HTTPBaseClient:
                 )
                 response.raise_for_status()
         except httpx.HTTPStatusError as e:
-            if response.status_code == 404:
+            if response.status_code == 404 and not raise_on_404:
                 logger.warning(f"Couldn't access url: {url}. Failed due to 404 error")
                 return None
             else:

--- a/integrations/azure-devops/azure_devops/client/rate_limiter.py
+++ b/integrations/azure-devops/azure_devops/client/rate_limiter.py
@@ -44,6 +44,17 @@ class AzureDevOpsRateLimiter:
         self._throttle_until: Optional[float] = None
 
     @property
+    def is_close_to_limit(self) -> bool:
+        """Whether the remaining request budget is at or below the configured threshold.
+
+        Returns False when no rate limit headers have been observed yet, since
+        Azure DevOps only sends them when approaching a limit.
+        """
+        if self._remaining is None:
+            return False
+        return self._remaining <= self._minimum_limit_remaining
+
+    @property
     def seconds_until_reset(self) -> float:
         """Calculate seconds until rate limit window resets.
 

--- a/integrations/azure-devops/azure_devops/webhooks/webhook_processors/pipeline_run_action_webhook_processor.py
+++ b/integrations/azure-devops/azure_devops/webhooks/webhook_processors/pipeline_run_action_webhook_processor.py
@@ -1,0 +1,111 @@
+from loguru import logger
+
+from azure_devops.actions.utils import build_external_id
+from azure_devops.client.azure_devops_client import PIPELINES_PUBLISHER_ID
+from azure_devops.webhooks.events import PipelineRunEvents
+from azure_devops.webhooks.webhook_processors.base_processor import (
+    AzureDevOpsBaseWebhookProcessor,
+)
+from port_ocean.context.ocean import ocean
+from port_ocean.core.handlers.port_app_config.models import ResourceConfig
+from port_ocean.core.handlers.webhook.abstract_webhook_processor import (
+    WebhookProcessorType,
+)
+from port_ocean.core.handlers.webhook.webhook_event import (
+    EventPayload,
+    WebhookEvent,
+    WebhookEventRawResults,
+)
+
+PIPELINE_RUN_COMPLETED_STATE = "completed"
+PIPELINE_RUN_SUCCEEDED_RESULT = "succeeded"
+
+
+class PipelineRunActionWebhookProcessor(AzureDevOpsBaseWebhookProcessor):
+    """Report ``trigger_pipeline`` action completion from run-state-changed events.
+
+    Unlike the catalog pipeline-run processor, this is an ACTION processor: it
+    correlates the completed pipeline run back to its Port action run via the
+    external id set at trigger time and reports the final success/failure.
+    """
+
+    @classmethod
+    def get_processor_type(cls) -> WebhookProcessorType:
+        return WebhookProcessorType.ACTION
+
+    async def get_matching_kinds(self, event: WebhookEvent) -> list[str]:
+        return []
+
+    async def should_process_event(self, event: WebhookEvent) -> bool:
+        try:
+            if event.payload["publisherId"] != PIPELINES_PUBLISHER_ID:
+                return False
+            return bool(PipelineRunEvents(event.payload["eventType"]))
+        except (KeyError, ValueError):
+            return False
+
+    async def validate_payload(self, payload: EventPayload) -> bool:
+        if not await super().validate_payload(payload):
+            return False
+        project_id = payload.get("resourceContainers", {}).get("project", {}).get("id")
+        run = payload.get("resource", {}).get("run", {})
+        pipeline_id = payload.get("resource", {}).get("pipeline", {}).get("id")
+        return bool(project_id and run.get("id") and pipeline_id)
+
+    async def _handle_webhook_event(
+        self, payload: EventPayload, resource_config: ResourceConfig
+    ) -> WebhookEventRawResults:
+        empty_results = WebhookEventRawResults(
+            updated_raw_results=[], deleted_raw_results=[]
+        )
+        run_resource = payload["resource"]["run"]
+        if run_resource.get("state") != PIPELINE_RUN_COMPLETED_STATE:
+            logger.debug(
+                f"Ignoring pipeline run event in state '{run_resource.get('state')}'",
+                run_id=run_resource.get("id"),
+                state=run_resource.get("state"),
+            )
+            return empty_results
+
+        project_id = payload["resourceContainers"]["project"]["id"]
+        pipeline_id = payload["resource"]["pipeline"]["id"]
+        run_id = run_resource["id"]
+        external_id = build_external_id(str(project_id), str(pipeline_id), str(run_id))
+
+        port_run = await ocean.port_client.find_run_by_external_id(external_id)
+        if not port_run:
+            # Expected for pipeline runs not triggered via the trigger_pipeline
+            # action (e.g. manual runs, other triggers), so this stays at debug.
+            logger.debug(
+                f"No Port action run found for completed pipeline run {run_id}",
+                external_id=external_id,
+                project_id=project_id,
+                pipeline_id=pipeline_id,
+            )
+            return empty_results
+        if not ocean.port_client.is_run_in_progress(port_run):
+            logger.debug(
+                f"Port run {port_run.id} is no longer in progress, skipping completion report",
+                run_id=port_run.id,
+                external_id=external_id,
+            )
+            return empty_results
+        if not port_run.execution_properties.get("reportPipelineStatus", True):
+            logger.info(
+                f"reportPipelineStatus is disabled for Port run {port_run.id}, skipping completion report",
+                run_id=port_run.id,
+                external_id=external_id,
+            )
+            return empty_results
+
+        result = run_resource.get("result")
+        is_success = result == PIPELINE_RUN_SUCCEEDED_RESULT
+        logger.info(
+            f"Reporting pipeline run completion for Port run {port_run.id}",
+            run_id=port_run.id,
+            result=result,
+        )
+        await ocean.port_client.report_run_completed(
+            port_run, is_success, f"Pipeline run {result}"
+        )
+        return empty_results

--- a/integrations/azure-devops/integration.py
+++ b/integrations/azure-devops/integration.py
@@ -719,12 +719,14 @@ class AzureDevopsIntegration(BaseIntegration, AzureDevopsHandlerMixin):
     def __init__(self, context: PortOceanContext):
         super().__init__(context)
         # Replace the Ocean's webhook manager with our custom one
-        self.context.app.webhook_manager = AzureDevopsLiveEventsProcessorManager(
+        processor_manager = AzureDevopsLiveEventsProcessorManager(
             self.context.app.integration_router,
             signal_handler,
             self.context.config.max_event_processing_seconds,
             self.context.config.max_wait_seconds_before_shutdown,
         )
+        self.context.app.webhook_manager = processor_manager
+        self.context.app.execution_manager._webhook_manager = processor_manager
 
     class AppConfigHandlerClass(APIPortAppConfig):
         CONFIG_CLASS = GitPortAppConfig

--- a/integrations/azure-devops/main.py
+++ b/integrations/azure-devops/main.py
@@ -65,6 +65,7 @@ from azure_devops.webhooks.webhook_processors.test_run_webhook_processor import 
 from azure_devops.webhooks.webhook_processors.release_deployment_webhook_processor import (
     ReleaseDeploymentWebhookProcessor,
 )
+from azure_devops.actions.registry import register_actions_executors
 from integration import (
     AzureDevopsBuildConfig,
     AzureDevopsPipelineResourceConfig,
@@ -472,3 +473,5 @@ ocean.add_webhook_processor("/webhook", ReleaseWebhookProcessor)
 ocean.add_webhook_processor("/webhook", ReleaseDefinitionWebhookProcessor)
 ocean.add_webhook_processor("/webhook", ReleaseDeploymentWebhookProcessor)
 ocean.add_webhook_processor("/webhook", TestRunWebhookProcessor)
+
+register_actions_executors()

--- a/integrations/azure-devops/pyproject.toml
+++ b/integrations/azure-devops/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "azure-devops"
-version = "0.10.33"
+version = "0.10.34"
 description = "An Azure Devops Ocean integration"
 authors = ["Matan Geva <matang@getport.io>"]
 

--- a/integrations/azure-devops/tests/azure_devops/actions/test_trigger_pipeline_executor.py
+++ b/integrations/azure-devops/tests/azure_devops/actions/test_trigger_pipeline_executor.py
@@ -1,0 +1,155 @@
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from azure_devops.actions.exceptions import (
+    InvalidActionParametersError,
+    TriggerPipelineError,
+)
+from azure_devops.actions.trigger_pipeline_executor import TriggerPipelineExecutor
+from azure_devops.client.azure_devops_client import RunPipelineOptions
+from port_ocean.core.models import (
+    ActionRun,
+    IntegrationActionInvocationPayload,
+    RunStatus,
+)
+
+
+def _make_run(props: dict[str, Any]) -> ActionRun:
+    return ActionRun(
+        id="run-1",
+        status=RunStatus.IN_PROGRESS,
+        action=ActionRun.Action(identifier="trigger_pipeline"),
+        payload=IntegrationActionInvocationPayload(
+            type="INTEGRATION_ACTION",
+            installationId="inst-1",
+            integrationActionType="trigger_pipeline",
+            integrationActionExecutionProperties=props,
+        ),
+    )
+
+
+@pytest.fixture
+def client() -> MagicMock:
+    mock = MagicMock()
+    mock.get_single_project = AsyncMock()
+    mock.run_pipeline = AsyncMock()
+    return mock
+
+
+@pytest.fixture
+def executor(client: MagicMock) -> TriggerPipelineExecutor:
+    instance = TriggerPipelineExecutor()
+    instance._client = client
+    return instance
+
+
+def _make_mock_ocean() -> MagicMock:
+    mock_ocean = MagicMock()
+    mock_ocean.port_client.update_run_started = AsyncMock()
+    mock_ocean.port_client.post_run_log = AsyncMock()
+    mock_ocean.port_client.report_run_completed = AsyncMock()
+    return mock_ocean
+
+
+@pytest.mark.asyncio
+async def test_execute_missing_pipeline_id_raises(
+    executor: TriggerPipelineExecutor,
+) -> None:
+    with pytest.raises(InvalidActionParametersError):
+        await executor.execute(_make_run({"project": "proj"}))
+
+
+@pytest.mark.asyncio
+async def test_execute_triggers_pipeline_and_marks_started(
+    executor: TriggerPipelineExecutor,
+    client: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client.get_single_project.return_value = {"id": "proj-guid"}
+    client.run_pipeline.return_value = {
+        "id": 4567,
+        "_links": {
+            "web": {
+                "href": "https://dev.azure.com/org/proj/_build/results?buildId=4567"
+            }
+        },
+    }
+    mock_ocean = _make_mock_ocean()
+    monkeypatch.setattr(
+        "azure_devops.actions.trigger_pipeline_executor.ocean", mock_ocean
+    )
+
+    run = _make_run(
+        {
+            "project": "My Project",
+            "pipelineId": "12",
+            "branch": "main",
+            "templateParameters": {"env": "prod"},
+            "reportPipelineStatus": True,
+        }
+    )
+    await executor.execute(run)
+
+    client.get_single_project.assert_awaited_once_with("My Project")
+    run_pipeline_call = client.run_pipeline.await_args
+    assert run_pipeline_call is not None
+    assert run_pipeline_call.args[0] == "proj-guid"
+    assert run_pipeline_call.args[1] == "12"
+    options = run_pipeline_call.args[2]
+    assert isinstance(options, RunPipelineOptions)
+    assert options.branch == "main"
+    assert options.template_parameters == {"env": "prod"}
+
+    started_call = mock_ocean.port_client.update_run_started.await_args
+    assert started_call is not None
+    assert started_call.args[0] is run
+    assert (
+        started_call.args[1]
+        == "https://dev.azure.com/org/proj/_build/results?buildId=4567"
+    )
+    assert started_call.args[2] == "ado_proj-guid_12_4567"
+    assert mock_ocean.port_client.post_run_log.await_count == 2
+    mock_ocean.port_client.report_run_completed.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_execute_project_not_found_raises(
+    executor: TriggerPipelineExecutor,
+    client: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client.get_single_project.return_value = None
+    monkeypatch.setattr(
+        "azure_devops.actions.trigger_pipeline_executor.ocean", _make_mock_ocean()
+    )
+
+    with pytest.raises(InvalidActionParametersError) as exc_info:
+        await executor.execute(_make_run({"project": "missing", "pipelineId": "12"}))
+
+    assert "was not found" in str(exc_info.value)
+    client.run_pipeline.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_execute_wraps_http_error_as_trigger_pipeline_error(
+    executor: TriggerPipelineExecutor,
+    client: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client.get_single_project.return_value = {"id": "proj-guid"}
+    client.run_pipeline.side_effect = httpx.HTTPStatusError(
+        "boom",
+        request=httpx.Request("POST", "https://dev.azure.com"),
+        response=httpx.Response(status_code=400, json={"message": "bad pipeline"}),
+    )
+    monkeypatch.setattr(
+        "azure_devops.actions.trigger_pipeline_executor.ocean", _make_mock_ocean()
+    )
+
+    with pytest.raises(TriggerPipelineError) as exc_info:
+        await executor.execute(_make_run({"project": "proj", "pipelineId": "12"}))
+
+    assert "bad pipeline" in str(exc_info.value)

--- a/integrations/azure-devops/tests/azure_devops/client/test_azure_devops_client.py
+++ b/integrations/azure-devops/tests/azure_devops/client/test_azure_devops_client.py
@@ -6145,3 +6145,61 @@ async def test_enrich_teams_with_area_paths() -> None:
     # Successful team gets its field values; a failing team does not break the batch
     assert enriched_teams[0]["__areaPaths"] == MOCK_TEAM_FIELD_VALUES
     assert enriched_teams[1]["__areaPaths"] is None
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_wraps_variables_and_sets_branch() -> None:
+    from azure_devops.client.azure_devops_client import RunPipelineOptions
+
+    client = AzureDevopsClient(MOCK_ORG_URL, MOCK_AUTH_PROVIDER, MOCK_AUTH_USERNAME)
+    options = RunPipelineOptions(
+        branch="main",
+        template_parameters={"env": "prod"},
+        variables={"ENV": "prod", "ADVANCED": {"value": "x", "isSecret": True}},
+    )
+
+    with patch.object(client, "send_request") as mock_send_request:
+        mock_send_request.return_value = Response(status_code=200, json={"id": 7})
+
+        result = await client.run_pipeline("proj-guid", "12", options)
+
+    assert result == {"id": 7}
+    sent_body = json.loads(mock_send_request.call_args.kwargs["data"])
+    assert sent_body["variables"] == {
+        "ENV": {"value": "prod"},
+        "ADVANCED": {"value": "x", "isSecret": True},
+    }
+    assert sent_body["templateParameters"] == {"env": "prod"}
+    assert sent_body["resources"] == {
+        "repositories": {"self": {"refName": "refs/heads/main"}}
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_pipeline_raises_http_status_error_on_404(
+    mock_event_context: MagicMock,
+) -> None:
+    # A 404 from the Run Pipeline API (e.g. a nonexistent pipelineId) must
+    # surface as an httpx.HTTPStatusError carrying ADO's error detail, not be
+    # swallowed into a generic "Failed to trigger pipeline" RuntimeError.
+    from azure_devops.client.azure_devops_client import RunPipelineOptions
+
+    client = AzureDevopsClient(MOCK_ORG_URL, MOCK_AUTH_PROVIDER, MOCK_AUTH_USERNAME)
+
+    async def mock_make_request(**kwargs: Any) -> Response:
+        return Response(
+            status_code=404,
+            json={"message": "The pipeline with id 102 does not exist"},
+            request=Request("POST", "https://google.com"),
+        )
+
+    async with event_context("test_event"):
+        with patch.object(client._client, "request", side_effect=mock_make_request):
+            with pytest.raises(HTTPStatusError) as exc_info:
+                await client.run_pipeline("proj-guid", "102", RunPipelineOptions())
+
+    assert exc_info.value.response.status_code == 404
+    assert (
+        exc_info.value.response.json()["message"]
+        == "The pipeline with id 102 does not exist"
+    )

--- a/integrations/azure-devops/tests/azure_devops/webhooks/webhook_processors/test_pipeline_run_action_webhook_processor.py
+++ b/integrations/azure-devops/tests/azure_devops/webhooks/webhook_processors/test_pipeline_run_action_webhook_processor.py
@@ -1,0 +1,168 @@
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from azure_devops.client.azure_devops_client import PIPELINES_PUBLISHER_ID
+from azure_devops.webhooks.events import PipelineRunEvents
+from azure_devops.webhooks.webhook_processors.pipeline_run_action_webhook_processor import (
+    PipelineRunActionWebhookProcessor,
+)
+from port_ocean.core.handlers.webhook.abstract_webhook_processor import (
+    WebhookProcessorType,
+)
+from port_ocean.core.handlers.webhook.webhook_event import WebhookEvent
+
+PROCESSOR_MODULE = (
+    "azure_devops.webhooks.webhook_processors."
+    "pipeline_run_action_webhook_processor.ocean"
+)
+
+
+def _payload(state: str = "completed", result: str = "succeeded") -> dict[str, Any]:
+    return {
+        "publisherId": PIPELINES_PUBLISHER_ID,
+        "eventType": PipelineRunEvents.PIPELINE_RUN_STATE_CHANGED,
+        "resourceContainers": {"project": {"id": "proj-guid"}},
+        "resource": {
+            "pipeline": {"id": 12},
+            "run": {"id": 4567, "state": state, "result": result},
+        },
+    }
+
+
+def _mock_ocean(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    port_run: Any,
+    in_progress: bool = True,
+) -> MagicMock:
+    mock_ocean = MagicMock()
+    mock_ocean.port_client.find_run_by_external_id = AsyncMock(return_value=port_run)
+    mock_ocean.port_client.is_run_in_progress = MagicMock(return_value=in_progress)
+    mock_ocean.port_client.report_run_completed = AsyncMock()
+    monkeypatch.setattr(PROCESSOR_MODULE, mock_ocean)
+    return mock_ocean
+
+
+@pytest.fixture
+def processor(event: WebhookEvent) -> PipelineRunActionWebhookProcessor:
+    return PipelineRunActionWebhookProcessor(event)
+
+
+def test_processor_type_is_action(
+    processor: PipelineRunActionWebhookProcessor,
+) -> None:
+    assert processor.get_processor_type() == WebhookProcessorType.ACTION
+
+
+@pytest.mark.asyncio
+async def test_should_process_event_valid(
+    processor: PipelineRunActionWebhookProcessor,
+) -> None:
+    event = WebhookEvent(
+        trace_id="t",
+        payload={
+            "publisherId": PIPELINES_PUBLISHER_ID,
+            "eventType": PipelineRunEvents.PIPELINE_RUN_STATE_CHANGED,
+        },
+        headers={},
+    )
+    assert await processor.should_process_event(event) is True
+
+
+@pytest.mark.asyncio
+async def test_should_process_event_wrong_publisher(
+    processor: PipelineRunActionWebhookProcessor,
+) -> None:
+    event = WebhookEvent(
+        trace_id="t",
+        payload={
+            "publisherId": "other",
+            "eventType": PipelineRunEvents.PIPELINE_RUN_STATE_CHANGED,
+        },
+        headers={},
+    )
+    assert await processor.should_process_event(event) is False
+
+
+@pytest.mark.asyncio
+async def test_validate_payload_missing_run_id(
+    processor: PipelineRunActionWebhookProcessor,
+) -> None:
+    payload = _payload()
+    del payload["resource"]["run"]["id"]
+    assert await processor.validate_payload(payload) is False
+
+
+@pytest.mark.asyncio
+async def test_handle_event_reports_success(
+    processor: PipelineRunActionWebhookProcessor, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    port_run = MagicMock()
+    port_run.id = "port-run-1"
+    port_run.execution_properties = {"reportPipelineStatus": True}
+    mock_ocean = _mock_ocean(monkeypatch, port_run=port_run)
+
+    results = await processor._handle_webhook_event(_payload(), MagicMock())
+
+    mock_ocean.port_client.find_run_by_external_id.assert_awaited_once_with(
+        "ado_proj-guid_12_4567"
+    )
+    completed_call = mock_ocean.port_client.report_run_completed.await_args
+    assert completed_call.args[0] is port_run
+    assert completed_call.args[1] is True
+    assert results.updated_raw_results == []
+
+
+@pytest.mark.asyncio
+async def test_handle_event_reports_failure(
+    processor: PipelineRunActionWebhookProcessor, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    port_run = MagicMock()
+    port_run.execution_properties = {"reportPipelineStatus": True}
+    mock_ocean = _mock_ocean(monkeypatch, port_run=port_run)
+
+    await processor._handle_webhook_event(_payload(result="failed"), MagicMock())
+
+    assert mock_ocean.port_client.report_run_completed.await_args.args[1] is False
+
+
+@pytest.mark.asyncio
+async def test_handle_event_skips_when_not_completed(
+    processor: PipelineRunActionWebhookProcessor, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mock_ocean = _mock_ocean(monkeypatch, port_run=MagicMock())
+
+    await processor._handle_webhook_event(
+        _payload(state="inProgress", result=""), MagicMock()
+    )
+
+    mock_ocean.port_client.find_run_by_external_id.assert_not_awaited()
+    mock_ocean.port_client.report_run_completed.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_event_skips_when_status_reporting_disabled(
+    processor: PipelineRunActionWebhookProcessor, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    port_run = MagicMock()
+    port_run.execution_properties = {"reportPipelineStatus": False}
+    mock_ocean = _mock_ocean(monkeypatch, port_run=port_run)
+
+    await processor._handle_webhook_event(_payload(), MagicMock())
+
+    mock_ocean.port_client.report_run_completed.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_handle_event_reports_when_status_flag_missing(
+    processor: PipelineRunActionWebhookProcessor, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    port_run = MagicMock()
+    port_run.execution_properties = {}
+    mock_ocean = _mock_ocean(monkeypatch, port_run=port_run)
+
+    await processor._handle_webhook_event(_payload(), MagicMock())
+
+    assert mock_ocean.port_client.report_run_completed.await_args.args[1] is True

--- a/integrations/gitlab-v2/CHANGELOG.md
+++ b/integrations/gitlab-v2/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.8.13 (2026-07-23)
+
+
+### Bug Fixes
+
+- Fixed `reportPipelineStatus=false` incorrectly completing `trigger_pipeline` runs immediately instead of leaving them in progress, aligning behavior with the GitHub integration's `reportWorkflowStatus` (the run stays in progress until externally updated, e.g. via a CI job calling back into Port).
+
+
 ## 0.8.12 (2026-07-23)
 
 

--- a/integrations/gitlab-v2/gitlab/actions/trigger_pipeline_executor.py
+++ b/integrations/gitlab-v2/gitlab/actions/trigger_pipeline_executor.py
@@ -80,8 +80,3 @@ class TriggerPipelineExecutor(AbstractGitlabExecutor):
             ref=ref,
             external_id=external_id,
         )
-
-        if not run.execution_properties.get("reportPipelineStatus", True):
-            await ocean.port_client.report_run_completed(
-                run, True, "Pipeline triggered successfully"
-            )

--- a/integrations/gitlab-v2/pyproject.toml
+++ b/integrations/gitlab-v2/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gitlab-v2"
-version = "0.8.12"
+version = "0.8.13"
 description = "Gitlab"
 authors = ["Shariff <mohammed.s@getport.io>"]
 

--- a/integrations/gitlab-v2/tests/actions/test_trigger_pipeline_executor.py
+++ b/integrations/gitlab-v2/tests/actions/test_trigger_pipeline_executor.py
@@ -77,7 +77,7 @@ class TestTriggerPipelineExecutor:
         assert mock_port_client.post_run_log.await_count == 2
         mock_port_client.report_run_completed.assert_not_called()
 
-    async def test_report_pipeline_status_false_completes_immediately(
+    async def test_report_pipeline_status_false_leaves_run_in_progress(
         self, executor: TriggerPipelineExecutor, mock_port_client: MagicMock
     ) -> None:
         run = make_run(
@@ -92,9 +92,7 @@ class TestTriggerPipelineExecutor:
             await executor.execute(run)
 
         mock_port_client.update_run_started.assert_called_once()
-        mock_port_client.report_run_completed.assert_called_once_with(
-            run, True, "Pipeline triggered successfully"
-        )
+        mock_port_client.report_run_completed.assert_not_called()
 
     async def test_missing_project_raises(
         self, executor: TriggerPipelineExecutor


### PR DESCRIPTION
Adds a `trigger_pipeline` action that runs an Azure DevOps pipeline and reports completion status back to Port via the pipeline run-state-changed service hook (Single Account mode). Includes the action executor, action registry, completion webhook processor, client run-pipeline support, spec definition, and tests. Bumps integration version to 0.10.23.

# Description

What -
Adds a new Azure DevOps integration action `trigger_pipeline` that can be invoked from Port actions and workflow `INTEGRATION_ACTION` nodes. When `reportPipelineStatus` is enabled, Ocean correlates the ADO `ms.vss-pipelines.run-state-changed-event` webhook back to the Port run via an external run id and reports success/failure. Also fixes action webhook processor registration so completion handlers are registered on the live `AzureDevopsLiveEventsProcessorManager` (same pattern as GitHub/GitLab).

Why -
Enable Port workflows/self-service to trigger Azure DevOps pipelines and wait for real pipeline completion instead of only acknowledging that the run was queued.

How -
- Spec: define `trigger_pipeline` inputs (`project`, `pipelineId`, `branch`, `reportPipelineStatus`, `templateParameters`, `variables`) and enable `actionsProcessingEnabled`
- Client: add Run Pipeline API support + external id helper `ado_{projectId}_{pipelineId}_{runId}`
- Executor: resolve project, run pipeline, call `update_run_started` with link + external id
- Webhook: `PipelineRunActionWebhookProcessor` handles completed run-state-changed events and calls `report_run_completed`
- Integration: after replacing `webhook_manager`, also point `execution_manager._webhook_manager` at the same manager so action processors receive HTTP webhooks
- Unit tests for executor and action webhook processor

## Type of change

- [x] New feature (non-breaking change which adds functionality)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [x] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [x] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [x] Handled rate limiting
- [ ] Handled pagination
- [x] Implemented the code in async
- [ ] Support Multi account

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces outbound pipeline triggers and correlates ADO webhooks to Port action runs; mis-correlation or webhook wiring bugs could leave runs stuck or report wrong status, though scope is limited to single-account mode with tests.
> 
> **Overview**
> Adds a **`trigger_pipeline`** Port integration action so workflows and self-service can queue an Azure DevOps pipeline and optionally wait for the real run to finish.
> 
> The integration spec enables **`actionsProcessingEnabled`** and documents inputs (`project`, `pipelineId`, optional `branch`, `templateParameters`, `variables`, and **`reportPipelineStatus`** defaulting to true). A new executor resolves the project, calls the **Run Pipeline** REST API, marks the Port run as started with a web link and external id `ado_{projectId}_{pipelineId}_{runId}`, and relies on **`PipelineRunActionWebhookProcessor`** to call **`report_run_completed`** when a completed **pipeline run-state-changed** event matches an in-progress run with status reporting enabled.
> 
> Action execution is **single-organization only** (lazy client resolution; errors if multiple orgs are configured). The client gains **`run_pipeline`** / **`RunPipelineOptions`** and rate-limit helpers for the action framework. **`execution_manager._webhook_manager`** is wired to the same custom live-events manager as **`webhook_manager`** so action webhooks are registered (aligned with GitHub/GitLab). Unit tests cover the executor and completion webhook processor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb33f9d99c5fb5e66cc503b838edf4f331ff0443. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->