### PR TITLE
[Integration][Gitlab-v2] Implement support for repository tree file search support

### DIFF
--- a/integrations/gitlab-v2/CHANGELOG.md
+++ b/integrations/gitlab-v2/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.8.9 (2026-07-22)
+
+
+### Improvements
+
+- Added the `repositoryTree` search strategy to the file kind, which discovers files by walking the Git repository tree instead of the GitLab search API. It does not depend on the search index, so it returns complete and consistent results even when search is stale or disabled, at the cost of being slower.
+
+
 ## 0.8.8 (2026-07-22)
 
 

--- a/integrations/gitlab-v2/gitlab/clients/gitlab_client.py
+++ b/integrations/gitlab-v2/gitlab/clients/gitlab_client.py
@@ -12,7 +12,11 @@ from port_ocean.utils.async_iterators import (
 from urllib.parse import quote
 from wcmatch import glob
 
-from gitlab.helpers.utils import parse_file_content, build_search_query, is_bot_member
+from gitlab.helpers.utils import (
+    parse_file_content,
+    SearchQuery,
+    is_bot_member,
+)
 
 from gitlab.clients.rate_limiter.utils import RateLimitInfo
 from gitlab.clients.rest_client import RestClient
@@ -552,7 +556,7 @@ class GitLabClient:
     async def search_files(
         self,
         scope: str,
-        path: str,
+        query: SearchQuery,
         skip_parsing: bool = False,
         repositories: list[str] | None = None,
         params: Optional[dict[str, Any]] = None,
@@ -562,6 +566,8 @@ class GitLabClient:
         """Search for files based on the specified strategy.
 
         Args:
+            query: The parsed search path, built once by the caller and threaded
+                through every strategy so the query string is never rebuilt.
             strategy: One of "projectSearch", "repositoryTree", or "groupSearch".
                 - projectSearch: Search across all accessible projects
                 - repositoryTree: Search across all accessible projects using tree API
@@ -572,11 +578,11 @@ class GitLabClient:
         if strategy in ("projectSearch", "repositoryTree"):
             logger.info(
                 f"Using {'repository tree' if use_tree else 'project-level'} file search "
-                f"for path pattern '{path}'."
+                f"for path pattern '{query.path}'."
             )
             async for batch in self.search_files_in_projects(
                 scope,
-                path,
+                query,
                 skip_parsing=skip_parsing,
                 repositories=repositories,
                 params=params,
@@ -585,10 +591,12 @@ class GitLabClient:
             ):
                 yield batch
         else:
-            logger.info(f"Using group-level file search for path pattern '{path}'.")
+            logger.info(
+                f"Using group-level file search for path pattern '{query.path}'."
+            )
             found_any = False
             async for batch in self._search_files_by_groups(
-                scope, path, repositories, skip_parsing, params, max_concurrent
+                scope, query, repositories, skip_parsing, params, max_concurrent
             ):
                 found_any = True
                 yield batch
@@ -600,7 +608,7 @@ class GitLabClient:
                 )
                 async for batch in self.search_files_in_projects(
                     scope,
-                    path,
+                    query,
                     skip_parsing=skip_parsing,
                     params=params,
                     use_tree=False,
@@ -611,20 +619,19 @@ class GitLabClient:
     async def _search_files_by_groups(
         self,
         scope: str,
-        path: str,
+        query: SearchQuery,
         repositories: list[str] | None = None,
         skip_parsing: bool = False,
         params: Optional[dict[str, Any]] = None,
         max_concurrent: int = 10,
     ) -> AsyncIterator[list[dict[str, Any]]]:
         """Search files by groups or repositories (internal helper)."""
-        search_query = build_search_query(path).to_query_string()
-        logger.info(f"Starting file search with path pattern: '{path}'")
+        logger.info(f"Starting file search with path pattern: '{query.path}'")
 
         semaphore = asyncio.BoundedSemaphore(max_concurrent)
         if repositories:
             logger.info(
-                f"Searching for {path} across {len(repositories)} specific repositories"
+                f"Searching for {query.path} across {len(repositories)} specific repositories"
             )
             tasks = [
                 semaphore_async_iterator(
@@ -633,7 +640,7 @@ class GitLabClient:
                         self._search_files_in_repository,
                         repo,
                         scope,
-                        search_query,
+                        query,
                         skip_parsing,
                     ),
                 )
@@ -642,7 +649,7 @@ class GitLabClient:
             async for batch in stream_async_iterators_tasks(*tasks):
                 yield batch
         else:
-            logger.info(f"Searching for {path} across groups")
+            logger.info(f"Searching for {query.path} across groups")
             async for top_level_groups in self.get_parent_groups(
                 params=params,
             ):
@@ -657,7 +664,7 @@ class GitLabClient:
                             self._search_files_in_group,
                             str(group["id"]),
                             scope,
-                            search_query,
+                            query,
                             skip_parsing,
                         ),
                     )
@@ -669,7 +676,7 @@ class GitLabClient:
     async def search_files_in_projects(
         self,
         scope: str,
-        path: str,
+        query: SearchQuery,
         *,
         skip_parsing: bool = False,
         repositories: list[str] | None = None,
@@ -686,13 +693,13 @@ class GitLabClient:
             use_tree: Whether to use the repository tree API for searching.
         """
         logger.info(
-            f"Starting project-level file search with path pattern: '{path}' using params: {params}"
+            f"Starting project-level file search with path pattern: '{query.path}' using params: {params}"
         )
         semaphore = asyncio.BoundedSemaphore(max_concurrent)
 
         if repositories:
             logger.info(
-                f"Searching for {path} across {len(repositories)} specific repositories"
+                f"Searching for {query.path} across {len(repositories)} specific repositories"
             )
             tasks = [
                 semaphore_async_iterator(
@@ -701,7 +708,7 @@ class GitLabClient:
                         self._search_files_in_repository,
                         repo,
                         scope,
-                        path,
+                        query,
                         skip_parsing,
                         use_tree=use_tree,
                     ),
@@ -711,7 +718,7 @@ class GitLabClient:
             async for batch in stream_async_iterators_tasks(*tasks):
                 yield batch
         else:
-            logger.info(f"Searching for {path} across all accessible projects")
+            logger.info(f"Searching for {query.path} across all accessible projects")
             async for projects_batch in self.get_projects(params=params):
                 tasks = [
                     semaphore_async_iterator(
@@ -720,7 +727,7 @@ class GitLabClient:
                             self._search_files_in_repository,
                             project["path_with_namespace"],
                             scope,
-                            path,
+                            query,
                             skip_parsing,
                             use_tree=use_tree,
                         ),
@@ -984,18 +991,18 @@ class GitLabClient:
         self,
         repo: str,
         scope: str,
-        path: str,
+        query: SearchQuery,
         skip_parsing: bool = False,
         use_tree: bool = False,
     ) -> AsyncIterator[list[dict[str, Any]]]:
         logger.debug(
-            f"Starting search in repository '{repo}' for query '{path}' with scope '{scope}'"
+            f"Starting search in repository '{repo}' for query '{query.path}' with scope '{scope}'"
         )
 
         search_handler = (
-            self._match_files_with_repository_tree(repo, path)
+            self._match_files_with_repository_tree(repo, query)
             if use_tree
-            else self._match_files_with_project_search(repo, scope, path)
+            else self._match_files_with_project_search(repo, scope, query)
         )
 
         async for file_batch in search_handler:
@@ -1007,17 +1014,18 @@ class GitLabClient:
                 yield processed_batch
 
     async def _match_files_with_project_search(
-        self, repo: str, scope: str, path: str
+        self, repo: str, scope: str, query: SearchQuery
     ) -> AsyncIterator[list[dict[str, Any]]]:
-        search_query = build_search_query(path).to_query_string()
-        params = {"scope": scope, "search": search_query}
+        params = {"scope": scope, "search": query.to_query_string()}
         encoded_repo = quote(repo, safe="")
-        path = f"projects/{encoded_repo}/search"
-        async for file_batch in self.rest.get_paginated_resource(path, params=params):
+        search_path = f"projects/{encoded_repo}/search"
+        async for file_batch in self.rest.get_paginated_resource(
+            search_path, params=params
+        ):
             yield file_batch
 
     async def _match_files_with_repository_tree(
-        self, repo: str, path: str
+        self, repo: str, query: SearchQuery
     ) -> AsyncIterator[list[dict[str, Any]]]:
         """Search for files in specified repository matching the given path pattern."""
         project = await self.get_project(repo)
@@ -1025,13 +1033,8 @@ class GitLabClient:
             return
 
         ref = project["default_branch"]
-        is_wildcard = _is_wildcard_path(path)
-
-        if is_wildcard:
-            tree_path = path
-        else:
-            search_components = build_search_query(path)
-            tree_path = search_components.directory or ""
+        is_wildcard = _is_wildcard_path(query.path)
+        tree_path = query.path if is_wildcard else (query.directory or "")
 
         async for items_batch in self.get_repository_tree(project, tree_path, ref):
             files_batch = [
@@ -1043,7 +1046,7 @@ class GitLabClient:
                 for item in items_batch
                 if item["type"] == "blob"
                 and glob.globmatch(
-                    item["path"], path, flags=glob.GLOBSTAR | glob.DOTGLOB
+                    item["path"], query.path, flags=glob.GLOBSTAR | glob.DOTGLOB
                 )
             ]
             if files_batch:
@@ -1053,7 +1056,7 @@ class GitLabClient:
         self,
         group_id: str,
         scope: str,
-        query: str,
+        query: SearchQuery,
         skip_parsing: bool = False,
         max_concurrent: int = 10,
     ) -> AsyncIterator[list[dict[str, Any]]]:
@@ -1081,13 +1084,17 @@ class GitLabClient:
         self,
         group_id: str,
         scope: str,
-        query: str,
+        query: SearchQuery,
         skip_parsing: bool = False,
     ) -> AsyncIterator[list[dict[str, Any]]]:
         logger.info(
-            f"Starting search in group '{group_id}' for query '{query}' with scope '{scope}'"
+            f"Starting search in group '{group_id}' for query '{query.path}' with scope '{scope}'"
         )
-        params = {"scope": scope, "search": query, "search_type": "advanced"}
+        params = {
+            "scope": scope,
+            "search": query.to_query_string(),
+            "search_type": "advanced",
+        }
         path = f"groups/{quote(group_id, safe='')}/search"
 
         try:

--- a/integrations/gitlab-v2/gitlab/clients/gitlab_client.py
+++ b/integrations/gitlab-v2/gitlab/clients/gitlab_client.py
@@ -1027,14 +1027,24 @@ class GitLabClient:
     async def _match_files_with_repository_tree(
         self, repo: str, query: SearchQuery
     ) -> AsyncIterator[list[dict[str, Any]]]:
-        """Search for files in specified repository matching the given path pattern."""
+        """Search for files in specified repository matching the given path pattern.
+
+        A pathless pattern (no directory component, e.g. ``*.yaml`` or ``readme.md``)
+        matches by filename anywhere in the repository, mirroring the search API's
+        ``filename:`` behavior: it is expanded to ``**/<filename>`` so the whole tree
+        is walked recursively and matches in subdirectories are not missed. A pattern
+        with a directory component is matched against the full path as given.
+        """
         project = await self.get_project(repo)
         if not project:
             return
 
         ref = project["default_branch"]
-        is_wildcard = _is_wildcard_path(query.path)
-        tree_path = query.path if is_wildcard else (query.directory or "")
+        match_pattern = (
+            f"**/{query.filename}" if query.directory is None else query.path
+        )
+        is_wildcard = _is_wildcard_path(match_pattern)
+        tree_path = match_pattern if is_wildcard else (query.directory or "")
 
         async for items_batch in self.get_repository_tree(project, tree_path, ref):
             files_batch = [
@@ -1046,7 +1056,7 @@ class GitLabClient:
                 for item in items_batch
                 if item["type"] == "blob"
                 and glob.globmatch(
-                    item["path"], query.path, flags=glob.GLOBSTAR | glob.DOTGLOB
+                    item["path"], match_pattern, flags=glob.GLOBSTAR | glob.DOTGLOB
                 )
             ]
             if files_batch:

--- a/integrations/gitlab-v2/gitlab/clients/gitlab_client.py
+++ b/integrations/gitlab-v2/gitlab/clients/gitlab_client.py
@@ -548,12 +548,72 @@ class GitLabClient:
         self,
         scope: str,
         path: str,
+        skip_parsing: bool = False,
+        repositories: list[str] | None = None,
+        params: Optional[dict[str, Any]] = None,
+        max_concurrent: int = 10,
+        strategy: str = "groupSearch",
+    ) -> AsyncIterator[list[dict[str, Any]]]:
+        """Search for files based on the specified strategy.
+
+        Args:
+            strategy: One of "projectSearch", "repositoryTree", or "groupSearch".
+                - projectSearch: Search across all accessible projects
+                - repositoryTree: Search across all accessible projects using tree API
+                - groupSearch: Search across groups (with fallback to projectSearch if no results)
+        """
+        use_tree = strategy == "repositoryTree"
+
+        if strategy in ("projectSearch", "repositoryTree"):
+            logger.info(
+                f"Using {'repository tree' if use_tree else 'project-level'} file search "
+                f"for path pattern '{path}'."
+            )
+            async for batch in self.search_files_in_projects(
+                scope,
+                path,
+                skip_parsing=skip_parsing,
+                repositories=repositories,
+                params=params,
+                use_tree=use_tree,
+                max_concurrent=max_concurrent,
+            ):
+                yield batch
+        else:
+            logger.info(f"Using group-level file search for path pattern '{path}'.")
+            found_any = False
+            async for batch in self._search_files_by_groups(
+                scope, path, repositories, skip_parsing, params, max_concurrent
+            ):
+                found_any = True
+                yield batch
+
+            if not found_any and not repositories:
+                logger.info(
+                    "Group-level file search returned no results. "
+                    "Falling back to project-level file search."
+                )
+                async for batch in self.search_files_in_projects(
+                    scope,
+                    path,
+                    skip_parsing=skip_parsing,
+                    params=params,
+                    use_tree=False,
+                    max_concurrent=max_concurrent,
+                ):
+                    yield batch
+
+    async def _search_files_by_groups(
+        self,
+        scope: str,
+        path: str,
         repositories: list[str] | None = None,
         skip_parsing: bool = False,
         params: Optional[dict[str, Any]] = None,
         max_concurrent: int = 10,
     ) -> AsyncIterator[list[dict[str, Any]]]:
