### PR TITLE
[Core] change default processing mode to single process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.46.2 (2026-07-26)
+
+### Changed
+
+- Changed the default `process_execution_mode` for OnPrem from `multi_process` to `single_process`. Multi-process can still be enabled via `OCEAN__PROCESS_EXECUTION_MODE=multi_process`.
+
 ## 0.46.1 (2026-07-23)
 
 ### Bug Fixes

--- a/port_ocean/config/settings.py
+++ b/port_ocean/config/settings.py
@@ -321,7 +321,7 @@ class IntegrationConfiguration(BaseOceanSettings, extra=Extra.allow):
         default=CachingStorageMode.disk
     )
     process_execution_mode: Optional[ProcessExecutionMode] = Field(
-        default=ProcessExecutionMode.multi_process
+        default=ProcessExecutionMode.single_process
     )
 
     upsert_entities_batch_max_length: int = 20

--- a/port_ocean/integration_testing/harness.py
+++ b/port_ocean/integration_testing/harness.py
@@ -96,9 +96,8 @@ class IntegrationTestHarness:
             _config_factory_cache[self.integration_path] = config_factory
 
         # Build config override with test defaults
-        # Force single_process: the Port mock captures entities in-process. On Linux CI,
-        # the default is multi_process, so subprocesses would have their own copy of
-        # upserted_entities and the harness would see an empty list.
+        # Force single_process: the Port mock captures entities in-process. Subprocesses
+        # would have their own copy of upserted_entities and the harness would see an empty list.
         config = {
             "port": {
                 "client_id": "test-client-id",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.46.1"
+version = "0.46.2"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What -

Why -

How -

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing the default execution model affects how OnPrem resyncs run (memory, parallelism, and prior multi-process-only fixes); operators who depended on implicit multi-process need to set the env var explicitly.
> 
> **Overview**
> **OnPrem integrations now default to `single_process` instead of `multi_process` for resync and related work.** Deployments that still want per-kind subprocess isolation can set `OCEAN__PROCESS_EXECUTION_MODE=multi_process`.
> 
> The integration test harness comment is updated to describe why tests force single process (in-process Port mock), without tying it to Linux CI defaults. Release **0.46.2** and changelog document the behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfc672aa2e800b19369d5ccf2e8b0a6bc049824d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->