### PR TITLE
[Core] support in redis cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.47.2 (2026-07-30)
+
+### Improvements
+
+- Upgraded `redis` to `^6.1.0` and auto-detect Redis Cluster connections for live events stream consumption.
+
 ## 0.47.1 (2026-07-29)
 
 ### Bug Fixes

--- a/poetry.lock
+++ b/poetry.lock
@@ -2355,22 +2355,22 @@ files = [
 
 [[package]]
 name = "redis"
-version = "5.3.1"
+version = "6.4.0"
 description = "Python client for Redis database and key-value store"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "redis-5.3.1-py3-none-any.whl", hash = "sha256:dc1909bd24669cc31b5f67a039700b16ec30571096c5f1f0d9d2324bff31af97"},
-    {file = "redis-5.3.1.tar.gz", hash = "sha256:ca49577a531ea64039b5a36db3d6cd1a0c7a60c34124d46924a45b956e8cf14c"},
+    {file = "redis-6.4.0-py3-none-any.whl", hash = "sha256:f0544fa9604264e9464cdf4814e7d4830f74b165d52f2a330a760a88dd248b7f"},
+    {file = "redis-6.4.0.tar.gz", hash = "sha256:b01bc7282b8444e28ec36b261df5375183bb47a07eb9c603f284e89cbc5ef010"},
 ]
 
 [package.dependencies]
-hiredis = {version = ">=3.0.0", optional = true, markers = "extra == \"hiredis\""}
-PyJWT = ">=2.9.0"
+hiredis = {version = ">=3.2.0", optional = true, markers = "extra == \"hiredis\""}
 
 [package.extras]
-hiredis = ["hiredis (>=3.0.0)"]
-ocsp = ["cryptography (>=36.0.1)", "pyopenssl (==23.2.1)", "requests (>=2.31.0)"]
+hiredis = ["hiredis (>=3.2.0)"]
+jwt = ["pyjwt (>=2.9.0)"]
+ocsp = ["cryptography (>=36.0.1)", "pyopenssl (>=20.0.1)", "requests (>=2.31.0)"]
 
 [[package]]
 name = "requests"
