### PR TITLE
[Integration][GitLab] Fix GitLab File Live Events to Ignore Non-default Branches

### DIFF
--- a/integrations/gitlab-v2/CHANGELOG.md
+++ b/integrations/gitlab-v2/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
-## 0.9.11 (2026-08-04)
+## 0.9.11 (2026-08-05)
 
 
 ### Bug Fixes

--- a/integrations/gitlab-v2/CHANGELOG.md
+++ b/integrations/gitlab-v2/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.9.11 (2026-08-04)
+
+
+### Bug Fixes
+
+- Fixed GitLab file live events to ignore non-default branch pushes, keeping file-kind webhook behavior consistent with default-branch-only resync discovery.
+- Fixed GitLab webhook matching to ignore non-GitLab webhook requests instead of failing when the `x-gitlab-event` header is missing.
+
+
 ## 0.9.10 (2026-08-04)
 
 

--- a/integrations/gitlab-v2/gitlab/webhook/webhook_processors/_gitlab_abstract_webhook_processor.py
+++ b/integrations/gitlab-v2/gitlab/webhook/webhook_processors/_gitlab_abstract_webhook_processor.py
@@ -31,3 +31,19 @@ class _GitlabAbstractWebhookProcessor(AbstractWebhookProcessor):
 
     async def validate_payload(self, payload: EventPayload) -> bool:
         return not ({"object_kind", "project"} - payload.keys())
+
+    def _get_branch_name(self, payload: EventPayload) -> str:
+        return payload.get("ref", "").removeprefix("refs/heads/")
+
+    def _is_default_branch_push(
+        self, payload: EventPayload, resource_name: str
+    ) -> bool:
+        project = payload["project"]
+        branch = self._get_branch_name(payload)
+        if branch != project.get("default_branch"):
+            logger.info(
+                f"Skipping {resource_name} push for {project['path_with_namespace']}: "
+                f"{branch} is not the default branch"
+            )
+            return False
+        return True

--- a/integrations/gitlab-v2/gitlab/webhook/webhook_processors/_gitlab_abstract_webhook_processor.py
+++ b/integrations/gitlab-v2/gitlab/webhook/webhook_processors/_gitlab_abstract_webhook_processor.py
@@ -26,9 +26,9 @@ class _GitlabAbstractWebhookProcessor(AbstractWebhookProcessor):
             or event.payload.get("event_type")
             or event.payload.get("object_kind")
         )
+        gitlab_event = event.headers.get("x-gitlab-event")
         return bool(
-            event.headers["x-gitlab-event"] in self.hooks
-            and event_identifier in self.events
+            gitlab_event in self.hooks and event_identifier in self.events
         )
 
     async def validate_payload(self, payload: EventPayload) -> bool:

--- a/integrations/gitlab-v2/gitlab/webhook/webhook_processors/_gitlab_abstract_webhook_processor.py
+++ b/integrations/gitlab-v2/gitlab/webhook/webhook_processors/_gitlab_abstract_webhook_processor.py
@@ -27,9 +27,7 @@ class _GitlabAbstractWebhookProcessor(AbstractWebhookProcessor):
             or event.payload.get("object_kind")
         )
         gitlab_event = event.headers.get("x-gitlab-event")
-        return bool(
-            gitlab_event in self.hooks and event_identifier in self.events
-        )
+        return bool(gitlab_event in self.hooks and event_identifier in self.events)
 
     async def validate_payload(self, payload: EventPayload) -> bool:
         return not ({"object_kind", "project"} - payload.keys())

--- a/integrations/gitlab-v2/gitlab/webhook/webhook_processors/file_push_webhook_processor.py
+++ b/integrations/gitlab-v2/gitlab/webhook/webhook_processors/file_push_webhook_processor.py
@@ -29,18 +29,16 @@ class FilePushWebhookProcessor(_GitlabAbstractWebhookProcessor):
     ) -> WebhookEventRawResults:
         project = payload["project"]
         project_id = project["id"]
