### PR TITLE
[Integration][Datadog] Enrich multi-org resources with __org_name

### DIFF
--- a/integrations/datadog/CHANGELOG.md
+++ b/integrations/datadog/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.6.24 (2026-07-20)
+
+
+### Features
+
+- Expanded multi-org enrichment by stamping `__org_name` alongside `__org_id` on every ingested resource, enabling dashboard filters and entity mappings to reference organization names instead of opaque IDs.
+
+
 ## 0.6.23 (2026-07-20)
 
 

--- a/integrations/datadog/datadog/utils.py
+++ b/integrations/datadog/datadog/utils.py
@@ -5,6 +5,7 @@ from typing import Any
 from datadog.types import RestrictionPolicyResource
 
 ORG_ID_ENRICHMENT_KEY = "__org_id"
+ORG_NAME_ENRICHMENT_KEY = "__org_name"
 
 
 def get_start_of_the_month_in_seconds_x_months_back(months_back: int) -> int:
@@ -59,8 +60,8 @@ def parse_restriction_policy_asset(asset_id: str) -> RestrictionPolicyResource |
 
 
 def enrich_batch(
-    data: list[dict[str, Any]], *, enrichment_key: str, enrichment_data: Any
+    data: list[dict[str, Any]], *, enrichments: dict[str, Any]
 ) -> list[dict[str, Any]]:
     for item in data:
-        item[enrichment_key] = enrichment_data
+        item.update(enrichments)
     return data

--- a/integrations/datadog/datadog/webhook/webhook_processors/audit_trails/base_processor.py
+++ b/integrations/datadog/datadog/webhook/webhook_processors/audit_trails/base_processor.py
@@ -109,7 +109,7 @@ class BaseAuditTrailProcessor(BaseWebhookProcessor):
             )
 
         if resource:
