### PR TITLE
[Core] Remove misleading Event Added To Queue log from Redis stream consumer 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.45.9 (2026-07-22)
+
+### Bug Fixes
+
+- Removed misleading `Event Added To Queue` log from the Redis stream consumer; queue latency is already reported via `time_until_consumed_ms` in the Redis stream processed log.
+
 ## 0.45.8 (2026-07-21)
 
 ### Improvements

--- a/port_ocean/consumers/redis_stream_consumer.py
+++ b/port_ocean/consumers/redis_stream_consumer.py
@@ -308,7 +308,6 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
                 error=str(error),
             )
         finally:
-
             elapsed_ms = round((time.monotonic() - start_time) * 1000, 2)
             await self._ack(message_id)
             time_until_acked_ms = self._time_since_queued_ms(queued_time)

--- a/port_ocean/consumers/redis_stream_consumer.py
+++ b/port_ocean/consumers/redis_stream_consumer.py
@@ -24,7 +24,6 @@ from port_ocean.consumers.redis_stream_utils import is_missing_stream_or_group_e
 from port_ocean.context.ocean import ocean
 from port_ocean.exceptions.live_events import InvalidLiveEventsRedisStreamFieldError
 from port_ocean.core.handlers.webhook.webhook_event import (
-    LiveEventTimestamp,
     WebhookEvent,
     WebhookRequestAdapter,
 )
@@ -300,7 +299,6 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
                 original_request=original_request,
             )
 
-            webhook_event.set_timestamp(LiveEventTimestamp.AddedToQueue)
             await self._on_message(webhook_path, webhook_event)
         except Exception as error:
             logger.exception(

--- a/port_ocean/consumers/redis_stream_consumer.py
+++ b/port_ocean/consumers/redis_stream_consumer.py
@@ -308,6 +308,7 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
                 error=str(error),
             )
         finally:
+
             elapsed_ms = round((time.monotonic() - start_time) * 1000, 2)
             await self._ack(message_id)
             time_until_acked_ms = self._time_since_queued_ms(queued_time)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.45.9"
+version = "0.45.10"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.45.8"
+version = "0.45.9"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

When Redis live-events consumption is enabled, the consumer was logging Event Added To Queue at consume time, which implied the local HTTP queue was still in use. That was misleading , events are already queued upstream in Redis (tracked via queuedAt), and Ocean reads them from the stream.

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change in the Redis live-events consumer; no change to message handling, acking, or webhook processing logic.
> 
> **Overview**
> Releases **0.45.9** and stops marking Redis stream webhook events with **`LiveEventTimestamp.AddedToQueue`** when the consumer hands them to the handler. That timestamp produced an **“Event Added To Queue”** info log at consume time, which implied a local enqueue even though the message was already queued upstream.
> 
> Queue wait is still visible on the existing **“Redis stream message processed”** log via **`time_until_consumed_ms`** (from stream **`queuedAt`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba658568d0ec0e83491836ad48e039dd81d9e6d4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->