### PR TITLE
[Core] fix ocean-core processing mode syncs stuck on syncing and getting aborted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.46.6 (2026-07-29)
+
+### Bug Fixes
+
+- Moved `clear_sync_context` from `sync_raw_all` finalizer into `update_after_resync` so the runtime terminal metric is sent with the correct `eventId` before it is cleared. Previously the `eventId` was wiped before `update_after_resync` ran, causing integ-service's stale-heartbeat abort consumer to miss the terminal runtime metric and incorrectly abort completed syncs.
+
 ## 0.46.5 (2026-07-28)
 
 ### Bug Fixes

--- a/port_ocean/core/handlers/resync_state_updater/updater.py
+++ b/port_ocean/core/handlers/resync_state_updater/updater.py
@@ -105,3 +105,5 @@ class ResyncStateUpdater:
             kinds=[ocean.metrics.current_resource_kind()],
             dsp_enabled=await is_dsp_mode_enabled(),
         )
+
+        ocean.metrics.clear_sync_context()

--- a/port_ocean/core/integrations/mixins/sync_raw.py
+++ b/port_ocean/core/integrations/mixins/sync_raw.py
@@ -1624,7 +1624,6 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                             "Lifecycle abort poll task failed during cleanup",
                             error=str(e),
                         )
-                ocean.metrics.clear_sync_context()
                 await ocean.app.cache_provider.clear()
                 ocean.port_client.clear_blueprint_cache()
                 if (

--- a/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
+++ b/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
@@ -1864,7 +1864,7 @@ async def test_sync_raw_all_dsp_notifies_resync_started_with_mapping(
     lifecycle_client.notify_resync_finished.assert_awaited_once()
     finished_kwargs = lifecycle_client.notify_resync_finished.await_args.kwargs
     assert "sync_type" not in finished_kwargs
-    assert mock_ocean.metrics.event_id == ""
+    assert mock_ocean.metrics.event_id != ""
 
 
 @pytest.mark.asyncio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.46.5"
+version = "0.46.6"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description
- `clear_sync_context()` wiped `eventId` in `sync_raw_all`'s `finally` before `update_after_resync` could send the runtime COMPLETED metric with it
- integ-service's stale abort consumer couldn't match the empty `eventId` to the heartbeat document, so it aborted completed syncs
- Fix: move `clear_sync_context()` into `update_after_resync`, after metrics are sent


## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small ordering fix for metrics lifecycle; no auth or data-path changes. Touches resync completion reporting used by integ-service abort logic.
> 
> **Overview**
> Fixes **processing-mode syncs** that stayed **Syncing** and were **incorrectly aborted** after a successful resync.
> 
> **`clear_sync_context()`** is no longer invoked in the **`sync_raw_all`** `finally` block. It now runs at the end of **`update_after_resync`** (after **`send_metrics_to_webhook`** and **`report_sync_metrics`**), so the **runtime terminal metric** still carries the correct **`eventId`**. Clearing the context in the finalizer ran before post-resync reporting, so integ-service’s stale-heartbeat abort path could miss the completion signal.
> 
> Release **0.46.6**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc38d815106442589939753cbebbe2e380e06cb6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->