-        search_query = build_search_query(path)
+        """Search files by groups or repositories (internal helper)."""
+        search_query = build_search_query(path).to_query_string()
         logger.info(f"Starting file search with path pattern: '{path}'")
 
         semaphore = asyncio.BoundedSemaphore(max_concurrent)
@@ -605,38 +665,65 @@ class GitLabClient:
         self,
         scope: str,
         path: str,
+        *,
         skip_parsing: bool = False,
+        repositories: list[str] | None = None,
         params: Optional[dict[str, Any]] = None,
+        use_tree: bool = False,
         max_concurrent: int = 10,
     ) -> AsyncIterator[list[dict[str, Any]]]:
-        """Search for files across all accessible projects.
+        """Search for files across accessible projects or specific repositories.
 
-        This is an alternative to search_files() for cases where the token
-        does not have group-level access. Instead of searching via the
-        Groups API, it iterates over all accessible projects and searches
-        each one individually using the Projects API.
+        Args:
+            repositories: List of specific repository paths to search. If None or empty,
+                         searches across all accessible projects.
+            params: Project filter parameters (only used when repositories is None).
+            use_tree: Whether to use the repository tree API for searching.
         """
-        search_query = build_search_query(path)
         logger.info(
             f"Starting project-level file search with path pattern: '{path}' using params: {params}"
         )
         semaphore = asyncio.BoundedSemaphore(max_concurrent)
-        async for projects_batch in self.get_projects(params=params):
+
+        if repositories:
+            logger.info(
+                f"Searching for {path} across {len(repositories)} specific repositories"
+            )
             tasks = [
                 semaphore_async_iterator(
                     semaphore,
                     partial(
                         self._search_files_in_repository,
-                        project["path_with_namespace"],
+                        repo,
                         scope,
-                        search_query,
+                        path,
                         skip_parsing,
+                        use_tree=use_tree,
                     ),
                 )
-                for project in projects_batch
+                for repo in repositories
             ]
             async for batch in stream_async_iterators_tasks(*tasks):
                 yield batch
+        else:
+            logger.info(f"Searching for {path} across all accessible projects")
+            async for projects_batch in self.get_projects(params=params):
+                tasks = [
+                    semaphore_async_iterator(
+                        semaphore,
+                        partial(
+                            self._search_files_in_repository,
+                            project["path_with_namespace"],
+                            scope,
+                            path,
+                            skip_parsing,
+                            use_tree=use_tree,
+                        ),
+                    )
+                    for project in projects_batch
+                ]
+                async for batch in stream_async_iterators_tasks(*tasks):
+                    yield batch
 
     async def get_repository_tree(
         self,
@@ -644,42 +731,32 @@ class GitLabClient:
         path: str,
         ref: str = "main",
     ) -> AsyncIterator[list[dict[str, Any]]]:
-        """Fetch repository tree (folders only) for a project."""
+        """Fetch repository tree items (files and folders) for a project."""
 
         project_path = project["path_with_namespace"]
         is_wildcard = any(c in path for c in "*?[]")
 
-        if is_wildcard:
-            # For wildcard patterns, we need to recursively search and filter using globmatch
-            params = {"ref": ref, "path": "", "recursive": True}
-
-            async for batch in self.rest.get_paginated_project_resource(
-                project_path, "repository/tree", params
-            ):
-                folders_batch = [
+        params = {
+            "ref": ref,
+            "path": "" if is_wildcard else path,
+            "recursive": is_wildcard,
+        }
+        async for batch in self.rest.get_paginated_project_resource(
+            project_path, "repository/tree", params
+        ):
+            filtered_batch = (
+                [
                     item
                     for item in batch
-                    if item["type"] == "tree"
-                    and glob.globmatch(
+                    if glob.globmatch(
                         item["path"], path, flags=glob.GLOBSTAR | glob.DOTGLOB
                     )
                 ]
-                if folders_batch:
-                    yield [
-                        {"folder": folder, "repo": project, "__branch": ref}
-                        for folder in folders_batch
-                    ]
-        else:
-            # For exact paths, use non-recursive search
-            params = {"ref": ref, "path": path, "recursive": False}
-            async for batch in self.rest.get_paginated_project_resource(
-                project_path, "repository/tree", params
-            ):
-                if folders_batch := [item for item in batch if item["type"] == "tree"]:
-                    yield [
-                        {"folder": folder, "repo": project, "__branch": ref}
-                        for folder in folders_batch
-                    ]
+                if is_wildcard
+                else batch
+            )
+            if filtered_batch:
+                yield filtered_batch
 
     async def get_repository_folders(
         self, path: str, repository: str, branch: Optional[str] = None
@@ -688,10 +765,16 @@ class GitLabClient:
         project = await self.get_project(repository)
         if project:
             effective_branch = branch or project["default_branch"]
-            async for folders_batch in self.get_repository_tree(
+            async for items_batch in self.get_repository_tree(
                 project, path, effective_branch
             ):
-                yield folders_batch
+                folders_batch = [
+                    {"folder": item, "repo": project, "__branch": effective_branch}
+                    for item in items_batch
+                    if item["type"] == "tree"
+                ]
+                if folders_batch:
+                    yield folders_batch
 
     async def _enrich_batch(
         self,
@@ -897,23 +980,67 @@ class GitLabClient:
         self,
         repo: str,
         scope: str,
-        query: str,
+        path: str,
         skip_parsing: bool = False,
+        use_tree: bool = False,
     ) -> AsyncIterator[list[dict[str, Any]]]:
         logger.debug(
-            f"Starting search in repository '{repo}' for query '{query}' with scope '{scope}'"
+            f"Starting search in repository '{repo}' for query '{path}' with scope '{scope}'"
         )
-        params = {"scope": scope, "search": query}
-        encoded_repo = quote(repo, safe="")
-        path = f"projects/{encoded_repo}/search"
 
-        async for file_batch in self.rest.get_paginated_resource(path, params=params):
+        search_handler = (
+            self._match_files_with_repository_tree(repo, path)
+            if use_tree
+            else self._match_files_with_project_search(repo, scope, path)
+        )
+
+        async for file_batch in search_handler:
             logger.debug(f"Found {len(file_batch)} files in '{repo}'")
             processed_batch = await self._process_file_batch(
                 file_batch, repo, skip_parsing
             )
             if processed_batch:
                 yield processed_batch
+
+    async def _match_files_with_project_search(
+        self, repo: str, scope: str, path: str
+    ) -> AsyncIterator[list[dict[str, Any]]]:
+        search_query = build_search_query(path).to_query_string()
+        params = {"scope": scope, "search": search_query}
+        encoded_repo = quote(repo, safe="")
+        path = f"projects/{encoded_repo}/search"
+        async for file_batch in self.rest.get_paginated_resource(path, params=params):
+            yield file_batch
+
+    async def _match_files_with_repository_tree(
+        self, repo: str, path: str
+    ) -> AsyncIterator[list[dict[str, Any]]]:
+        """Search for files in specified repository matching the given path pattern."""
+        project = await self.get_project(repo)
+        if not project:
+            return
+
+        search_components = build_search_query(path)
+        ref = project["default_branch"]
+        async for items_batch in self.get_repository_tree(
+            project, search_components.directory or "", ref
+        ):
+            files_batch = [
+                {
+                    **item,
+                    "ref": ref,
+                    "project_id": project["id"],
+                }
+                for item in items_batch
+                if item["type"] == "blob"
+                and glob.globmatch(
+                    item.get("name", ""),
+                    search_components.filename,
+                    flags=glob.GLOBSTAR | glob.DOTGLOB,
+                )
+            ]
+            if files_batch:
+                yield files_batch
 
     async def _search_files_in_group_projects(
         self,

--- a/integrations/gitlab-v2/gitlab/clients/gitlab_client.py
+++ b/integrations/gitlab-v2/gitlab/clients/gitlab_client.py
@@ -44,6 +44,11 @@ def _is_personal_namespace_project(project: dict[str, Any]) -> bool:
     return project.get("namespace", {}).get("kind") == "user"
 
 
+def _is_wildcard_path(path: str) -> bool:
+    """Check if a path contains glob wildcard characters."""
+    return any(c in path for c in "*?[]")
+
+
 class GitLabClient:
     DEFAULT_PARAMS: dict[str, Any] = {
         "all_available": True,  # Fetch all resources accessible to the user
@@ -731,10 +736,13 @@ class GitLabClient:
         path: str,
         ref: str = "main",
     ) -> AsyncIterator[list[dict[str, Any]]]:
-        """Fetch repository tree items (files and folders) for a project."""
+        """Fetch repository tree items for a project.
 
