### PR TITLE
[Core] Bumped action versions in ocean CI

### DIFF
--- a/.github/workflows/apply-release.yml
+++ b/.github/workflows/apply-release.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5

--- a/.github/workflows/apply-release.yml
+++ b/.github/workflows/apply-release.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Open pull request
         id: open_pr
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.PORT_MACHINE_USER_GITHUB_TOKEN }}
           title: ${{ steps.version.outputs.pr_name }}
@@ -113,7 +113,7 @@ jobs:
       - name: Send Slack notification
         if: ${{ success() && steps.version.outputs.version != '' && steps.open_pr.outputs.pull-request-url != '' }}
         continue-on-error: true
-        uses: fjogeleit/http-request-action@v1
+        uses: fjogeleit/http-request-action@v2
         with:
           url: ${{ secrets.OCEAN_SLACK_WEBHOOK }}
           method: 'POST'

--- a/.github/workflows/apply-release.yml
+++ b/.github/workflows/apply-release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 

--- a/.github/workflows/build-infra-images.yml
+++ b/.github/workflows/build-infra-images.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Configure AWS Credentials 🔒
         id: aws-credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: "eu-west-1"
           role-to-assume: ${{ secrets.AWS_ECR_ROLE_ARN }}

--- a/.github/workflows/build-infra-images.yml
+++ b/.github/workflows/build-infra-images.yml
@@ -18,7 +18,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || needs.detect-changes.outputs.infra == 'true' }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Configure AWS Credentials 🔒
         id: aws-credentials

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       matrix: ${{ steps.prepare-matrix.outputs.INTEGRATIONS_MATRIX }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Prepare matrix
         id: prepare-matrix
         run: |
@@ -94,7 +94,7 @@ jobs:
           - linux/arm64
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Prepare Docker images tags
         id: prepare_tags

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
 
       - name: Comment if image size limit exceeded
         if: failure() && steps.size_check.outputs.image_size_exceeded == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/claude-generic.yml
+++ b/.github/workflows/claude-generic.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Configure Git
         run: |
           git config --global user.name "Port Claude AI"

--- a/.github/workflows/claude-tag.yml
+++ b/.github/workflows/claude-tag.yml
@@ -25,7 +25,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/combine-dependabot-prs.yml
+++ b/.github/workflows/combine-dependabot-prs.yml
@@ -32,7 +32,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         id: create-combined-pr
         name: Create Combined PR
         with:

--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -25,7 +25,7 @@ jobs:
         run: pipx install 'poetry>=1.0.0,<2.0.0'
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
           cache: 'poetry'

--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -159,7 +159,7 @@ jobs:
 
       - name: Upload coverage report
         id: upload-coverage
-        uses: actions/upload-artifact@v7ˇ
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: htmlcov

--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -19,7 +19,7 @@ jobs:
       RUN_SMOKE_TESTS: ${{ github.event_name != 'pull_request' || github.repository == github.event.pull_request.head.repo.full_name }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Install poetry
         run: pipx install 'poetry>=1.0.0,<2.0.0'

--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -159,7 +159,7 @@ jobs:
 
       - name: Upload coverage report
         id: upload-coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7ˇ
         with:
           name: coverage-report
           path: htmlcov
@@ -172,7 +172,7 @@ jobs:
 
       - name: Comment PR with code coverage summary
         if: ${{ steps.pr-number.outputs.PR_NUMBER != 0 }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           CODE_COVERAGE_ARTIFACT_URL: ${{ steps.upload-coverage.outputs.artifact-url }}
           PR_NUMBER: ${{ steps.pr-number.outputs.PR_NUMBER }}
@@ -206,7 +206,7 @@ jobs:
 
       - name: Comment if Coverage Regression
         if: ${{ (fromJson(steps.set-stmts-coverage.outputs.STMTS_COVERAGE) < fromJson(steps.set-current-coverage.outputs.CURRENT_COVERAGE)) && (steps.pr-number.outputs.PR_NUMBER != 0) }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           PR_NUMBER: ${{ steps.pr-number.outputs.PR_NUMBER }}
           CURRENT_COVERAGE: ${{ steps.set-current-coverage.outputs.CURRENT_COVERAGE }}

--- a/.github/workflows/detect-changes-matrix.yml
+++ b/.github/workflows/detect-changes-matrix.yml
@@ -42,7 +42,7 @@ jobs:
       has_code_changes: ${{ steps.set-all-matrix.outputs.has_code_changes }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Get list of changed files
         id: changed-files

--- a/.github/workflows/docker-images-security-scan.yml
+++ b/.github/workflows/docker-images-security-scan.yml
@@ -47,7 +47,7 @@ jobs:
       images: ${{ steps.set-images.outputs.images }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Determine which image to scan
         id: set-images
@@ -78,7 +78,7 @@ jobs:
         image: ${{ fromJson(needs.detect-images.outputs.images) }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Extract version and image tag
         id: enrich-version

--- a/.github/workflows/docker-images-security-scan.yml
+++ b/.github/workflows/docker-images-security-scan.yml
@@ -136,7 +136,7 @@ jobs:
 
       - name: Send slack alert if vulnerabilities found
         if: ${{ env.VULNERABILITIES_COUNT != '0' }}
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v4.0.0
         with:
           webhook-type: incoming-webhook
           payload: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -22,7 +22,7 @@ jobs:
         || steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set integration test matrix
         id: set-matrix
@@ -60,7 +60,7 @@ jobs:
         folder: ${{ fromJson(needs.integration-test-matrix.outputs.matrix) }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Install poetry
         run: pipx install 'poetry>=1.0.0,<2.0.0'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -66,7 +66,7 @@ jobs:
         run: pipx install 'poetry>=1.0.0,<2.0.0'
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
           cache: 'poetry'

--- a/.github/workflows/integrations-unit-test.yml
+++ b/.github/workflows/integrations-unit-test.yml
@@ -18,7 +18,7 @@ jobs:
         folder: ${{ fromJson(needs.detect-changes.outputs.integrations) }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Install poetry
         run: pipx install 'poetry>=1.0.0,<2.0.0'

--- a/.github/workflows/integrations-unit-test.yml
+++ b/.github/workflows/integrations-unit-test.yml
@@ -24,7 +24,7 @@ jobs:
         run: pipx install 'poetry>=1.0.0,<2.0.0'
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
           cache: 'poetry'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
         run: pipx install 'poetry>=1.0.0,<2.0.0'
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
           cache: 'poetry'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
         folder: ${{ fromJson(needs.detect-changes.outputs.matrix) }}
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Install poetry
         run: pipx install 'poetry>=1.0.0,<2.0.0'

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -75,7 +75,7 @@ jobs:
         run: pipx install 'poetry>=1.0.0,<2.0.0'
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
           cache: 'poetry'

--- a/.github/workflows/perf-test.yml
+++ b/.github/workflows/perf-test.yml
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Install poetry
         run: pipx install 'poetry>=1.0.0,<2.0.0'

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: size-label
-        uses: "pascalgn/size-label-action@v0.5.5"
+        uses: "pascalgn/size-label-action@v0.5.7"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:

--- a/.github/workflows/release-framework.yml
+++ b/.github/workflows/release-framework.yml
@@ -54,7 +54,7 @@ jobs:
           git push origin refs/tags/v${CURRENT_TAG}
       - name: Create GitHub Release
         if: steps.get_current_version.outputs.current_tag != steps.get_previous_version.outputs.prev_tag
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ steps.get_current_version.outputs.current_tag }}
           name: Ocean Framework ${{ steps.get_current_version.outputs.current_tag }}
@@ -105,7 +105,7 @@ jobs:
       - name: Send internal release notification
         if: env.VERSION != ''
         continue-on-error: true
-        uses: fjogeleit/http-request-action@v1
+        uses: fjogeleit/http-request-action@v2
         with:
           url: ${{ secrets.OCEAN_SLACK_WEBHOOK }}
           method: 'POST'

--- a/.github/workflows/release-framework.yml
+++ b/.github/workflows/release-framework.yml
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 

--- a/.github/workflows/release-framework.yml
+++ b/.github/workflows/release-framework.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 2
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -76,7 +76,7 @@ jobs:
           python-version: '3.12'
 
       - name: Checkout Repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ref: v${{ needs.tag-main.outputs.current_tag }}
 

--- a/.github/workflows/release-integrations.yml
+++ b/.github/workflows/release-integrations.yml
@@ -15,7 +15,7 @@ jobs:
       matrix: ${{ steps.prepare-matrix.outputs.INTEGRATIONS_MATRIX }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Prepare matrix
         id: prepare-matrix
@@ -65,7 +65,7 @@ jobs:
         integration: ${{fromJson(needs.prepare-matrix.outputs.matrix)}}
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Prepare Docker images tags
         id: prepare_tags
@@ -233,7 +233,7 @@ jobs:
     needs: release-integration
     steps:
       - name: Check out code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Configure AWS Credentials 🔒
         id: aws-credentials

--- a/.github/workflows/release-integrations.yml
+++ b/.github/workflows/release-integrations.yml
@@ -185,7 +185,7 @@ jobs:
 
       - name: Configure AWS Credentials 🔒
         if: steps.prepare_tags.outputs.is_dev_version == 'false'
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: ${{ vars.ECR_PULL_THROUGH_CACHE_AWS_REGION }}
           role-to-assume: ${{ vars.ECR_PULL_THROUGH_CACHE_DELETE_ROLE_ARN }}
@@ -237,7 +237,7 @@ jobs:
 
       - name: Configure AWS Credentials 🔒
         id: aws-credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -387,7 +387,7 @@ jobs:
     steps:
       - name: Send Slack notification
         continue-on-error: true
-        uses: fjogeleit/http-request-action@v1
+        uses: fjogeleit/http-request-action@v2
         with:
           url: ${{ secrets.OCEAN_SLACK_WEBHOOK }}
           method: 'POST'

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -104,7 +104,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 
@@ -339,7 +339,7 @@ jobs:
           ref: ${{ github.ref_name }}
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -39,7 +39,7 @@ jobs:
           fi
 
       - name: Check out branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.ref_name }}
           fetch-depth: 0
@@ -109,7 +109,7 @@ jobs:
           python-version: '3.12'
 
       - name: Check out branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.ref_name }}
 
@@ -194,7 +194,7 @@ jobs:
       contents: write
     steps:
       - name: Check out branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -253,7 +253,7 @@ jobs:
       matrix: ${{ steps.prepare-matrix.outputs.INTEGRATIONS_MATRIX }}
     steps:
       - name: Check out branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.ref_name }}
 
@@ -334,7 +334,7 @@ jobs:
         integration: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
     steps:
       - name: Check out branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.ref_name }}
 
