### PR TITLE
[Core] Default processing mode to DSP and enable lakehouse by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.47.7 (2026-08-05)
+
+### Improvements
+
+- Default `processing_mode` to `dsp` and `lakehouse_enabled` to `true`. DSP still only activates when the required org feature flags are present; otherwise Ocean falls back to `ocean-core`.
+
 ## 0.47.6 (2026-08-04)
 
 ### Improvements

--- a/port_ocean/config/settings.py
+++ b/port_ocean/config/settings.py
@@ -331,11 +331,11 @@ class IntegrationConfiguration(BaseOceanSettings, extra=Extra.allow):
 
     upsert_entities_batch_max_length: int = 20
     upsert_entities_batch_max_size_in_bytes: int = 1024 * 1024
-    lakehouse_enabled: bool = False
+    lakehouse_enabled: bool = True
     disable_ip_outbound_blocker: bool | None = None
     lakehouse_buffer_interval_seconds: float = 10.0
     lakehouse_buffer_max_count: int = 50
-    processing_mode: ProcessingMode = ProcessingMode.ocean_core
+    processing_mode: ProcessingMode = ProcessingMode.dsp
     yield_items_to_parse_batch_size: int = 200
     process_in_queue_timeout: int = 120
     process_in_queue_max_workers: int = Field(

--- a/port_ocean/core/integrations/mixins/utils.py
+++ b/port_ocean/core/integrations/mixins/utils.py
@@ -113,8 +113,9 @@ async def is_dsp_mode_enabled() -> bool:
 
     DSP mode offloads all transform/load/reconciliation to an external service.
     Ocean still extracts raw data and forwards it to the lakehouse, but skips
-    all entity processing.  Requires an explicit opt-in via config AND the right
-    org feature flags.  Errors are swallowed so this never blocks core flows.
+    all entity processing.  Requires processing_mode=dsp (the default), lakehouse
+    enabled, and the right org feature flags.  Errors are swallowed so this never
+    blocks core flows.
 
     Returns:
         bool: True only when all four conditions are met, False otherwise.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.47.6"
+version = "0.47.7"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

What -

Why -

How -

## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing core defaults alters resync and lakehouse behavior for integrations that relied on implicit `ocean-core`/disabled lakehouse; mitigated by feature-flag gating and opt-out via config.
> 
> **Overview**
> **Ocean core 0.47.7** flips the out-of-the-box integration config so new and unset deployments prefer the DSP + lakehouse path instead of `ocean-core` with lakehouse off.
> 
> `IntegrationConfiguration` now defaults **`lakehouse_enabled`** to `true` and **`processing_mode`** to `dsp` (was `false` and `ocean_core`). The `is_dsp_mode_enabled()` docstring is updated to match: DSP is the default mode string, but **runtime behavior is unchanged**—DSP still runs only when lakehouse is on and the org has `LAKEHOUSE_ELIGIBLE` and `DATA_SOURCE_PROCESSOR_ENABLED`; otherwise Ocean keeps using **ocean-core**.
> 
> Explicit env/config overrides (`OCEAN__PROCESSING_MODE`, `OCEAN__LAKEHOUSE_ENABLED`, etc.) still win. Version and changelog are bumped for the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d99e702e6059c04deabc9fd8adb52c17a1334a9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->