### PR TITLE
[Core] Wire DSP lifecycle events and sync metrics to incremental sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.46.2 (2026-07-26)
+
+### Features
+
+- Wire DSP lifecycle events and sync metrics for incremental resyncs: set the metrics event ID, emit kind-level started/finished/failed notifications, pass `sync_type` and `kind_identifiers` on resync started, and clear metrics sync context when the run completes.
+
 ## 0.46.1 (2026-07-23)
 
 ### Bug Fixes

--- a/port_ocean/clients/dsp/lifecycle.py
+++ b/port_ocean/clients/dsp/lifecycle.py
@@ -21,6 +21,11 @@ class GranularityType(Enum):
     RECONCILIATION = "RECONCILIATION"
 
 
+class SyncType(Enum):
+    FULL_SYNC = "full_sync"
+    INCREMENTAL_RESYNC = "incremental_resync"
+
+
 class LifecycleClient:
     """Client for the integration-life-cycle service."""
 
@@ -73,8 +78,10 @@ class LifecycleClient:
         resync_id: str,
         integration_id: str,
         integration_type: str,
+        sync_type: str,
         started_at: datetime | None = None,
         mapping: dict[str, Any] | None = None,
+        kind_identifiers: list[str] | None = None,
     ) -> None:
         started_at = started_at or datetime.now(tz=timezone.utc)
         extra = {"mapping": mapping} if mapping else {}
@@ -83,17 +90,25 @@ class LifecycleClient:
             integration_id=integration_id,
             integration_type=integration_type,
             integration_version=__integration_version__,
+            sync_type=sync_type,
             ocean_version=__version__,
             started_at=started_at.isoformat(),
             **extra,
         )
+        if kind_identifiers is not None:
+            body["kind_identifiers"] = kind_identifiers
+
         logger.info(f"Notifying lifecycle API resync started, resync_id={resync_id}")
         await self._lifecycle_http_client.do_post(
             await self._resync_url(resync_id), json=body
         )
 
     async def notify_resync_finished(
-        self, resync_id: str, integration_id: str, integration_type: str
+        self,
+        resync_id: str,
+        integration_id: str,
+        integration_type: str,
+        sync_type: str,
     ) -> None:
         body = self._build_body(
             "finished",
@@ -101,6 +116,7 @@ class LifecycleClient:
             integration_type=integration_type,
             integration_version=__integration_version__,
             ocean_version=__version__,
+            sync_type=sync_type,
         )
         logger.info(f"Notifying lifecycle API resync finished, resync_id={resync_id}")
         await self._lifecycle_http_client.do_post(
@@ -108,18 +124,26 @@ class LifecycleClient:
         )
 
     async def notify_resync_failed(
-        self, resync_id: str, integration_id: str, integration_type: str
+        self,
+        resync_id: str,
+        integration_id: str,
+        integration_type: str,
+        sync_type: str,
     ) -> None:
-        body = self._build_body("failed")
+        body = self._build_body("failed", sync_type=sync_type)
         logger.info(f"Notifying lifecycle API resync failed, resync_id={resync_id}")
         await self._lifecycle_http_client.do_post(
             await self._resync_url(resync_id), json=body
         )
 
     async def notify_resync_aborted(
-        self, resync_id: str, integration_id: str, integration_type: str
+        self,
+        resync_id: str,
+        integration_id: str,
+        integration_type: str,
+        sync_type: str,
     ) -> None:
-        body = self._build_body("aborted")
+        body = self._build_body("aborted", sync_type=sync_type)
         logger.info(f"Notifying lifecycle API resync aborted, resync_id={resync_id}")
         await self._lifecycle_http_client.do_post(
             await self._resync_url(resync_id), json=body

--- a/port_ocean/clients/dsp/lifecycle.py
+++ b/port_ocean/clients/dsp/lifecycle.py
@@ -108,7 +108,6 @@ class LifecycleClient:
         resync_id: str,
         integration_id: str,
         integration_type: str,
-        sync_type: str,
     ) -> None:
         body = self._build_body(
             "finished",
@@ -116,7 +115,6 @@ class LifecycleClient:
             integration_type=integration_type,
             integration_version=__integration_version__,
             ocean_version=__version__,
-            sync_type=sync_type,
         )
         logger.info(f"Notifying lifecycle API resync finished, resync_id={resync_id}")
         await self._lifecycle_http_client.do_post(
@@ -128,9 +126,8 @@ class LifecycleClient:
         resync_id: str,
         integration_id: str,
         integration_type: str,
-        sync_type: str,
     ) -> None:
-        body = self._build_body("failed", sync_type=sync_type)
+        body = self._build_body("failed")
         logger.info(f"Notifying lifecycle API resync failed, resync_id={resync_id}")
         await self._lifecycle_http_client.do_post(
             await self._resync_url(resync_id), json=body
@@ -141,9 +138,8 @@ class LifecycleClient:
         resync_id: str,
         integration_id: str,
         integration_type: str,
-        sync_type: str,
     ) -> None:
-        body = self._build_body("aborted", sync_type=sync_type)
+        body = self._build_body("aborted")
         logger.info(f"Notifying lifecycle API resync aborted, resync_id={resync_id}")
         await self._lifecycle_http_client.do_post(
             await self._resync_url(resync_id), json=body

--- a/port_ocean/clients/dsp/lifecycle.py
+++ b/port_ocean/clients/dsp/lifecycle.py
@@ -104,10 +104,7 @@ class LifecycleClient:
         )
 
     async def notify_resync_finished(
-        self,
-        resync_id: str,
-        integration_id: str,
-        integration_type: str,
+        self, resync_id: str, integration_id: str, integration_type: str
     ) -> None:
         body = self._build_body(
             "finished",
@@ -122,10 +119,7 @@ class LifecycleClient:
         )
 
     async def notify_resync_failed(
-        self,
-        resync_id: str,
-        integration_id: str,
-        integration_type: str,
+        self, resync_id: str, integration_id: str, integration_type: str
     ) -> None:
         body = self._build_body("failed")
         logger.info(f"Notifying lifecycle API resync failed, resync_id={resync_id}")
@@ -134,10 +128,7 @@ class LifecycleClient:
         )
 
     async def notify_resync_aborted(
-        self,
-        resync_id: str,
-        integration_id: str,
-        integration_type: str,
+        self, resync_id: str, integration_id: str, integration_type: str
     ) -> None:
         body = self._build_body("aborted")
         logger.info(f"Notifying lifecycle API resync aborted, resync_id={resync_id}")

--- a/port_ocean/core/integrations/mixins/sync_raw.py
+++ b/port_ocean/core/integrations/mixins/sync_raw.py
@@ -1262,87 +1262,99 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
         ):
             ocean.metrics.event_id = event.id
             ocean.metrics.sync_type = SyncType.INCREMENTAL_RESYNC.value
-            app_config = await self.port_app_config_handler.get_port_app_config(
-                use_cache=False
-            )
-
-            incremental_resources = [
-                (index, resource_cfg)
-                for index, resource_cfg in enumerate(app_config.resources)
-                if self.event_strategy["incremental"].get(resource_cfg.kind)
-            ]
-
-            if not incremental_resources:
-                logger.info("No kinds registered for incremental sync, skipping")
-                return
-
-            logger.info(
-                "Incremental sync kinds registered",
-                kinds=[cfg.kind for _, cfg in incremental_resources],
-            )
-
             dsp_enabled = await is_dsp_mode_enabled()
