### PR TITLE
[Core] add relative time helpers in core

### DIFF
--- a/.github/workflows/validate-integration-files.yml
+++ b/.github/workflows/validate-integration-files.yml
@@ -2,30 +2,40 @@ name: Validate integration files
 
 on:
   pull_request:
-    paths:
-      - "integrations/**"
 
 
 jobs:
+  detect-changes:
+    uses: ./.github/workflows/detect-changes-matrix.yml
+
   validate-files:
+    needs: detect-changes
     runs-on: ubuntu-latest
 
     steps:
+      - name: No integration changes
+        if: needs.detect-changes.outputs.has_integration_code_changes != 'true'
+        run: echo "No integration changes detected"
+
       - name: Set up Python 3.12
+        if: needs.detect-changes.outputs.has_integration_code_changes == 'true'
         uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
       - name: Checkout code
+        if: needs.detect-changes.outputs.has_integration_code_changes == 'true'
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Setup
+        if: needs.detect-changes.outputs.has_integration_code_changes == 'true'
         run: |
           pip install toml-cli yq packaging
 
       - name: Check Ocean version 🌊
+        if: needs.detect-changes.outputs.has_integration_code_changes == 'true'
         run: |
           git remote add ocean-origin https://github.com/port-labs/ocean.git
           git fetch ocean-origin
@@ -47,6 +57,7 @@ jobs:
           done
 
       - name: Validate integration version format
+        if: needs.detect-changes.outputs.has_integration_code_changes == 'true'
         run: |
           changed_dirs=$(git diff --name-only ocean-origin/main HEAD | grep 'integrations/' | cut -d'/' -f 1,2 | sort -u)
           for dir in $changed_dirs; do
@@ -69,6 +80,7 @@ jobs:
           done
 
       - name: Validate integration not duplicated
