### PR TITLE
[Core] Add Redis stream consumer receive and dispatch logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,25 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.48.1 (2026-08-10)
+
+
+### Improvements
+
+- Add Redis stream consumer logs when a message is received and before dispatch, including `redis_event_id`, `queued_at`, `trace_id`, and consume latency (`time_until_consumed_ms`). Redis stream `eventId` is used as the webhook `trace_id`.
+
+
 ## 0.48.0 (2026-08-10)
 
 ### Improvements
 
 - Added retry lifecycle hooks that run after retry sleep and before retry send, enabling integrations to refresh request state immediately before retrying.
 
+
 ## 0.47.10 (2026-08-09)
 
 ### Improvements
 
 - Support for either YAML or JSON for spec files.
-
-
-## 0.47.10 (2026-08-09)
-
-
-### Improvements
-
-- Add Redis stream consumer logs when a message is received and before dispatch, including `redis_event_id`, `queued_at`, `trace_id`, and consume latency (`time_until_consumed_ms`). Redis stream `eventId` is used as the webhook `trace_id`.
 
 
 ## 0.47.9 (2026-08-09)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 <!-- towncrier release notes start -->
 
+## 0.47.10 (2026-08-09)
+
+
+### Improvements
+
+- Add Redis stream consumer logs when a message is received and before dispatch, including `stream_fields`, `queued_at`, `trace_id`, and consume latency (`time_until_consumed_ms`).
+
+
+## 0.47.9 (2026-08-09)
+
+
+### Improvements
+
+- Reduce monitor log noise by downgrading response size recording logs to debug level.
+
+
 ## 0.47.8 (2026-08-09)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Improvements
 
-- Add Redis stream consumer logs when a message is received and before dispatch, including `stream_fields`, `queued_at`, `trace_id`, and consume latency (`time_until_consumed_ms`).
+- Add Redis stream consumer logs when a message is received and before dispatch, including `redis_event_id`, `queued_at`, `trace_id`, and consume latency (`time_until_consumed_ms`). Redis stream `eventId` is used as the webhook `trace_id`.
 
 
 ## 0.47.9 (2026-08-09)

--- a/port_ocean/consumers/redis_stream_consumer.py
+++ b/port_ocean/consumers/redis_stream_consumer.py
@@ -263,6 +263,15 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
             fields.get("queuedAt"), stream_key=self._stream_key
         )
         time_until_consumed_ms = self._time_since_queued_ms(queued_time)
+        logger.info(
+            "Redis stream message received",
+            stream_key=self._stream_key,
+            message_id=message_id,
+            webhook_path=fields.get("webhookPath"),
+            queued_at=fields.get("queuedAt"),
+            stream_fields=fields,
+            time_until_consumed_ms=time_until_consumed_ms,
+        )
         try:
             raw_webhook_path = fields.get("webhookPath")
             if not raw_webhook_path:
@@ -275,11 +284,13 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
 
             webhook_path = self._normalize_webhook_path(raw_webhook_path)
             if webhook_path not in self._registered_paths:
+                elapsed_ms = round((time.monotonic() - start_time) * 1000, 2)
                 logger.warning(
                     "No processors registered for webhookPath, acknowledging",
                     stream_key=self._stream_key,
                     webhook_path=webhook_path,
                     message_id=message_id,
+                    elapsed_ms=elapsed_ms,
                 )
                 return
 
@@ -302,6 +313,13 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
                 original_request=original_request,
             )
 
+            logger.info(
+                "Dispatching Redis stream message to handler",
+                stream_key=self._stream_key,
+                message_id=message_id,
+                webhook_path=webhook_path,
+                trace_id=webhook_event.trace_id,
+            )
             await self._on_message(webhook_path, webhook_event)
         except Exception as error:
             logger.exception(
@@ -320,7 +338,6 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
                 message_id=message_id,
                 webhook_path=webhook_path,
                 elapsed_ms=elapsed_ms,
-                time_until_consumed_ms=time_until_consumed_ms,
                 time_until_acked_ms=time_until_acked_ms,
             )
 

--- a/port_ocean/consumers/redis_stream_consumer.py
+++ b/port_ocean/consumers/redis_stream_consumer.py
@@ -259,7 +259,6 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
         start_time = time.monotonic()
         webhook_path: str | None = None
         redis_event_id = fields["eventId"]