-
-            cursor_store = CursorStore(ocean.port_client)
-            run_started_at = datetime.now(timezone.utc)
-
-            if dsp_enabled:
-                await ocean.app.lifecycle_client.notify_resync_started(
-                    resync_id=event.id,
-                    integration_id=ocean.config.integration.identifier,
-                    integration_type=ocean.config.integration.type,
-                    started_at=datetime.now(timezone.utc),
-                    sync_type=ocean.metrics.sync_type,
-                    kind_identifiers=[
-                        f"{resource_cfg.kind}-{index}"
-                        for index, resource_cfg in incremental_resources
-                    ],
+            try:
+                app_config = await self.port_app_config_handler.get_port_app_config(
+                    use_cache=False
                 )
 
-            for index, resource_cfg in incremental_resources:
-                stored_cursor = await cursor_store.get(resource_cfg.kind, index)
-                effective_cursor = stored_cursor or (
-                    run_started_at - timedelta(seconds=interval_seconds)
-                )
+                incremental_resources = [
+                    (index, resource_cfg)
+                    for index, resource_cfg in enumerate(app_config.resources)
+                    if self.event_strategy["incremental"].get(resource_cfg.kind)
+                ]
 
-                logger.info(
-                    "Starting incremental sync for kind",
-                    kind=resource_cfg.kind,
-                    index=index,
-                    cursor=effective_cursor.isoformat(),
-                    next_cursor=run_started_at.isoformat(),
-                )
-
-                success = await self._sync_incremental_kind(
-                    resource_cfg,
-                    index,
-                    effective_cursor,
-                    run_started_at,
-                    cursor_store,
-                    user_agent_type,
-                )
-                if not success:
-                    if dsp_enabled:
-                        await ocean.app.lifecycle_client.notify_resync_failed(
-                            resync_id=event.id,
-                            integration_id=ocean.config.integration.identifier,
-                            integration_type=ocean.config.integration.type,
-                            sync_type=ocean.metrics.sync_type,
-                        )
+                if not incremental_resources:
+                    logger.info("No kinds registered for incremental sync, skipping")
                     return
 
-            if dsp_enabled:
-                await ocean.app.lifecycle_client.notify_resync_finished(
-                    resync_id=event.id,
-                    integration_id=ocean.config.integration.identifier,
-                    integration_type=ocean.config.integration.type,
-                    sync_type=ocean.metrics.sync_type,
+                logger.info(
+                    "Incremental sync kinds registered",
+                    kinds=[cfg.kind for _, cfg in incremental_resources],
                 )
 
-            logger.info(
-                "Incremental sync completed",
-                kinds=len(incremental_resources),
-            )
+                cursor_store = CursorStore(ocean.port_client)
+                run_started_at = datetime.now(timezone.utc)
+
+                if dsp_enabled:
+                    await ocean.app.lifecycle_client.notify_resync_started(
+                        resync_id=event.id,
+                        integration_id=ocean.config.integration.identifier,
+                        integration_type=ocean.config.integration.type,
+                        started_at=datetime.now(timezone.utc),
+                        sync_type=ocean.metrics.sync_type,
+                        kind_identifiers=[
+                            f"{resource_cfg.kind}-{index}"
+                            for index, resource_cfg in incremental_resources
+                        ],
+                    )
+
+                for index, resource_cfg in incremental_resources:
+                    stored_cursor = await cursor_store.get(resource_cfg.kind, index)
+                    effective_cursor = stored_cursor or (
+                        run_started_at - timedelta(seconds=interval_seconds)
+                    )
+
+                    logger.info(
+                        "Starting incremental sync for kind",
+                        kind=resource_cfg.kind,
+                        index=index,
+                        cursor=effective_cursor.isoformat(),
+                        next_cursor=run_started_at.isoformat(),
+                    )
+
+                    success = await self._sync_incremental_kind(
+                        resource_cfg,
+                        index,
+                        effective_cursor,
+                        run_started_at,
+                        cursor_store,
+                        user_agent_type,
+                    )
+                    if not success:
+                        if dsp_enabled:
+                            await ocean.app.lifecycle_client.notify_resync_failed(
+                                resync_id=event.id,
+                                integration_id=ocean.config.integration.identifier,
+                                integration_type=ocean.config.integration.type,
+                                sync_type=ocean.metrics.sync_type,
+                            )
+                        return
+
+                if dsp_enabled:
+                    await ocean.app.lifecycle_client.notify_resync_finished(
+                        resync_id=event.id,
+                        integration_id=ocean.config.integration.identifier,
+                        integration_type=ocean.config.integration.type,
+                        sync_type=ocean.metrics.sync_type,
+                    )
+
+                logger.info(
+                    "Incremental sync completed",
+                    kinds=len(incremental_resources),
+                )
+            except asyncio.CancelledError:
+                logger.warning("Incremental sync was aborted")
+                if dsp_enabled:
+                    await ocean.app.lifecycle_client.notify_resync_aborted(
+                        resync_id=event.id,
+                        integration_id=ocean.config.integration.identifier,
+                        integration_type=ocean.config.integration.type,
+                        sync_type=ocean.metrics.sync_type,
+                    )
+                raise
+            finally:
+                ocean.metrics.clear_sync_context()
 
     @TimeMetric(MetricPhase.RESYNC)
     async def sync_raw_all(
@@ -1579,6 +1591,7 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
 
                 return success
             finally:
+                ocean.metrics.clear_sync_context()
                 await ocean.app.cache_provider.clear()
                 ocean.port_client.clear_blueprint_cache()
                 if (

--- a/port_ocean/core/integrations/mixins/sync_raw.py
+++ b/port_ocean/core/integrations/mixins/sync_raw.py
@@ -1261,7 +1261,6 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
             EventType.INCREMENTAL_RESYNC, trigger_type=trigger_type
         ):
             ocean.metrics.event_id = event.id
-            ocean.metrics.sync_type = SyncType.INCREMENTAL_RESYNC.value
             dsp_enabled = await is_dsp_mode_enabled()
             try:
                 app_config = await self.port_app_config_handler.get_port_app_config(
@@ -1292,7 +1291,7 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                         integration_id=ocean.config.integration.identifier,
                         integration_type=ocean.config.integration.type,
                         started_at=datetime.now(timezone.utc),
-                        sync_type=ocean.metrics.sync_type,
+                        sync_type=SyncType.INCREMENTAL_RESYNC.value,
                         kind_identifiers=[
                             f"{resource_cfg.kind}-{index}"
                             for index, resource_cfg in incremental_resources
@@ -1327,7 +1326,6 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                                 resync_id=event.id,
                                 integration_id=ocean.config.integration.identifier,
                                 integration_type=ocean.config.integration.type,
-                                sync_type=ocean.metrics.sync_type,
                             )
                         return
 
@@ -1336,7 +1334,6 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                         resync_id=event.id,
                         integration_id=ocean.config.integration.identifier,
                         integration_type=ocean.config.integration.type,
-                        sync_type=ocean.metrics.sync_type,
                     )
 
                 logger.info(
@@ -1350,7 +1347,6 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                         resync_id=event.id,
                         integration_id=ocean.config.integration.identifier,
                         integration_type=ocean.config.integration.type,
-                        sync_type=ocean.metrics.sync_type,
                     )
                 raise
             finally:
@@ -1383,7 +1379,6 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
             attributes={"resync_start_time": datetime.now(timezone.utc)},
         ):
             ocean.metrics.event_id = event.id
-            ocean.metrics.sync_type = SyncType.FULL_SYNC.value
 
             # If a resync is triggered due to a mappings change, we want to make sure that we have the updated version
             # rather than the old cache
@@ -1437,7 +1432,7 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                     integration_type=ocean.config.integration.type,
                     started_at=datetime.now(timezone.utc),
                     mapping=app_config.to_dsp_lifecycle_mapping(),
-                    sync_type=ocean.metrics.sync_type,
+                    sync_type=SyncType.FULL_SYNC.value,
                 )
 
             try:
@@ -1484,7 +1479,6 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                         resync_id=event.id,
                         integration_id=ocean.config.integration.identifier,
                         integration_type=ocean.config.integration.type,
-                        sync_type=ocean.metrics.sync_type,
                     )
                 raise
             except Exception as e:
@@ -1497,7 +1491,6 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                         resync_id=event.id,
                         integration_id=ocean.config.integration.identifier,
                         integration_type=ocean.config.integration.type,
-                        sync_type=ocean.metrics.sync_type,
                     )
                 raise
             else:
@@ -1544,7 +1537,6 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                         resync_id=event.id,
                         integration_id=ocean.config.integration.identifier,
                         integration_type=ocean.config.integration.type,
-                        sync_type=ocean.metrics.sync_type,
                     )
                     return True
 
