### PR TITLE
[Core] Load port_app_config in action run event context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.48.2 (2026-08-10)
+
+
+### Bug Fixes
+
+- Load `port_app_config` into the action-run event context (same as live events), so nested or inherited event contexts no longer raise `Port app config is not set`.
+
+
 ## 0.48.1 (2026-08-10)
 
 

--- a/port_ocean/core/handlers/actions/execution_manager.py
+++ b/port_ocean/core/handlers/actions/execution_manager.py
@@ -486,9 +486,7 @@ class ExecutionManager:
                 "run_kind": run.run_kind.value,
             },
         ):
-            await ocean.integration.port_app_config_handler.get_port_app_config(
-                use_cache=False
-            )
+            await ocean.integration.port_app_config_handler.get_port_app_config()
             with logger.contextualize(run_id=run.id, action=run.action_type):
                 try:
                     executor = self._actions_executors[run.action_type]

--- a/port_ocean/core/handlers/actions/execution_manager.py
+++ b/port_ocean/core/handlers/actions/execution_manager.py
@@ -486,6 +486,9 @@ class ExecutionManager:
                 "run_kind": run.run_kind.value,
             },
         ):
+            await ocean.integration.port_app_config_handler.get_port_app_config(
+                use_cache=False
+            )
             with logger.contextualize(run_id=run.id, action=run.action_type):
                 try:
                     executor = self._actions_executors[run.action_type]

--- a/port_ocean/tests/core/handlers/actions/test_execution_manager.py
+++ b/port_ocean/tests/core/handlers/actions/test_execution_manager.py
@@ -113,6 +113,8 @@ def mock_ocean(mock_port_client: PortClient) -> Ocean:
     ocean_mock.port_client = mock_port_client
     ocean_mock.integration_router = APIRouter()
     ocean_mock.fast_api_app = FastAPI()
+    ocean_mock.integration = MagicMock()
+    ocean_mock.integration.port_app_config_handler.get_port_app_config = AsyncMock()
     return ocean_mock
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.48.1"
+version = "0.48.2"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
## Summary
- Load `port_app_config` into the `ACTION_RUN` event context the same way live events do (`get_port_app_config(use_cache=False)`), so nested/inherited event contexts no longer raise `Port app config is not set`
- Bump Ocean core to `0.48.2`

Port task: https://app.getport.io/taskEntity?identifier=task_tjk0ij

## Test plan
- [x] `pytest port_ocean/tests/core/handlers/actions/test_execution_manager.py`
- [ ] Trigger a GitHub Ocean action run and confirm it no longer fails with `Port app config is not set` on event context enter/nest


Made with [Cursor](https://cursor.com)