@@ -452,7 +452,7 @@ jobs:
     if: always()
     steps:
       - name: Check out branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.ref_name }}
 

--- a/.github/workflows/release-rc.yml
+++ b/.github/workflows/release-rc.yml
@@ -230,7 +230,7 @@ jobs:
 
       - name: Create GitHub Release (Pre-release)
         if: inputs.dry_run != true && steps.check-tag.outputs.exists != 'true'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ needs.validate-inputs.outputs.version }}
           name: Ocean Framework ${{ needs.validate-inputs.outputs.version }} (RC)

--- a/.github/workflows/trigger-doc-sync.yml
+++ b/.github/workflows/trigger-doc-sync.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/upgrade-integrations.yml
+++ b/.github/workflows/upgrade-integrations.yml
@@ -30,7 +30,7 @@ jobs:
 
 
       - name: Open pull request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.PORT_MACHINE_USER_GITHUB_TOKEN }}
           title: ${{ steps.version.outputs.pr_name }}

--- a/.github/workflows/upgrade-integrations.yml
+++ b/.github/workflows/upgrade-integrations.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 

--- a/.github/workflows/upgrade-integrations.yml
+++ b/.github/workflows/upgrade-integrations.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5

--- a/.github/workflows/validate-integration-files.yml
+++ b/.github/workflows/validate-integration-files.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 