@@ -1579,14 +1571,12 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                             resync_id=event.id,
                             integration_id=ocean.config.integration.identifier,
                             integration_type=ocean.config.integration.type,
-                            sync_type=ocean.metrics.sync_type,
                         )
                     else:
                         await ocean.app.lifecycle_client.notify_resync_failed(
                             resync_id=event.id,
                             integration_id=ocean.config.integration.identifier,
                             integration_type=ocean.config.integration.type,
-                            sync_type=ocean.metrics.sync_type,
                         )
 
                 return success

--- a/port_ocean/core/integrations/mixins/sync_raw.py
+++ b/port_ocean/core/integrations/mixins/sync_raw.py
@@ -1349,6 +1349,15 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                         integration_type=ocean.config.integration.type,
                     )
                 raise
+            except Exception as e:
+                logger.error(f"Incremental sync failed unexpectedly: {e}")
+                if dsp_enabled:
+                    await ocean.app.lifecycle_client.notify_resync_failed(
+                        resync_id=event.id,
+                        integration_id=ocean.config.integration.identifier,
+                        integration_type=ocean.config.integration.type,
+                    )
+                raise
             finally:
                 ocean.metrics.clear_sync_context()
 

--- a/port_ocean/core/integrations/mixins/sync_raw.py
+++ b/port_ocean/core/integrations/mixins/sync_raw.py
@@ -858,7 +858,7 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                 )
 
             resync_id = ocean.metrics.event_id
-            if not is_incremental and dsp_enabled and resync_id:
+            if dsp_enabled and resync_id:
                 await ocean.app.lifecycle_client.notify_started(
                     event_id=resync_id,
                     integration_id=ocean.config.integration.identifier,
@@ -906,20 +906,20 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                     dsp_enabled=dsp_enabled,
                 )
 
-                if dsp_enabled and resync_id:
-                    if ocean.metrics.sync_state == SyncState.FAILED:
-                        await ocean.app.lifecycle_client.notify_failed(
-                            event_id=resync_id,
-                            granularity=GranularityType.KIND,
-                            kind_identifier=resource_kind_id,
-                        )
-                    else:
-                        await ocean.app.lifecycle_client.notify_finished(
-                            event_id=resync_id,
-                            integration_type=ocean.config.integration.type,
-                            granularity=GranularityType.KIND,
-                            kind_identifier=resource_kind_id,
-                        )
+            if dsp_enabled and resync_id:
+                if ocean.metrics.sync_state == SyncState.FAILED:
+                    await ocean.app.lifecycle_client.notify_failed(
+                        event_id=resync_id,
+                        granularity=GranularityType.KIND,
+                        kind_identifier=resource_kind_id,
+                    )
+                else:
+                    await ocean.app.lifecycle_client.notify_finished(
+                        event_id=resync_id,
+                        integration_type=ocean.config.integration.type,
+                        granularity=GranularityType.KIND,
+                        kind_identifier=resource_kind_id,
+                    )
 
             return kind_results
 

--- a/port_ocean/core/integrations/mixins/sync_raw.py
+++ b/port_ocean/core/integrations/mixins/sync_raw.py
@@ -10,7 +10,7 @@ import multiprocessing
 import httpx
 import json
 from loguru import logger
-from port_ocean.clients.dsp.lifecycle import GranularityType
+from port_ocean.clients.dsp.lifecycle import GranularityType, SyncType
 from port_ocean.clients.port.types import UserAgentType
 from port_ocean.context.event import TriggerType, event_context, EventType, event
 from port_ocean.context.metric_resource import metric_resource_context
@@ -880,7 +880,7 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
             except asyncio.CancelledError:
                 logger.warning(f"Resource {resource.kind} processing was aborted")
                 ocean.metrics.sync_state = SyncState.ABORTED
-                if not is_incremental and dsp_enabled and resync_id:
+                if dsp_enabled and resync_id:
                     await ocean.app.lifecycle_client.notify_aborted(
                         event_id=resync_id,
                         granularity=GranularityType.KIND,
@@ -1260,6 +1260,8 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
         async with event_context(
             EventType.INCREMENTAL_RESYNC, trigger_type=trigger_type
         ):
+            ocean.metrics.event_id = event.id
+            ocean.metrics.sync_type = SyncType.INCREMENTAL_RESYNC.value
             app_config = await self.port_app_config_handler.get_port_app_config(
                 use_cache=False
             )
@@ -1290,6 +1292,11 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                     integration_id=ocean.config.integration.identifier,
                     integration_type=ocean.config.integration.type,
                     started_at=datetime.now(timezone.utc),
+                    sync_type=ocean.metrics.sync_type,
+                    kind_identifiers=[
+                        f"{resource_cfg.kind}-{index}"
+                        for index, resource_cfg in incremental_resources
+                    ],
                 )
 
             for index, resource_cfg in incremental_resources:
@@ -1320,6 +1327,7 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                             resync_id=event.id,
                             integration_id=ocean.config.integration.identifier,
                             integration_type=ocean.config.integration.type,
+                            sync_type=ocean.metrics.sync_type,
                         )
                     return
 
@@ -1328,6 +1336,7 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                     resync_id=event.id,
                     integration_id=ocean.config.integration.identifier,
                     integration_type=ocean.config.integration.type,
+                    sync_type=ocean.metrics.sync_type,
                 )
 
             logger.info(
@@ -1362,6 +1371,7 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
             attributes={"resync_start_time": datetime.now(timezone.utc)},
         ):
             ocean.metrics.event_id = event.id
+            ocean.metrics.sync_type = SyncType.FULL_SYNC.value
 
             # If a resync is triggered due to a mappings change, we want to make sure that we have the updated version
             # rather than the old cache
@@ -1415,6 +1425,7 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                     integration_type=ocean.config.integration.type,
                     started_at=datetime.now(timezone.utc),
                     mapping=app_config.to_dsp_lifecycle_mapping(),
+                    sync_type=ocean.metrics.sync_type,
                 )
 
             try:
@@ -1461,6 +1472,7 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                         resync_id=event.id,
                         integration_id=ocean.config.integration.identifier,
                         integration_type=ocean.config.integration.type,
+                        sync_type=ocean.metrics.sync_type,
                     )
                 raise
             except Exception as e:
@@ -1473,6 +1485,7 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                         resync_id=event.id,
                         integration_id=ocean.config.integration.identifier,
                         integration_type=ocean.config.integration.type,
+                        sync_type=ocean.metrics.sync_type,
                     )
                 raise
             else:
@@ -1519,6 +1532,7 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                         resync_id=event.id,
                         integration_id=ocean.config.integration.identifier,
                         integration_type=ocean.config.integration.type,
+                        sync_type=ocean.metrics.sync_type,
                     )
                     return True
 
@@ -1553,12 +1567,14 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                             resync_id=event.id,
                             integration_id=ocean.config.integration.identifier,
                             integration_type=ocean.config.integration.type,
+                            sync_type=ocean.metrics.sync_type,
                         )
                     else:
                         await ocean.app.lifecycle_client.notify_resync_failed(
                             resync_id=event.id,
                             integration_id=ocean.config.integration.identifier,
                             integration_type=ocean.config.integration.type,
+                            sync_type=ocean.metrics.sync_type,
                         )
 
                 return success

--- a/port_ocean/helpers/metric/metric.py
+++ b/port_ocean/helpers/metric/metric.py
@@ -214,6 +214,7 @@ class Metrics:
         self._installation_type: str = "Unknown"
         self._execution_mode: str = "Unknown"
         self._event_id = ""
+        self._sync_type = ""
         self.sync_state = SyncState.PENDING
 
     @property
@@ -223,6 +224,14 @@ class Metrics:
     @event_id.setter
     def event_id(self, value: str) -> None:
         self._event_id = value
+
+    @property
+    def sync_type(self) -> str:
+        return self._sync_type
+
+    @sync_type.setter
+    def sync_type(self, value: str) -> None:
+        self._sync_type = value
 
     @property
     def sync_state(self) -> str:

--- a/port_ocean/helpers/metric/metric.py
+++ b/port_ocean/helpers/metric/metric.py
@@ -233,6 +233,10 @@ class Metrics:
     def sync_type(self, value: str) -> None:
         self._sync_type = value
 
