### PR TITLE
[Integration][AWS-v3] Improve instruction for adding new AWS kinds - NFC

### DIFF
--- a/integrations/aws-v3/ADDING_NEW_KINDS.md
+++ b/integrations/aws-v3/ADDING_NEW_KINDS.md
@@ -34,6 +34,37 @@ class ObjectKind(StrEnum):
     SQS_QUEUE = "AWS::SQS::Queue"  # Example
 ```
 
+**File:** `integration.py`
+
+Create a new `AWSResourceConfig` subclass named `AWS<Resource>ResourceConfig`. Its `kind` field must be a `Literal` matching the exact `ObjectKind` string value added above:
+
+```python
+class AWSSQSQueueResourceConfig(AWSResourceConfig):
+    kind: Literal["AWS::SQS::Queue"] = Field(
+        title="AWS SQS Queue",
+        description="AWS SQS Queue resource kind.",
+    )
+```
+
+**File:** `integration.py`
+
+Append the new subclass to the `Union` in `AWSPortAppConfig.resources` so Ocean can validate `port-app-config.yml` entries for this kind.
+
+```python
+class AWSPortAppConfig(PortAppConfig):
+    resources: List[
+        AWSS3BucketResourceConfig
+        | AWSEC2InstanceResourceConfig
+        | AWSECSClusterResourceConfig
+        | AWSSQSQueueResourceConfig # example
+    ] = Field(
+        default_factory=list,
+        title="Resources",
+        description="The list of resource configurations to sync from AWS.",
+    )  # type: ignore[assignment]
+
+```
+
 **Why:** This defines the resource type that Ocean will recognize and trigger resync events for.
 
 ### Step 2: Create the Resource Models

--- a/integrations/aws-v3/CHANGELOG.md
+++ b/integrations/aws-v3/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 2.16.4-beta (2026-07-27)
+
+
+### Improvements
+
+- Improve "ADDING NEW KINDS" instructions
+
+
 ## 2.16.3-beta (2026-07-26)
 
 

--- a/integrations/aws-v3/pyproject.toml
+++ b/integrations/aws-v3/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-v3"
-version = "2.16.4-beta"
+version = "2.16.5-beta"
 description = "AWS"
 authors = ["Shariff Mohammed <mohammed.s@getport.io>", "Michael Armah <mikeyarmah@gmail.com>"]
 

--- a/integrations/aws-v3/pyproject.toml
+++ b/integrations/aws-v3/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aws-v3"
-version = "2.16.3-beta"
+version = "2.16.4-beta"
 description = "AWS"
 authors = ["Shariff Mohammed <mohammed.s@getport.io>", "Michael Armah <mikeyarmah@gmail.com>"]
 


### PR DESCRIPTION
# Description

What - Improves the instruction in `ADDING_NEW_KINDS.md` to include create AWSResourceConfig subclass.

Why - Since the work on selector propagation, available kinds are required to be explicitly listed in `PortAppConfig` subclasses, which means the current instruction is incomplete, and when followed to the latter, would result in a solution that doesn't work. Indeed, this is currently an issue when "Add new AWS kind" SSA is used, since the generated kind doesn't run OOTB.

How -

## Type of change

Please leave one option from the following and delete the rest:

- [ x ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or integration behavior impact.
> 
> **Overview**
> **Step 1** of `ADDING_NEW_KINDS.md` now covers wiring new kinds into Ocean’s port-app-config validation, not only adding an `ObjectKind` enum entry.
> 
> Contributors are told to add an `AWS<Resource>ResourceConfig` subclass in `integration.py` with a `kind` `Literal` that matches the enum value, and to include that class in the `AWSPortAppConfig.resources` union so `port-app-config.yml` entries for the new kind validate. The guide uses SQS as the example, aligned with existing patterns like `AWSS3BucketResourceConfig`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7f341a376d8df9c72596ee8b70923f3beaadfbd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->