### PR TITLE
fix(jenkins): don't double context path when building folder job base URL

### DIFF
--- a/integrations/jenkins/changelog/3024.bugfix
+++ b/integrations/jenkins/changelog/3024.bugfix
@@ -1,0 +1,1 @@
+Fixed `_build_base_url` doubling the Jenkins context path when recursing into folder jobs on a Jenkins instance not served at the root path (e.g. `https://host/jenkins`), which caused nested folder jobs to fail with `Exception: 'jobs'` and be silently skipped during resync.

--- a/integrations/jenkins/client.py
+++ b/integrations/jenkins/client.py
@@ -1,6 +1,6 @@
 from enum import StrEnum
 from typing import Any, AsyncGenerator, Optional
-from urllib.parse import urlparse, urljoin
+from urllib.parse import urljoin
 import httpx
 
 from loguru import logger
@@ -207,8 +207,9 @@ class JenkinsClient:
         return {"tree": jobs_query + jobs_pagination}
 
     def _build_base_url(self, parent_job: Optional[dict[str, Any]]) -> str:
-        job_path = urlparse(parent_job["url"]).path if parent_job else ""
-        return f"{self.jenkins_base_url}{job_path}".rstrip("/")
+        if parent_job is None:
+            return self.jenkins_base_url
+        return parent_job["url"].rstrip("/")
 
     def enrich_jobs(
         self, jobs: list[dict[str, Any]], parent_job: dict[str, Any] | None

--- a/integrations/jenkins/tests/test_client.py
+++ b/integrations/jenkins/tests/test_client.py
@@ -237,3 +237,37 @@ async def test_build_base_url_removes_trailing_slash(
     url2 = client._build_base_url(None)
     assert not url2.endswith("/"), f"URL should not end with a slash: {url2}"
     assert url2 == "http://jenkins.example.com"
+
+
+@pytest.mark.asyncio
+@patch(
+    "port_ocean.context.ocean.PortOceanContext.integration_config",
+    new_callable=AsyncMock,
+)
+@patch("port_ocean.utils.async_http.OceanAsyncClient", new_callable=AsyncMock)
+async def test_build_base_url_does_not_double_context_path(
+    mock_ocean_client: AsyncMock, mock_integration_config: AsyncMock
+) -> None:
+    # Reproduces https://github.com/port-labs/ocean/issues/3024:
+    # when Jenkins is served under a non-root context path, the job's own
+    # "url" from the Jenkins API already includes that context path, so
+    # re-prepending jenkins_base_url doubled it (e.g. ".../jenkins/jenkins/job/...").
+    mock_integration_config.return_value = {
+        "jenkins_host": "http://jenkins.example.com/jenkins",
+        "jenkins_user": "user",
+        "jenkins_token": "token",
+    }
+
+    with patch("client.http_async_client", new=mock_ocean_client):
+        client = JenkinsClient("http://jenkins.example.com/jenkins", "user", "token")
+
+    parent_job = {"url": "http://jenkins.example.com/jenkins/job/MyFolder/"}
+    url = client._build_base_url(parent_job)
+    assert url == "http://jenkins.example.com/jenkins/job/MyFolder"
+
+    # Nested folder job one level deeper, to make sure it doesn't compound
+    nested_parent_job = {
+        "url": "http://jenkins.example.com/jenkins/job/MyFolder/job/SubFolder/"
+    }
+    nested_url = client._build_base_url(nested_parent_job)
+    assert nested_url == "http://jenkins.example.com/jenkins/job/MyFolder/job/SubFolder"


### PR DESCRIPTION
# Description

**What -** Fixes `_build_base_url` in the Jenkins integration doubling the Jenkins context path when recursing into folder jobs, which broke syncing for any Jenkins instance not served at the root path (e.g. `https://host/jenkins`).

**Why -** When Jenkins runs under a non-root context path, the `url` field Jenkins returns for a job already includes that context path. `_build_base_url` was reconstructing the URL by taking `urlparse(parent_job["url"]).path` and prepending `self.jenkins_base_url`, which also contains the context path — doubling it (e.g. `.../jenkins/jenkins/job/MyFolder`). The resulting request 404s, `_send_api_request` raises `Exception: 'jobs'` on the missing key, and the folder's child jobs are silently skipped during resync. Any installation with folder-type jobs behind a reverse proxy with path-based routing is affected.

**How -** Use the job's own `url` directly instead of reconstructing it from `jenkins_base_url` + path. Jenkins always returns a full, correct URL per job (the existing code already relied on this for the `urlparse(...).path` extraction), so using it as-is avoids the doubling regardless of how Jenkins is deployed.

Fixes #3024

## Release (integrations / ocean core)

Added `integrations/jenkins/changelog/3024.bugfix`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Integration testing checklist

- [x] Added a regression test (`test_build_base_url_does_not_double_context_path`) that fails against the pre-fix code with the exact doubled-path symptom from the issue, and passes with the fix
- [x] Ran the full existing `integrations/jenkins` test suite locally — all 17 tests pass
- [ ] Not tested against a live Jenkins/Port instance — I don't have access to a Jenkins deployment behind a non-root context path to verify end-to-end; the fix and regression test are based on reading `_build_base_url` and its call site directly, not a live repro

## Screenshots

N/A — this is a backend URL-construction fix with no UI surface.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted URL construction fix in the Jenkins client with regression tests; no auth or data-model changes.
> 
> **Overview**
> Fixes folder-job pagination when Jenkins is mounted under a non-root path (e.g. `https://host/jenkins`). **`_build_base_url`** no longer rebuilds URLs from `jenkins_base_url` plus the job path; it returns the parent job’s API **`url`** (trimmed) or **`jenkins_base_url`** at the root, so nested folder requests no longer hit doubled paths like `.../jenkins/jenkins/job/...` and skip child jobs during resync.
> 
> Adds a regression test for context-path and nested-folder URLs and a changelog entry for #3024.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ba66fdb790a0d3bf9533db8c87806555b226f47. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->