### PR TITLE
[Integration][GitHub] Omit unset skill path filters from schema defaults

### DIFF
--- a/integrations/github/CHANGELOG.md
+++ b/integrations/github/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 6.7.1 (2026-07-28)
+
+
+### Improvements
+
+- Omit unset repository filters from default Skill path schema entries.
+
+
 ## 6.7.0 (2026-07-27)
 
 

--- a/integrations/github/CHANGELOG.md
+++ b/integrations/github/CHANGELOG.md
@@ -7,12 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
-## 6.7.1 (2026-07-28)
+## 6.7.2 (2026-07-28)
 
 
 ### Improvements
 
 - Omit unset repository filters from default Skill path schema entries.
+
+
+## 6.7.1 (2026-07-28)
+
+
+### Improvements
+
 - Bumped ocean version to ^0.46.5
 
 

--- a/integrations/github/integration.py
+++ b/integrations/github/integration.py
@@ -308,6 +308,14 @@ class GithubSkillSelector(Selector):
         ),
     )
 
+    class Config:
+        @staticmethod
+        def schema_extra(schema: dict[str, Any], model: Type[BaseModel]) -> None:
+            default_paths = model.__fields__["paths"].default
+            schema["properties"]["paths"]["default"] = [
+                path.dict(exclude_none=True) for path in default_paths
+            ]
+
 
 class GithubSkillResourceConfig(ResourceConfig):
     kind: Literal[ObjectKind.SKILL] = Field(

--- a/integrations/github/pyproject.toml
+++ b/integrations/github/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "github-ocean"
-version = "6.7.0"
+version = "6.7.1"
 description = "This integration ingest data from github"
 authors = ["Chukwuemeka Nwaoma <joelchukks@gmail.com>", "Melody Anyaegbulam <melodyogonna@gmail.com>", "Michael Armah <mikeyarmah@gmail.com>"]
 

--- a/integrations/github/pyproject.toml
+++ b/integrations/github/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "github-ocean"
-version = "6.7.1"
+version = "6.7.2"
 description = "This integration ingest data from github"
 authors = ["Chukwuemeka Nwaoma <joelchukks@gmail.com>", "Melody Anyaegbulam <melodyogonna@gmail.com>", "Michael Armah <mikeyarmah@gmail.com>"]
 

--- a/integrations/github/tests/test_config_schema.py
+++ b/integrations/github/tests/test_config_schema.py
@@ -1,0 +1,8 @@
+from github.core.exporters.skill_exporter.utils import DEFAULT_SKILL_PATHS
+from integration import GithubSkillSelector
+
+
+def test_skill_path_defaults_omit_unset_repository_filters() -> None:
+    defaults = GithubSkillSelector.schema()["properties"]["paths"]["default"]
+
+    assert defaults == [{"path": path} for path in DEFAULT_SKILL_PATHS]


### PR DESCRIPTION
## Summary
- omit `null` repository filter fields from generated GitHub Skill path defaults
- retain the existing typed selector defaults as the single source of truth
- add regression coverage and bump the GitHub integration patch version

## Test plan
- [x] `PYTHONPATH=/Users/omribarouch/Desktop/ocean ./.venv/bin/pytest -n 0 tests/test_config_schema.py`
- [x] `ruff check integration.py tests/test_config_schema.py`
- [x] `black --check integration.py tests/test_config_schema.py`
- [ ] Full `make lint` remains blocked by existing unrelated mypy and formatting failures

Made with [Cursor](https://cursor.com)