+        if: needs.detect-changes.outputs.has_integration_code_changes == 'true'
         run: |
           for integration in $(find integrations -name 'pyproject.yaml' -not -path "**/.venv/*"); do
             type=$(grep -E '^name = ".*"' "$integration" | cut -d'"' -f2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.45.8 (2026-07-21)
+
+### Features
+
+- Added `port_ocean.utils.relative_time` helpers (`days_ago`, `months_ago`, `to_rfc3339`) for integration lookback selectors.
+
+
 ## 0.45.7 (2026-07-21)
 
 ### Improvements

--- a/port_ocean/tests/utils/test_relative_time.py
+++ b/port_ocean/tests/utils/test_relative_time.py
@@ -38,12 +38,6 @@ def test_months_ago_calendar(monkeypatch: pytest.MonkeyPatch) -> None:
     assert months_ago(1) == datetime(2025, 12, 31, 12, 0, 0, tzinfo=timezone.utc)
 
 
-def test_months_ago_negative_is_future(freeze_now: datetime) -> None:
-    assert months_ago(-2) == datetime(
-        2026, 9, 21, 12, 30, 45, 123456, tzinfo=timezone.utc
-    )
-
-
 def test_to_rfc3339_seconds() -> None:
     assert to_rfc3339(FROZEN_NOW) == "2026-07-21T12:30:45Z"
 

--- a/port_ocean/tests/utils/test_relative_time.py
+++ b/port_ocean/tests/utils/test_relative_time.py
@@ -1,52 +1,47 @@
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 
-from dateutil.relativedelta import relativedelta
+import pytest
 
+import port_ocean.utils.relative_time as relative_time
 from port_ocean.utils.relative_time import days_ago, months_ago, to_rfc3339
 
 FROZEN_NOW = datetime(2026, 7, 21, 12, 30, 45, 123456, tzinfo=timezone.utc)
 
 
-def test_days_ago() -> None:
-    assert days_ago(7, now=FROZEN_NOW) == FROZEN_NOW - timedelta(days=7)
-
-
-def test_days_ago_negative_is_future() -> None:
-    assert days_ago(-3, now=FROZEN_NOW) == FROZEN_NOW + timedelta(days=3)
-
-
-def test_days_ago_normalizes_offset_timezone_to_utc() -> None:
-    offset = timezone(timedelta(hours=2))
-    local = datetime(2026, 7, 21, 14, 30, 45, tzinfo=offset)
-    result = days_ago(1, now=local)
-    assert result == datetime(2026, 7, 20, 12, 30, 45, tzinfo=timezone.utc)
-    assert result.tzinfo == timezone.utc
-
-
-def test_days_ago_treats_naive_as_utc() -> None:
-    naive = datetime(2026, 7, 21, 12, 30, 45)
-    result = days_ago(1, now=naive)
-    assert result == datetime(2026, 7, 20, 12, 30, 45, tzinfo=timezone.utc)
-    assert result.tzinfo == timezone.utc
-
-
-def test_months_ago_calendar() -> None:
-    end_of_jan = datetime(2026, 1, 31, 12, 0, 0, tzinfo=timezone.utc)
-    assert months_ago(1, now=end_of_jan) == datetime(
-        2025, 12, 31, 12, 0, 0, tzinfo=timezone.utc
+def _freeze_clock(monkeypatch: pytest.MonkeyPatch, frozen: datetime) -> None:
+    monkeypatch.setattr(
+        relative_time,
+        "datetime",
+        SimpleNamespace(now=lambda tz=None: frozen),
     )
 
 
-def test_months_ago_negative_is_future() -> None:
-    assert months_ago(-2, now=FROZEN_NOW) == FROZEN_NOW + relativedelta(months=2)
+@pytest.fixture
+def freeze_now(monkeypatch: pytest.MonkeyPatch) -> datetime:
+    _freeze_clock(monkeypatch, FROZEN_NOW)
+    return FROZEN_NOW
 
 
-def test_months_ago_normalizes_offset_timezone_to_utc() -> None:
-    offset = timezone(timedelta(hours=3))
-    local = datetime(2026, 7, 21, 15, 0, 0, tzinfo=offset)
-    result = months_ago(1, now=local)
-    assert result == datetime(2026, 6, 21, 12, 0, 0, tzinfo=timezone.utc)
-    assert result.tzinfo == timezone.utc
+def test_days_ago(freeze_now: datetime) -> None:
+    assert days_ago(7) == datetime(2026, 7, 14, 12, 30, 45, 123456, tzinfo=timezone.utc)
+
+
+def test_days_ago_negative_is_future(freeze_now: datetime) -> None:
+    assert days_ago(-3) == datetime(
+        2026, 7, 24, 12, 30, 45, 123456, tzinfo=timezone.utc
+    )
+
+
+def test_months_ago_calendar(monkeypatch: pytest.MonkeyPatch) -> None:
+    _freeze_clock(monkeypatch, datetime(2026, 1, 31, 12, 0, 0, tzinfo=timezone.utc))
+    assert months_ago(1) == datetime(2025, 12, 31, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def test_months_ago_negative_is_future(freeze_now: datetime) -> None:
+    assert months_ago(-2) == datetime(
+        2026, 9, 21, 12, 30, 45, 123456, tzinfo=timezone.utc
+    )
 
 
 def test_to_rfc3339_seconds() -> None:
@@ -63,3 +58,8 @@ def test_to_rfc3339_normalizes_offset_timezone() -> None:
     offset = timezone(timedelta(hours=2))
     local = datetime(2026, 7, 21, 14, 30, 45, tzinfo=offset)
     assert to_rfc3339(local) == "2026-07-21T12:30:45Z"
+
+
+def test_to_rfc3339_treats_naive_as_utc() -> None:
+    naive = datetime(2026, 7, 21, 12, 30, 45)
+    assert to_rfc3339(naive) == "2026-07-21T12:30:45Z"

--- a/port_ocean/tests/utils/test_relative_time.py
+++ b/port_ocean/tests/utils/test_relative_time.py
@@ -15,6 +15,21 @@ def test_days_ago_negative_is_future() -> None:
     assert days_ago(-3, now=FROZEN_NOW) == FROZEN_NOW + timedelta(days=3)
 
 
+def test_days_ago_normalizes_offset_timezone_to_utc() -> None:
+    offset = timezone(timedelta(hours=2))
+    local = datetime(2026, 7, 21, 14, 30, 45, tzinfo=offset)
+    result = days_ago(1, now=local)
+    assert result == datetime(2026, 7, 20, 12, 30, 45, tzinfo=timezone.utc)
+    assert result.tzinfo == timezone.utc
+
+
+def test_days_ago_treats_naive_as_utc() -> None:
+    naive = datetime(2026, 7, 21, 12, 30, 45)
+    result = days_ago(1, now=naive)
+    assert result == datetime(2026, 7, 20, 12, 30, 45, tzinfo=timezone.utc)
+    assert result.tzinfo == timezone.utc
+
+
 def test_months_ago_calendar() -> None:
     end_of_jan = datetime(2026, 1, 31, 12, 0, 0, tzinfo=timezone.utc)
     assert months_ago(1, now=end_of_jan) == datetime(
@@ -26,6 +41,14 @@ def test_months_ago_negative_is_future() -> None:
     assert months_ago(-2, now=FROZEN_NOW) == FROZEN_NOW + relativedelta(months=2)
 
 
+def test_months_ago_normalizes_offset_timezone_to_utc() -> None:
+    offset = timezone(timedelta(hours=3))
+    local = datetime(2026, 7, 21, 15, 0, 0, tzinfo=offset)
+    result = months_ago(1, now=local)
+    assert result == datetime(2026, 6, 21, 12, 0, 0, tzinfo=timezone.utc)
+    assert result.tzinfo == timezone.utc
+
+
 def test_to_rfc3339_seconds() -> None:
     assert to_rfc3339(FROZEN_NOW) == "2026-07-21T12:30:45Z"
 
@@ -34,3 +57,9 @@ def test_to_rfc3339_microseconds() -> None:
     assert to_rfc3339(FROZEN_NOW, timespec="microseconds") == (
         "2026-07-21T12:30:45.123456Z"
     )
+
+
+def test_to_rfc3339_normalizes_offset_timezone() -> None:
+    offset = timezone(timedelta(hours=2))
+    local = datetime(2026, 7, 21, 14, 30, 45, tzinfo=offset)
+    assert to_rfc3339(local) == "2026-07-21T12:30:45Z"

--- a/port_ocean/tests/utils/test_relative_time.py
+++ b/port_ocean/tests/utils/test_relative_time.py
@@ -1,0 +1,36 @@
+from datetime import datetime, timedelta, timezone
+
+from dateutil.relativedelta import relativedelta
+
+from port_ocean.utils.relative_time import days_ago, months_ago, to_rfc3339
+
+FROZEN_NOW = datetime(2026, 7, 21, 12, 30, 45, 123456, tzinfo=timezone.utc)
+
+
+def test_days_ago() -> None:
+    assert days_ago(7, now=FROZEN_NOW) == FROZEN_NOW - timedelta(days=7)
+
+
+def test_days_ago_negative_is_future() -> None:
+    assert days_ago(-3, now=FROZEN_NOW) == FROZEN_NOW + timedelta(days=3)
+
+
+def test_months_ago_calendar() -> None:
+    end_of_jan = datetime(2026, 1, 31, 12, 0, 0, tzinfo=timezone.utc)
+    assert months_ago(1, now=end_of_jan) == datetime(
+        2025, 12, 31, 12, 0, 0, tzinfo=timezone.utc
+    )
+
+
+def test_months_ago_negative_is_future() -> None:
+    assert months_ago(-2, now=FROZEN_NOW) == FROZEN_NOW + relativedelta(months=2)
+
+
+def test_to_rfc3339_seconds() -> None:
+    assert to_rfc3339(FROZEN_NOW) == "2026-07-21T12:30:45Z"
+
+
+def test_to_rfc3339_microseconds() -> None:
+    assert to_rfc3339(FROZEN_NOW, timespec="microseconds") == (
+        "2026-07-21T12:30:45.123456Z"
+    )

--- a/port_ocean/utils/relative_time.py
+++ b/port_ocean/utils/relative_time.py
@@ -6,8 +6,6 @@ Keep vendor-specific behavior local (start-of-day/month snaps, ``30d`` strings,
 search prefixes like ``>=...``, window partitioning, API clamps).
 """
 
-from __future__ import annotations
-
 from datetime import datetime, timedelta, timezone
 from typing import Literal
 
@@ -16,15 +14,21 @@ from dateutil.relativedelta import relativedelta
 Rfc3339Timespec = Literal["seconds", "microseconds"]
 
 
+def _as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
 def days_ago(days: int, *, now: datetime | None = None) -> datetime:
     """UTC datetime ``days`` ago (negative ``days`` = in the future)."""
-    current = now or datetime.now(timezone.utc)
+    current = _as_utc(now) if now is not None else datetime.now(timezone.utc)
     return current - timedelta(days=days)
 
 
 def months_ago(months: int, *, now: datetime | None = None) -> datetime:
     """UTC datetime ``months`` calendar months ago (negative = in the future)."""
-    current = now or datetime.now(timezone.utc)
+    current = _as_utc(now) if now is not None else datetime.now(timezone.utc)
     return current - relativedelta(months=months)
 
 
@@ -34,8 +38,4 @@ def to_rfc3339(
     timespec: Rfc3339Timespec = "seconds",
 ) -> str:
     """Format a datetime as RFC3339 UTC ending in ``Z``."""
-    if value.tzinfo is None:
-        value = value.replace(tzinfo=timezone.utc)
-    else:
-        value = value.astimezone(timezone.utc)
-    return value.isoformat(timespec=timespec).replace("+00:00", "Z")
+    return _as_utc(value).isoformat(timespec=timespec).replace("+00:00", "Z")

--- a/port_ocean/utils/relative_time.py
+++ b/port_ocean/utils/relative_time.py
@@ -1,0 +1,41 @@
+"""Relative lookback helpers for integration selectors.
+
+Returns UTC datetimes; format with ``to_rfc3339`` when an API wants a string.
+
+Keep vendor-specific behavior local (start-of-day/month snaps, ``30d`` strings,
+search prefixes like ``>=...``, window partitioning, API clamps).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Literal
+
+from dateutil.relativedelta import relativedelta
+
+Rfc3339Timespec = Literal["seconds", "microseconds"]
+
+
+def days_ago(days: int, *, now: datetime | None = None) -> datetime:
+    """UTC datetime ``days`` ago (negative ``days`` = in the future)."""
+    current = now or datetime.now(timezone.utc)
+    return current - timedelta(days=days)
+
+
+def months_ago(months: int, *, now: datetime | None = None) -> datetime:
+    """UTC datetime ``months`` calendar months ago (negative = in the future)."""
+    current = now or datetime.now(timezone.utc)
+    return current - relativedelta(months=months)
+
+
+def to_rfc3339(
+    value: datetime,
+    *,
+    timespec: Rfc3339Timespec = "seconds",
+) -> str:
+    """Format a datetime as RFC3339 UTC ending in ``Z``."""
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    else:
+        value = value.astimezone(timezone.utc)
+    return value.isoformat(timespec=timespec).replace("+00:00", "Z")

--- a/port_ocean/utils/relative_time.py
+++ b/port_ocean/utils/relative_time.py
@@ -20,16 +20,14 @@ def _as_utc(value: datetime) -> datetime:
     return value.astimezone(timezone.utc)
 
 
-def days_ago(days: int, *, now: datetime | None = None) -> datetime:
+def days_ago(days: int) -> datetime:
     """UTC datetime ``days`` ago (negative ``days`` = in the future)."""
-    current = _as_utc(now) if now is not None else datetime.now(timezone.utc)
-    return current - timedelta(days=days)
+    return datetime.now(timezone.utc) - timedelta(days=days)
 
 
-def months_ago(months: int, *, now: datetime | None = None) -> datetime:
+def months_ago(months: int) -> datetime:
     """UTC datetime ``months`` calendar months ago (negative = in the future)."""
-    current = _as_utc(now) if now is not None else datetime.now(timezone.utc)
-    return current - relativedelta(months=months)
+    return datetime.now(timezone.utc) - relativedelta(months=months)
 
 
 def to_rfc3339(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.45.7"
+version = "0.45.8"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description
- Add shared lookback helpers in `port_ocean.utils.relative_time`: `days_ago`, `months_ago`, and `to_rfc3339`
- Covering the common day/month → UTC datetime → RFC3339 cases integrations reimplement today
- Leave vendor-specific behavior local (start-of-day/month snaps, 30d strings, search prefixes, window partitioning, API clamps)

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive utility module and tests only; no changes to resync, auth, or existing integration paths.
> 
> **Overview**
> Introduces **`port_ocean.utils.relative_time`** for shared UTC lookback math in integration selectors: **`days_ago`** and **`months_ago`** (optional injectable `now`, negative offsets treated as future), plus **`to_rfc3339`** for API-friendly UTC strings (naive datetimes assumed UTC; `timespec` seconds or microseconds).
> 
> Adds **`port_ocean/tests/utils/test_relative_time.py`** with frozen-clock coverage for day/month edges, negative offsets, and RFC3339 formatting. Release notes and **`pyproject.toml`** version bump to **0.45.8**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ac0a2761e9c8bab8f3b4ffac9f512c7dace51aa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->