-        branch = payload.get("ref", "").replace("refs/heads/", "")
+        branch = self._get_branch_name(payload)
         repo_path = project["path_with_namespace"]
-        logger.info(
-            f"Processing push event for project {project_id} on branch {branch}"
-        )
-        if branch != project.get("default_branch"):
-            logger.info(
-                f"Skipping file push for {repo_path}: {branch} is not the default branch"
-            )
+        if not self._is_default_branch_push(payload, "file"):
             return WebhookEventRawResults(
                 updated_raw_results=[], deleted_raw_results=[]
             )
+
+        logger.info(
+            f"Processing push event for project {project_id} on branch {branch}"
+        )
 
         config = cast(GitLabFilesResourceConfig, resource_config)
         selector = config.selector

--- a/integrations/gitlab-v2/gitlab/webhook/webhook_processors/file_push_webhook_processor.py
+++ b/integrations/gitlab-v2/gitlab/webhook/webhook_processors/file_push_webhook_processor.py
@@ -27,12 +27,20 @@ class FilePushWebhookProcessor(_GitlabAbstractWebhookProcessor):
     async def handle_event(
         self, payload: EventPayload, resource_config: ResourceConfig
     ) -> WebhookEventRawResults:
-        project_id = payload["project"]["id"]
+        project = payload["project"]
+        project_id = project["id"]
         branch = payload.get("ref", "").replace("refs/heads/", "")
-        repo_path = payload["project"]["path_with_namespace"]
+        repo_path = project["path_with_namespace"]
         logger.info(
             f"Processing push event for project {project_id} on branch {branch}"
         )
+        if branch != project.get("default_branch"):
+            logger.info(
+                f"Skipping file push for {repo_path}: {branch} is not the default branch"
+            )
+            return WebhookEventRawResults(
+                updated_raw_results=[], deleted_raw_results=[]
+            )
 
         config = cast(GitLabFilesResourceConfig, resource_config)
         selector = config.selector

--- a/integrations/gitlab-v2/gitlab/webhook/webhook_processors/plugin_push_webhook_processor.py
+++ b/integrations/gitlab-v2/gitlab/webhook/webhook_processors/plugin_push_webhook_processor.py
@@ -46,12 +46,9 @@ class PluginPushWebhookProcessor(_GitlabAbstractWebhookProcessor):
 
         project = payload["project"]
         project_id = project["id"]
-        branch = payload.get("ref", "").removeprefix("refs/heads/")
+        branch = self._get_branch_name(payload)
         repo_path = project["path_with_namespace"]
-        if branch != project.get("default_branch"):
-            logger.info(
-                f"Skipping plugin push for {repo_path}: {branch} is not the default branch"
-            )
+        if not self._is_default_branch_push(payload, "plugin"):
             return WebhookEventRawResults(
                 updated_raw_results=[], deleted_raw_results=[]
             )

--- a/integrations/gitlab-v2/gitlab/webhook/webhook_processors/skill_push_webhook_processor.py
+++ b/integrations/gitlab-v2/gitlab/webhook/webhook_processors/skill_push_webhook_processor.py
@@ -41,12 +41,9 @@ class SkillPushWebhookProcessor(_GitlabAbstractWebhookProcessor):
 
         project = payload["project"]
         project_id = project["id"]
-        branch = payload.get("ref", "").removeprefix("refs/heads/")
+        branch = self._get_branch_name(payload)
         repo_path = project["path_with_namespace"]
-        if branch != project.get("default_branch"):
-            logger.info(
-                f"Skipping skill push for {repo_path}: {branch} is not the default branch"
-            )
+        if not self._is_default_branch_push(payload, "skill"):
             return WebhookEventRawResults(
                 updated_raw_results=[], deleted_raw_results=[]
             )

--- a/integrations/gitlab-v2/pyproject.toml
+++ b/integrations/gitlab-v2/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gitlab-v2"
-version = "0.9.10"
+version = "0.9.11"
 description = "Gitlab"
 authors = ["Shariff <mohammed.s@getport.io>"]
 