+        Determines whether to fetch recursively (wildcard path) or a specific subdirectory.
+        Callers should filter the results according to their needs.
+        """
         project_path = project["path_with_namespace"]
-        is_wildcard = any(c in path for c in "*?[]")
+        is_wildcard = _is_wildcard_path(path)
 
         params = {
             "ref": ref,
@@ -744,19 +752,8 @@ class GitLabClient:
         async for batch in self.rest.get_paginated_project_resource(
             project_path, "repository/tree", params
         ):
-            filtered_batch = (
-                [
-                    item
-                    for item in batch
-                    if glob.globmatch(
-                        item["path"], path, flags=glob.GLOBSTAR | glob.DOTGLOB
-                    )
-                ]
-                if is_wildcard
-                else batch
-            )
-            if filtered_batch:
-                yield filtered_batch
+            if batch:
+                yield batch
 
     async def get_repository_folders(
         self, path: str, repository: str, branch: Optional[str] = None
@@ -765,6 +762,7 @@ class GitLabClient:
         project = await self.get_project(repository)
         if project:
             effective_branch = branch or project["default_branch"]
+            is_wildcard = _is_wildcard_path(path)
             async for items_batch in self.get_repository_tree(
                 project, path, effective_branch
             ):
@@ -772,6 +770,12 @@ class GitLabClient:
                     {"folder": item, "repo": project, "__branch": effective_branch}
                     for item in items_batch
                     if item["type"] == "tree"
+                    and (
+                        not is_wildcard
+                        or glob.globmatch(
+                            item["path"], path, flags=glob.GLOBSTAR | glob.DOTGLOB
+                        )
+                    )
                 ]
                 if folders_batch:
                     yield folders_batch
@@ -1020,11 +1024,16 @@ class GitLabClient:
         if not project:
             return
 
-        search_components = build_search_query(path)
         ref = project["default_branch"]
-        async for items_batch in self.get_repository_tree(
-            project, search_components.directory or "", ref
-        ):
+        is_wildcard = _is_wildcard_path(path)
+
+        if is_wildcard:
+            tree_path = path
+        else:
+            search_components = build_search_query(path)
+            tree_path = search_components.directory or ""
+
+        async for items_batch in self.get_repository_tree(project, tree_path, ref):
             files_batch = [
                 {
                     **item,
@@ -1034,9 +1043,7 @@ class GitLabClient:
                 for item in items_batch
                 if item["type"] == "blob"
                 and glob.globmatch(
-                    item.get("name", ""),
-                    search_components.filename,
-                    flags=glob.GLOBSTAR | glob.DOTGLOB,
+                    item["path"], path, flags=glob.GLOBSTAR | glob.DOTGLOB
                 )
             ]
             if files_batch:

--- a/integrations/gitlab-v2/gitlab/clients/gitlab_client.py
+++ b/integrations/gitlab-v2/gitlab/clients/gitlab_client.py
@@ -573,11 +573,11 @@ class GitLabClient:
                 - repositoryTree: Search across all accessible projects using tree API
                 - groupSearch: Search across groups (with fallback to projectSearch if no results)
         """