-        trace_id = redis_event_id
         queued_time = self._parse_queued_at(
             fields.get("queuedAt"), stream_key=self._stream_key
         )
@@ -307,7 +306,7 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
                 )
 
             webhook_event = WebhookEvent(
-                trace_id=trace_id,
+                trace_id=redis_event_id,
                 payload=payload,
                 headers=headers,
                 original_request=original_request,
@@ -318,7 +317,7 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
                 stream_key=self._stream_key,
                 redis_event_id=redis_event_id,
                 webhook_path=webhook_path,
-                trace_id=trace_id,
+                trace_id=redis_event_id,
             )
             await self._on_message(webhook_path, webhook_event)
         except Exception as error:
@@ -326,7 +325,7 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
                 "Failed to handle Redis stream message",
                 stream_key=self._stream_key,
                 redis_event_id=redis_event_id,
-                trace_id=trace_id,
+                trace_id=redis_event_id,
                 error=str(error),
             )
         finally:
@@ -338,7 +337,7 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
                 stream_key=self._stream_key,
                 redis_event_id=redis_event_id,
                 webhook_path=webhook_path,
-                trace_id=trace_id,
+                trace_id=redis_event_id,
                 elapsed_ms=elapsed_ms,
                 time_until_acked_ms=time_until_acked_ms,
             )

--- a/port_ocean/consumers/redis_stream_consumer.py
+++ b/port_ocean/consumers/redis_stream_consumer.py
@@ -8,7 +8,6 @@ import time
 from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
 from typing import Any
-from uuid import uuid4
 
 from loguru import logger
 from redis.asyncio.connection import SSLConnection
@@ -259,6 +258,8 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
     async def _handle_message(self, message_id: str, fields: dict[str, str]) -> None:
         start_time = time.monotonic()
         webhook_path: str | None = None
+        redis_event_id = fields["eventId"]
+        trace_id = redis_event_id
         queued_time = self._parse_queued_at(
             fields.get("queuedAt"), stream_key=self._stream_key
         )
@@ -266,10 +267,9 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
         logger.info(
             "Redis stream message received",
             stream_key=self._stream_key,
-            message_id=message_id,
+            redis_event_id=redis_event_id,
             webhook_path=fields.get("webhookPath"),
             queued_at=fields.get("queuedAt"),
-            stream_fields=fields,
             time_until_consumed_ms=time_until_consumed_ms,
         )
         try:
@@ -278,7 +278,7 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
                 logger.warning(
                     "Redis stream message missing webhookPath, acknowledging",
                     stream_key=self._stream_key,
-                    message_id=message_id,
+                    redis_event_id=redis_event_id,
                 )
                 return
 
@@ -288,8 +288,8 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
                 logger.warning(
                     "No processors registered for webhookPath, acknowledging",
                     stream_key=self._stream_key,
+                    redis_event_id=redis_event_id,
                     webhook_path=webhook_path,
-                    message_id=message_id,
                     elapsed_ms=elapsed_ms,
                 )
                 return
@@ -307,7 +307,7 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
                 )
 
             webhook_event = WebhookEvent(
-                trace_id=str(uuid4()),
+                trace_id=trace_id,
                 payload=payload,
                 headers=headers,
                 original_request=original_request,
@@ -316,16 +316,17 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
             logger.info(
                 "Dispatching Redis stream message to handler",
                 stream_key=self._stream_key,
-                message_id=message_id,
+                redis_event_id=redis_event_id,
                 webhook_path=webhook_path,
-                trace_id=webhook_event.trace_id,
+                trace_id=trace_id,
             )
             await self._on_message(webhook_path, webhook_event)
         except Exception as error:
             logger.exception(
                 "Failed to handle Redis stream message",
                 stream_key=self._stream_key,
-                message_id=message_id,
+                redis_event_id=redis_event_id,
+                trace_id=trace_id,
                 error=str(error),
             )
         finally:
@@ -335,8 +336,9 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
             logger.info(
                 "Redis stream message processed",
                 stream_key=self._stream_key,
-                message_id=message_id,
+                redis_event_id=redis_event_id,
                 webhook_path=webhook_path,
+                trace_id=trace_id,
                 elapsed_ms=elapsed_ms,
                 time_until_acked_ms=time_until_acked_ms,
             )

--- a/port_ocean/tests/consumers/test_redis_stream_consumer.py
+++ b/port_ocean/tests/consumers/test_redis_stream_consumer.py
@@ -805,12 +805,14 @@ class TestRedisStreamConsumer:
             stream_fields=stream_fields,
             time_until_consumed_ms=2000.0,
         )
