### PR TITLE
[Core] Log error when reporting failed run completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.45.5 (2026-07-20)
+
+### Improvements
+
+- Log an error when `report_run_completed` is called with `success=False`, including the run ID for easier failure debugging.
+
 ## 0.45.4 (2026-07-19)
 
 ### Vulnerabilities

--- a/port_ocean/clients/port/mixins/actions_and_workflow_runs.py
+++ b/port_ocean/clients/port/mixins/actions_and_workflow_runs.py
@@ -1,6 +1,7 @@
 from typing import Any, Literal
 
 import httpx
+from loguru import logger
 from port_ocean.clients.port.authentication import PortAuthentication
 from port_ocean.clients.port.mixins.actions import ActionsClientMixin
 from port_ocean.clients.port.mixins.workflow_nodes import WorkflowNodesClientMixin
@@ -165,6 +166,9 @@ class ActionsAndWorkflowRunsClientMixin(ActionsClientMixin, WorkflowNodesClientM
         should_raise: bool = False,
     ) -> None:
         """Report a run as completed with success or failure."""
+        if not success:
+            logger.error("Run completed with failure", run_id=run.id)
+
         if isinstance(run, WorkflowNodeRun):
             result = (
                 WorkflowNodeRunResult.SUCCESS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.45.4"
+version = "0.45.5"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
## Summary
- Log an error in `report_run_completed` when `success=False`, including the run ID for easier debugging of failed action and workflow node runs
- Bump Ocean core version to `0.45.5`

## Test plan
- [x] `pytest port_ocean/tests/clients/port/mixins/test_actions_and_workflow_runs.py -n0`
- [ ] Verify failed integration action runs emit the new error log in integration logs


Made with [Cursor](https://cursor.com)