+    def clear_sync_context(self) -> None:
+        self._event_id = ""
+        self._sync_type = ""
+
     @property
     def sync_state(self) -> str:
         return self._sync_state

--- a/port_ocean/helpers/metric/metric.py
+++ b/port_ocean/helpers/metric/metric.py
@@ -214,7 +214,6 @@ class Metrics:
         self._installation_type: str = "Unknown"
         self._execution_mode: str = "Unknown"
         self._event_id = ""
-        self._sync_type = ""
         self.sync_state = SyncState.PENDING
 
     @property
@@ -225,17 +224,8 @@ class Metrics:
     def event_id(self, value: str) -> None:
         self._event_id = value
 
-    @property
-    def sync_type(self) -> str:
-        return self._sync_type
-
-    @sync_type.setter
-    def sync_type(self, value: str) -> None:
-        self._sync_type = value
-
     def clear_sync_context(self) -> None:
         self._event_id = ""
-        self._sync_type = ""
 
     @property
     def sync_state(self) -> str:

--- a/port_ocean/ocean.py
+++ b/port_ocean/ocean.py
@@ -160,6 +160,7 @@ class Ocean:
                                 resync_id=resync_id,
                                 integration_id=self.config.integration.identifier,
                                 integration_type=self.config.integration.type,
+                                sync_type=self.metrics.sync_type,
                             )
                 else:
                     logger.info(

--- a/port_ocean/ocean.py
+++ b/port_ocean/ocean.py
@@ -160,7 +160,6 @@ class Ocean:
                                 resync_id=resync_id,
                                 integration_id=self.config.integration.identifier,
                                 integration_type=self.config.integration.type,
-                                sync_type=self.metrics.sync_type,
                             )
                 else:
                     logger.info(

--- a/port_ocean/tests/clients/test_lifecycle_client.py
+++ b/port_ocean/tests/clients/test_lifecycle_client.py
@@ -10,6 +10,7 @@ import pytest_asyncio
 from port_ocean.clients.dsp.lifecycle import (
     GranularityType,
     LifecycleClient,
+    SyncType,
 )
 from port_ocean.clients.dsp.lifecycle_http import (
     OceanResyncHttpClient,
@@ -137,6 +138,7 @@ class TestNotifyResyncStarted:
             resync_id="r1",
             integration_id="i1",
             integration_type="github",
+            sync_type=SyncType.FULL_SYNC.value,
             started_at=started_at,
         )
         url = mock_post.call_args[0][0]
@@ -151,6 +153,7 @@ class TestNotifyResyncStarted:
             resync_id="r1",
             integration_id="i1",
             integration_type="github",
+            sync_type=SyncType.FULL_SYNC.value,
             started_at=started_at,
         )
         body = mock_post.call_args[1]["json"]
@@ -158,11 +161,13 @@ class TestNotifyResyncStarted:
         assert body["integration_id"] == "i1"
         assert body["integration_type"] == "github"
         assert body["started_at"] == started_at.isoformat()
+        assert body["sync_type"] == "full_sync"
         assert "integration_version" in body
         assert "ocean_version" in body
         assert "granularity" not in body
         assert "event_id" not in body
         assert "mapping" not in body
+        assert "kind_identifiers" not in body
 
     @pytest.mark.asyncio
     async def test_body_includes_mapping_when_provided(
@@ -180,10 +185,26 @@ class TestNotifyResyncStarted:
             resync_id="r1",
             integration_id="i1",
             integration_type="github",
+            sync_type=SyncType.FULL_SYNC.value,
             mapping=mapping,
         )
         body = mock_post.call_args[1]["json"]
         assert body["mapping"] == mapping
+
+    @pytest.mark.asyncio
+    async def test_body_includes_kind_identifiers_when_provided(
+        self, lifecycle_client: LifecycleClient, mock_post: AsyncMock
+    ) -> None:
+        await lifecycle_client.notify_resync_started(
+            resync_id="r1",
+            integration_id="i1",
+            integration_type="github",
+            sync_type=SyncType.INCREMENTAL_RESYNC.value,
+            kind_identifiers=["issue-0", "pull-request-1"],
+        )
+        body = mock_post.call_args[1]["json"]
+        assert body["sync_type"] == "incremental_resync"
+        assert body["kind_identifiers"] == ["issue-0", "pull-request-1"]
 
     @pytest.mark.asyncio
     async def test_defaults_started_at(
@@ -191,7 +212,10 @@ class TestNotifyResyncStarted:
     ) -> None:
         before = datetime.now(tz=timezone.utc)
         await lifecycle_client.notify_resync_started(
-            resync_id="r1", integration_id="i1", integration_type="github"
+            resync_id="r1",
+            integration_id="i1",
+            integration_type="github",
+            sync_type=SyncType.FULL_SYNC.value,
         )
         after = datetime.now(tz=timezone.utc)
 
@@ -205,7 +229,10 @@ class TestNotifyResyncStarted:
     ) -> None:
         mock_post.side_effect = httpx.ConnectError("refused")
         await lifecycle_client.notify_resync_started(
-            resync_id="r1", integration_id="i1", integration_type="github"
+            resync_id="r1",
+            integration_id="i1",
+            integration_type="github",
+            sync_type=SyncType.FULL_SYNC.value,
         )
 
 
@@ -215,7 +242,10 @@ class TestNotifyResyncFinished:
         self, lifecycle_client: LifecycleClient, mock_post: AsyncMock
     ) -> None:
         await lifecycle_client.notify_resync_finished(
-            resync_id="r1", integration_id="i1", integration_type="github"
+            resync_id="r1",
+            integration_id="i1",
+            integration_type="github",
+            sync_type=SyncType.FULL_SYNC.value,
         )
         url = mock_post.call_args[0][0]
         assert url == "http://localhost:3017/v1/lifecycle/r1"
@@ -223,6 +253,7 @@ class TestNotifyResyncFinished:
         assert body["status"] == "finished"
         assert body["integration_id"] == "i1"
         assert body["integration_type"] == "github"
+        assert body["sync_type"] == "full_sync"
         assert "integration_version" in body
         assert "ocean_version" in body
 
@@ -233,12 +264,15 @@ class TestNotifyResyncFailed:
         self, lifecycle_client: LifecycleClient, mock_post: AsyncMock
     ) -> None:
         await lifecycle_client.notify_resync_failed(
-            resync_id="r1", integration_id="i1", integration_type="github"
+            resync_id="r1",
+            integration_id="i1",
+            integration_type="github",
+            sync_type=SyncType.FULL_SYNC.value,
         )
         url = mock_post.call_args[0][0]
         assert url == "http://localhost:3017/v1/lifecycle/r1"
         body = mock_post.call_args[1]["json"]
-        assert body == {"status": "failed"}
+        assert body == {"status": "failed", "sync_type": "full_sync"}
 
     @pytest.mark.asyncio
     async def test_swallows_exception(
@@ -246,7 +280,10 @@ class TestNotifyResyncFailed:
     ) -> None:
         mock_post.side_effect = Exception("network error")
         await lifecycle_client.notify_resync_failed(
-            resync_id="r1", integration_id="i1", integration_type="github"
+            resync_id="r1",
+            integration_id="i1",
+            integration_type="github",
+            sync_type=SyncType.FULL_SYNC.value,
         )
 
 
@@ -256,12 +293,15 @@ class TestNotifyResyncAborted:
         self, lifecycle_client: LifecycleClient, mock_post: AsyncMock
     ) -> None:
         await lifecycle_client.notify_resync_aborted(
-            resync_id="r1", integration_id="i1", integration_type="github"
+            resync_id="r1",
+            integration_id="i1",
+            integration_type="github",
+            sync_type=SyncType.FULL_SYNC.value,
         )
         url = mock_post.call_args[0][0]
         assert url == "http://localhost:3017/v1/lifecycle/r1"
         body = mock_post.call_args[1]["json"]
