### PR TITLE
[Core] Abort DSP resync only on explicit Lakehouse resync_stale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.47.4 (2026-08-03)
+
+### Bug Fixes
+
+- Do not abort DSP resyncs when Lakehouse returns `count: 0` on an idempotent raw-data write retry; abort only when Lakehouse reports an explicit `resync_stale` error (HTTP 409).
+
 ## 0.47.3 (2026-08-03)
 
 ### Improvements

--- a/port_ocean/clients/port/mixins/integrations.py
+++ b/port_ocean/clients/port/mixins/integrations.py
@@ -28,6 +28,28 @@ if TYPE_CHECKING:
 
 INTEGRATION_POLLING_INTERVAL_INITIAL_SECONDS = 3
 INTEGRATION_POLLING_INTERVAL_BACKOFF_FACTOR = 1.55
+
+RESYNC_STALE_ERROR_CODE = "resync_stale"
+
+
+def _is_resync_stale_lakehouse_response(response: httpx.Response) -> bool:
+    if response.status_code != 409:
+        return False
+    try:
+        payload = response.json()
+    except Exception:
+        return False
+    if not isinstance(payload, dict):
+        return False
+    error = payload.get("error")
+    code: str | None = None
+    if isinstance(error, dict):
+        code = error.get("code") or error.get("name")
+    else:
+        code = payload.get("code")
+    return code == RESYNC_STALE_ERROR_CODE
+
+
 INTEGRATION_POLLING_RETRY_LIMIT = 30
 CREATE_RESOURCES_PARAM_NAME = "integration_modes"
 CREATE_RESOURCES_PARAM_VALUE = ["create_resources"]
@@ -441,21 +463,18 @@ class IntegrationClientMixin:
             json=body,
             extensions={"retryable": True},
         )
-        handle_port_status_code(response, should_raise=True, should_log=True)
-        try:
-            payload = response.json()
-        except Exception:
-            payload = {}
-        if isinstance(payload, dict) and payload.get("count") == 0:
+        if _is_resync_stale_lakehouse_response(response):
             logger.warning(
-                "Lakehouse reported zero pending inserts for raw data batch, aborting current resync"
+                "Lakehouse reported resync is stale, aborting current resync"
             )
             try:
                 current_event.abort(external_abort=True)
             except EventContextNotFoundError:
                 logger.warning(
-                    "Lakehouse aborted response received without active event context"
+                    "Lakehouse stale response received without active event context"
                 )
+            return
+        handle_port_status_code(response, should_raise=True, should_log=True)
         logger.debug("Finished POST raw data batch request")
 
     async def get_integration_cursor(self, kind: str, index: int) -> Optional[datetime]:

--- a/port_ocean/tests/clients/port/mixins/test_integrations_lakehouse.py
+++ b/port_ocean/tests/clients/port/mixins/test_integrations_lakehouse.py
@@ -582,7 +582,7 @@ async def test_post_integration_raw_data_batch_serializes_datetime_values(
     assert entry["response"]["received_at"] == created_at.isoformat()
 
 
-async def test_post_integration_raw_data_batch_aborts_resync_on_zero_pending_count(
+async def test_post_integration_raw_data_batch_does_not_abort_on_zero_pending_count(
     lakehouse_integration_client: IntegrationClientMixin,
 ) -> None:
     raw_data = [{"name": "repo-one"}]
@@ -609,7 +609,84 @@ async def test_post_integration_raw_data_batch_aborts_resync_on_zero_pending_cou
                 sync_id,
                 batch_event,
             )
-            assert current_event.aborted
+            assert not current_event.aborted
+
+
+async def test_post_integration_raw_data_batch_aborts_resync_on_resync_stale(
+    lakehouse_integration_client: IntegrationClientMixin,
+) -> None:
+    raw_data = [{"name": "repo-one"}]
+    sync_id = "sync-stale"
+    kind = "repository"
+
+    response = MagicMock()
+    response.status_code = 409
+    response.is_error = True
+    response.json.return_value = {
+        "ok": False,
+        "error": {"code": "resync_stale", "message": "resync is not active"},
+    }
+    lakehouse_integration_client.client.post.return_value = response
+
+    async with event_context(
+        EventType.RESYNC,
+        trigger_type="machine",
+        attributes={},
+    ) as current_event:
+        assert not current_event.aborted
+        batch_event = make_single_entry_lakehouse_batch(raw_data, kind=kind, index=0)
+        await lakehouse_integration_client.post_integration_raw_data_batch(
+            sync_id,
+            batch_event,
+        )
+        assert current_event.aborted
+        assert current_event.external_abort
+
+
+async def test_post_integration_raw_data_batch_raises_on_other_409(
+    lakehouse_integration_client: IntegrationClientMixin,
+) -> None:
+    raw_data = [{"name": "repo-one"}]
+    sync_id = "sync-conflict"
+    kind = "repository"
+
+    response = MagicMock()
+    response.status_code = 409
+    response.is_error = True
+    response.text = '{"ok": false, "error": {"code": "conflict"}}'
+    response.json.return_value = {
+        "ok": False,
+        "error": {"code": "conflict", "message": "resource conflict"},
+    }
+    response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "409 Conflict",
+        request=MagicMock(),
+        response=response,
+    )
+    lakehouse_integration_client.client.post.return_value = response
+
+    with patch(
+        "port_ocean.clients.port.mixins.integrations.handle_port_status_code",
+        side_effect=httpx.HTTPStatusError(
+            "409 Conflict",
+            request=MagicMock(),
+            response=response,
+        ),
+    ):
+        async with event_context(
+            EventType.RESYNC,
+            trigger_type="machine",
+            attributes={},
+        ) as current_event:
+            batch_event = make_single_entry_lakehouse_batch(
+                raw_data, kind=kind, index=0
+            )
+            with pytest.raises(httpx.HTTPStatusError):
+                await lakehouse_integration_client.post_integration_raw_data_batch(
+                    sync_id,
+                    batch_event,
+                )
+            assert not current_event.aborted
 
 
 @pytest.mark.asyncio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.47.3"
+version = "0.47.4"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
Stop treating Lakehouse count: 0 as a fatal resync abort after idempotent write retries; abort only when Lakehouse returns HTTP 409 with resync_stale.

# Description

What -

Why -

How -

## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when long-running DSP resyncs are cancelled mid-flight, which affects sync completion vs. stale-run cleanup but is scoped to Lakehouse batch writes with clear test coverage.
> 
> **Overview**
> **DSP resync abort** no longer treats a successful Lakehouse raw-data write with `count: 0` as a reason to stop the sync—common on idempotent retries—so those resyncs can finish instead of aborting early.
> 
> **External abort** now happens only when Lakehouse returns **HTTP 409** with error code `resync_stale`, via new `_is_resync_stale_lakehouse_response` checked in `post_integration_raw_data_batch` before normal status handling. Other 409s still raise through `handle_port_status_code`.
> 
> Releases as **0.47.4** with matching changelog and tests for zero-count (no abort), `resync_stale` (abort + `external_abort`), and non-stale 409 (error, no abort).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1cda85a024adbcf91991171f35475d1d7ed32bd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->