-        use_tree = strategy == "repositoryTree"
+        should_use_tree = strategy == "repositoryTree"
 
         if strategy in ("projectSearch", "repositoryTree"):
             logger.info(
-                f"Using {'repository tree' if use_tree else 'project-level'} file search "
+                f"Using {'repository tree' if should_use_tree else 'project-level'} file search "
                 f"for path pattern '{query.path}'."
             )
             async for batch in self.search_files_in_projects(
@@ -586,7 +586,7 @@ class GitLabClient:
                 skip_parsing=skip_parsing,
                 repositories=repositories,
                 params=params,
-                use_tree=use_tree,
+                should_use_tree=should_use_tree,
                 max_concurrent=max_concurrent,
             ):
                 yield batch
@@ -594,14 +594,14 @@ class GitLabClient:
             logger.info(
                 f"Using group-level file search for path pattern '{query.path}'."
             )
-            found_any = False
+            has_group_results = False
             async for batch in self._search_files_by_groups(
                 scope, query, repositories, skip_parsing, params, max_concurrent
             ):
-                found_any = True
+                has_group_results = True
                 yield batch
 
-            if not found_any and not repositories:
+            if not has_group_results and not repositories:
                 logger.info(
                     "Group-level file search returned no results. "
                     "Falling back to project-level file search."
@@ -611,7 +611,7 @@ class GitLabClient:
                     query,
                     skip_parsing=skip_parsing,
                     params=params,
-                    use_tree=False,
+                    should_use_tree=False,
                     max_concurrent=max_concurrent,
                 ):
                     yield batch
