### PR TITLE
[Core] changed response size recording logs level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.47.9 (2026-08-09)
+
+
+### Improvements
+
+- Reduce monitor log noise by downgrading response size recording logs to debug level.
+
+
 ## 0.47.8 (2026-08-09)
 
 

--- a/port_ocean/helpers/monitor/monitor.py
+++ b/port_ocean/helpers/monitor/monitor.py
@@ -240,14 +240,14 @@ class PerformanceMonitor:
             self._current_tracking_kind
             and self._current_tracking_kind in self._kind_tracking
         ):
-            logger.info(
+            logger.debug(
                 f"[Monitor] Recorded response size: {size_bytes} bytes for kind: {self._current_tracking_kind} (monitor_id={id(self)})"
             )
             self._kind_tracking[self._current_tracking_kind]["response_sizes"].append(
                 size_bytes
             )
         else:
-            logger.info(
+            logger.debug(
                 f"[Monitor] Cannot record response size: {size_bytes} bytes - current_kind={self._current_tracking_kind}, tracking_kinds={list(self._kind_tracking.keys())} (monitor_id={id(self)})"
             )
 

--- a/port_ocean/helpers/monitor/monitor.py
+++ b/port_ocean/helpers/monitor/monitor.py
@@ -241,14 +241,21 @@ class PerformanceMonitor:
             and self._current_tracking_kind in self._kind_tracking
         ):
             logger.debug(
-                f"[Monitor] Recorded response size: {size_bytes} bytes for kind: {self._current_tracking_kind} (monitor_id={id(self)})"
+                "[Monitor] Recorded response size: {} bytes for kind: {} (monitor_id={})",
+                size_bytes,
+                self._current_tracking_kind,
+                id(self),
             )
             self._kind_tracking[self._current_tracking_kind]["response_sizes"].append(
                 size_bytes
             )
         else:
             logger.debug(
-                f"[Monitor] Cannot record response size: {size_bytes} bytes - current_kind={self._current_tracking_kind}, tracking_kinds={list(self._kind_tracking.keys())} (monitor_id={id(self)})"
+                "[Monitor] Cannot record response size: {} bytes - current_kind={}, tracking_kinds={} (monitor_id={})",
+                size_bytes,
+                self._current_tracking_kind,
+                list(self._kind_tracking.keys()),
+                id(self),
             )
 
     def get_kind_stats(self, kind: str) -> ResourceUsageStats:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.47.8"
+version = "0.47.9"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION


## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only change with no impact on metrics collection or resync logic.
> 
> **Overview**
> **Ocean core 0.47.9** quiets monitor logs during resyncs by logging HTTP response size recording at **debug** instead of **info** in `PerformanceMonitor.record_response_size` (both successful recordings and “cannot record” cases). **Monitoring behavior is unchanged**—sizes still accumulate for per-kind stats; only default log verbosity is lower.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5435c8da64fd157f5b940a56c5012e1db817123. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->