### PR TITLE
[Docs] Task tjjuz8/mention intent files in contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Contributing to the framework involves actively participating in its development
 2. **Bug Fixes**: If you encounter any bugs or issues while using the framework, you can contribute by investigating the problem, identifying the root cause, and submitting fixes. By addressing these issues, you ensure a more stable and reliable framework for all users.
 
 3. **Performance Optimization**: Improving the framework's performance is always a priority. You can contribute by optimizing algorithms, reducing resource usage, and implementing caching mechanisms, resulting in faster and more efficient data integration processes.
-CON
+
 4. **Documentation**: Clear and comprehensive documentation is crucial for users to understand and leverage the framework's capabilities. You can help by improving existing documentation, writing new guides, and providing code examples that demonstrate various integration scenarios.
 
 5. **Code Reviews**: Reviewing code submissions from other contributors is an essential part of maintaining code quality. By participating in code reviews, you can provide feedback, suggest improvements, and ensure adherence to coding standards.
@@ -40,10 +40,30 @@ By contributing a new integration, you enable users of the framework to seamless
 
 1. Ensure any install or build dependencies are removed before the end of the layer when doing a
    build.
-2. Create a new change fragment using towncrier. See [here](https://towncrier.readthedocs.io/en/latest/tutorial.html#creating-news-fragments) for more information.
-   ```bash
-    towncrier create --content 'My very important changelog message' <Issue Id / title>.<type (feature / bugfix / etc...)>
-    ```
+2. If your PR changes an integration under `integrations/` or the Ocean framework under
+   `port_ocean/`, declare how the change should be released using one of the following options:
+
+   **Option A — declarative release (recommended):** Add a release intent file (changeset) alongside
+   your code changes:
+
+   - Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
+   - Ocean core: `.ocean-release/core/<unique-name>.yaml`
+
+   ```yaml
+   bump: patch
+   changelog-type: bugfix
+   changelog: Describe the change
+   ```
+
+   `bump` must be one of `patch`, `minor`, or `major`. `changelog-type` must be one of `breaking`,
+   `deprecation`, `feature`, `improvement`, `bugfix`, or `doc`.
+
+   After your PR is merged to `main`, CI opens a follow-up PR with the version bump and changelog
+   updates. Review and merge that PR to publish the release.
+
+   **Option B — manual release:** Bump the version in `pyproject.toml` and add an entry to
+   `CHANGELOG.md`. If you update both manually and add a release intent file, the manual changes
+   take priority.
 
 3. You may merge the Pull Request in once you have the sign-off of one of Port developers.
 

--- a/docs/framework-guides/docs/contributing/contributing.md
+++ b/docs/framework-guides/docs/contributing/contributing.md
@@ -18,6 +18,37 @@ import TBD from '../\_common/tbd.md';
 
 <TBD />
 
+### Releasing changes
+
+When contributing changes to an integration under `integrations/` or the Ocean framework under
+`port_ocean/`, declare how the change should be released using one of the following options.
+
+#### Option A — declarative release (recommended)
+
+Add a release intent file (changeset) alongside your code changes:
+
+- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
+- Ocean core: `.ocean-release/core/<unique-name>.yaml`
+
+```yaml
+bump: patch
+changelog-type: bugfix
+changelog: Describe the change
+```
+
+`bump` must be one of `patch`, `minor`, or `major`. `changelog-type` must be one of `breaking`,
+`deprecation`, `feature`, `improvement`, `bugfix`, or `doc`.
+
+After your PR is merged to `main`, CI opens a follow-up PR with the version bump and changelog
+updates. Review and merge that PR to publish the release.
+
+#### Option B — manual release
+
+Bump the version in `pyproject.toml` and add an entry to `CHANGELOG.md`. If you update both manually
+and add a release intent file, the manual changes take priority.
+
+For the full publishing workflow, see [Publishing Your Integration](../developing-an-integration/publishing-your-integration.md).
+
 ## Suggest a Documentation Change
 
 <TBD />

--- a/docs/framework-guides/docs/developing-an-integration/developing-an-integration.md
+++ b/docs/framework-guides/docs/developing-an-integration/developing-an-integration.md
@@ -42,7 +42,7 @@ These steps do not follow a specific order. Some steps only become relevant near
 5. **Define resource mappings** in the [`.port/resources`](./defining-configuration-files.md) directory including blueprints, entity mappings, and selectors for resource filtering.
 6. **Test your integration** thoroughly with unit tests, integration tests, webhook processing tests, and resync functionality tests as described in [testing guide](./testing-the-integration.md).
 7. **Document** your integration including README with setup instructions, CHANGELOG for version history, API documentation, and example configurations.
-8. **Publish** your [integration](./publishing-your-integration.md) for others to use by creating a changelog, bumping version in `pyproject.toml`, and submitting a pull request to the Ocean repository.
+8. **Publish** your [integration](./publishing-your-integration.md) for others to use by adding a release intent file (changeset) or manually bumping the version in `pyproject.toml` and submitting a pull request to the Ocean repository.
 
 :::tip Integration Performance
 Be sure to review the integration [performance](./performance.md) and [code guidelines](./guidelines.md) to ensure your integration is efficient and well-written. Consider handling rate limiting, implementing pagination, using async code, supporting multi-account scenarios, managing webhook processing, and optimizing resync operations.

--- a/docs/framework-guides/docs/developing-an-integration/managing-dependencies.md
+++ b/docs/framework-guides/docs/developing-an-integration/managing-dependencies.md
@@ -222,12 +222,13 @@ poetry update pydantic
 
 
 :::info Version Management
-When releasing a new version of your integration:
+When releasing a new version of your integration or Ocean core changes:
 
-1. Update the version in `pyproject.toml`
-2. Create a changelog entry using `towncrier`
-3. Commit the changes
-4. Create a new release tag
+**Option A — declarative release (recommended):** Add a release intent file (changeset) under
+`integrations/<name>/.ocean-release/` or `.ocean-release/core/`. CI applies the version bump and
+changelog after merge.
+
+**Option B — manual release:** Update the version in `pyproject.toml` and add a changelog entry.
 :::
 
 For more details on Poetry and dependency management, see the [Poetry documentation](https://python-poetry.org/docs/).

--- a/docs/framework-guides/docs/developing-an-integration/publishing-your-integration.md
+++ b/docs/framework-guides/docs/developing-an-integration/publishing-your-integration.md
@@ -30,13 +30,19 @@ If you've already cloned and developed your changes to an existing integration w
 
 **Option A — declarative release (recommended):**
 
-1. Add a release intent file, e.g. `integrations/jira/.ocean-release/my-change.yaml`:
+1. Add a release intent file (changeset), for example:
+
+   - Integration: `integrations/jira/.ocean-release/my-change.yaml`
+   - Ocean core: `.ocean-release/core/my-change.yaml`
 
    ```yaml
    bump: patch
    changelog-type: bugfix
    changelog: Fixed pagination when Jira returns empty pages
    ```
+
+   `bump` must be one of `patch`, `minor`, or `major`. `changelog-type` must be one of `breaking`,
+   `deprecation`, `feature`, `improvement`, `bugfix`, or `doc`.
 
 2. Commit your code changes and the release file to a new branch
 3. Push and open a pull request


### PR DESCRIPTION
# Description

What -

Why -

How -

## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or release tooling behavior modified in this diff.
> 
> **Overview**
> Updates contributor documentation so **integration and Ocean core releases** are described via **`.ocean-release` YAML changesets** instead of the old **towncrier** PR step.
> 
> **`CONTRIBUTING.md`** PR process step 2 now tells contributors to add a release intent file under `integrations/<name>/.ocean-release/` or `.ocean-release/core/`, documents `bump` / `changelog-type` values, explains the **CI follow-up PR** after merge, and keeps **manual** `pyproject.toml` + `CHANGELOG.md` as Option B (manual wins if both are used).
> 
> The same **Option A / Option B** flow is added under **Develop a New Feature → Releasing changes** in the framework contributing guide, with a link to the publishing doc. **Developing an integration** step 8 and the **version management** callout in **managing dependencies** are aligned to changesets vs manual bumps. **Publishing your integration** clarifies example paths for integration vs core and spells out allowed `bump` and `changelog-type` values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24a8eef5fe2648babf86aacb27359d0ec40d183e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->