### PR TITLE
[Core] Don't Trigger Duplicate Resyncs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.46.5 (2026-07-28)
+
+### Bug Fixes
+
+- Call patch config rather than full patch integration route when setting up a default origin integration in order to avoid double resync.
+
 ## 0.46.4 (2026-07-27)
 
 ### Bug Fixes

--- a/port_ocean/clients/port/mixins/integrations.py
+++ b/port_ocean/clients/port/mixins/integrations.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import asyncio
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypedDict

--- a/port_ocean/clients/port/mixins/integrations.py
+++ b/port_ocean/clients/port/mixins/integrations.py
@@ -245,40 +245,20 @@ class IntegrationClientMixin:
 
     async def patch_integration_config(
         self,
-        _type: str | None = None,
-        changelog_destination: dict[str, Any] | None = None,
-        port_app_config: PortAppConfig | None = None,
-        actions_processing_enabled: bool | None = None,
-        are_port_resources_initialized: bool | None = None,
-        processing_mode: ProcessingMode | None = None,
+        port_app_config: "PortAppConfig",
         skip_resync: bool = False,
     ) -> dict:
         logger.info(
             f"Updating config of integration with id: {self.integration_identifier}"
         )
         headers = await self.auth.headers()
-        json: dict[str, Any] = {}
-        if _type:
-            json["installationAppType"] = _type
-        if port_app_config:
-            json["config"] = port_app_config.to_request()
-        if are_port_resources_initialized is not None:
-            json["arePortResourcesInitialized"] = are_port_resources_initialized
-        if actions_processing_enabled is not None:
-            json["actionsProcessingEnabled"] = actions_processing_enabled
-        if changelog_destination is not None:
-            json["changelogDestination"] = changelog_destination
-        if processing_mode is not None:
-            json["processingMode"] = processing_mode.value
         if skip_resync:
             headers["x-skip-resync"] = "true"
-
-        json["version"] = self.integration_version
 
         response = await self.client.patch(
             f"{self.auth.api_url}/integration/{self.integration_identifier}/config",
             headers=headers,
-            json=json,
+            json={"config": port_app_config.to_request()},
         )
         handle_port_status_code(response)
         return response.json()["integration"]

--- a/port_ocean/clients/port/mixins/integrations.py
+++ b/port_ocean/clients/port/mixins/integrations.py
@@ -245,7 +245,7 @@ class IntegrationClientMixin:
 
     async def patch_integration_config(
         self,
-        port_app_config: "PortAppConfig",
+        port_app_config: PortAppConfig | None,
         skip_resync: bool = False,
     ) -> dict:
         logger.info(

--- a/port_ocean/clients/port/mixins/integrations.py
+++ b/port_ocean/clients/port/mixins/integrations.py
@@ -216,9 +216,46 @@ class IntegrationClientMixin:
         actions_processing_enabled: Optional[bool] = None,
         are_port_resources_initialized: Optional[bool] = None,
         processing_mode: ProcessingMode | None = None,
-        skip_resync: bool = False,
     ) -> dict:
         logger.info(f"Updating integration with id: {self.integration_identifier}")
+        headers = await self.auth.headers()
+        json: dict[str, Any] = {}
+        if _type:
+            json["installationAppType"] = _type
+        if port_app_config:
+            json["config"] = port_app_config.to_request()
+        if are_port_resources_initialized is not None:
+            json["arePortResourcesInitialized"] = are_port_resources_initialized
+        if actions_processing_enabled is not None:
+            json["actionsProcessingEnabled"] = actions_processing_enabled
+        if changelog_destination is not None:
+            json["changelogDestination"] = changelog_destination
+        if processing_mode is not None:
+            json["processingMode"] = processing_mode.value
+
+        json["version"] = self.integration_version
+
+        response = await self.client.patch(
+            f"{self.auth.api_url}/integration/{self.integration_identifier}",
+            headers=headers,
+            json=json,
+        )
+        handle_port_status_code(response)
+        return response.json()["integration"]
+
+    async def patch_integration_config(
+        self,
+        _type: str | None = None,
+        changelog_destination: dict[str, Any] | None = None,
+        port_app_config: PortAppConfig | None = None,
+        actions_processing_enabled: bool | None = None,
+        are_port_resources_initialized: bool | None = None,
+        processing_mode: ProcessingMode | None = None,
+        skip_resync: bool = False,
+    ) -> dict:
+        logger.info(
+            f"Updating config of integration with id: {self.integration_identifier}"
+        )
         headers = await self.auth.headers()
         json: dict[str, Any] = {}
         if _type:
@@ -239,7 +276,7 @@ class IntegrationClientMixin:
         json["version"] = self.integration_version
 
         response = await self.client.patch(
-            f"{self.auth.api_url}/integration/{self.integration_identifier}",
+            f"{self.auth.api_url}/integration/{self.integration_identifier}/config",
             headers=headers,
             json=json,
         )

--- a/port_ocean/clients/port/mixins/integrations.py
+++ b/port_ocean/clients/port/mixins/integrations.py
@@ -216,6 +216,7 @@ class IntegrationClientMixin:
         actions_processing_enabled: Optional[bool] = None,
         are_port_resources_initialized: Optional[bool] = None,
         processing_mode: ProcessingMode | None = None,
+        skip_resync: bool = False,
     ) -> dict:
         logger.info(f"Updating integration with id: {self.integration_identifier}")
         headers = await self.auth.headers()
@@ -232,6 +233,8 @@ class IntegrationClientMixin:
             json["changelogDestination"] = changelog_destination
         if processing_mode is not None:
             json["processingMode"] = processing_mode.value
+        if skip_resync:
+            headers["x-skip-resync"] = "true"
 
         json["version"] = self.integration_version
 

--- a/port_ocean/core/defaults/initialization/default_origin_setup.py
+++ b/port_ocean/core/defaults/initialization/default_origin_setup.py
@@ -49,7 +49,7 @@ class DefaultOriginSetup(BaseSetup):
         try:
             logger.info("Found default resources, starting creation process")
             if not current_config:
-                await self.port_client.patch_integration(
+                await self.port_client.patch_integration_config(
                     port_app_config=self._default_mapping,
                     skip_resync=self.integration_config.runtime == Runtime.Saas,
                 )

--- a/port_ocean/core/defaults/initialization/default_origin_setup.py
+++ b/port_ocean/core/defaults/initialization/default_origin_setup.py
@@ -10,7 +10,7 @@ from port_ocean.config.settings import IntegrationConfiguration
 from port_ocean.core.defaults.common import Defaults, get_port_integration_defaults
 from port_ocean.core.defaults.initialization.base_setup import BaseSetup
 from port_ocean.core.handlers.port_app_config.models import PortAppConfig
-from port_ocean.core.models import Blueprint
+from port_ocean.core.models import Blueprint, Runtime
 from port_ocean.core.utils.utils import gather_and_split_errors_from_results
 from port_ocean.exceptions.port_defaults import AbortDefaultCreationError
 
@@ -51,6 +51,7 @@ class DefaultOriginSetup(BaseSetup):
             if not current_config:
                 await self.port_client.patch_integration(
                     port_app_config=self._default_mapping,
+                    skip_resync=self.integration_config.runtime == Runtime.Saas,
                 )
             await self._create_resources(self._defaults)
             has_initialized = True

--- a/port_ocean/tests/clients/port/mixins/test_integrations.py
+++ b/port_ocean/tests/clients/port/mixins/test_integrations.py
@@ -65,6 +65,11 @@ def integration_client(monkeypatch: Any) -> IntegrationClientMixin:
     client.get.return_value = MagicMock()
     client.get.return_value.status_code = 200
     client.get.return_value.is_error = False
+    client.patch = AsyncMock()
+    client.patch.return_value = MagicMock()
+    client.patch.return_value.status_code = 200
+    client.patch.return_value.is_error = False
+    client.patch.return_value.json.return_value = {"integration": {}}
 
     integration_client = IntegrationClientMixin(
         integration_identifier=TEST_INTEGRATION_IDENTIFIER,
@@ -294,3 +299,23 @@ async def test_get_integration_resync_request_returns_empty_dict_when_request_is
         result = await integration_client.get_integration_resync_request()
 
     assert result == {}
+
+
+async def test_patch_integration_sends_skip_resync_header_when_requested(
+    integration_client: IntegrationClientMixin,
+) -> None:
+    with patch("port_ocean.clients.port.mixins.integrations.handle_port_status_code"):
+        await integration_client.patch_integration(skip_resync=True)
+
+    call_args = integration_client.client.patch.call_args
+    assert call_args[1]["headers"]["x-skip-resync"] == "true"
+
+
+async def test_patch_integration_omits_skip_resync_header_by_default(
+    integration_client: IntegrationClientMixin,
+) -> None:
+    with patch("port_ocean.clients.port.mixins.integrations.handle_port_status_code"):
+        await integration_client.patch_integration()
+
+    call_args = integration_client.client.patch.call_args
+    assert "x-skip-resync" not in call_args[1]["headers"]

--- a/port_ocean/tests/clients/port/mixins/test_integrations.py
+++ b/port_ocean/tests/clients/port/mixins/test_integrations.py
@@ -5,6 +5,7 @@ import pytest
 import httpx
 
 from port_ocean.clients.port.mixins.integrations import IntegrationClientMixin
+from port_ocean.core.handlers.port_app_config.models import PortAppConfig
 
 TEST_INTEGRATION_IDENTIFIER = "test-integration"
 TEST_INTEGRATION_VERSION = "1.0.0"
@@ -301,21 +302,40 @@ async def test_get_integration_resync_request_returns_empty_dict_when_request_is
     assert result == {}
 
 
-async def test_patch_integration_sends_skip_resync_header_when_requested(
+async def test_patch_integration_config_patches_config_route(
     integration_client: IntegrationClientMixin,
 ) -> None:
-    with patch("port_ocean.clients.port.mixins.integrations.handle_port_status_code"):
-        await integration_client.patch_integration(skip_resync=True)
+    # Arrange
+    port_app_config = PortAppConfig(resources=[])
 
+    # Act
+    with patch("port_ocean.clients.port.mixins.integrations.handle_port_status_code"):
+        await integration_client.patch_integration_config(port_app_config)
+
+    # Assert
+    call_args = integration_client.client.patch.call_args
+
+    assert (
+        call_args[0][0]
+        == f"{TEST_API_URL}/integration/{TEST_INTEGRATION_IDENTIFIER}/config"
+    )
+    assert call_args[1]["json"] == {"config": port_app_config.to_request()}
+    assert "x-skip-resync" not in call_args[1]["headers"]
+
+
+async def test_patch_integration_config_sends_skip_resync_header_when_requested(
+    integration_client: IntegrationClientMixin,
+) -> None:
+    # Arrange
+    port_app_config = PortAppConfig(resources=[])
+
+    # Act
+    with patch("port_ocean.clients.port.mixins.integrations.handle_port_status_code"):
+        await integration_client.patch_integration_config(
+            port_app_config,
+            skip_resync=True,
+        )
+
+    # Assert
     call_args = integration_client.client.patch.call_args
     assert call_args[1]["headers"]["x-skip-resync"] == "true"
-
-
-async def test_patch_integration_omits_skip_resync_header_by_default(
-    integration_client: IntegrationClientMixin,
-) -> None:
-    with patch("port_ocean.clients.port.mixins.integrations.handle_port_status_code"):
-        await integration_client.patch_integration()
-
-    call_args = integration_client.client.patch.call_args
-    assert "x-skip-resync" not in call_args[1]["headers"]

--- a/port_ocean/tests/core/defaults/test_initialize.py
+++ b/port_ocean/tests/core/defaults/test_initialize.py
@@ -17,6 +17,7 @@ from port_ocean.core.models import (
     CreatePortResourcesOrigin,
     IntegrationFeatureFlag,
     ProcessingMode,
+    Runtime,
 )
 from port_ocean.ocean import Ocean
 
@@ -440,6 +441,7 @@ async def test_default_setup_integration_not_exists(
         CreatePortResourcesOrigin.Default
     )
     mock_integration_config.initialize_port_resources = True
+    mock_integration_config.runtime = Runtime.OnPrem
     mock_port_client.is_integration_provision_enabled.return_value = False  # type: ignore[attr-defined]
     mock_port_client.get_organization_feature_flags.return_value = []  # type: ignore[attr-defined]
     # First call returns empty (integration doesn't exist), subsequent calls return created integration
@@ -732,6 +734,7 @@ async def test_none_origin_provision_disabled_integration_not_exists(
     """Test None origin with provision disabled when integration doesn't exist - should use Ocean and create it."""
     mock_integration_config.create_port_resources_origin = None
     mock_integration_config.initialize_port_resources = True
+    mock_integration_config.runtime = Runtime.OnPrem
 
     # Mock provision disabled
     mock_port_client.is_integration_provision_enabled.return_value = False  # type: ignore[attr-defined]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.46.4"
+version = "0.46.5"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What - Call patch config rather than full patch integration route when setting up a default origin integration

Why - Causes double resync

How - Added a new util function to send a request to the patch config route and invoked it in the relevant spot

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to integration PATCH headers and SaaS-only default setup; behavior for non-SaaS and other `patch_integration` callers is unchanged.
> 
> **Overview**
> Adds an optional **`skip_resync`** flag on **`patch_integration`** that sends the **`x-skip-resync: true`** header so Port does not start a resync when the integration record is updated.
> 
> During **default origin setup**, when there is no existing config yet, the initial **`port_app_config`** patch now passes **`skip_resync=True`** for **SaaS** runtimes only. That avoids a redundant resync on top of sync work that already runs in that environment.
> 
> Unit tests cover that the header is set when requested and omitted by default; the integration test fixture now mocks **`client.patch`** for those cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88f5570d9d3f929e88cd07dbf8e5ee70e8fe5b54. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->