-            self._enrich_with_org_id([resource], client)
+            self._enrich_with_org_identity([resource], client)
 
         return WebhookEventRawResults(
             updated_raw_results=[resource] if resource else [],

--- a/integrations/datadog/datadog/webhook/webhook_processors/base_webhook_processor.py
+++ b/integrations/datadog/datadog/webhook/webhook_processors/base_webhook_processor.py
@@ -9,7 +9,7 @@ from port_ocean.core.handlers.webhook.abstract_webhook_processor import (
 from port_ocean.core.handlers.webhook.webhook_event import EventPayload, WebhookEvent
 
 from datadog.client import DatadogClient
-from datadog.utils import ORG_ID_ENRICHMENT_KEY, enrich_batch
+from datadog.utils import ORG_ID_ENRICHMENT_KEY, ORG_NAME_ENRICHMENT_KEY, enrich_batch
 from datadog.webhook.webhook_client import PORT_AUTH_HEADER_NAME
 
 
@@ -19,14 +19,16 @@ class BaseWebhookProcessor(AbstractWebhookProcessor):
         super().__init__(event)
         self._client_manager = get_client_manager()
 
-    def _enrich_with_org_id(
+    def _enrich_with_org_identity(
         self, items: list[dict[str, Any]], client: DatadogClient
     ) -> None:
         if self._client_manager.is_multi_org:
             enrich_batch(
                 items,
-                enrichment_key=ORG_ID_ENRICHMENT_KEY,
-                enrichment_data=client.org_id,
+                enrichments={
+                    ORG_ID_ENRICHMENT_KEY: client.org_id,
+                    ORG_NAME_ENRICHMENT_KEY: client.org_name,
+                },
             )
 
     async def authenticate(

--- a/integrations/datadog/datadog/webhook/webhook_processors/monitor_events/monitor_webhook_processor.py
+++ b/integrations/datadog/datadog/webhook/webhook_processors/monitor_events/monitor_webhook_processor.py
@@ -64,7 +64,7 @@ class MonitorWebhookProcessor(BaseWebhookProcessor):
                 )
                 continue
             if monitor:
-                self._enrich_with_org_id([monitor], client)
+                self._enrich_with_org_identity([monitor], client)
                 break
 
         return WebhookEventRawResults(

--- a/integrations/datadog/datadog/webhook/webhook_processors/monitor_events/service_dependency_webhook_processor.py
+++ b/integrations/datadog/datadog/webhook/webhook_processors/monitor_events/service_dependency_webhook_processor.py
@@ -81,7 +81,7 @@ class ServiceDependencyWebhookProcessor(BaseWebhookProcessor):
                 continue
             service_dependencies = [result for result in results if result]
             if service_dependencies:
-                self._enrich_with_org_id(service_dependencies, client)
+                self._enrich_with_org_identity(service_dependencies, client)
                 break
 
         return WebhookEventRawResults(

--- a/integrations/datadog/main.py
+++ b/integrations/datadog/main.py
@@ -11,7 +11,7 @@ from port_ocean.utils.async_iterators import (
 )
 
 from datadog.client import DatadogClient
-from datadog.utils import ORG_ID_ENRICHMENT_KEY, enrich_batch
+from datadog.utils import ORG_ID_ENRICHMENT_KEY, ORG_NAME_ENRICHMENT_KEY, enrich_batch
 from datadog.core.exporters.role_exporter import ListRoleOptions
 from client_manager import get_client_manager
 from integration import ObjectKind
@@ -55,7 +55,7 @@ MAX_CONCURRENT_CLIENTS = 100
 async def _resync_across_orgs(
     build_iterator: Callable[[DatadogClient], ASYNC_GENERATOR_RESYNC_TYPE],
     context: str,
-    enrich_with_org_id: bool = True,
+    enrich_with_org_identity: bool = True,
 ) -> ASYNC_GENERATOR_RESYNC_TYPE:
     manager = get_client_manager()
 
@@ -66,11 +66,13 @@ async def _resync_across_orgs(
     ) -> Callable[[], ASYNC_GENERATOR_RESYNC_TYPE]:
         async def iterator() -> ASYNC_GENERATOR_RESYNC_TYPE:
             async for batch in build_iterator(client):
-                if enrich_with_org_id and manager.is_multi_org:
+                if enrich_with_org_identity and manager.is_multi_org:
                     enrich_batch(
                         batch,
-                        enrichment_key=ORG_ID_ENRICHMENT_KEY,
-                        enrichment_data=client.org_id,
+                        enrichments={
+                            ORG_ID_ENRICHMENT_KEY: client.org_id,
+                            ORG_NAME_ENRICHMENT_KEY: client.org_name,
+                        },
                     )
                 yield batch
 
@@ -204,7 +206,7 @@ async def on_resync_orgs(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     async for orgs in _resync_across_orgs(
         lambda client: OrgExporter(client).get_paginated_resources(),
         context="Organization exporter",
-        enrich_with_org_id=False,
+        enrich_with_org_identity=False,
     ):
         yield orgs
 

--- a/integrations/datadog/pyproject.toml
+++ b/integrations/datadog/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "datadog"
-version = "0.6.23"
+version = "0.6.24"
 description = "Datadog Ocean Integration"
 authors = ["Albert Luganga <albertluganga@getport.io>"]
 

--- a/integrations/datadog/tests/datadog/test_utils.py
+++ b/integrations/datadog/tests/datadog/test_utils.py
@@ -3,6 +3,9 @@ from datetime import datetime
 from freezegun import freeze_time
 
 from datadog.utils import (
+    ORG_ID_ENRICHMENT_KEY,
+    ORG_NAME_ENRICHMENT_KEY,
+    enrich_batch,
     get_start_of_the_day_in_seconds_x_day_back,
     generate_time_windows_from_interval_days,
 )
@@ -59,3 +62,20 @@ def test_generate_time_windows_from_interval_days() -> None:
 
     # Last interval should end at current time
     assert result[-1][1] == current_time
+
+
+def test_enrich_batch_stamps_all_enrichments_onto_every_item() -> None:
+    data: list[dict] = [{"id": 1}, {"id": 2}]
+    result = enrich_batch(
+        data,
+        enrichments={ORG_ID_ENRICHMENT_KEY: "uuid-1", ORG_NAME_ENRICHMENT_KEY: "DPN | Port"},
+    )
+    for item in result:
+        assert item[ORG_ID_ENRICHMENT_KEY] == "uuid-1"
+        assert item[ORG_NAME_ENRICHMENT_KEY] == "DPN | Port"
+
+
+def test_enrich_batch_overwrites_existing_keys() -> None:
+    data: list[dict] = [{"id": 1, ORG_ID_ENRICHMENT_KEY: "old-uuid"}]
+    result = enrich_batch(data, enrichments={ORG_ID_ENRICHMENT_KEY: "new-uuid"})
+    assert result[0][ORG_ID_ENRICHMENT_KEY] == "new-uuid"

--- a/integrations/datadog/tests/datadog/test_utils.py
+++ b/integrations/datadog/tests/datadog/test_utils.py
@@ -1,5 +1,6 @@
 import time
 from datetime import datetime
+from typing import Any
 from freezegun import freeze_time
 
 from datadog.utils import (
@@ -65,7 +66,7 @@ def test_generate_time_windows_from_interval_days() -> None:
 
 
 def test_enrich_batch_stamps_all_enrichments_onto_every_item() -> None:
-    data: list[dict] = [{"id": 1}, {"id": 2}]
+    data: list[dict[str, Any]] = [{"id": 1}, {"id": 2}]
     result = enrich_batch(
         data,
         enrichments={ORG_ID_ENRICHMENT_KEY: "uuid-1", ORG_NAME_ENRICHMENT_KEY: "DPN | Port"},
@@ -76,6 +77,6 @@ def test_enrich_batch_stamps_all_enrichments_onto_every_item() -> None:
 
 
 def test_enrich_batch_overwrites_existing_keys() -> None:
-    data: list[dict] = [{"id": 1, ORG_ID_ENRICHMENT_KEY: "old-uuid"}]
+    data: list[dict[str, Any]] = [{"id": 1, ORG_ID_ENRICHMENT_KEY: "old-uuid"}]
     result = enrich_batch(data, enrichments={ORG_ID_ENRICHMENT_KEY: "new-uuid"})
     assert result[0][ORG_ID_ENRICHMENT_KEY] == "new-uuid"

--- a/integrations/datadog/tests/datadog/test_utils.py
+++ b/integrations/datadog/tests/datadog/test_utils.py
@@ -69,7 +69,10 @@ def test_enrich_batch_stamps_all_enrichments_onto_every_item() -> None:
     data: list[dict[str, Any]] = [{"id": 1}, {"id": 2}]
     result = enrich_batch(
         data,
-        enrichments={ORG_ID_ENRICHMENT_KEY: "uuid-1", ORG_NAME_ENRICHMENT_KEY: "DPN | Port"},
+        enrichments={
+            ORG_ID_ENRICHMENT_KEY: "uuid-1",
+            ORG_NAME_ENRICHMENT_KEY: "DPN | Port",
+        },
     )
     for item in result:
         assert item[ORG_ID_ENRICHMENT_KEY] == "uuid-1"

--- a/integrations/datadog/tests/datadog/webhook/webhook_processors/audit_trails/test_base_processor.py
+++ b/integrations/datadog/tests/datadog/webhook/webhook_processors/audit_trails/test_base_processor.py
@@ -185,17 +185,18 @@ async def test_handle_event_routes_by_audit_org_id(
 
 
 @pytest.mark.asyncio
-async def test_handle_event_enriches_fetched_resource_with_org_id_when_multi_org(
+async def test_handle_event_enriches_fetched_resource_with_org_identity_when_multi_org(
     processor: _StubProcessor,
     mock_client_manager: Any,
 ) -> None:
-    from datadog.utils import ORG_ID_ENRICHMENT_KEY
+    from datadog.utils import ORG_ID_ENRICHMENT_KEY, ORG_NAME_ENRICHMENT_KEY
 
     from unittest.mock import MagicMock
 
     mock_client_manager.is_multi_org = True
     client = MagicMock()
     client.org_id = "uuid-1"
+    client.org_name = "DPN | Port"
     mock_client_manager.get_client_by_org_id.return_value = client
 
     raw = _raw("Stub", "modified", "stub", "s-1")
@@ -204,6 +205,7 @@ async def test_handle_event_enriches_fetched_resource_with_org_id_when_multi_org
     result = await processor.handle_event(raw, resource_config={})  # type: ignore[arg-type]
 
     assert result.updated_raw_results[0][ORG_ID_ENRICHMENT_KEY] == "uuid-1"
+    assert result.updated_raw_results[0][ORG_NAME_ENRICHMENT_KEY] == "DPN | Port"
 
 
 @pytest.mark.asyncio
@@ -211,7 +213,7 @@ async def test_handle_event_does_not_enrich_when_single_org(
     processor: _StubProcessor,
     mock_client_manager: Any,
 ) -> None:
-    from datadog.utils import ORG_ID_ENRICHMENT_KEY
+    from datadog.utils import ORG_ID_ENRICHMENT_KEY, ORG_NAME_ENRICHMENT_KEY
 
     raw = _raw("Stub", "modified", "stub", "s-1")
     raw["attributes"]["org"] = {"name": "DPN | Port", "uuid": "uuid-1"}
@@ -219,6 +221,7 @@ async def test_handle_event_does_not_enrich_when_single_org(
     result = await processor.handle_event(raw, resource_config={})  # type: ignore[arg-type]
 
     assert ORG_ID_ENRICHMENT_KEY not in result.updated_raw_results[0]
+    assert ORG_NAME_ENRICHMENT_KEY not in result.updated_raw_results[0]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description

What - Every resource ingested in multi-org mode now receives both `__org_id` and `__org_name` fields,

Why - The org name is added as human-readable entity identifiers

How -

## Type of change

Please leave one option from the following and delete the rest:

- [X] New feature (non-breaking change which adds functionality)
<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [X] Integration able to create all default resources from scratch
- [X] Resync finishes successfully
- [X] Resync able to create entities
- [X] Resync able to update entities
- [X] Resync able to detect and delete entities
- [X] Scheduled resync able to abort existing resync and start a new one
- [X] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots
<img width="1480" height="706" alt="Screenshot 2026-07-20 at 15 28 27" src="https://github.com/user-attachments/assets/2c2a62d5-60e6-45a8-a21a-cf30c6a6f12a" />

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive metadata in multi-org mode only; no change to single-org behavior or auth paths.
> 
> **Overview**
> Multi-org Datadog ingestion now adds **`__org_name`** next to the existing **`__org_id`** on resync batches and webhook-fetched resources, so Port mappings and filters can use readable org names.
> 
> **`enrich_batch`** now takes an **`enrichments`** dict (replacing a single key/value). Shared webhook helper **`_enrich_with_org_id`** is renamed **`_enrich_with_org_identity`** and applies both fields from **`DatadogClient.org_name`**. Organization resync still skips this enrichment. Release **0.6.24** and tests cover the new field in multi-org mode.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e89356ef2b135c10cf9cfd58f0158b99adee23c3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->