-        assert body == {"status": "aborted"}
+        assert body == {"status": "aborted", "sync_type": "full_sync"}
 
     @pytest.mark.asyncio
     async def test_logs_warning_on_error_response(
@@ -275,7 +315,10 @@ class TestNotifyResyncAborted:
 
         with patch("port_ocean.clients.dsp.lifecycle_http.logger") as mock_logger:
             await lifecycle_client.notify_resync_aborted(
-                resync_id="r1", integration_id="i1", integration_type="github"
+                resync_id="r1",
+                integration_id="i1",
+                integration_type="github",
+                sync_type=SyncType.FULL_SYNC.value,
             )
 
         mock_logger.warning.assert_called_once()
@@ -293,7 +336,10 @@ class TestNotifyResyncAborted:
 
         with patch("port_ocean.clients.dsp.lifecycle_http.logger") as mock_logger:
             await lifecycle_client.notify_resync_aborted(
-                resync_id="r1", integration_id="i1", integration_type="github"
+                resync_id="r1",
+                integration_id="i1",
+                integration_type="github",
+                sync_type=SyncType.FULL_SYNC.value,
             )
 
         logged_body = mock_logger.warning.call_args[1]["response_body"]
@@ -374,17 +420,26 @@ class TestLifecycleClientIntegration:
         self, lifecycle_client: LifecycleClient, mock_post: AsyncMock
     ) -> None:
         await lifecycle_client.notify_resync_started(
-            resync_id="r1", integration_id="i1", integration_type="github"
+            resync_id="r1",
+            integration_id="i1",
+            integration_type="github",
+            sync_type=SyncType.FULL_SYNC.value,
         )
         assert mock_post.call_count == 1
 
         await lifecycle_client.notify_resync_finished(
-            resync_id="r1", integration_id="i1", integration_type="github"
+            resync_id="r1",
+            integration_id="i1",
+            integration_type="github",
+            sync_type=SyncType.FULL_SYNC.value,
         )
         assert mock_post.call_count == 2
 
         await lifecycle_client.notify_resync_failed(
-            resync_id="r1", integration_id="i1", integration_type="github"
+            resync_id="r1",
+            integration_id="i1",
+            integration_type="github",
+            sync_type=SyncType.FULL_SYNC.value,
         )
         assert mock_post.call_count == 3
 
@@ -590,7 +645,10 @@ class TestRetryBehavior:
             patch("port_ocean.helpers.retry.asyncio.sleep", new=AsyncMock()),
         ):
             await client.notify_resync_started(
-                resync_id="r1", integration_id="i1", integration_type="github"
+                resync_id="r1",
+                integration_id="i1",
+                integration_type="github",
+                sync_type=SyncType.FULL_SYNC.value,
             )
         assert inner.handle_async_request.await_count == 2
 
@@ -609,7 +667,10 @@ class TestRetryBehavior:
             patch("port_ocean.helpers.retry.asyncio.sleep", new=AsyncMock()),
         ):
             await client.notify_resync_started(
-                resync_id="r1", integration_id="i1", integration_type="github"
+                resync_id="r1",
+                integration_id="i1",
+                integration_type="github",
+                sync_type=SyncType.FULL_SYNC.value,
             )
         assert inner.handle_async_request.await_count == 2
 
@@ -633,7 +694,10 @@ class TestRetryBehavior:
             patch("port_ocean.clients.dsp.lifecycle_http.logger") as mock_logger,
         ):
             await client.notify_resync_started(
-                resync_id="r1", integration_id="i1", integration_type="github"
+                resync_id="r1",
+                integration_id="i1",
+                integration_type="github",
+                sync_type=SyncType.FULL_SYNC.value,
             )
         assert inner.handle_async_request.await_count == max_attempts + 1
         mock_logger.warning.assert_called_once()

--- a/port_ocean/tests/clients/test_lifecycle_client.py
+++ b/port_ocean/tests/clients/test_lifecycle_client.py
@@ -245,7 +245,6 @@ class TestNotifyResyncFinished:
             resync_id="r1",
             integration_id="i1",
             integration_type="github",
-            sync_type=SyncType.FULL_SYNC.value,
         )
         url = mock_post.call_args[0][0]
         assert url == "http://localhost:3017/v1/lifecycle/r1"
@@ -253,7 +252,6 @@ class TestNotifyResyncFinished:
         assert body["status"] == "finished"
         assert body["integration_id"] == "i1"
         assert body["integration_type"] == "github"
-        assert body["sync_type"] == "full_sync"
         assert "integration_version" in body
         assert "ocean_version" in body
 
@@ -267,12 +265,11 @@ class TestNotifyResyncFailed:
             resync_id="r1",
             integration_id="i1",
             integration_type="github",
-            sync_type=SyncType.FULL_SYNC.value,
         )
         url = mock_post.call_args[0][0]
         assert url == "http://localhost:3017/v1/lifecycle/r1"
         body = mock_post.call_args[1]["json"]
-        assert body == {"status": "failed", "sync_type": "full_sync"}
+        assert body == {"status": "failed"}
 
     @pytest.mark.asyncio
     async def test_swallows_exception(
@@ -283,7 +280,6 @@ class TestNotifyResyncFailed:
             resync_id="r1",
             integration_id="i1",
             integration_type="github",
-            sync_type=SyncType.FULL_SYNC.value,
         )
 
 
@@ -296,12 +292,11 @@ class TestNotifyResyncAborted:
             resync_id="r1",
             integration_id="i1",
             integration_type="github",
-            sync_type=SyncType.FULL_SYNC.value,
         )
         url = mock_post.call_args[0][0]
         assert url == "http://localhost:3017/v1/lifecycle/r1"
         body = mock_post.call_args[1]["json"]
-        assert body == {"status": "aborted", "sync_type": "full_sync"}
+        assert body == {"status": "aborted"}
 
     @pytest.mark.asyncio
     async def test_logs_warning_on_error_response(
@@ -318,7 +313,6 @@ class TestNotifyResyncAborted:
                 resync_id="r1",
                 integration_id="i1",
                 integration_type="github",
-                sync_type=SyncType.FULL_SYNC.value,
             )
 
         mock_logger.warning.assert_called_once()
@@ -339,7 +333,6 @@ class TestNotifyResyncAborted:
                 resync_id="r1",
                 integration_id="i1",
                 integration_type="github",
-                sync_type=SyncType.FULL_SYNC.value,
             )
 
         logged_body = mock_logger.warning.call_args[1]["response_body"]
@@ -431,7 +424,6 @@ class TestLifecycleClientIntegration:
             resync_id="r1",
             integration_id="i1",
             integration_type="github",
-            sync_type=SyncType.FULL_SYNC.value,
         )
         assert mock_post.call_count == 2
 
@@ -439,7 +431,6 @@ class TestLifecycleClientIntegration:
             resync_id="r1",
             integration_id="i1",
             integration_type="github",
-            sync_type=SyncType.FULL_SYNC.value,
         )
         assert mock_post.call_count == 3
 

