### PR TITLE
[Integration][Fake-Integration] Task tiruzh/test on fake integration

### DIFF
--- a/integrations/fake-integration/.ocean-release/test-2.yaml
+++ b/integrations/fake-integration/.ocean-release/test-2.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: improvement
+changelog: Validate CI changes

--- a/integrations/fake-integration/main.py
+++ b/integrations/fake-integration/main.py
@@ -15,6 +15,8 @@ from fake_org_data.fake_client import (
 from port_ocean.core.ocean_types import ASYNC_GENERATOR_RESYNC_TYPE
 from fake_org_data.fake_router import initialize_fake_routes
 
+# Temp change
+
 
 @ocean.on_resync("fake-department")
 async def resync_department(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:


### PR DESCRIPTION
Testing CI auto-bump change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No runtime behavior changes—only a release metadata file and a comment in the fake integration.
> 
> **Overview**
> This PR is a **test harness** for fake-integration CI/release automation, not a functional integration change.
> 
> It adds `integrations/fake-integration/.ocean-release/test-2.yaml` with a **patch** bump and changelog entry *"Validate CI changes"* so the release pipeline can be exercised end-to-end.
> 
> `main.py` only gains a `# Temp change` comment and an extra blank line; resync handlers and routes are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 045a87fb9cbd65315a50fa4f2d5ddc116276bad6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->