--- a/integrations/gitlab-v2/tests/webhook/webhook_processors/test_file_push_webhook_processor.py
+++ b/integrations/gitlab-v2/tests/webhook/webhook_processors/test_file_push_webhook_processor.py
@@ -51,6 +51,7 @@ class TestFilePushWebhookProcessor:
                 "id": 68204746,
                 "name": "project7",
                 "path_with_namespace": "getport-labs/project7",
+                "default_branch": "main",
                 "url": "https://gitlab.example.com/getport-labs/project7.git",
                 "description": "Test repository",
                 "homepage": "https://gitlab.example.com/getport-labs/project7",
@@ -116,6 +117,40 @@ class TestFilePushWebhookProcessor:
     ) -> None:
         """Test that get_matching_kinds returns the FILE kind"""
         assert await processor.get_matching_kinds(mock_event) == [ObjectKind.FILE]
+
+    async def test_skips_non_default_branch(
+        self,
+        processor: FilePushWebhookProcessor,
+        push_payload: dict[str, Any],
+        resource_config: ResourceConfig,
+    ) -> None:
+        """Test that file push events only process default branch changes"""
+        payload = {**push_payload, "ref": "refs/heads/feature"}
+        processor._gitlab_webhook_client = MagicMock()
+
+        result = await processor.handle_event(payload, resource_config)
+
+        assert result.updated_raw_results == []
+        assert result.deleted_raw_results == []
+        processor._gitlab_webhook_client.compare_repository.assert_not_called()
+
+    async def test_skips_when_default_branch_unknown(
+        self,
+        processor: FilePushWebhookProcessor,
+        push_payload: dict[str, Any],
+        resource_config: ResourceConfig,
+    ) -> None:
+        """Test that file push events are skipped when the default branch is missing"""
+        project = {**push_payload["project"]}
+        project.pop("default_branch")
+        payload = {**push_payload, "project": project}
+        processor._gitlab_webhook_client = MagicMock()
+
+        result = await processor.handle_event(payload, resource_config)
+
+        assert result.updated_raw_results == []
+        assert result.deleted_raw_results == []
+        processor._gitlab_webhook_client.compare_repository.assert_not_called()
 
     async def test_handle_event_with_no_repos(
         self,

--- a/integrations/gitlab-v2/tests/webhook/webhook_processors/test_file_push_webhook_processor.py
+++ b/integrations/gitlab-v2/tests/webhook/webhook_processors/test_file_push_webhook_processor.py
@@ -152,6 +152,47 @@ class TestFilePushWebhookProcessor:
         assert result.deleted_raw_results == []
         processor._gitlab_webhook_client.compare_repository.assert_not_called()
 
+    async def test_processes_default_branch_push(
+        self,
+        processor: FilePushWebhookProcessor,
+        push_payload: dict[str, Any],
+        resource_config: ResourceConfig,
+    ) -> None:
+        """Test that default branch file push events resolve changed paths."""
+        project_id = push_payload["project_id"]
+        processor._gitlab_webhook_client = MagicMock()
+        self.mock_compare(
+            processor._gitlab_webhook_client,
+            added=["package.json"],
+        )
+        processor._gitlab_webhook_client._process_file_batch = AsyncMock(
+            return_value=[]
+        )
+        processor._gitlab_webhook_client._enrich_files_with_repos = AsyncMock(
+            return_value=[]
+        )
+
+        result = await processor.handle_event(push_payload, resource_config)
+
+        processor._gitlab_webhook_client.compare_repository.assert_awaited_once_with(
+            push_payload["project"]["path_with_namespace"],
+            push_payload["before"],
+            push_payload["after"],
+        )
+        processor._gitlab_webhook_client._process_file_batch.assert_called_once_with(
+            [
+                {
+                    "project_id": str(project_id),
+                    "path": "package.json",
+                    "ref": push_payload["after"],
+                }
+            ],
+            context=f"project:{project_id}",
+            skip_parsing=False,
+        )
+        assert result.updated_raw_results == []
+        assert result.deleted_raw_results == []
+
     async def test_handle_event_with_no_repos(
         self,
         processor: FilePushWebhookProcessor,

--- a/integrations/gitlab-v2/tests/webhook/webhook_processors/test_gitlab_abstract_webhook_processor.py
+++ b/integrations/gitlab-v2/tests/webhook/webhook_processors/test_gitlab_abstract_webhook_processor.py
@@ -1,0 +1,43 @@
+import pytest
+
+from gitlab.webhook.webhook_processors._gitlab_abstract_webhook_processor import (
+    _GitlabAbstractWebhookProcessor,
+)
+from port_ocean.core.handlers.webhook.webhook_event import WebhookEvent
+
+
+class ConcreteGitlabWebhookProcessor(_GitlabAbstractWebhookProcessor):
+    events = ["push"]
+    hooks = ["Push Hook"]
+
+    async def get_matching_kinds(self, event):  # type: ignore[no-untyped-def]
+        return ["project"]
+
+    async def handle_event(self, payload, resource_config):  # type: ignore[no-untyped-def]
+        return None
+
+
+@pytest.mark.asyncio
+async def test_should_process_event_ignores_missing_gitlab_event_header() -> None:
+    processor = ConcreteGitlabWebhookProcessor(
+        event=WebhookEvent(
+            trace_id="test-trace-id",
+            headers={"x-github-event": "dependabot_alert"},
+            payload={"event_name": "push"},
+        )
+    )
+
+    assert await processor.should_process_event(processor.event) is False
+
+
+@pytest.mark.asyncio
+async def test_should_process_event_matches_gitlab_header_and_event() -> None:
+    processor = ConcreteGitlabWebhookProcessor(
+        event=WebhookEvent(
+            trace_id="test-trace-id",
+            headers={"x-gitlab-event": "Push Hook"},
+            payload={"event_name": "push"},
+        )
+    )
+
+    assert await processor.should_process_event(processor.event) is True


### PR DESCRIPTION
# Description

What - Fixed GitLab v2 file live events so file-kind push webhooks only process changes from the repository default branch. Also made GitLab webhook matching ignore non-GitLab webhook requests when `x-gitlab-event` is missing.

Why - GitLab file resync is documented and implemented as default-branch-only, but file live events could ingest files from non-default branches and create entities that resync would never rediscover.

How - Added a default-branch guard to the file push webhook processor, added regression tests for non-default branch pushes, and changed the abstract GitLab webhook matcher to safely ignore events without the GitLab event header.


## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [x] Integration able to create all default resources from scratch
- [x] Resync finishes successfully
- [x] Resync able to create entities
- [x] Resync able to update entities
- [x] Resync able to detect and delete entities
- [x] Scheduled resync able to abort existing resync and start a new one
- [x] Tested with at least 2 integrations from scratch
- [x] Tested with Kafka and Polling event listeners
- [x] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [x] Integration able to create all default resources from scratch
- [x] Completed a full resync from a freshly installed integration and it completed successfully
- [x]  Resync able to create entities
- [x] Resync able to update entities
- [x] Resync able to detect and delete entities
- [x]  Resync finishes successfully
- [x] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [x] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [x] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted webhook guards and safer header lookup; behavior narrows file live ingestion to default branch only, which fixes inconsistency rather than broadening exposure.
> 
> **Overview**
> **File live events** now match **default-branch-only** file resync: `FilePushWebhookProcessor` returns empty results when the push ref is not the project `default_branch`, or when `default_branch` is absent—no compare/fetch work runs on feature branches.
> 
> **Webhook routing** no longer raises on non-GitLab traffic: `_GitlabAbstractWebhookProcessor.should_process_event` reads `x-gitlab-event` via `.get()` so missing headers are ignored instead of failing matching.
> 
> Regression tests cover non-default branch skips, missing `default_branch`, and header behavior. Release **0.9.11** (patch).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e3c14ccabb076dcd6fbfe2e5d1cb58f4a3c9814. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->