--- a/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
+++ b/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
@@ -1758,11 +1758,15 @@ async def test_sync_raw_all_dsp_notifies_resync_started_with_mapping(
     assert call_kwargs["resync_id"] == mock_ocean.metrics.event_id
     assert call_kwargs["integration_id"] == "integration-id"
     assert call_kwargs["integration_type"] == "integration-type"
+    assert call_kwargs["sync_type"] == "full_sync"
     assert call_kwargs["mapping"] == expected_mapping
     mappings = call_kwargs["mapping"]["resources"][0]["port"]["entity"]["mappings"]
     assert isinstance(mappings, list)
     assert len(mappings) == 1
+    assert mock_ocean.metrics.sync_type == "full_sync"
     lifecycle_client.notify_resync_finished.assert_awaited_once()
+    finished_kwargs = lifecycle_client.notify_resync_finished.await_args.kwargs
+    assert finished_kwargs["sync_type"] == "full_sync"
 
 
 @pytest.mark.asyncio

--- a/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
+++ b/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
@@ -1,3 +1,4 @@
+import asyncio
 from graphlib import CycleError
 from typing import Any, AsyncGenerator, Awaitable, Callable, Generator, cast
 from concurrent.futures import ThreadPoolExecutor
@@ -1720,6 +1721,104 @@ async def test_process_resource_dsp_notifies_lifecycle_kind_boundaries(
     )
     lifecycle_client.notify_failed.assert_not_awaited()
     lifecycle_client.notify_aborted.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_process_resource_incremental_dsp_notifies_kind_finished(
+    mock_sync_raw_mixin: SyncRawMixin,
+    mock_resource_config: ResourceConfig,
+    mock_ocean: Ocean,
+) -> None:
+    mock_sync_raw_mixin._register_in_batches = AsyncMock(return_value=([], []))
+    mock_ocean.metrics.event_id = "incremental-resync-1"
+    mock_ocean.config.integration.identifier = "integration-id"
+    mock_ocean.config.integration.type = "integration-type"
+
+    lifecycle_client = MagicMock()
+    lifecycle_client.notify_started = AsyncMock()
+    lifecycle_client.notify_finished = AsyncMock()
+    lifecycle_client.notify_failed = AsyncMock()
+    lifecycle_client.notify_aborted = AsyncMock()
+    mock_ocean.lifecycle_client = lifecycle_client
+
+    with patch(
+        "port_ocean.core.integrations.mixins.sync_raw.is_dsp_mode_enabled",
+        AsyncMock(return_value=True),
+    ):
+        async with event_context(
+            EventType.INCREMENTAL_RESYNC,
+            trigger_type="machine",
+        ):
+            entities, errors = await mock_sync_raw_mixin._process_resource(
+                mock_resource_config,
+                index=0,
+                user_agent_type=UserAgentType.exporter,
+            )
+
+    assert entities == []
+    assert errors == []
+    lifecycle_client.notify_started.assert_awaited_once_with(
+        event_id="incremental-resync-1",
+        integration_id="integration-id",
+        integration_type="integration-type",
+        granularity=GranularityType.KIND,
+        kind_identifier="service-0",
+    )
+    lifecycle_client.notify_finished.assert_awaited_once_with(
+        event_id="incremental-resync-1",
+        integration_type="integration-type",
+        granularity=GranularityType.KIND,
+        kind_identifier="service-0",
+    )
+    lifecycle_client.notify_failed.assert_not_awaited()
+    lifecycle_client.notify_aborted.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_process_resource_incremental_dsp_notifies_kind_aborted(
+    mock_sync_raw_mixin: SyncRawMixin,
+    mock_resource_config: ResourceConfig,
+    mock_ocean: Ocean,
+) -> None:
+    mock_sync_raw_mixin._register_in_batches = AsyncMock(
+        side_effect=asyncio.CancelledError
+    )
+    mock_ocean.metrics.event_id = "incremental-resync-1"
+    mock_ocean.config.integration.identifier = "integration-id"
+    mock_ocean.config.integration.type = "integration-type"
+
+    lifecycle_client = MagicMock()
+    lifecycle_client.notify_started = AsyncMock()
+    lifecycle_client.notify_finished = AsyncMock()
+    lifecycle_client.notify_failed = AsyncMock()
+    lifecycle_client.notify_aborted = AsyncMock()
+    mock_ocean.lifecycle_client = lifecycle_client
+
+    with (
+        patch(
+            "port_ocean.core.integrations.mixins.sync_raw.is_dsp_mode_enabled",
+            AsyncMock(return_value=True),
+        ),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        async with event_context(
+            EventType.INCREMENTAL_RESYNC,
+            trigger_type="machine",
+        ):
+            await mock_sync_raw_mixin._process_resource(
+                mock_resource_config,
+                index=0,
+                user_agent_type=UserAgentType.exporter,
+            )
+
+    lifecycle_client.notify_started.assert_awaited_once()
+    lifecycle_client.notify_aborted.assert_awaited_once_with(
+        event_id="incremental-resync-1",
+        granularity=GranularityType.KIND,
+        kind_identifier="service-0",
+    )
+    lifecycle_client.notify_finished.assert_not_awaited()
+    lifecycle_client.notify_failed.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
+++ b/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
@@ -1863,9 +1863,8 @@ async def test_sync_raw_all_dsp_notifies_resync_started_with_mapping(
     assert len(mappings) == 1
     lifecycle_client.notify_resync_finished.assert_awaited_once()
     finished_kwargs = lifecycle_client.notify_resync_finished.await_args.kwargs
-    assert finished_kwargs["sync_type"] == "full_sync"
+    assert "sync_type" not in finished_kwargs
     assert mock_ocean.metrics.event_id == ""
-    assert mock_ocean.metrics.sync_type == ""
 
 
 @pytest.mark.asyncio

--- a/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
+++ b/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
@@ -1854,7 +1854,6 @@ async def test_sync_raw_all_dsp_notifies_resync_started_with_mapping(
 
     lifecycle_client.notify_resync_started.assert_awaited_once()
     call_kwargs = lifecycle_client.notify_resync_started.await_args.kwargs
-    assert call_kwargs["resync_id"] == mock_ocean.metrics.event_id
     assert call_kwargs["integration_id"] == "integration-id"
     assert call_kwargs["integration_type"] == "integration-type"
     assert call_kwargs["sync_type"] == "full_sync"
@@ -1862,10 +1861,11 @@ async def test_sync_raw_all_dsp_notifies_resync_started_with_mapping(
     mappings = call_kwargs["mapping"]["resources"][0]["port"]["entity"]["mappings"]
     assert isinstance(mappings, list)
     assert len(mappings) == 1
-    assert mock_ocean.metrics.sync_type == "full_sync"
     lifecycle_client.notify_resync_finished.assert_awaited_once()
     finished_kwargs = lifecycle_client.notify_resync_finished.await_args.kwargs
     assert finished_kwargs["sync_type"] == "full_sync"
+    assert mock_ocean.metrics.event_id == ""
+    assert mock_ocean.metrics.sync_type == ""
 
 
 @pytest.mark.asyncio

--- a/port_ocean/tests/core/incremental/test_sync_incremental.py
+++ b/port_ocean/tests/core/incremental/test_sync_incremental.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from port_ocean.clients.dsp.lifecycle import SyncType
 from port_ocean.context.event import EventType
 from port_ocean.core.handlers.port_app_config.models import (
     EntityMapping,
@@ -87,6 +88,28 @@ def register_incremental_handler(
     return handler
 
 
+def _configure_ocean_for_incremental(
+    mock_ocean: MagicMock,
+    mock_port_client: MagicMock,
+    lifecycle_client: MagicMock | None = None,
+) -> MagicMock:
+    mock_ocean.port_client = mock_port_client
+    mock_ocean.config.integration.identifier = "test-integration"
+    mock_ocean.config.integration.type = "fake-integration"
+    if lifecycle_client is not None:
+        mock_ocean.app.lifecycle_client = lifecycle_client
+    return mock_ocean
+
+
+def _make_lifecycle_client() -> MagicMock:
+    client = MagicMock()
+    client.notify_resync_started = AsyncMock()
+    client.notify_resync_finished = AsyncMock()
+    client.notify_resync_failed = AsyncMock()
+    client.notify_resync_aborted = AsyncMock()
+    return client
+
+
 class TestSyncIncrementalNoHandlers:
     async def test_exits_early_when_no_incremental_kinds_registered(
         self, mock_mixin: SyncRawMixin, mock_port_client: MagicMock
@@ -123,9 +146,7 @@ class TestSyncIncrementalCursorSeeding:
 
         before = datetime.now(timezone.utc)
         with patch("port_ocean.core.integrations.mixins.sync_raw.ocean") as mock_ocean:
-            mock_ocean.port_client = mock_port_client
-            mock_ocean.config.integration.identifier = "test-integration"
-            mock_ocean.config.integration.type = "fake-integration"
+            _configure_ocean_for_incremental(mock_ocean, mock_port_client)
             await mock_mixin.sync_incremental(interval_seconds=900)
         after = datetime.now(timezone.utc)
 
@@ -145,9 +166,7 @@ class TestSyncIncrementalCursorSeeding:
         register_incremental_handler(mock_mixin, kind="issue")
 
         with patch("port_ocean.core.integrations.mixins.sync_raw.ocean") as mock_ocean:
-            mock_ocean.port_client = mock_port_client
-            mock_ocean.config.integration.identifier = "test-integration"
-            mock_ocean.config.integration.type = "fake-integration"
+            _configure_ocean_for_incremental(mock_ocean, mock_port_client)
             await mock_mixin.sync_incremental(interval_seconds=900)
 
         mock_port_client.upsert_integration_cursor.assert_called_once()
@@ -172,9 +191,7 @@ class TestSyncIncrementalCursorScope:
         mock_mixin.process_resource.side_effect = capture_cursor  # type: ignore[attr-defined]
 
         with patch("port_ocean.core.integrations.mixins.sync_raw.ocean") as mock_ocean:
-            mock_ocean.port_client = mock_port_client
-            mock_ocean.config.integration.identifier = "test-integration"
-            mock_ocean.config.integration.type = "fake-integration"
+            _configure_ocean_for_incremental(mock_ocean, mock_port_client)
             await mock_mixin.sync_incremental(interval_seconds=900)
 
         assert captured["cursor"] is not None
@@ -188,9 +205,7 @@ class TestSyncIncrementalFailure:
         register_incremental_handler(mock_mixin, kind="issue")
 
         with patch("port_ocean.core.integrations.mixins.sync_raw.ocean") as mock_ocean:
-            mock_ocean.port_client = mock_port_client
-            mock_ocean.config.integration.identifier = "test-integration"
-            mock_ocean.config.integration.type = "fake-integration"
+            _configure_ocean_for_incremental(mock_ocean, mock_port_client)
             await mock_mixin.sync_incremental(interval_seconds=900)
 
         mock_port_client.upsert_integration_cursor.assert_called_once()
@@ -203,9 +218,7 @@ class TestSyncIncrementalFailure:
         mock_mixin.process_resource.side_effect = RuntimeError("error")  # type: ignore[attr-defined]
 
         with patch("port_ocean.core.integrations.mixins.sync_raw.ocean") as mock_ocean:
-            mock_ocean.port_client = mock_port_client
-            mock_ocean.config.integration.identifier = "test-integration"
-            mock_ocean.config.integration.type = "fake-integration"
+            _configure_ocean_for_incremental(mock_ocean, mock_port_client)
             await mock_mixin.sync_incremental(interval_seconds=900)
 
         mock_mixin.process_resource.assert_called_once()  # type: ignore[attr-defined]
@@ -220,14 +233,96 @@ class TestSyncIncrementalFailure:
         mock_mixin.process_resource.side_effect = RuntimeError("error")  # type: ignore[attr-defined]
 
         with patch("port_ocean.core.integrations.mixins.sync_raw.ocean") as mock_ocean:
-            mock_ocean.port_client = mock_port_client
-            mock_ocean.config.integration.identifier = "test-integration"
-            mock_ocean.config.integration.type = "fake-integration"
+            _configure_ocean_for_incremental(mock_ocean, mock_port_client)
             await mock_mixin.sync_incremental(interval_seconds=900)
 
         # First kind failed — second kind was never attempted
         mock_mixin.process_resource.assert_called_once()  # type: ignore[attr-defined]
         mock_port_client.upsert_integration_cursor.assert_not_called()
+
+
+class TestSyncIncrementalDspLifecycle:
+    async def test_notifies_started_and_finished_with_incremental_sync_type(
+        self, mock_mixin: SyncRawMixin, mock_port_client: MagicMock
+    ) -> None:
+        configure_app_config(mock_mixin, ["issue", "pull-request"])
+        register_incremental_handler(mock_mixin, kind="issue")
+        register_incremental_handler(mock_mixin, kind="pull-request")
+        lifecycle_client = _make_lifecycle_client()
+
+        with (
+            patch("port_ocean.core.integrations.mixins.sync_raw.ocean") as mock_ocean,
+            patch(
+                "port_ocean.core.integrations.mixins.sync_raw.is_dsp_mode_enabled",
+                AsyncMock(return_value=True),
+            ),
+        ):
+            _configure_ocean_for_incremental(
+                mock_ocean, mock_port_client, lifecycle_client
+            )
+            await mock_mixin.sync_incremental(interval_seconds=900)
+
+        assert mock_ocean.metrics.sync_type == SyncType.INCREMENTAL_RESYNC.value
+        lifecycle_client.notify_resync_started.assert_awaited_once()
+        started_kwargs = lifecycle_client.notify_resync_started.await_args.kwargs
+        assert started_kwargs["sync_type"] == SyncType.INCREMENTAL_RESYNC.value
+        assert started_kwargs["integration_id"] == "test-integration"
+        assert started_kwargs["integration_type"] == "fake-integration"
+        assert started_kwargs["kind_identifiers"] == ["issue-0", "pull-request-1"]
+
+        lifecycle_client.notify_resync_finished.assert_awaited_once()
+        finished_kwargs = lifecycle_client.notify_resync_finished.await_args.kwargs
+        assert finished_kwargs["sync_type"] == SyncType.INCREMENTAL_RESYNC.value
+        lifecycle_client.notify_resync_failed.assert_not_awaited()
+
+    async def test_notifies_failed_on_kind_failure(
+        self, mock_mixin: SyncRawMixin, mock_port_client: MagicMock
+    ) -> None:
+        configure_app_config(mock_mixin, ["issue"])
+        register_incremental_handler(mock_mixin, kind="issue")
+        mock_mixin.process_resource.side_effect = RuntimeError("error")  # type: ignore[attr-defined]
+        lifecycle_client = _make_lifecycle_client()
+
+        with (
+            patch("port_ocean.core.integrations.mixins.sync_raw.ocean") as mock_ocean,
+            patch(
+                "port_ocean.core.integrations.mixins.sync_raw.is_dsp_mode_enabled",
+                AsyncMock(return_value=True),
+            ),
+        ):
+            _configure_ocean_for_incremental(
+                mock_ocean, mock_port_client, lifecycle_client
+            )
+            await mock_mixin.sync_incremental(interval_seconds=900)
+
+        lifecycle_client.notify_resync_started.assert_awaited_once()
+        lifecycle_client.notify_resync_failed.assert_awaited_once()
+        failed_kwargs = lifecycle_client.notify_resync_failed.await_args.kwargs
+        assert failed_kwargs["sync_type"] == SyncType.INCREMENTAL_RESYNC.value
+        lifecycle_client.notify_resync_finished.assert_not_awaited()
+
+    async def test_skips_lifecycle_when_dsp_disabled(
+        self, mock_mixin: SyncRawMixin, mock_port_client: MagicMock
+    ) -> None:
+        configure_app_config(mock_mixin, ["issue"])
+        register_incremental_handler(mock_mixin, kind="issue")
+        lifecycle_client = _make_lifecycle_client()
+
+        with (
+            patch("port_ocean.core.integrations.mixins.sync_raw.ocean") as mock_ocean,
+            patch(
+                "port_ocean.core.integrations.mixins.sync_raw.is_dsp_mode_enabled",
+                AsyncMock(return_value=False),
+            ),
+        ):
+            _configure_ocean_for_incremental(
+                mock_ocean, mock_port_client, lifecycle_client
+            )
+            await mock_mixin.sync_incremental(interval_seconds=900)
+
+        assert mock_ocean.metrics.sync_type == SyncType.INCREMENTAL_RESYNC.value
+        lifecycle_client.notify_resync_started.assert_not_awaited()
+        lifecycle_client.notify_resync_finished.assert_not_awaited()
 
 
 class TestEventType:

--- a/port_ocean/tests/core/incremental/test_sync_incremental.py
+++ b/port_ocean/tests/core/incremental/test_sync_incremental.py
@@ -96,6 +96,7 @@ def _configure_ocean_for_incremental(
     mock_ocean.port_client = mock_port_client
     mock_ocean.config.integration.identifier = "test-integration"
     mock_ocean.config.integration.type = "fake-integration"
+    mock_ocean.metrics.clear_sync_context = MagicMock()
     if lifecycle_client is not None:
         mock_ocean.app.lifecycle_client = lifecycle_client
     return mock_ocean
@@ -117,7 +118,7 @@ class TestSyncIncrementalNoHandlers:
         configure_app_config(mock_mixin, ["issue"])
 
         with patch("port_ocean.core.integrations.mixins.sync_raw.ocean") as mock_ocean:
-            mock_ocean.port_client = mock_port_client
+            _configure_ocean_for_incremental(mock_ocean, mock_port_client)
             await mock_mixin.sync_incremental(interval_seconds=900)
 
         mock_mixin.process_resource.assert_not_called()  # type: ignore[attr-defined]
@@ -128,7 +129,7 @@ class TestSyncIncrementalNoHandlers:
         configure_app_config(mock_mixin, [])
 
         with patch("port_ocean.core.integrations.mixins.sync_raw.ocean") as mock_ocean:
-            mock_ocean.port_client = mock_port_client
+            _configure_ocean_for_incremental(mock_ocean, mock_port_client)
             await mock_mixin.sync_incremental(interval_seconds=900)
 
         mock_mixin.process_resource.assert_not_called()  # type: ignore[attr-defined]
@@ -262,7 +263,6 @@ class TestSyncIncrementalDspLifecycle:
             )
             await mock_mixin.sync_incremental(interval_seconds=900)
 
-        assert mock_ocean.metrics.sync_type == SyncType.INCREMENTAL_RESYNC.value
         lifecycle_client.notify_resync_started.assert_awaited_once()
         started_kwargs = lifecycle_client.notify_resync_started.await_args.kwargs
         assert started_kwargs["sync_type"] == SyncType.INCREMENTAL_RESYNC.value
@@ -274,6 +274,7 @@ class TestSyncIncrementalDspLifecycle:
         finished_kwargs = lifecycle_client.notify_resync_finished.await_args.kwargs
         assert finished_kwargs["sync_type"] == SyncType.INCREMENTAL_RESYNC.value
         lifecycle_client.notify_resync_failed.assert_not_awaited()
+        mock_ocean.metrics.clear_sync_context.assert_called()
 
     async def test_notifies_failed_on_kind_failure(
         self, mock_mixin: SyncRawMixin, mock_port_client: MagicMock
@@ -320,9 +321,27 @@ class TestSyncIncrementalDspLifecycle:
             )
             await mock_mixin.sync_incremental(interval_seconds=900)
 
-        assert mock_ocean.metrics.sync_type == SyncType.INCREMENTAL_RESYNC.value
+        mock_ocean.metrics.clear_sync_context.assert_called()
         lifecycle_client.notify_resync_started.assert_not_awaited()
         lifecycle_client.notify_resync_finished.assert_not_awaited()
+
+    async def test_clears_sync_context_after_successful_run(
+        self, mock_mixin: SyncRawMixin, mock_port_client: MagicMock
+    ) -> None:
+        configure_app_config(mock_mixin, ["issue"])
+        register_incremental_handler(mock_mixin, kind="issue")
+
+        with (
+            patch("port_ocean.core.integrations.mixins.sync_raw.ocean") as mock_ocean,
+            patch(
+                "port_ocean.core.integrations.mixins.sync_raw.is_dsp_mode_enabled",
+                AsyncMock(return_value=False),
+            ),
+        ):
+            _configure_ocean_for_incremental(mock_ocean, mock_port_client)
+            await mock_mixin.sync_incremental(interval_seconds=900)
+
+            mock_ocean.metrics.clear_sync_context.assert_called()
 
 
 class TestEventType:

--- a/port_ocean/tests/core/incremental/test_sync_incremental.py
+++ b/port_ocean/tests/core/incremental/test_sync_incremental.py
@@ -302,6 +302,36 @@ class TestSyncIncrementalDspLifecycle:
         assert "sync_type" not in failed_kwargs
         lifecycle_client.notify_resync_finished.assert_not_awaited()
 
+    async def test_notifies_failed_on_unexpected_exception(
+        self, mock_mixin: SyncRawMixin, mock_port_client: MagicMock
+    ) -> None:
+        """An unexpected exception (e.g. from cursor_store.get()) must still
+        call notify_resync_failed so the DSP lifecycle doesn't get stuck."""
+        configure_app_config(mock_mixin, ["issue"])
+        register_incremental_handler(mock_mixin, kind="issue")
+        mock_port_client.get_integration_cursor.side_effect = RuntimeError(
+            "cursor store unavailable"
+        )
+        lifecycle_client = _make_lifecycle_client()
+
+        with (
+            patch("port_ocean.core.integrations.mixins.sync_raw.ocean") as mock_ocean,
+            patch(
+                "port_ocean.core.integrations.mixins.sync_raw.is_dsp_mode_enabled",
+                AsyncMock(return_value=True),
+            ),
+        ):
+            _configure_ocean_for_incremental(
+                mock_ocean, mock_port_client, lifecycle_client
+            )
+            with pytest.raises(RuntimeError, match="cursor store unavailable"):
+                await mock_mixin.sync_incremental(interval_seconds=900)
+
+        lifecycle_client.notify_resync_started.assert_awaited_once()
+        lifecycle_client.notify_resync_failed.assert_awaited_once()
+        lifecycle_client.notify_resync_finished.assert_not_awaited()
+        mock_ocean.metrics.clear_sync_context.assert_called()
+
     async def test_skips_lifecycle_when_dsp_disabled(
         self, mock_mixin: SyncRawMixin, mock_port_client: MagicMock
     ) -> None:

--- a/port_ocean/tests/core/incremental/test_sync_incremental.py
+++ b/port_ocean/tests/core/incremental/test_sync_incremental.py
@@ -272,7 +272,7 @@ class TestSyncIncrementalDspLifecycle:
 
         lifecycle_client.notify_resync_finished.assert_awaited_once()
         finished_kwargs = lifecycle_client.notify_resync_finished.await_args.kwargs
-        assert finished_kwargs["sync_type"] == SyncType.INCREMENTAL_RESYNC.value
+        assert "sync_type" not in finished_kwargs
         lifecycle_client.notify_resync_failed.assert_not_awaited()
         mock_ocean.metrics.clear_sync_context.assert_called()
 
@@ -299,7 +299,7 @@ class TestSyncIncrementalDspLifecycle:
         lifecycle_client.notify_resync_started.assert_awaited_once()
         lifecycle_client.notify_resync_failed.assert_awaited_once()
         failed_kwargs = lifecycle_client.notify_resync_failed.await_args.kwargs
-        assert failed_kwargs["sync_type"] == SyncType.INCREMENTAL_RESYNC.value
+        assert "sync_type" not in failed_kwargs
         lifecycle_client.notify_resync_finished.assert_not_awaited()
 
     async def test_skips_lifecycle_when_dsp_disabled(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.46.1"
+version = "0.46.2"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description
- Emit resync & kind-level started/finished/failed/aborted events for incremental runs
- Add `sync_type` (`full_sync` / `incremental_resync`) and optional `kind_identifiers` on resync start
- Report abort/failure for unexpected incremental errors; clear sync context when a run ends

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch DSP lifecycle contracts and when kind-level events fire during incremental sync; incorrect `sync_type` or uncleared context could mislead Port/lifecycle consumers, but behavior is covered by new tests and is additive for API fields.
> 
> **Overview**
> **DSP lifecycle payloads now distinguish full vs incremental syncs** via a required `sync_type` (`full_sync` / `incremental_resync`) on resync-level started/finished/failed/aborted calls. Incremental runs also send optional `kind_identifiers` on start.
> 
> **Incremental sync** is wired into the same DSP lifecycle flow as full resync: resync-level notifications with `incremental_resync`, per-kind started/finished/aborted when DSP is enabled (previously kind events were skipped for incremental), plus abort handling on `CancelledError`. **Full resync** sets `sync_type` on all matching lifecycle calls.
> 
> **Metrics** track `sync_type` alongside `event_id`; `clear_sync_context()` runs after full and incremental sync so heartbeats and graceful shutdown do not treat completed runs as still active or mis-report aborts (shutdown abort now includes `sync_type`).
> 
> Tests cover lifecycle client bodies and incremental/full sync lifecycle wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d33dc9fabfe714da4860015c1ebc2201640a1e0f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->