### PR TITLE
[CI] Made core tests run all integrations tests with matrix

### DIFF
--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -15,6 +15,8 @@ jobs:
     needs: detect-changes
     runs-on: ubuntu-latest
     if: ${{ needs.detect-changes.outputs.core == 'true' || needs.detect-changes.outputs.core_ci_files_changed == 'true' }}
+    outputs:
+      integrations: ${{ steps.list-integrations.outputs.integrations }}
     env:
       RUN_SMOKE_TESTS: ${{ github.event_name != 'pull_request' || github.repository == github.event.pull_request.head.repo.full_name }}
     steps:
@@ -90,32 +92,117 @@ jobs:
         run: |
           make smoke/clean
 
-      - name: Install current core for all integrations
+      - name: List integrations with tests
+        id: list-integrations
         run: |
-          echo "Installing local core for all integrations"
-          SCRIPT_TO_RUN='make install/local-core' make execute/all
+          INTEGRATIONS=$(
+            for dir in integrations/*; do
+              count=$(find "$dir" -type f -name '*.py' -not -path "*/venv/*" | wc -l)
+              if [ "$count" -ne 0 ]; then
+                basename "$dir"
+              fi
+            done | jq -R -s -c 'split("\n") | map(select(length > 0))'
+          )
+          echo "integrations=$INTEGRATIONS" >> $GITHUB_OUTPUT
 
-      - name: Test all integrations with current core
-        run: |
-          echo "Testing all integrations with local core"
-          SCRIPT_TO_RUN="PYTEST_ADDOPTS=\"--cov --cov-report= --cov-append --junitxml=${PWD}/junit/test-results-core-change/\`pwd | xargs basename\`.xml\" make test" make execute/all
+      - name: Upload core coverage
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-core
+          path: .coverage
+          if-no-files-found: ignore
 
-      - name: Get PR_NUMBER
-        id: pr-number
-        run: |
-          if [ ! -z ${{ inputs.PR_NUMBER }} ]; then
-            echo "PR_NUMBER=${{ inputs.PR_NUMBER }}" >> $GITHUB_OUTPUT
-          elif [ ! -z ${{ github.event.pull_request.number }} ]; then
-            echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
-          else
-            echo "PR_NUMBER=0" >> $GITHUB_OUTPUT
-          fi
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v5
+        if: ${{ always() }}
+        with:
+          report_paths: '**/junit/**-test-results-**/*.xml'
+          include_passed: true
+          require_tests: true
+          fail_on_failure: true
+
+  test-integrations:
+    name: ${{ format('🌊 Test {0} with local core', matrix.folder) }}
+    needs: test
+    runs-on: ubuntu-latest
+    if: ${{ needs.test.outputs.integrations != '[]' }}
+    strategy:
+      fail-fast: false
+      max-parallel: 10
+      matrix:
+        folder: ${{ fromJson(needs.test.outputs.integrations) }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v7
+
+      - name: Install poetry
+        run: pipx install 'poetry>=2.0.0,<3.0.0'
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+          cache: 'poetry'
+
+      - name: Install local core
+        working-directory: ${{ format('integrations/{0}', matrix.folder) }}
+        run: make install/local-core
+
+      - name: Test integration with local core
+        working-directory: ${{ format('integrations/{0}', matrix.folder) }}
+        env:
+          PYTEST_ADDOPTS: --cov --cov-report= --cov-append --junitxml=junit/test-results-core-change/${{ matrix.folder }}.xml
+        run: make test
+
+      - name: Upload integration coverage
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-${{ matrix.folder }}
+          path: integrations/${{ matrix.folder }}/.coverage
+          if-no-files-found: ignore
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v5
+        if: ${{ always() }}
+        with:
+          report_paths: ${{ format('integrations/{0}/junit/test-results-core-change/*.xml', matrix.folder) }}
+          include_passed: true
+          require_tests: true
+          fail_on_failure: true
+
+  finalize:
+    name: 🌊 Ocean Core Tests — Finalize
+    needs: [test, test-integrations]
+    runs-on: ubuntu-latest
+    if: ${{ !cancelled() && needs.test.result == 'success' && (needs.test-integrations.result == 'success' || needs.test-integrations.result == 'skipped') }}
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v7
+
+      - name: Install poetry
+        run: pipx install 'poetry>=2.0.0,<3.0.0'
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+          cache: 'poetry'
+
+      - name: Install dependencies
+        run: make install
+
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-*
+          merge-multiple: true
+          path: coverage-artifacts
 
       - name: Produce coverage report
         run: |
           mkdir -p coverage-merge
           i=0
-          find . -type f -name ".coverage" | while read -r file; do
+          find coverage-artifacts -type f \( -name '.coverage' -o -name '.coverage.*' \) | while read -r file; do
             i=$((i + 1))
             cp "$file" "coverage-merge/.coverage.$i"
           done
@@ -127,6 +214,17 @@ jobs:
         with:
           name: coverage-report
           path: htmlcov
+
+      - name: Get PR_NUMBER
+        id: pr-number
+        run: |
+          if [ ! -z ${{ inputs.PR_NUMBER }} ]; then
+            echo "PR_NUMBER=${{ inputs.PR_NUMBER }}" >> $GITHUB_OUTPUT
+          elif [ ! -z ${{ github.event.pull_request.number }} ]; then
+            echo "PR_NUMBER=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          else
+            echo "PR_NUMBER=0" >> $GITHUB_OUTPUT
+          fi
 
       - name: Set repo code coverage percentage by the percentage of statements covered in the tests
         id: set-stmts-coverage
@@ -212,12 +310,3 @@ jobs:
             {
               "coverage_percent": "${{ steps.set-stmts-coverage.outputs.STMTS_COVERAGE }}"
             }
-
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v5
-        if: ${{ always() }}
-        with:
-          report_paths: '**/junit/**-test-results-**/*.xml'
-          include_passed: true
-          require_tests: true
-          fail_on_failure: true

--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -110,6 +110,7 @@ jobs:
         with:
           name: coverage-core
           path: .coverage
+          include-hidden-files: true
           if-no-files-found: ignore
 
       - name: Publish Test Report
@@ -159,6 +160,7 @@ jobs:
         with:
           name: coverage-${{ matrix.folder }}
           path: integrations/${{ matrix.folder }}/.coverage
+          include-hidden-files: true
           if-no-files-found: ignore
 
       - name: Publish Test Report

--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -123,7 +123,7 @@ jobs:
           fail_on_failure: true
 
   test-integrations:
-    name: ${{ format('🌊 Test {0} with local core', matrix.folder) }}
+    name: ${{ format('🌊 Test integrations shard {0}/10', matrix.shard) }}
     needs: test
     runs-on: ubuntu-latest
     if: ${{ needs.test.outputs.integrations != '[]' }}
@@ -131,7 +131,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        folder: ${{ fromJson(needs.test.outputs.integrations) }}
+        shard: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v7
@@ -145,21 +145,53 @@ jobs:
           python-version: '3.12'
           cache: 'poetry'
 
-      - name: Install local core
-        working-directory: ${{ format('integrations/{0}', matrix.folder) }}
-        run: make install/local-core
-
-      - name: Test integration with local core
-        working-directory: ${{ format('integrations/{0}', matrix.folder) }}
+      - name: Test integrations with local core
         env:
-          PYTEST_ADDOPTS: --cov --cov-report= --cov-append --junitxml=junit/test-results-core-change/${{ matrix.folder }}.xml
-        run: make test
+          INTEGRATIONS: ${{ needs.test.outputs.integrations }}
+          SHARD: ${{ matrix.shard }}
+        run: |
+          mapfile -t folders < <(
+            echo "$INTEGRATIONS" | jq -r --argjson shard "$SHARD" '
+              . as $all |
+              ($all | length) as $len |
+              10 as $count |
+              ((($len + $count - 1) / $count) | floor) as $size |
+              ($shard * $size) as $start |
+              $all[$start:$start + $size][]
+            '
+          )
 
-      - name: Upload integration coverage
+          if [ ${#folders[@]} -eq 0 ]; then
+            echo "No integrations assigned to shard ${SHARD}"
+            exit 0
+          fi
+
+          echo "Shard ${SHARD} integrations: ${folders[*]}"
+          exit_code=0
+
+          for folder in "${folders[@]}"; do
+            echo "Installing local core for ${folder}"
+            if ! (cd "integrations/${folder}" && make install/local-core); then
+              exit_code=1
+              continue
+            fi
+
+            echo "Testing ${folder} with local core"
+            if ! (
+              cd "integrations/${folder}" &&
+              PYTEST_ADDOPTS="--cov --cov-report= --cov-append --junitxml=junit/test-results-core-change/${folder}.xml" make test
+            ); then
+              exit_code=1
+            fi
+          done
+
+          exit $exit_code
+
+      - name: Upload shard coverage
         uses: actions/upload-artifact@v7
         with:
-          name: coverage-${{ matrix.folder }}
-          path: integrations/${{ matrix.folder }}/.coverage
+          name: coverage-shard-${{ matrix.shard }}
+          path: integrations/**/.coverage
           include-hidden-files: true
           if-no-files-found: ignore
 
@@ -167,7 +199,7 @@ jobs:
         uses: mikepenz/action-junit-report@v5
         if: ${{ always() }}
         with:
-          report_paths: ${{ format('integrations/{0}/junit/test-results-core-change/*.xml', matrix.folder) }}
+          report_paths: 'integrations/**/junit/test-results-core-change/*.xml'
           include_passed: true
           require_tests: true
           fail_on_failure: true

--- a/.github/workflows/core-test.yml
+++ b/.github/workflows/core-test.yml
@@ -264,7 +264,10 @@ jobs:
 
       - name: Set current code coverage
         id: set-current-coverage
-        run: echo "CURRENT_COVERAGE=${{ fromJson(steps.get-current-coverage.outputs.entity).properties.coverage_percent }}" >> $GITHUB_OUTPUT
+        env:
+          PORT_ENTITY: ${{ steps.get-current-coverage.outputs.entity }}
+        run: |
+          echo "CURRENT_COVERAGE=$(echo "$PORT_ENTITY" | jq -r '.properties.coverage_percent')" >> $GITHUB_OUTPUT
 
       - name: Comment if Coverage Regression
         if: ${{ (fromJson(steps.set-stmts-coverage.outputs.STMTS_COVERAGE) < fromJson(steps.set-current-coverage.outputs.CURRENT_COVERAGE)) && (steps.pr-number.outputs.PR_NUMBER != 0) }}


### PR DESCRIPTION
# Description

What -

Why -

How -

## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI behavior changes materially (job graph, parallelism, coverage merge path); failures could block PRs or skew coverage until artifacts align, but no runtime product code is touched.
> 
> **Overview**
> Refactors **Ocean Core Tests** so integration testing no longer runs sequentially via `make execute/all` in the main job. Instead, the core job discovers integration folders that contain Python tests, exposes them as a job output, and uploads core coverage as an artifact.
> 
> A new **`test-integrations`** job runs a **matrix** (up to 10 parallel runners) over that list: each cell installs local core in one integration directory, runs `make test`, uploads per-integration coverage, and publishes JUnit for that folder.
> 
> A **`finalize`** job waits for core + matrix jobs, **downloads and merges** all `coverage-*` artifacts (replacing in-repo `find` for `.coverage`), then runs the existing coverage report, PR comments, Port coverage sync, and regression checks. JUnit publishing for the core job stays on the main `test` job; integration reports publish per matrix cell.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bdc8f5171119933770246eb1516c9e76492470c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->