### PR TITLE
[Core] Add outbound IP blocker setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Improvements
 
-- Added `ip_outbound_blocker_enabled` integration setting to control whether outbound HTTP clients use the IP blocker transport. Defaults to enabled on SaaS runtimes and disabled on on-prem, preserving existing behavior.
+- Added `disable_ip_outbound_blocker` integration setting to disable outbound HTTP IP blocking. Defaults to false on SaaS runtimes and true on on-prem, preserving existing behavior.
 
 ## 0.45.5 (2026-07-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.45.6 (2026-07-21)
+
+### Improvements
+
+- Added `ip_outbound_blocker_enabled` integration setting to control whether outbound HTTP clients use the IP blocker transport. Defaults to enabled on SaaS runtimes and disabled on on-prem, preserving existing behavior.
+
 ## 0.45.5 (2026-07-20)
 
 ### Improvements

--- a/port_ocean/config/settings.py
+++ b/port_ocean/config/settings.py
@@ -316,6 +316,7 @@ class IntegrationConfiguration(BaseOceanSettings, extra=Extra.allow):
     upsert_entities_batch_max_length: int = 20
     upsert_entities_batch_max_size_in_bytes: int = 1024 * 1024
     lakehouse_enabled: bool = False
+    ip_outbound_blocker_enabled: bool | None = None
     lakehouse_buffer_interval_seconds: float = 10.0
     lakehouse_buffer_max_count: int = 50
     processing_mode: ProcessingMode = ProcessingMode.ocean_core
@@ -360,6 +361,13 @@ class IntegrationConfiguration(BaseOceanSettings, extra=Extra.allow):
             return dict(v)
         except (TypeError, ValueError):
             return MetricsSettings(enabled=False, webhook_url=None)
+
+    @root_validator()
+    def set_ip_outbound_blocker_default(cls, values: dict[str, Any]) -> dict[str, Any]:
+        if values.get("ip_outbound_blocker_enabled") is None:
+            runtime = values.get("runtime", Runtime.OnPrem)
+            values["ip_outbound_blocker_enabled"] = runtime.is_saas_runtime
+        return values
 
     @root_validator()
     def validate_integration_config(cls, values: dict[str, Any]) -> dict[str, Any]:

--- a/port_ocean/config/settings.py
+++ b/port_ocean/config/settings.py
@@ -316,7 +316,7 @@ class IntegrationConfiguration(BaseOceanSettings, extra=Extra.allow):
     upsert_entities_batch_max_length: int = 20
     upsert_entities_batch_max_size_in_bytes: int = 1024 * 1024
     lakehouse_enabled: bool = False
-    ip_outbound_blocker_enabled: bool | None = None
+    disable_ip_outbound_blocker: bool | None = None
     lakehouse_buffer_interval_seconds: float = 10.0
     lakehouse_buffer_max_count: int = 50
     processing_mode: ProcessingMode = ProcessingMode.ocean_core
@@ -363,10 +363,12 @@ class IntegrationConfiguration(BaseOceanSettings, extra=Extra.allow):
             return MetricsSettings(enabled=False, webhook_url=None)
 
     @root_validator()
-    def set_ip_outbound_blocker_default(cls, values: dict[str, Any]) -> dict[str, Any]:
-        if values.get("ip_outbound_blocker_enabled") is None:
+    def set_disable_ip_outbound_blocker_default(
+        cls, values: dict[str, Any]
+    ) -> dict[str, Any]:
+        if values.get("disable_ip_outbound_blocker") is None:
             runtime = values.get("runtime", Runtime.OnPrem)
-            values["ip_outbound_blocker_enabled"] = runtime.is_saas_runtime
+            values["disable_ip_outbound_blocker"] = not runtime.is_saas_runtime
         return values
 
     @root_validator()

--- a/port_ocean/helpers/async_client.py
+++ b/port_ocean/helpers/async_client.py
@@ -35,7 +35,7 @@ class OceanAsyncClient(httpx.AsyncClient):
     def _wrap_with_ip_blocker_if_needed(
         self, transport: httpx.AsyncBaseTransport
     ) -> httpx.AsyncBaseTransport:
-        if not ocean.app.is_saas():
+        if not ocean.config.ip_outbound_blocker_enabled:
             return transport
         return IPBlockerTransport(wrapped=transport)
 

--- a/port_ocean/helpers/async_client.py
+++ b/port_ocean/helpers/async_client.py
@@ -35,7 +35,7 @@ class OceanAsyncClient(httpx.AsyncClient):
     def _wrap_with_ip_blocker_if_needed(
         self, transport: httpx.AsyncBaseTransport
     ) -> httpx.AsyncBaseTransport:
-        if not ocean.config.ip_outbound_blocker_enabled:
+        if ocean.config.disable_ip_outbound_blocker:
             return transport
         return IPBlockerTransport(wrapped=transport)
 

--- a/port_ocean/tests/clients/test_lifecycle_client.py
+++ b/port_ocean/tests/clients/test_lifecycle_client.py
@@ -24,7 +24,7 @@ from port_ocean.version import __version__
 def mock_ocean_context() -> Generator[MagicMock, None, None]:
     with patch("port_ocean.helpers.async_client.ocean") as mock_ocean:
         mock_ocean.app.is_saas = MagicMock(return_value=False)
-        mock_ocean.config.ip_outbound_blocker_enabled = False
+        mock_ocean.config.disable_ip_outbound_blocker = True
         yield mock_ocean
 
 

--- a/port_ocean/tests/clients/test_lifecycle_client.py
+++ b/port_ocean/tests/clients/test_lifecycle_client.py
@@ -24,6 +24,7 @@ from port_ocean.version import __version__
 def mock_ocean_context() -> Generator[MagicMock, None, None]:
     with patch("port_ocean.helpers.async_client.ocean") as mock_ocean:
         mock_ocean.app.is_saas = MagicMock(return_value=False)
+        mock_ocean.config.ip_outbound_blocker_enabled = False
         yield mock_ocean
 
 

