### PR TITLE
[Core] split oversized log batches to prevent HTTP 413 on log ingestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.46.5 (2026-07-28)
+
+### Bug Fixes
+
+- Split dynamically log batches that exceed the Port ingest size limit to prevent HTTP 413 (Payload Too Large) errors and avoid losing integration logs.
+
 ## 0.46.4 (2026-07-27)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Bug Fixes
 
-- Split dynamically log batches that exceed the Port ingest size limit to prevent HTTP 413 (Payload Too Large) errors and avoid losing integration logs.
+- Dynamically split log batches that exceed the Port ingest size limit to prevent HTTP 413 (Payload Too Large) errors and avoid losing integration logs.
 
 ## 0.46.5 (2026-07-28)
 

--- a/port_ocean/log/handlers.py
+++ b/port_ocean/log/handlers.py
@@ -1,5 +1,6 @@
 import logging
 import json
+import asyncio
 from pathlib import PosixPath
 import sys
 import threading
@@ -127,24 +128,17 @@ class HTTPMemoryHandler(MemoryHandler):
             self._thread_pool.append(thread)
         self.release()
 
-    async def _send_logs_chunked(
-        self, _ocean: Ocean, logs: list[dict[str, Any]]
-    ) -> None:
-        if not logs:
-            return
-
+    def _split_logs_into_size_bounded_chunks(
+        self, logs: list[dict[str, Any]]
+    ) -> list[list[dict[str, Any]]]:
+        chunks: list[list[dict[str, Any]]] = []
         current_chunk: list[dict[str, Any]] = []
         current_chunk_size = 0
 
         for log in logs:
             log_size = len(json.dumps(log).encode())
-
             if current_chunk and current_chunk_size + log_size > _MAX_LOG_BATCH_BYTES:
-                try:
-                    await _ocean.port_client.ingest_integration_logs(current_chunk)
-                except Exception as e:
-                    logger.error(f"Failed to send logs to Port with error: {e}")
-
+                chunks.append(current_chunk)
                 current_chunk = []
                 current_chunk_size = 0
 
@@ -152,10 +146,26 @@ class HTTPMemoryHandler(MemoryHandler):
             current_chunk_size += log_size
 
         if current_chunk:
-            try:
-                await _ocean.port_client.ingest_integration_logs(current_chunk)
-            except Exception as e:
-                logger.error(f"Failed to send logs to Port with error: {e}")
+            chunks.append(current_chunk)
+
+        return chunks
+
+    async def _send_logs_chunked(
+        self, _ocean: Ocean, logs: list[dict[str, Any]]
+    ) -> None:
+        if not logs:
+            return
+
+        result = await asyncio.gather(
+            *[
+                _ocean.port_client.ingest_integration_logs(logs=logs_chunk)
+                for logs_chunk in self._split_logs_into_size_bounded_chunks(logs)
+            ],
+            return_exceptions=True,
+        )
+        for chunk_result in result:
+            if isinstance(chunk_result, Exception):
+                logger.error(f"Failed to send logs chunk: {chunk_result}")
 
     async def send_logs(
         self, _ocean: Ocean, logs_to_send: list[dict[str, Any]]

--- a/port_ocean/log/handlers.py
+++ b/port_ocean/log/handlers.py
@@ -1,4 +1,5 @@
 import logging
+import json
 from pathlib import PosixPath
 import sys
 import threading
@@ -14,6 +15,8 @@ from loguru import logger
 from port_ocean import Ocean
 from port_ocean.context.ocean import ocean
 from port_ocean.utils.misc import run_async_in_new_event_loop
+
+_MAX_LOG_BATCH_BYTES = 1_000_000  # 1 MB log size limit
 
 
 def _serialize_posix_paths(
@@ -124,10 +127,34 @@ class HTTPMemoryHandler(MemoryHandler):
             self._thread_pool.append(thread)
         self.release()
 
+    async def _send_logs_chunked(
+        self, _ocean: Ocean, logs: list[dict[str, Any]]
+    ) -> None:
+        if not logs:
+            return
+
+        current_chunk: list[dict[str, Any]] = []
+        current_chunk_size = 0
+
+        for log in logs:
+            log_size = len(json.dumps(log).encode())
+
+            if current_chunk and current_chunk_size + log_size > _MAX_LOG_BATCH_BYTES:
+                try:
+                    await _ocean.port_client.ingest_integration_logs(current_chunk)
+                except Exception as e:
+                    logger.error(f"Failed to send logs to Port with error: {e}")
+
+                current_chunk = []
+                current_chunk_size = 0
+
+            current_chunk.append(log)
+            current_chunk_size += log_size
+
+        if current_chunk:
+            await self.send_logs(_ocean, current_chunk)
+
     async def send_logs(
         self, _ocean: Ocean, logs_to_send: list[dict[str, Any]]
     ) -> None:
-        try:
-            await _ocean.port_client.ingest_integration_logs(logs_to_send)
-        except Exception as e:
-            logger.error(f"Failed to send logs to Port with error: {e}")
+        await self._send_logs_chunked(_ocean, logs_to_send)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.46.4"
+version = "0.46.5"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What - splits log batches that exceed 1 MB before sending to the Port log ingest endpoint. The goal is to dynamically calculate the size of the logs payload then splits it and push those splits in batches. 

Why - Large GitHub resources (PRs, branches, workflow runs) produce verbose log entries. When batched together they can push the serialized payload past Port's ~1.2 MiB ingest limit, causing HTTP 413 errors and silently dropping diagnostic logs. Customer data is unaffected but operational visibility is lost.

How - `send_logs` delegates to `_send_logs_chunked` which walks the batch in a single linear pass, measuring each entry's exact wire size via `json.dumps(log).encode()`. When adding the next entry would exceed 1 MB, the current chunk is flushed and a new one starts. Each chunk is sent independently so a failure on one does not prevent the rest from being delivered.


## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the log-shipping path to Port; the final chunk is sent via `send_logs` → `_send_logs_chunked` rather than a direct ingest with the previous try/except, which may recurse for batches that never split and should be verified.
> 
> **Overview**
> Fixes integration event logs failing with **HTTP 413** when a buffered flush exceeds Port’s ingest payload limit.
> 
> `HTTPMemoryHandler` now caps each `ingest_integration_logs` request at **~1 MB** (`_MAX_LOG_BATCH_BYTES`), estimating size per entry with `json.dumps` and splitting the flush into multiple chunks. Intermediate chunks log ingest failures; version **0.46.5** and changelog document the fix.
> 
> `send_logs` is a thin wrapper around the new `_send_logs_chunked` path instead of posting the full buffer in one call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64e3ed1533a64b5c61e46f6ecb5e3d7173468c2b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->