### PR TITLE
[Integration][Fake Integration] Validate Version Bump Changes

### DIFF
--- a/integrations/fake-integration/CHANGELOG.md
+++ b/integrations/fake-integration/CHANGELOG.md
@@ -5,6 +5,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.1.312-dev (2026-08-02)
+
+
+### Improvements
+
+- Manual change test
+
 ## 0.1.311-dev (2026-07-30)
 
 

--- a/integrations/fake-integration/main.py
+++ b/integrations/fake-integration/main.py
@@ -16,6 +16,9 @@ from port_ocean.core.ocean_types import ASYNC_GENERATOR_RESYNC_TYPE
 from fake_org_data.fake_router import initialize_fake_routes
 
 
+# Temp comment just to check changes, will remove in follow-up
+
+
 @ocean.on_resync("fake-department")
 async def resync_department(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     async for department_batch in get_departments():

--- a/integrations/fake-integration/main.py
+++ b/integrations/fake-integration/main.py
@@ -15,7 +15,6 @@ from fake_org_data.fake_client import (
 from port_ocean.core.ocean_types import ASYNC_GENERATOR_RESYNC_TYPE
 from fake_org_data.fake_router import initialize_fake_routes
 
-
 # Temp comment just to check changes, will remove in follow-up
 
 

--- a/integrations/fake-integration/pyproject.toml
+++ b/integrations/fake-integration/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fake-integration"
-version = "0.1.311-dev"
+version = "0.1.312-dev"
 description = "A useless fake integration that helps us test the Ocean Core"
 authors = ["Erik Zaadi <erik@getport.io>"]
 


### PR DESCRIPTION
# Description

The goal here is to validate that the CI changes made in [this PR](https://github.com/port-labs/ocean/pull/3612) are fully functional. This one validates there aren't any regressions