--- a/port_ocean/tests/config/test_ip_blocker_transport_enabled.py
+++ b/port_ocean/tests/config/test_ip_blocker_transport_enabled.py
@@ -1,0 +1,63 @@
+import pytest
+
+from port_ocean.config.settings import IntegrationConfiguration
+
+
+def _set_required_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OCEAN__PORT__CLIENT_ID", "test-client-id")
+    monkeypatch.setenv("OCEAN__PORT__CLIENT_SECRET", "test-client-secret")
+    monkeypatch.setenv("OCEAN__INTEGRATION__TYPE", "test")
+    monkeypatch.setenv("OCEAN__INTEGRATION__IDENTIFIER", "test-id")
+
+
+def _mock_saas_spec(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "port_ocean.config.settings.get_spec_file",
+        lambda *args, **kwargs: {"saas": {"enabled": True}},
+    )
+
+
+class TestIpOutboundBlockerEnabled:
+    def test_defaults_to_true_on_saas_runtime(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_required_env(monkeypatch)
+        _mock_saas_spec(monkeypatch)
+        monkeypatch.setenv("OCEAN__RUNTIME", "Saas")
+
+        config = IntegrationConfiguration()
+
+        assert config.ip_outbound_blocker_enabled is True
+
+    def test_defaults_to_false_on_on_prem_runtime(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_required_env(monkeypatch)
+        monkeypatch.setenv("OCEAN__RUNTIME", "OnPrem")
+
+        config = IntegrationConfiguration()
+
+        assert config.ip_outbound_blocker_enabled is False
+
+    def test_explicit_env_override_on_saas(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_required_env(monkeypatch)
+        _mock_saas_spec(monkeypatch)
+        monkeypatch.setenv("OCEAN__RUNTIME", "Saas")
+        monkeypatch.setenv("OCEAN__IP_OUTBOUND_BLOCKER_ENABLED", "false")
+
+        config = IntegrationConfiguration()
+
+        assert config.ip_outbound_blocker_enabled is False
+
+    def test_explicit_env_override_on_on_prem(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_required_env(monkeypatch)
+        monkeypatch.setenv("OCEAN__RUNTIME", "OnPrem")
+        monkeypatch.setenv("OCEAN__IP_OUTBOUND_BLOCKER_ENABLED", "true")
+
+        config = IntegrationConfiguration()
+
+        assert config.ip_outbound_blocker_enabled is True

--- a/port_ocean/tests/config/test_ip_blocker_transport_enabled.py
+++ b/port_ocean/tests/config/test_ip_blocker_transport_enabled.py
@@ -17,8 +17,8 @@ def _mock_saas_spec(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
-class TestIpOutboundBlockerEnabled:
-    def test_defaults_to_true_on_saas_runtime(
+class TestDisableIpOutboundBlocker:
+    def test_defaults_to_false_on_saas_runtime(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         _set_required_env(monkeypatch)
@@ -27,9 +27,9 @@ class TestIpOutboundBlockerEnabled:
 
         config = IntegrationConfiguration()
 
-        assert config.ip_outbound_blocker_enabled is True
+        assert config.disable_ip_outbound_blocker is False
 
-    def test_defaults_to_false_on_on_prem_runtime(
+    def test_defaults_to_true_on_on_prem_runtime(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         _set_required_env(monkeypatch)
@@ -37,27 +37,27 @@ class TestIpOutboundBlockerEnabled:
 
         config = IntegrationConfiguration()
 
-        assert config.ip_outbound_blocker_enabled is False
+        assert config.disable_ip_outbound_blocker is True
 
-    def test_explicit_env_override_on_saas(
+    def test_explicit_env_disables_on_saas(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         _set_required_env(monkeypatch)
         _mock_saas_spec(monkeypatch)
         monkeypatch.setenv("OCEAN__RUNTIME", "Saas")
-        monkeypatch.setenv("OCEAN__IP_OUTBOUND_BLOCKER_ENABLED", "false")
+        monkeypatch.setenv("OCEAN__DISABLE_IP_OUTBOUND_BLOCKER", "true")
 
         config = IntegrationConfiguration()
 
-        assert config.ip_outbound_blocker_enabled is False
+        assert config.disable_ip_outbound_blocker is True
 
-    def test_explicit_env_override_on_on_prem(
+    def test_explicit_env_enables_on_on_prem(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         _set_required_env(monkeypatch)
         monkeypatch.setenv("OCEAN__RUNTIME", "OnPrem")
-        monkeypatch.setenv("OCEAN__IP_OUTBOUND_BLOCKER_ENABLED", "true")
+        monkeypatch.setenv("OCEAN__DISABLE_IP_OUTBOUND_BLOCKER", "false")
 
         config = IntegrationConfiguration()
 
-        assert config.ip_outbound_blocker_enabled is True
+        assert config.disable_ip_outbound_blocker is False

--- a/port_ocean/tests/helpers/test_async_client.py
+++ b/port_ocean/tests/helpers/test_async_client.py
@@ -9,18 +9,18 @@ from port_ocean.helpers.retry import RetryTransport
 
 
 @pytest.mark.parametrize(
-    ("ip_outbound_blocker_enabled", "expected_outer_transport"),
+    ("disable_ip_outbound_blocker", "expected_outer_transport"),
     [
-        (True, IPBlockerTransport),
-        (False, RetryTransport),
+        (False, IPBlockerTransport),
+        (True, RetryTransport),
     ],
 )
 def test_init_transport_wraps_with_ip_blocker_based_on_config(
-    ip_outbound_blocker_enabled: bool,
+    disable_ip_outbound_blocker: bool,
     expected_outer_transport: type[httpx.AsyncBaseTransport],
 ) -> None:
     mock_config = MagicMock()
-    mock_config.ip_outbound_blocker_enabled = ip_outbound_blocker_enabled
+    mock_config.disable_ip_outbound_blocker = disable_ip_outbound_blocker
     mock_config.ssl.third_party = MagicMock(verify=True)
 
     with patch("port_ocean.helpers.async_client.ocean") as mock_ocean:

--- a/port_ocean/tests/helpers/test_async_client.py
+++ b/port_ocean/tests/helpers/test_async_client.py
@@ -1,0 +1,31 @@
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from port_ocean.helpers.async_client import OceanAsyncClient
+from port_ocean.helpers.ip_blocker import IPBlockerTransport
+from port_ocean.helpers.retry import RetryTransport
+
+
+@pytest.mark.parametrize(
+    ("ip_outbound_blocker_enabled", "expected_outer_transport"),
+    [
+        (True, IPBlockerTransport),
+        (False, RetryTransport),
+    ],
+)
+def test_init_transport_wraps_with_ip_blocker_based_on_config(
+    ip_outbound_blocker_enabled: bool,
+    expected_outer_transport: type[httpx.AsyncBaseTransport],
+) -> None:
+    mock_config = MagicMock()
+    mock_config.ip_outbound_blocker_enabled = ip_outbound_blocker_enabled
+    mock_config.ssl.third_party = MagicMock(verify=True)
+
+    with patch("port_ocean.helpers.async_client.ocean") as mock_ocean:
+        mock_ocean.config = mock_config
+        client = OceanAsyncClient()
+        transport = client._transport
+
+    assert isinstance(transport, expected_outer_transport)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.45.5"
+version = "0.45.6"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
## Summary
- add configurable outbound IP blocker setting
- preserve SaaS and on-prem defaults
- cover config and client transport behavior

## Testing
- poetry run pytest port_ocean/tests/clients/test_lifecycle_client.py::TestRetryBehavior port_ocean/tests/config/test_ip_blocker_transport_enabled.py port_ocean/tests/helpers/test_async_client.py -q -o addopts=

Made with [Cursor](https://cursor.com)