--- a/.github/workflows/validate-integration-files.yml
+++ b/.github/workflows/validate-integration-files.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: "3.12"
 
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/verify-docs-build.yml
+++ b/.github/workflows/verify-docs-build.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           persist-credentials: true
       - name: Install dependencies
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: lts/*
           cache: npm

--- a/.github/workflows/verify-docs-build.yml
+++ b/.github/workflows/verify-docs-build.yml
@@ -21,7 +21,7 @@ jobs:
       run:
         working-directory: docs/framework-guides/
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           persist-credentials: true
       - name: Install dependencies

--- a/.github/workflows/version-changelog-check.yml
+++ b/.github/workflows/version-changelog-check.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
# Description

What - Bumped action versions in ocean CI

Why - Dependabot spotted misalignments

How - bumping the version on each action

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Workflow-only dependency bumps are low risk, but the malformed `upload-artifact` ref in core tests could break coverage uploads and downstream PR comments on core CI runs.
> 
> **Overview**
> Bumps **third-party GitHub Actions** across Ocean CI workflows to align with Dependabot recommendations—no changes to job logic or scripts.
> 
> **`actions/github-script`** moves from v7 to **v9** in `ci.yml`, `combine-dependabot-prs.yml`, and `core-test.yml` (coverage and regression PR comments). **`aws-actions/configure-aws-credentials`** goes from v4 to **v6** in infra build and integration release/upload paths. **`peter-evans/create-pull-request`** is **v8** in apply-release and upgrade-integrations; **`fjogeleit/http-request-action`** is **v2** for Slack webhooks; **`softprops/action-gh-release`** is **v3** for framework and RC releases; **`pascalgn/size-label-action`** is **v0.5.7** in PR labeling.
> 
> **`core-test.yml`** also bumps **`actions/upload-artifact`** from v4 to v7, but the ref is written as `actions/upload-artifact@v7ˇ` (stray character), which may prevent that step from resolving the action.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2999eb7383c924dcfa05ca4bbe6916fa4237c3aa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->