### PR TITLE
[Integration][Github] Disable Github Auth Mode Toggle On Edit

### DIFF
--- a/integrations/github/.port/spec.yaml
+++ b/integrations/github/.port/spec.yaml
@@ -113,7 +113,7 @@ saas:
       integrationSpec:
         githubHost: "'https://api.github.com'"
         githubAppId: .oauthData.appId
-        authenticationMode: "Github App"
+        authenticationMode: "'Github App'"
 actionsProcessingEnabled: true
 actions:
   - name: dispatch_workflow

--- a/integrations/github/.port/spec.yaml
+++ b/integrations/github/.port/spec.yaml
@@ -113,6 +113,7 @@ saas:
       integrationSpec:
         githubHost: "'https://api.github.com'"
         githubAppId: .oauthData.appId
+        authenticationMode: "Github App"
 actionsProcessingEnabled: true
 actions:
   - name: dispatch_workflow

--- a/integrations/github/CHANGELOG.md
+++ b/integrations/github/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 6.7.9 (2026-08-03)
+
+
+### Improvements
+
+- Add a default value override for authentication mode
+
+
 ## 6.7.8 (2026-08-03)
 
 

--- a/integrations/github/pyproject.toml
+++ b/integrations/github/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "github-ocean"
-version = "6.7.8"
+version = "6.7.9"
 description = "This integration ingest data from github"
 authors = ["Chukwuemeka Nwaoma <joelchukks@gmail.com>", "Melody Anyaegbulam <melodyogonna@gmail.com>", "Michael Armah <mikeyarmah@gmail.com>"]
 


### PR DESCRIPTION
# Description

What -

Why -

How -

## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line integration spec change for SaaS UI behavior only; no runtime auth logic in this diff.
> 
> **Overview**
> For **Port-hosted GitHub** integrations using `oauthConfiguration`, the spec now sets **`authenticationMode: "Github App"`** in `valuesOverride.integrationSpec` alongside the existing `githubHost` and `githubAppId` overrides.
> 
> That pins SaaS/OAuth installs to GitHub App auth so the **GitHub App vs Personal Access Token** tab switcher is not editable when users change integration settings—avoiding a mode switch that would not match the OAuth-provided app credentials.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4ccb8f8e9dd07010387dce80175a8b2cb21142a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->