### PR TITLE
[Integration][ServiceNow] Extend live events to support any table in mapping config

### DIFF
--- a/integrations/servicenow/.port/spec.yaml
+++ b/integrations/servicenow/.port/spec.yaml
@@ -41,13 +41,13 @@ configurations:
     required: false
     type: boolean
     default: false
-    description: "Enable automatic creation of Business Rules in ServiceNow for real-time events forwarding to Port. This is a heavy operation that creates Business Rules for All/specified tables by `liveEventTables`."
+    description: "Enable automatic creation of Business Rules in ServiceNow for real-time events forwarding to Port. When enabled, business rules are created for every table in your mapping configuration, or only for tables specified in `liveEventTables`."
   - name: liveEventTables
     required: false
     type: array
     items:
       type: string
-    description: "Optional list of specific table names to configure for live events. If not specified but enableTablesLiveEventsWebhooks is true, all supported tables will be configured. Use this to limit which tables trigger live events."
+    description: "Optional list of specific table names to configure for live events. If not specified but enableTablesLiveEventsWebhooks is true, all tables from the mapping configuration will be configured. Use this to limit which tables trigger live events."
   - name: webhookSecret
     required: false
     type: string

--- a/integrations/servicenow/CHANGELOG.md
+++ b/integrations/servicenow/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.5.0 (2026-08-07)
+
+
+### Features
+
+- Extended live events to support any table configured in the mapping, not just the 5 hardcoded defaults. Business rules are now auto-created for every kind in the port-app-config, with a generic webhook processor that routes events by table name.
+
+
 ## 0.4.2 (2026-08-05)
 
 

--- a/integrations/servicenow/main.py
+++ b/integrations/servicenow/main.py
@@ -8,16 +8,7 @@ from port_ocean.core.ocean_types import ASYNC_GENERATOR_RESYNC_TYPE
 from initialize_client import initialize_client
 from webhook.initialize_client import initialize_webhook_client
 from webhook.webhook_client import WEBHOOK_ENDPOINT
-from webhook.events import DEFAULT_FIELDS_PER_TABLE
-from webhook.processors.incident_processor import IncidentWebhookProcessor
-from webhook.processors.service_catalog_processor import ServiceCatalogWebhookProcessor
-from webhook.processors.user_group_processor import UserGroupWebhookProcessor
-from webhook.processors.release_project_processor import (
-    ReleaseProjectWebhookProcessor,
-)
-from webhook.processors.vulnerability_processor import (
-    VulnerabilityWebhookProcessor,
-)
+from webhook.processors.generic_processor import GenericWebhookProcessor
 from integration import ResourceSelector
 
 
@@ -75,17 +66,15 @@ async def on_start() -> None:
         return
 
     live_event_tables = ocean.integration_config.get("live_event_tables")
-    if not live_event_tables:
-        logger.info("No tables specified for live events webhook. Using defaults")
-        live_event_tables = [str(kind) for kind in DEFAULT_FIELDS_PER_TABLE.keys()]
+    if live_event_tables:
+        tables = [table.strip() for table in live_event_tables]
+    else:
+        app_config = await ocean.integration.port_app_config_handler.get_port_app_config()
+        tables = list({resource.kind for resource in app_config.resources})
+    logger.info(f"Configuring live events for {len(tables)} tables: {tables}")
 
     webhook_client = initialize_webhook_client()
-    tables = [table.strip() for table in live_event_tables]
     await webhook_client.create_webhook(base_url, tables)
 
 
-ocean.add_webhook_processor(WEBHOOK_ENDPOINT, IncidentWebhookProcessor)
-ocean.add_webhook_processor(WEBHOOK_ENDPOINT, ServiceCatalogWebhookProcessor)
-ocean.add_webhook_processor(WEBHOOK_ENDPOINT, UserGroupWebhookProcessor)
-ocean.add_webhook_processor(WEBHOOK_ENDPOINT, ReleaseProjectWebhookProcessor)
-ocean.add_webhook_processor(WEBHOOK_ENDPOINT, VulnerabilityWebhookProcessor)
+ocean.add_webhook_processor(WEBHOOK_ENDPOINT, GenericWebhookProcessor)