+        assert on_message.await_args is not None
+        trace_id = on_message.await_args.args[1].trace_id
         mock_logger_info.assert_any_call(
             "Dispatching Redis stream message to handler",
             stream_key="1111111/live-events/raw/event-stream",
             message_id="1700000000000-0",
             webhook_path="/webhook",
-            trace_id=on_message.await_args.args[1].trace_id,
+            trace_id=trace_id,
         )
         mock_logger_info.assert_any_call(
             "Redis stream message processed",

--- a/port_ocean/tests/consumers/test_redis_stream_consumer.py
+++ b/port_ocean/tests/consumers/test_redis_stream_consumer.py
@@ -790,13 +790,34 @@ class TestRedisStreamConsumer:
                     },
                 )
 
+        stream_fields = {
+            "payload": json.dumps({}),
+            "headers": json.dumps({}),
+            "webhookPath": "integration/webhook",
+            "queuedAt": "1700000000000000000",
+        }
+        mock_logger_info.assert_any_call(
+            "Redis stream message received",
+            stream_key="1111111/live-events/raw/event-stream",
+            message_id="1700000000000-0",
+            webhook_path="integration/webhook",
+            queued_at="1700000000000000000",
+            stream_fields=stream_fields,
+            time_until_consumed_ms=2000.0,
+        )
+        mock_logger_info.assert_any_call(
+            "Dispatching Redis stream message to handler",
+            stream_key="1111111/live-events/raw/event-stream",
+            message_id="1700000000000-0",
+            webhook_path="/webhook",
+            trace_id=on_message.await_args.args[1].trace_id,
+        )
         mock_logger_info.assert_any_call(
             "Redis stream message processed",
             stream_key="1111111/live-events/raw/event-stream",
             message_id="1700000000000-0",
             webhook_path="/webhook",
             elapsed_ms=ANY,
-            time_until_consumed_ms=2000.0,
             time_until_acked_ms=2500.0,
         )
 

--- a/port_ocean/tests/consumers/test_redis_stream_consumer.py
+++ b/port_ocean/tests/consumers/test_redis_stream_consumer.py
@@ -589,6 +589,7 @@ class TestRedisStreamConsumerPelWorkerLifecycle:
             "webhookPath": "integration/webhook",
             "payload": json.dumps({}),
             "headers": json.dumps({}),
+            "eventId": "pel-requeue-event-1",
         }
 
         mock_redis = AsyncMock()
@@ -787,38 +788,34 @@ class TestRedisStreamConsumer:
                         "headers": json.dumps({}),
                         "webhookPath": "integration/webhook",
                         "queuedAt": "1700000000000000000",
+                        "eventId": "redis-event-123",
                     },
                 )
 
-        stream_fields = {
-            "payload": json.dumps({}),
-            "headers": json.dumps({}),
-            "webhookPath": "integration/webhook",
-            "queuedAt": "1700000000000000000",
-        }
         mock_logger_info.assert_any_call(
             "Redis stream message received",
             stream_key="1111111/live-events/raw/event-stream",
-            message_id="1700000000000-0",
+            redis_event_id="redis-event-123",
             webhook_path="integration/webhook",
             queued_at="1700000000000000000",
-            stream_fields=stream_fields,
             time_until_consumed_ms=2000.0,
         )
         assert on_message.await_args is not None
         trace_id = on_message.await_args.args[1].trace_id
+        assert trace_id == "redis-event-123"
         mock_logger_info.assert_any_call(
             "Dispatching Redis stream message to handler",
             stream_key="1111111/live-events/raw/event-stream",
-            message_id="1700000000000-0",
+            redis_event_id="redis-event-123",
             webhook_path="/webhook",
             trace_id=trace_id,
         )
         mock_logger_info.assert_any_call(
             "Redis stream message processed",
             stream_key="1111111/live-events/raw/event-stream",
-            message_id="1700000000000-0",
+            redis_event_id="redis-event-123",
             webhook_path="/webhook",
+            trace_id=trace_id,
             elapsed_ms=ANY,
             time_until_acked_ms=2500.0,
         )