@@ -681,7 +681,7 @@ class GitLabClient:
         skip_parsing: bool = False,
         repositories: list[str] | None = None,
         params: Optional[dict[str, Any]] = None,
-        use_tree: bool = False,
+        should_use_tree: bool = False,
         max_concurrent: int = 10,
     ) -> AsyncIterator[list[dict[str, Any]]]:
         """Search for files across accessible projects or specific repositories.
@@ -690,7 +690,7 @@ class GitLabClient:
             repositories: List of specific repository paths to search. If None or empty,
                          searches across all accessible projects.
             params: Project filter parameters (only used when repositories is None).
-            use_tree: Whether to use the repository tree API for searching.
+            should_use_tree: Whether to use the repository tree API for searching.
         """
         logger.info(
             f"Starting project-level file search with path pattern: '{query.path}' using params: {params}"
@@ -710,7 +710,7 @@ class GitLabClient:
                         scope,
                         query,
                         skip_parsing,
-                        use_tree=use_tree,
+                        should_use_tree=should_use_tree,
                     ),
                 )
                 for repo in repositories
@@ -729,7 +729,7 @@ class GitLabClient:
                             scope,
                             query,
                             skip_parsing,
-                            use_tree=use_tree,
+                            should_use_tree=should_use_tree,
                         ),
                     )
                     for project in projects_batch
@@ -993,7 +993,7 @@ class GitLabClient:
         scope: str,
         query: SearchQuery,
         skip_parsing: bool = False,