--- a/integrations/servicenow/main.py
+++ b/integrations/servicenow/main.py
@@ -69,8 +69,10 @@ async def on_start() -> None:
     if live_event_tables:
         tables = [table.strip() for table in live_event_tables]
     else:
-        app_config = await ocean.integration.port_app_config_handler.get_port_app_config()
-        tables = list({resource.kind for resource in app_config.resources})
+        app_config = (
+            await ocean.integration.port_app_config_handler.get_port_app_config()
+        )
+        tables = sorted({resource.kind for resource in app_config.resources})
     logger.info(f"Configuring live events for {len(tables)} tables: {tables}")
 
     webhook_client = initialize_webhook_client()

--- a/integrations/servicenow/pyproject.toml
+++ b/integrations/servicenow/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "servicenow"
-version = "0.4.2"
+version = "0.5.0"
 description = "ServiceNow Ocean Integration"
 authors = ["Isaac Coffie <isaac@getport.io>"]
 

--- a/integrations/servicenow/tests/webhook/test_webhook_client.py
+++ b/integrations/servicenow/tests/webhook/test_webhook_client.py
@@ -139,6 +139,9 @@ class TestServicenowWebhookClient:
                 )
 
                 assert mock_create_rule.call_count == 2
+                mock_create_rule.assert_any_call(
+                    "cmdb_ci_server", ["sys_id"], order=210
+                )
 
     @pytest.mark.asyncio
     async def test_create_webhook_no_rest_message(

--- a/integrations/servicenow/tests/webhook/test_webhook_client.py
+++ b/integrations/servicenow/tests/webhook/test_webhook_client.py
@@ -122,10 +122,10 @@ class TestServicenowWebhookClient:
                 assert mock_create_rule.call_count == 2
 
     @pytest.mark.asyncio
-    async def test_create_webhook_skips_unknown_tables(
+    async def test_create_webhook_accepts_custom_tables(
         self, webhook_client: ServicenowWebhookClient
     ) -> None:
-        """Test that unknown tables are skipped."""
+        """Test that custom tables are accepted with generic fields."""
         with patch(
             "webhook.webhook_client.ServicenowWebhookClient._create_rest_message_if_not_exists",
             AsyncMock(return_value="parent_sys_id"),
@@ -135,10 +135,10 @@ class TestServicenowWebhookClient:
                 AsyncMock(),
             ) as mock_create_rule:
                 await webhook_client.create_webhook(
-                    "https://example.com", ["incident", "unknown_table"]
+                    "https://example.com", ["incident", "cmdb_ci_server"]
                 )
 
-                assert mock_create_rule.call_count == 1
+                assert mock_create_rule.call_count == 2
 
     @pytest.mark.asyncio
     async def test_create_webhook_no_rest_message(
@@ -467,10 +467,11 @@ class TestBusinessRule:
     ) -> None:
         """Test generating a business rule script with basic fields."""
         fields = ["sys_id", "number", "state"]
-        script = webhook_client._generate_business_rule_script(fields)
+        script = webhook_client._generate_business_rule_script("incident", fields)
 
         assert "RESTMessageV2" in script
         assert REST_MESSAGE_NAME in script
+        assert '"__table_name": "incident",' in script
         assert '"sys_id": current.sys_id + "",' in script
         assert '"number": current.number + "",' in script
         assert '"state": current.state + ""' in script
@@ -480,8 +481,9 @@ class TestBusinessRule:
     ) -> None:
         """Test generating a business rule script with fields containing dots."""
         fields = ["caller_id.name", "assignment_group.name"]
-        script = webhook_client._generate_business_rule_script(fields)
+        script = webhook_client._generate_business_rule_script("incident", fields)
 
+        assert '"__table_name": "incident",' in script
         assert '"caller_id_name": current.caller_id.name + "",' in script
         assert '"assignment_group_name": current.assignment_group.name + ""' in script
 
@@ -491,9 +493,10 @@ class TestBusinessRule:
         """Test generating a business rule script for delete events."""
         fields = ["sys_id", "number"]
         script = webhook_client._generate_business_rule_script(
-            fields, delete_event=True
+            "incident", fields, delete_event=True
         )
 
+        assert '"__table_name": "incident",' in script
         assert "previous.sys_id" in script
         assert "previous.number" in script
         assert "current." not in script

--- a/integrations/servicenow/webhook/events.py
+++ b/integrations/servicenow/webhook/events.py
@@ -1,3 +1,5 @@
+DEFAULT_GENERIC_FIELDS: list[str] = ["sys_id"]
+
 DEFAULT_FIELDS_PER_TABLE: dict[str, list[str]] = {
     "incident": [
         "sys_id",

--- a/integrations/servicenow/webhook/processors/generic_processor.py
+++ b/integrations/servicenow/webhook/processors/generic_processor.py
@@ -1,0 +1,50 @@
+from typing import Any, List
+from webhook.processors._base_processor import (
+    ServicenowAbstractWebhookProcessor,
+)
+from port_ocean.core.handlers.webhook.webhook_event import (
+    EventPayload,
+    WebhookEvent,
+    WebhookEventRawResults,
+)
+from port_ocean.core.handlers.port_app_config.models import ResourceConfig
+from webhook.initialize_client import initialize_webhook_client
+
+
+class GenericWebhookProcessor(ServicenowAbstractWebhookProcessor):
+
+    def _get_table_name(self, payload: EventPayload) -> str | None:
+        return payload.get("__table_name") or payload.get("sys_class_name")
+
+    async def get_matching_kinds(self, event: WebhookEvent) -> list[str]:
+        table_name = self._get_table_name(event.payload)
+        return [table_name] if table_name else []
+
+    def _should_process_event(self, event: WebhookEvent) -> bool:
+        return self._get_table_name(event.payload) is not None
+
+    async def handle_event(
+        self, payload: EventPayload, resource_config: ResourceConfig
+    ) -> WebhookEventRawResults:
+        sys_id = payload["sys_id"]
+        table_name = self._get_table_name(payload)
+        if not table_name:
+            return WebhookEventRawResults(
+                updated_raw_results=[], deleted_raw_results=[]
+            )
+
+        updated_raw_results: List[dict[str, Any]] = []
+        deleted_raw_results: List[dict[str, Any]] = []
+
+        client = initialize_webhook_client()
+        record = await client.get_record_by_sys_id(table_name, sys_id)
+
+        if record:
+            updated_raw_results.append(record)
+        else:
+            deleted_raw_results.append(payload)
+
+        return WebhookEventRawResults(
+            updated_raw_results=updated_raw_results,
+            deleted_raw_results=deleted_raw_results,
+        )

--- a/integrations/servicenow/webhook/webhook_client.py
+++ b/integrations/servicenow/webhook/webhook_client.py
@@ -4,7 +4,7 @@ from port_ocean.context.ocean import ocean
 from typing import List, Dict, Any, Optional
 import asyncio
 
-from webhook.events import DEFAULT_FIELDS_PER_TABLE
+from webhook.events import DEFAULT_FIELDS_PER_TABLE, DEFAULT_GENERIC_FIELDS
 
 REST_MESSAGE_NAME = "Ocean Port Webhook"
 WEBHOOK_ENDPOINT = "/webhook"
@@ -16,13 +16,13 @@ class ServicenowWebhookClient(ServicenowClient):
     """Handles ServiceNow outbound webhook setup (REST Message + Business Rules)"""
 
     def _generate_business_rule_script(
-        self, fields: List[str], delete_event: bool = False
+        self, table_name: str, fields: List[str], delete_event: bool = False
     ) -> str:
-        payload_lines: List[str] = []
+        source = "previous" if delete_event else "current"
+        payload_lines: List[str] = [f'    "__table_name": "{table_name}",']
 
         for field in fields:
             safe_name = field.replace(".", "_")
-            source = "previous" if delete_event else "current"
             payload_lines.append(f'    "{safe_name}": {source}.{field} + "",')
 
         if payload_lines:
@@ -51,7 +51,7 @@ class ServicenowWebhookClient(ServicenowClient):
         order: int,
     ) -> Dict[str, Any]:
         """Build the payload for an `upsert event` business rule."""
-        upsert_event_script = self._generate_business_rule_script(fields)
+        upsert_event_script = self._generate_business_rule_script(table_name, fields)
         return {
             "name": rule_name,
             "sys_scope": "global",
@@ -78,7 +78,7 @@ class ServicenowWebhookClient(ServicenowClient):
     ) -> Dict[str, Any]:
         """Build the payload for a `delete event` business rule."""
         delete_event_script = self._generate_business_rule_script(
-            fields, delete_event=True
+            table_name, fields, delete_event=True
         )
         return {
             "name": f"{rule_name} (delete)",
@@ -396,21 +396,18 @@ class ServicenowWebhookClient(ServicenowClient):
         order = 200
 
         for table_name in tables:
-            if table_name not in DEFAULT_FIELDS_PER_TABLE:
-                logger.warning(f"Skipping unknown table: {table_name}")
-                continue
-
+            fields = DEFAULT_FIELDS_PER_TABLE.get(table_name, DEFAULT_GENERIC_FIELDS)
             tasks.append(
                 self._create_business_rule_if_not_exists(
                     table_name,
-                    DEFAULT_FIELDS_PER_TABLE[table_name],
+                    fields,
                     order=order,
                 )
             )
-            order += 10  # prevent order collisions
+            order += 10
 
         if tasks:
             await asyncio.gather(*tasks)
             logger.success(f"Webhook configuration completed for {len(tasks)} tables")
         else:
-            logger.info("No valid tables to configure")
+            logger.info("No tables to configure")


### PR DESCRIPTION
# Description

What -  Replace 5 hardcoded webhook processors with a single generic processor that routes live events by table name.

Why - The existing live events implementation was rigid — only 5 predefined tables could receive live events, despite resync already supporting any table via allow_custom_kinds.

How -
  - Added __table_name to business rule script payloads for routing, with sys_class_name fallback for old BRs                                                                                                        
  - Created GenericWebhookProcessor that extracts table name from payload and routes to the matching kind    
  - Derived live event tables from the mapping config (get_port_app_config()) instead of a hardcoded list                                                                                                            
  - Added DEFAULT_GENERIC_FIELDS (["sys_id"]) fallback for tables not in DEFAULT_FIELDS_PER_TABLE                                                                                                                  
  - Kept liveEventTables config as an optional override  

## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [X] New feature (non-breaking change which adds functionality)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [X] Integration able to create all default resources from scratch
- [X] Resync finishes successfully
- [X] Resync able to create entities
- [X] Resync able to update entities
- [X] Resync able to detect and delete entities
- [X] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots
<img width="1481" height="805" alt="Screenshot 2026-08-09 at 00 21 36" src="https://github.com/user-attachments/assets/191218a4-50e3-43fc-9dfb-c158d145d603" />


Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live-event provisioning and webhook routing behavior; enabling webhooks may create business rules on more ServiceNow tables than before, and custom tables only forward `sys_id` unless listed in `DEFAULT_FIELDS_PER_TABLE`.
> 
> **Overview**
> **ServiceNow live events** are no longer limited to five built-in tables. When `liveEventTables` is omitted, webhook setup now uses every **kind** from the Port mapping (`port-app-config`) instead of a fixed default list.
> 
> Inbound handling is consolidated into a single **`GenericWebhookProcessor`** (replacing per-table processors). Outbound business rules embed **`__table_name`** in the JSON payload so events can be routed by table. Unknown tables still get rules with a minimal field set (`sys_id` via `DEFAULT_GENERIC_FIELDS`) instead of being skipped.
> 
> Config copy in **`.port/spec.yaml`** is updated to describe mapping-driven table selection. Release **0.5.0** with changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6529b57eac5459838555ce457de8c5c1377a881f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->