@@ -855,6 +852,7 @@ class TestRedisStreamConsumer:
                     "headers": json.dumps({}),
                     "webhookPath": "integration/webhook",
                     "queuedAt": "not-a-timestamp",
+                    "eventId": "invalid-queued-at-event",
                 },
             )
 
@@ -890,6 +888,7 @@ class TestRedisStreamConsumer:
                     "payload": json.dumps({"hello": "world"}),
                     "headers": json.dumps({"x-github-event": "push"}),
                     "webhookPath": "integration/webhook",
+                    "eventId": "handler-event-1",
                 },
             )
 
@@ -898,7 +897,7 @@ class TestRedisStreamConsumer:
         assert on_message.await_args.args[0] == path
         assert on_message.await_args.args[1].payload == {"hello": "world"}
         assert on_message.await_args.args[1].headers == {"x-github-event": "push"}
-        assert on_message.await_args.args[1].trace_id
+        assert on_message.await_args.args[1].trace_id == "handler-event-1"
         consumer._ack.assert_awaited_once_with("1700000000000-0")
 
     @pytest.mark.asyncio
@@ -926,6 +925,7 @@ class TestRedisStreamConsumer:
                     "payload": json.dumps({}),
                     "headers": json.dumps({}),
                     "webhookPath": "/unknown",
+                    "eventId": "unknown-path-event",
                 },
             )
 
@@ -956,6 +956,7 @@ class TestRedisStreamConsumer:
                 {
                     "payload": json.dumps({}),
                     "headers": json.dumps({}),
+                    "eventId": "missing-path-event",
                 },
             )
 
@@ -989,6 +990,7 @@ class TestRedisStreamConsumer:
                     "payload": raw_payload,
                     "headers": json.dumps({"x-hub-signature-256": "sha256=abc"}),
                     "webhookPath": "integration/webhook",
+                    "eventId": "original-request-event",
                 },
             )
 
@@ -1024,6 +1026,7 @@ class TestRedisStreamConsumer:
                 {
                     "headers": json.dumps({}),
                     "webhookPath": "integration/webhook",
+                    "eventId": "no-payload-event",
                 },
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.48.0"
+version = "0.48.1"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.47.8"
+version = "0.47.10"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
## Summary

Improves observability for live events consumed from Redis streams by adding structured logs at key points in the message lifecycle.

- On receive: logs when a message is picked up from the stream, including `stream_key`, `message_id`, `webhook_path`, `queued_at`, full `stream_fields`, and `time_until_consumed_ms` (queue-to-consume latency).
- Before dispatch(`Dispatching Redis stream message to handler`): logs `trace_id` alongside `webhook_path` and `message_id` so downstream processing can be correlated.
- On processed (`Redis stream message processed`): keeps `elapsed_ms` and `time_until_acked_ms`

## Motivation

Makes it easier to trace a live event from Redis consumption through handler dispatch, without repeating the same timing field across multiple log lines.

## Test plan

- [x] `pytest port_ocean/tests/consumers/test_redis_stream_consumer.py`
- [x] `make test`
- [ ] Verify in staging/Datadog that the three log messages appear per consumed event with expected fields

## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only changes on the Redis consumer path with no behavior change to ack/dispatch logic; slightly higher log volume from full stream_fields on receive.
> 
> **Overview**
> **Improves live-events observability** for Redis stream consumption by splitting timing and correlation across the message lifecycle instead of one “processed” line.
> 
> On pickup, the consumer logs **Redis stream message received** with `stream_fields`, `queued_at`, and **`time_until_consumed_ms`** (queue-to-consume latency). Right before calling the webhook handler it logs **Dispatching Redis stream message to handler** with **`trace_id`** for downstream correlation. The **Redis stream message processed** log keeps `elapsed_ms` and `time_until_acked_ms` and no longer repeats `time_until_consumed_ms`. Unregistered-path warnings now include **`elapsed_ms`**.
> 
> Releases **port-ocean 0.47.10** with a matching changelog entry; consumer tests assert the new log shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 082d9c4f8a4dac8242ad6b6224c20a667ec4ef75. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->