@@ -2796,4 +2796,4 @@ cli = ["click", "cookiecutter", "jinja2-strcase", "jinja2-time", "jsonref", "ric
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.12"
-content-hash = "cf9e1e7ea907001c0f86922abcff4c51b7197d779c571035da760fa905c0a95f"
+content-hash = "a1d0fcdc25c26b3a4a99d50ca7f93d7921f1420c7eb3148a7a73bdc7516994a5"

--- a/port_ocean/consumers/pel_requeue/worker.py
+++ b/port_ocean/consumers/pel_requeue/worker.py
@@ -18,9 +18,8 @@ import asyncio
 from typing import Any, cast
 
 from loguru import logger
-from redis.asyncio import Redis
-
 from port_ocean.config.settings import LiveEventsRedisSettings
+from port_ocean.consumers.redis_client import RedisClient
 from port_ocean.consumers.pel_requeue.settings import PEL_CONSUMER_NAME
 
 
@@ -34,7 +33,7 @@ class PELRequeueWorker:
 
     def __init__(
         self,
-        redis: Redis,
+        redis: RedisClient,
         redis_settings: LiveEventsRedisSettings,
         stream_key: str,
         consumer_group: str,

--- a/port_ocean/consumers/redis_client.py
+++ b/port_ocean/consumers/redis_client.py
@@ -25,5 +25,5 @@ async def create_redis_client(url: str, **kwargs: Any) -> RedisClient:
         await client.aclose()
         raise
 
-    logger.debug("Using standalone Redis client")
+    logger.info("Using standalone Redis client")
     return client

--- a/port_ocean/consumers/redis_client.py
+++ b/port_ocean/consumers/redis_client.py
@@ -1,0 +1,29 @@
+from typing import Any
+
+from loguru import logger
+from redis.asyncio import Redis
+from redis.asyncio.cluster import RedisCluster
+
+RedisClient = Redis | RedisCluster
+
+
+async def is_redis_cluster_enabled(redis_client: Redis) -> bool:
+    """Return True when the connected Redis instance has cluster mode enabled."""
+    cluster_info = await redis_client.info("cluster")
+    return bool(cluster_info.get("cluster_enabled"))
+
+
+async def create_redis_client(url: str, **kwargs: Any) -> RedisClient:
+    """Connect to Redis, using a cluster client when cluster mode is enabled."""
+    client = Redis.from_url(url, **kwargs)
+    try:
+        if await is_redis_cluster_enabled(client):
+            await client.aclose()
+            logger.info("Detected Redis cluster mode, using RedisCluster client")
+            return RedisCluster.from_url(url, **kwargs)
+    except Exception:
+        await client.aclose()
+        raise
+
+    logger.debug("Using standalone Redis client")
+    return client

--- a/port_ocean/consumers/redis_stream_consumer.py
+++ b/port_ocean/consumers/redis_stream_consumer.py
@@ -11,11 +11,11 @@ from typing import Any
 from uuid import uuid4
 
 from loguru import logger
-from redis.asyncio import Redis
 from redis.asyncio.connection import SSLConnection
 from redis.exceptions import ResponseError
 
 from port_ocean.config.settings import LiveEventsRedisSettings
+from port_ocean.consumers.redis_client import RedisClient, create_redis_client
 from port_ocean.consumers.abstract_live_events_consumer import (
     AbstractLiveEventsConsumer,
 )
@@ -50,7 +50,7 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
         self._on_message = on_message
         self._consumer_group = self._resolve_consumer_group()
         self._registered_paths = registered_paths or set()
-        self._redis: Redis | None = None
+        self._redis: RedisClient | None = None
         self._ssl_cert_file: str | None = None
         self._ssl_key_file: str | None = None
         self._is_running = False
@@ -116,7 +116,9 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
         return kwargs
 
     async def start(self) -> None:
-        self._redis = Redis.from_url(self._settings.url, **self._redis_client_kwargs())
+        self._redis = await create_redis_client(
+            self._settings.url, **self._redis_client_kwargs()
+        )
         await self._ensure_consumer_group()
         self._is_running = True
         self._read_task = asyncio.create_task(self._read_loop())
@@ -168,7 +170,7 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
             )
             await self._ensure_consumer_group()
 
-    def _require_redis(self) -> Redis:
+    def _require_redis(self) -> RedisClient:
         if self._redis is None:
             raise RuntimeError(
                 "Redis stream consumer has not been started or has been stopped"

--- a/port_ocean/tests/consumers/test_redis_client.py
+++ b/port_ocean/tests/consumers/test_redis_client.py
@@ -1,0 +1,96 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from port_ocean.consumers.redis_client import (
+    create_redis_client,
+    is_redis_cluster_enabled,
+)
+
+
+class TestIsRedisClusterEnabled:
+    @pytest.mark.asyncio
+    async def test_returns_true_when_cluster_enabled(self) -> None:
+        redis_client = AsyncMock()
+        redis_client.info = AsyncMock(return_value={"cluster_enabled": 1})
+
+        assert await is_redis_cluster_enabled(redis_client) is True
+        redis_client.info.assert_awaited_once_with("cluster")
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_cluster_disabled(self) -> None:
+        redis_client = AsyncMock()
+        redis_client.info = AsyncMock(return_value={"cluster_enabled": 0})
+
+        assert await is_redis_cluster_enabled(redis_client) is False
+
+
+class TestCreateRedisClient:
+    @pytest.mark.asyncio
+    async def test_returns_standalone_client_when_cluster_disabled(self) -> None:
+        mock_standalone = AsyncMock()
+        mock_standalone.info = AsyncMock(return_value={"cluster_enabled": 0})
+
+        with patch(
+            "port_ocean.consumers.redis_client.Redis.from_url",
+            return_value=mock_standalone,
+        ) as mock_from_url:
+            client = await create_redis_client(
+                "redis://localhost:6379",
+                decode_responses=True,
+            )
+
+        assert client is mock_standalone
+        mock_from_url.assert_called_once_with(
+            "redis://localhost:6379",
+            decode_responses=True,
+        )
+        mock_standalone.aclose.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_returns_cluster_client_when_cluster_enabled(self) -> None:
+        mock_standalone = AsyncMock()
+        mock_standalone.info = AsyncMock(return_value={"cluster_enabled": 1})
+        mock_cluster = MagicMock()
+
+        with (
+            patch(
+                "port_ocean.consumers.redis_client.Redis.from_url",
+                return_value=mock_standalone,
+            ) as mock_from_url,
+            patch(
+                "port_ocean.consumers.redis_client.RedisCluster.from_url",
+                return_value=mock_cluster,
+            ) as mock_cluster_from_url,
+        ):
+            client = await create_redis_client(
+                "rediss://localhost:6379",
+                decode_responses=True,
+            )
+
+        assert client is mock_cluster
+        mock_from_url.assert_called_once_with(
+            "rediss://localhost:6379",
+            decode_responses=True,
+        )
+        mock_standalone.aclose.assert_awaited_once()
+        mock_cluster_from_url.assert_called_once_with(
+            "rediss://localhost:6379",
+            decode_responses=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_closes_probe_client_when_detection_fails(self) -> None:
+        mock_standalone = AsyncMock()
+        mock_standalone.info = AsyncMock(side_effect=ConnectionError("refused"))
+
+        with (
+            patch(
+                "port_ocean.consumers.redis_client.Redis.from_url",
+                return_value=mock_standalone,
+            ),
+            pytest.raises(ConnectionError, match="refused"),
+        ):
+            await create_redis_client("redis://localhost:6379")
+
+        mock_standalone.aclose.assert_awaited_once()

--- a/port_ocean/tests/consumers/test_redis_stream_consumer.py
+++ b/port_ocean/tests/consumers/test_redis_stream_consumer.py
@@ -502,8 +502,8 @@ class TestRedisStreamConsumerPelWorkerLifecycle:
                 "port_ocean.consumers.redis_stream_consumer.ocean", mock_ocean_config
             ),
             patch(
-                "port_ocean.consumers.redis_stream_consumer.Redis.from_url",
-                return_value=mock_redis,
+                "port_ocean.consumers.redis_stream_consumer.create_redis_client",
+                new=AsyncMock(return_value=mock_redis),
             ),
             patch(
                 "port_ocean.consumers.redis_stream_consumer.PELRequeueWorker",
@@ -544,8 +544,8 @@ class TestRedisStreamConsumerPelWorkerLifecycle:
                 "port_ocean.consumers.redis_stream_consumer.ocean", mock_ocean_config
             ),
             patch(
-                "port_ocean.consumers.redis_stream_consumer.Redis.from_url",
-                return_value=mock_redis,
+                "port_ocean.consumers.redis_stream_consumer.create_redis_client",
+                new=AsyncMock(return_value=mock_redis),
             ),
             patch(
                 "port_ocean.consumers.redis_stream_consumer.PELRequeueWorker",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.47.1"
+version = "0.47.2"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"
@@ -69,7 +69,7 @@ aiofiles = "^24.1.0"
 cryptography = "^49.0.0"
 jmespath = "^1.0.1"
 psutil = "^7.2.1"
-redis = { version = "^5.2.1", extras = ["hiredis"] }
+redis = { version = "^6.1.0", extras = ["hiredis"] }
 
 # CLI
 click = { version = "^8.1.3", optional = true }


### PR DESCRIPTION
# Description

Adds Redis Cluster support for Ocean live events stream consumption.

Previously, the Redis live events consumer always used the standalone redis.asyncio.Redis client via Redis.from_url(). That fails against cluster-mode Redis (e.g. AWS ElastiCache with cluster mode enabled), which returns MOVED / CLUSTERDOWN errors because the client does not follow slot redirects.

Upgrades redis from ^5.2.1 to ^6.1.0 so cluster transactional pipelines work in the PEL requeue worker (pipeline(transaction=True) for atomic XADD + XACK on the same stream key)

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how live-events Redis connections are established (including TLS kwargs), which can affect production connectivity; behavior for standalone Redis should stay the same when cluster is disabled.
> 
> **Overview**
> Adds **automatic Redis Cluster support** for the live-events Redis stream path by probing the server after connect and switching to `RedisCluster` when cluster mode is on.
> 
> A new `redis_client` helper defines a shared `RedisClient` type (`Redis | RedisCluster`), implements `create_redis_client` (probe via `INFO cluster`, close probe client on cluster or on failure), and wires **`RedisStreamConsumer.start`** to use it instead of `Redis.from_url` directly. **`PELRequeueWorker`** is updated to accept the same `RedisClient` type. Unit tests cover cluster detection, standalone vs cluster client selection, probe cleanup on errors, and stream consumer start tests now mock `create_redis_client`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eed472724e6a1c9476ed6636de579ed125e5863d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->