-        use_tree: bool = False,
+        should_use_tree: bool = False,
     ) -> AsyncIterator[list[dict[str, Any]]]:
         logger.debug(
             f"Starting search in repository '{repo}' for query '{query.path}' with scope '{scope}'"
@@ -1001,7 +1001,7 @@ class GitLabClient:
 
         search_handler = (
             self._match_files_with_repository_tree(repo, query)
-            if use_tree
+            if should_use_tree
             else self._match_files_with_project_search(repo, scope, query)
         )
 

--- a/integrations/gitlab-v2/gitlab/helpers/utils.py
+++ b/integrations/gitlab-v2/gitlab/helpers/utils.py
@@ -1,9 +1,10 @@
 import json
 import re
 from copy import deepcopy
+from dataclasses import dataclass
 from enum import IntEnum
 from enum import StrEnum
-from typing import Any, Union
+from typing import Any, Optional, Union
 
 from loguru import logger
 from yaml import YAMLError, safe_load
@@ -102,8 +103,24 @@ def parse_file_content(
         return content
 
 
-def build_search_query(search_path: str) -> str:
-    """Build a GitLab search query string from a file path pattern.
+@dataclass
+class SearchQueryComponents:
+    """Parsed components of a file search path pattern."""
+
+    keyword: str
+    filename: str
+    directory: Optional[str] = None
+
+    def to_query_string(self) -> str:
+        """Build the GitLab search query string from components."""
+        parts = [self.keyword, f"filename:{self.filename}"]
+        if self.directory:
+            parts.insert(1, f"path:{self.directory}")
+        return " ".join(parts)
+
+
+def build_search_query(search_path: str) -> SearchQueryComponents:
+    """Parse a file path pattern into search query components.
 
     The query always includes a ``filename:`` modifier so results are filtered
     by file name rather than just file contents.  When a directory component is
@@ -112,17 +129,20 @@ def build_search_query(search_path: str) -> str:
     they are preserved inside the ``filename:`` and ``path:`` modifiers.
 
     Examples:
-        ``readme.md``            -> ``readme.md filename:readme.md``
-        ``src/config/app.json``  -> ``app.json path:src/config filename:app.json``
-        ``home/directory/*.txt`` -> ``.txt path:home/directory filename:*.txt``
-        ``home/*/*.txt``         -> ``.txt path:home/* filename:*.txt``
+        ``readme.md``            -> keyword='readme', filename='readme.md'
+        ``src/config/app.json``  -> keyword='app', filename='app.json', directory='src/config'
+        ``home/directory/*.txt`` -> keyword='.txt', filename='*.txt', directory='home/directory'
+        ``home/*/*.txt``         -> keyword='.txt', filename='*.txt', directory='home/*'
     """
     if "/" not in search_path:
         keyword = search_path.replace("*", "")
-        return f"{keyword} filename:{search_path}"
+        return SearchQueryComponents(keyword=keyword, filename=search_path)
+
     directory, filename = search_path.rsplit("/", 1)
     keyword = filename.replace("*", "")
-    return f"{keyword} path:{directory} filename:{filename}"
+    return SearchQueryComponents(
+        keyword=keyword, filename=filename, directory=directory
+    )
 
 
 def enrich_resources_with_project(

--- a/integrations/gitlab-v2/gitlab/helpers/utils.py
+++ b/integrations/gitlab-v2/gitlab/helpers/utils.py
@@ -104,9 +104,15 @@ def parse_file_content(
 
 
 @dataclass
-class SearchQueryComponents:
-    """Parsed components of a file search path pattern."""
+class SearchQuery:
+    """Parsed components of a file search path pattern.
 
+    ``path`` preserves the original pattern so tree-based lookups can glob-match
+    against it, while ``keyword``/``filename``/``directory`` back the search API
+    query string.
+    """
+
+    path: str
     keyword: str
     filename: str
     directory: Optional[str] = None
@@ -119,7 +125,7 @@ class SearchQueryComponents:
         return " ".join(parts)
 
 
-def build_search_query(search_path: str) -> SearchQueryComponents:
+def build_search_query(search_path: str) -> SearchQuery:
     """Parse a file path pattern into search query components.
 
     The query always includes a ``filename:`` modifier so results are filtered
@@ -136,12 +142,12 @@ def build_search_query(search_path: str) -> SearchQueryComponents:
     """
     if "/" not in search_path:
         keyword = search_path.replace("*", "")
-        return SearchQueryComponents(keyword=keyword, filename=search_path)
+        return SearchQuery(path=search_path, keyword=keyword, filename=search_path)
 
     directory, filename = search_path.rsplit("/", 1)
     keyword = filename.replace("*", "")
-    return SearchQueryComponents(
-        keyword=keyword, filename=filename, directory=directory
+    return SearchQuery(
+        path=search_path, keyword=keyword, filename=filename, directory=directory
     )
 
 

--- a/integrations/gitlab-v2/integration.py
+++ b/integrations/gitlab-v2/integration.py
@@ -346,9 +346,11 @@ class FilesSelector(BaseModel):
         alias="searchStrategy",
         title="Search Strategy",
         description=(
-            "Controls how files are discovered when repositories are not explicitly configured. "
-            "Use groupSearch to search through GitLab groups, projectSearch to enumerate "
-            "projects and search each project directly, and repositoryTree to match against the Git repository tree."
+            "Controls how files are discovered. groupSearch and projectSearch query GitLab's "
+            "search API; repositoryTree walks the Git repository tree via the tree API, which "
+            "does not depend on GitLab's search index, so it returns complete, consistent "
+            "results even when search indexing is stale or disabled, at the cost of being "
+            "considerably slower."
         ),
     )
 

--- a/integrations/gitlab-v2/integration.py
+++ b/integrations/gitlab-v2/integration.py
@@ -341,14 +341,14 @@ class FilesSelector(BaseModel):
         description="Skip parsing the files and just return the raw file content",
         title="Skip Parsing",
     )
-    search_strategy: Literal["groupSearch", "projectSearch"] = Field(
+    search_strategy: Literal["groupSearch", "projectSearch", "repositoryTree"] = Field(
         default="groupSearch",
         alias="searchStrategy",
         title="Search Strategy",
         description=(
             "Controls how files are discovered when repositories are not explicitly configured. "
-            "Use groupSearch to search through GitLab groups, or projectSearch to enumerate "
-            "projects and search each project directly."
+            "Use groupSearch to search through GitLab groups, projectSearch to enumerate "
+            "projects and search each project directly, and repositoryTree to match against the Git repository tree."
         ),
     )
 

--- a/integrations/gitlab-v2/main.py
+++ b/integrations/gitlab-v2/main.py
@@ -461,7 +461,6 @@ async def on_resync_files(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     )
 
     files_cache: dict[str, dict[str, Any]] = {}
-    found_any_files = False
 
     async def _enrich_and_yield(
         files_batch: list[dict[str, Any]],
@@ -478,61 +477,23 @@ async def on_resync_files(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
                 file_entity["__includedFiles"] = files_cache[repo_key]
         return enriched_batch
 
-    should_use_project_search = search_strategy == "projectSearch" and not repositories
+    params = (
+        build_project_params(include_only_active_projects=include_only_active_groups)
+        if search_strategy in ("projectSearch", "repositoryTree")
+        else build_group_params(include_only_active_groups=include_only_active_groups)
+    )
 
-    if should_use_project_search:
-        logger.info(
-            f"Using project-level file search for path pattern '{search_path}' "
-            "based on selector searchStrategy."
-        )
-        logger.info(
-            "Project-level file search scans accessible projects according to "
-            "the file selector filters because no file repositories were explicitly configured."
-        )
-        params = build_project_params(
-            include_only_active_projects=include_only_active_groups
-        )
-        search_iter = client.search_files_in_projects(
-            scope, search_path, skip_parsing, params
-        )
-    else:
-        level = (
-            f"repository-level file search across {len(repositories)} configured repositories"
-            if repositories
-            else "group-level file search"
-        )
-        logger.info(f"Using {level} for path pattern '{search_path}'.")
-        search_iter = client.search_files(
-            scope,
-            search_path,
-            repositories,
-            skip_parsing,
-            build_group_params(include_only_active_groups=include_only_active_groups),
-        )
-
-    async for files_batch in search_iter:
+    async for files_batch in client.search_files(
+        scope,
+        search_path,
+        skip_parsing=skip_parsing,
+        repositories=repositories,
+        params=params,
+        strategy=search_strategy,
+    ):
         enriched_batch = await _enrich_and_yield(files_batch)
         if enriched_batch:
-            found_any_files = True
             yield enriched_batch
-
-    if not should_use_project_search and not found_any_files and not repositories:
-        logger.info(
-            "Group-level file search returned no results. "
-            "Falling back to project-level file search."
-        )
-        params = build_project_params(
-            include_only_active_projects=include_only_active_groups
-        )
-        async for files_batch in client.search_files_in_projects(
-            scope,
-            search_path,
-            skip_parsing,
-            params,
-        ):
-            enriched_batch = await _enrich_and_yield(files_batch)
-            if enriched_batch:
-                yield enriched_batch
 
 
 @ocean.on_resync(ObjectKind.FOLDER)

--- a/integrations/gitlab-v2/main.py
+++ b/integrations/gitlab-v2/main.py
@@ -16,7 +16,11 @@ from gitlab.clients.utils import (
     build_project_params,
     build_branch_params,
 )
-from gitlab.helpers.utils import ObjectKind, enrich_resources_with_project
+from gitlab.helpers.utils import (
+    ObjectKind,
+    build_search_query,
+    enrich_resources_with_project,
+)
 from integration import (
     GitLabFilesResourceConfig,
     GroupResourceConfig,
@@ -485,7 +489,7 @@ async def on_resync_files(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
 
     async for files_batch in client.search_files(
         scope,
-        search_path,
+        build_search_query(search_path),
         skip_parsing=skip_parsing,
         repositories=repositories,
         params=params,

--- a/integrations/gitlab-v2/pyproject.toml
+++ b/integrations/gitlab-v2/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gitlab-v2"
-version = "0.8.8"
+version = "0.8.9"
 description = "Gitlab"
 authors = ["Shariff <mohammed.s@getport.io>"]
 

--- a/integrations/gitlab-v2/tests/clients/test_gitlab_client.py
+++ b/integrations/gitlab-v2/tests/clients/test_gitlab_client.py
@@ -7,7 +7,7 @@ from port_ocean.context.ocean import initialize_port_ocean_context
 from port_ocean.exceptions.context import PortOceanContextAlreadyInitializedError
 
 from gitlab.clients.gitlab_client import GitLabClient
-from gitlab.helpers.utils import is_bot_member
+from gitlab.helpers.utils import build_search_query, is_bot_member
 
 
 @pytest.fixture(autouse=True)
@@ -745,7 +745,7 @@ class TestGitLabClient:
         ]
         repos = ["group/project"]
         scope = "blobs"
-        query = "test.json"
+        query = build_search_query("test.json")
         with patch.object(
             client,
             "_search_files_in_repository",
@@ -763,7 +763,7 @@ class TestGitLabClient:
                 assert results[0]["path"] == "test.json"
                 assert results[0]["content"] == {"key": "value"}
                 mock_search_repo.assert_called_once_with(
-                    "group/project", "blobs", "test.json filename:test.json", False
+                    "group/project", "blobs", query, False
                 )
 
     async def test_search_files_in_groups(self, client: GitLabClient) -> None:
@@ -773,7 +773,7 @@ class TestGitLabClient:
             {"path": "test.yaml", "project_id": "123", "content": {"key": "value"}}
         ]
         scope = "blobs"
-        query = "test.yaml"
+        query = build_search_query("test.yaml")
 
         with patch.object(
             client, "get_groups", return_value=async_mock_generator([mock_groups])
@@ -805,7 +805,7 @@ class TestGitLabClient:
                         params={"min_access_level": 30}
                     )
                     mock_search_group.assert_called_once_with(
-                        "1", "blobs", "test.yaml filename:test.yaml", False
+                        "1", "blobs", query, False
                     )
 
     async def test_search_files_in_group_blobs_scope_unavailable(
@@ -833,7 +833,7 @@ class TestGitLabClient:
             ):
                 results = []
                 async for batch in client._search_files_in_group(
-                    "my-group", "blobs", "test.json"
+                    "my-group", "blobs", build_search_query("test.json")
                 ):
                     results.extend(batch)
 
@@ -863,7 +863,7 @@ class TestGitLabClient:
             ) as mock_fallback:
                 with pytest.raises(httpx.HTTPStatusError):
                     async for _ in client._search_files_in_group(
-                        "my-group", "blobs", "test.json"
+                        "my-group", "blobs", build_search_query("test.json")
                     ):
                         pass
                 mock_fallback.assert_not_called()

--- a/integrations/gitlab-v2/tests/clients/test_gitlab_client.py
+++ b/integrations/gitlab-v2/tests/clients/test_gitlab_client.py
@@ -1010,6 +1010,104 @@ class TestGitLabClient:
                     {"ref": "develop", "path": "src", "recursive": False},
                 )
 
+    async def test_match_files_with_repository_tree_scoped_directory(
+        self, client: GitLabClient
+    ) -> None:
+        """A non-wildcard directory pattern scopes the tree listing to that directory
+        (non-recursive) and matches items against the full repo-root-relative path."""
+        mock_project = {
+            "id": "1",
+            "path_with_namespace": "group/project",
+            "default_branch": "main",
+        }
+        # GitLab returns full repo-root-relative paths even when `path` scopes the listing.
+        mock_tree = [
+            {"type": "blob", "name": "app.json", "path": "src/config/app.json"},
+            {"type": "blob", "name": "other.json", "path": "src/config/other.json"},
+        ]
+
+        with patch.object(client, "get_project", AsyncMock(return_value=mock_project)):
+            with patch.object(
+                client.rest,
+                "get_paginated_project_resource",
+                return_value=async_mock_generator([mock_tree]),
+            ) as mock_get_paginated:
+                results = []
+                async for batch in client._match_files_with_repository_tree(
+                    "group/project", build_search_query("src/config/app.json")
+                ):
+                    results.extend(batch)
+
+                assert [f["path"] for f in results] == ["src/config/app.json"]
+                assert results[0]["ref"] == "main"
+                assert results[0]["project_id"] == "1"
+                mock_get_paginated.assert_called_once_with(
+                    "group/project",
+                    "repository/tree",
+                    {"ref": "main", "path": "src/config", "recursive": False},
+                )
+
+    async def test_match_files_with_repository_tree_pathless_is_recursive(
+        self, client: GitLabClient
+    ) -> None:
+        """A pathless pattern (no directory) walks the whole tree recursively and
+        matches by filename anywhere, including subdirectories — mirroring the
+        search API's filename: behavior rather than only listing the repo root."""
+        mock_project = {
+            "id": "1",
+            "path_with_namespace": "group/project",
+            "default_branch": "main",
+        }
+        mock_tree = [
+            {"type": "blob", "name": "app.yaml", "path": "app.yaml"},
+            {"type": "blob", "name": "app.yaml", "path": "config/app.yaml"},
+            {"type": "blob", "name": "deep.yaml", "path": "a/b/deep.yaml"},
+            {"type": "blob", "name": "notes.md", "path": "docs/notes.md"},
+            {"type": "tree", "name": "config", "path": "config"},
+        ]
+
+        with patch.object(client, "get_project", AsyncMock(return_value=mock_project)):
+            with patch.object(
+                client.rest,
+                "get_paginated_project_resource",
+                return_value=async_mock_generator([mock_tree]),
+            ) as mock_get_paginated:
+                results = []
+                async for batch in client._match_files_with_repository_tree(
+                    "group/project", build_search_query("*.yaml")
+                ):
+                    results.extend(batch)
+
+                # Matches every *.yaml at any depth, not just the repo root.
+                assert sorted(f["path"] for f in results) == [
+                    "a/b/deep.yaml",
+                    "app.yaml",
+                    "config/app.yaml",
+                ]
+                # Whole-repo recursive listing (path empty, recursive True).
+                mock_get_paginated.assert_called_once_with(
+                    "group/project",
+                    "repository/tree",
+                    {"ref": "main", "path": "", "recursive": True},
+                )
+
+    async def test_match_files_with_repository_tree_missing_project(
+        self, client: GitLabClient
+    ) -> None:
+        """No project resolved → no tree fetched, no results."""
+        with patch.object(client, "get_project", AsyncMock(return_value=None)):
+            with patch.object(
+                client.rest, "get_paginated_project_resource"
+            ) as mock_get_paginated:
+                results = []
+                async for batch in client._match_files_with_repository_tree(
+                    "group/missing", build_search_query("*.yaml")
+                ):
+                    results.extend(batch)
+
+                assert results == []
+                mock_get_paginated.assert_not_called()
+
     async def test_process_file_with_file_reference(self, client: GitLabClient) -> None:
         """Test that parsed file content with file:// reference fetches and resolves content."""
         # Arrange

--- a/integrations/gitlab-v2/tests/clients/test_gitlab_client.py
+++ b/integrations/gitlab-v2/tests/clients/test_gitlab_client.py
@@ -933,7 +933,7 @@ class TestGitLabClient:
             assert exists is False
 
     async def test_get_repository_tree(self, client: GitLabClient) -> None:
-        """Test fetching repository tree (folders only) for a project"""
+        """Test fetching repository tree (files and folders) for a project"""
         project = {"path_with_namespace": "group/project"}
         path = "src"
         ref = "main"
@@ -951,11 +951,13 @@ class TestGitLabClient:
             async for batch in client.get_repository_tree(project, path, ref):
                 results.extend(batch)
 
-            assert len(results) == 2
-            assert results[0]["folder"]["name"] == "folder1"
-            assert results[1]["folder"]["name"] == "folder2"
-            assert all(r["repo"] == project for r in results)
-            assert all(r["__branch"] == ref for r in results)
+            assert len(results) == 3
+            assert results[0]["type"] == "tree"
+            assert results[0]["name"] == "folder1"
+            assert results[1]["type"] == "blob"
+            assert results[1]["name"] == "file.txt"
+            assert results[2]["type"] == "tree"
+            assert results[2]["name"] == "folder2"
             mock_get_paginated.assert_called_once_with(
                 "group/project",
                 "repository/tree",

--- a/integrations/gitlab-v2/tests/clients/test_gitlab_client.py
+++ b/integrations/gitlab-v2/tests/clients/test_gitlab_client.py
@@ -978,8 +978,8 @@ class TestGitLabClient:
         }
 
         mock_tree = [
-            {"type": "tree", "name": "folder1"},
-            {"type": "blob", "name": "file.txt"},
+            {"type": "tree", "name": "folder1", "path": "src/folder1"},
+            {"type": "blob", "name": "file.txt", "path": "src/file.txt"},
         ]
 
         with patch.object(

--- a/integrations/gitlab-v2/tests/helpers/test_utils.py
+++ b/integrations/gitlab-v2/tests/helpers/test_utils.py
@@ -89,3 +89,9 @@ class TestBuildSearchQuery:
             build_search_query("ci/.gitlab-ci.yml").to_query_string()
             == ".gitlab-ci.yml path:ci filename:.gitlab-ci.yml"
         )
+
+    def test_globstar_and_wildcard_in_path(self) -> None:
+        assert (
+            build_search_query("**/skills/*/SKILL.md").to_query_string()
+            == "SKILL.md path:**/skills/* filename:SKILL.md"
+        )

--- a/integrations/gitlab-v2/tests/helpers/test_utils.py
+++ b/integrations/gitlab-v2/tests/helpers/test_utils.py
@@ -34,49 +34,49 @@ class TestUtils:
 
 class TestBuildSearchQuery:
     def test_single_filename(self) -> None:
-        assert build_search_query("readme.md") == "readme.md filename:readme.md"
+        assert build_search_query("readme.md").to_query_string() == "readme.md filename:readme.md"
 
     def test_single_filename_no_extension(self) -> None:
-        assert build_search_query("Makefile") == "Makefile filename:Makefile"
+        assert build_search_query("Makefile").to_query_string() == "Makefile filename:Makefile"
 
     def test_simple_path(self) -> None:
         assert (
-            build_search_query("home/file.yaml")
+            build_search_query("home/file.yaml").to_query_string()
             == "file.yaml path:home filename:file.yaml"
         )
 
     def test_wildcard_path(self) -> None:
         assert (
-            build_search_query("home/*/file.yaml")
+            build_search_query("home/*/file.yaml").to_query_string()
             == "file.yaml path:home/* filename:file.yaml"
         )
 
     def test_nested_path(self) -> None:
         assert (
-            build_search_query("src/config/settings.json")
+            build_search_query("src/config/settings.json").to_query_string()
             == "settings.json path:src/config filename:settings.json"
         )
 
     def test_glob_filename(self) -> None:
-        assert build_search_query("*.yaml") == ".yaml filename:*.yaml"
+        assert build_search_query("*.yaml").to_query_string() == ".yaml filename:*.yaml"
 
     def test_glob_filename_in_path(self) -> None:
         assert (
-            build_search_query("home/directory/*.txt")
+            build_search_query("home/directory/*.txt").to_query_string()
             == ".txt path:home/directory filename:*.txt"
         )
 
     def test_glob_in_path_and_filename(self) -> None:
-        assert build_search_query("home/*/*.txt") == ".txt path:home/* filename:*.txt"
+        assert build_search_query("home/*/*.txt").to_query_string() == ".txt path:home/* filename:*.txt"
 
     def test_dotfile_single(self) -> None:
         assert (
-            build_search_query(".gitlab-ci.yml")
+            build_search_query(".gitlab-ci.yml").to_query_string()
             == ".gitlab-ci.yml filename:.gitlab-ci.yml"
         )
 
     def test_dotfile_in_path(self) -> None:
         assert (
-            build_search_query("ci/.gitlab-ci.yml")
+            build_search_query("ci/.gitlab-ci.yml").to_query_string()
             == ".gitlab-ci.yml path:ci filename:.gitlab-ci.yml"
         )

--- a/integrations/gitlab-v2/tests/helpers/test_utils.py
+++ b/integrations/gitlab-v2/tests/helpers/test_utils.py
@@ -34,10 +34,16 @@ class TestUtils:
 
 class TestBuildSearchQuery:
     def test_single_filename(self) -> None:
-        assert build_search_query("readme.md").to_query_string() == "readme.md filename:readme.md"
+        assert (
+            build_search_query("readme.md").to_query_string()
+            == "readme.md filename:readme.md"
+        )
 
     def test_single_filename_no_extension(self) -> None:
-        assert build_search_query("Makefile").to_query_string() == "Makefile filename:Makefile"
+        assert (
+            build_search_query("Makefile").to_query_string()
+            == "Makefile filename:Makefile"
+        )
 
     def test_simple_path(self) -> None:
         assert (
@@ -67,7 +73,10 @@ class TestBuildSearchQuery:
         )
 
     def test_glob_in_path_and_filename(self) -> None:
-        assert build_search_query("home/*/*.txt").to_query_string() == ".txt path:home/* filename:*.txt"
+        assert (
+            build_search_query("home/*/*.txt").to_query_string()
+            == ".txt path:home/* filename:*.txt"
+        )
 
     def test_dotfile_single(self) -> None:
         assert (


### PR DESCRIPTION
# Description

What - Implement support for using repositoryTree as a file fetching strategy.

Why - Search API can sometimes be inconsistent, for the few customers where this is an issue, repositoryTree can offer a workaround.

How - Extend the new `SearchStrategy` selector.

## Type of change

Please leave one option from the following and delete the rest:

- [ x ] Non-breaking change (fix of existing functionality that will not change current behavior)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> File resync behavior changes only when customers opt into repositoryTree; tree walks can be heavier on large repos and matching differs from search API semantics, but defaults and existing strategies are preserved.
> 
> **Overview**
> Adds a **`repositoryTree`** option to the file resource **`searchStrategy`** selector so file discovery can walk the GitLab repository tree API instead of relying on group/project search when search results are unreliable.
> 
> **`GitLabClient.search_files`** now routes by strategy: **`projectSearch`** and **`repositoryTree`** go through **`search_files_in_projects`** (with optional repo list and **`use_tree`**); **`groupSearch`** uses group search and still falls back to project search when nothing is found and no repos are pinned. File resync in **`main.py`** delegates to this single entry point instead of duplicating strategy and fallback logic.
> 
> **`build_search_query`** now returns **`SearchQueryComponents`** (keyword, filename, optional directory) with **`to_query_string()`** for the search API and structured fields for tree matching. Per-repo lookup splits into **`_match_files_with_project_search`** vs **`_match_files_with_repository_tree`** (glob on blob names under the parsed directory). **`get_repository_tree`** returns raw tree entries (files and folders); folder resync filters to **`type == tree`** in **`get_repository_folders`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62f5eff1a3d1360a2cb028da088eb8490a9bbb11. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->