### PR TITLE
[Integration][Gitlab-v2] Fix file kind resync aborting on 400/404 from blob search

### DIFF
--- a/integrations/gitlab-v2/.ocean-release/PORT-18338-file-kind-blob-search-400.yaml
+++ b/integrations/gitlab-v2/.ocean-release/PORT-18338-file-kind-blob-search-400.yaml
@@ -1,3 +1,0 @@
-bump: patch
-changelog-type: bugfix
-changelog: Fixed file kind resync aborting when a single repository returns 400 on project blob search; that repo is now skipped so remaining repositories continue syncing

--- a/integrations/gitlab-v2/.ocean-release/PORT-18338-file-kind-blob-search-400.yaml
+++ b/integrations/gitlab-v2/.ocean-release/PORT-18338-file-kind-blob-search-400.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: bugfix
+changelog: Fixed file kind resync aborting when a single repository returns 400 on project blob search; that repo is now skipped so remaining repositories continue syncing

--- a/integrations/gitlab-v2/.ocean-release/PORT-18338-file-kind-blob-search-skip.yaml
+++ b/integrations/gitlab-v2/.ocean-release/PORT-18338-file-kind-blob-search-skip.yaml
@@ -1,3 +1,3 @@
 bump: patch
 changelog-type: bugfix
-changelog: Fixed file kind resync aborting when a single repository returns 400 or 301 on project blob search; that repo is now skipped so remaining repositories continue syncing
+changelog: Fixed file kind resync aborting when a single repository returns 400 or 404 on project blob search; that repo is now skipped so remaining repositories continue syncing

--- a/integrations/gitlab-v2/.ocean-release/PORT-18338-file-kind-blob-search-skip.yaml
+++ b/integrations/gitlab-v2/.ocean-release/PORT-18338-file-kind-blob-search-skip.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: bugfix
+changelog: Fixed file kind resync aborting when a single repository returns 400 or 301 on project blob search; that repo is now skipped so remaining repositories continue syncing

--- a/integrations/gitlab-v2/gitlab/clients/gitlab_client.py
+++ b/integrations/gitlab-v2/gitlab/clients/gitlab_client.py
@@ -1092,7 +1092,7 @@ class GitLabClient:
             ):
                 yield file_batch
         except httpx.HTTPStatusError as e:
-            if e.response.status_code != 400:
+            if e.response.status_code not in (301, 400):
                 raise
             logger.warning(
                 f"Project blob search failed for repository '{repo}' "

--- a/integrations/gitlab-v2/gitlab/clients/gitlab_client.py
+++ b/integrations/gitlab-v2/gitlab/clients/gitlab_client.py
@@ -1086,10 +1086,19 @@ class GitLabClient:
         params = {"scope": scope, "search": query.to_query_string()}
         encoded_repo = quote(repo, safe="")
         search_path = f"projects/{encoded_repo}/search"
-        async for file_batch in self.rest.get_paginated_resource(
-            search_path, params=params
-        ):
-            yield file_batch
+        try:
+            async for file_batch in self.rest.get_paginated_resource(
+                search_path, params=params
+            ):
+                yield file_batch
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code != 400:
+                raise
+            logger.warning(
+                f"Project blob search failed for repository '{repo}' "
+                f"(status {e.response.status_code}): {e.response.text}. "
+                "Skipping repository and continuing with remaining repositories."
+            )
 
     async def _match_files_with_repository_tree(
         self, repo: str, query: SearchQuery

--- a/integrations/gitlab-v2/gitlab/clients/gitlab_client.py
+++ b/integrations/gitlab-v2/gitlab/clients/gitlab_client.py
@@ -1092,7 +1092,7 @@ class GitLabClient:
             ):
                 yield file_batch
         except httpx.HTTPStatusError as e:
-            if e.response.status_code not in (301, 400):
+            if e.response.status_code not in (400, 404):
                 raise
             logger.warning(
                 f"Project blob search failed for repository '{repo}' "

--- a/integrations/gitlab-v2/tests/clients/test_gitlab_client.py
+++ b/integrations/gitlab-v2/tests/clients/test_gitlab_client.py
@@ -766,6 +766,80 @@ class TestGitLabClient:
                     "group/project", "blobs", query, False
                 )
 
+    async def test_match_files_with_project_search_skips_repo_on_400(
+        self, client: GitLabClient
+    ) -> None:
+        """A 400 from project blob search skips that repo instead of aborting."""
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.text = "Bad Request"
+        error = httpx.HTTPStatusError(
+            "400 Bad Request", request=MagicMock(), response=mock_response
+        )
+
+        with patch.object(
+            client.rest,
+            "get_paginated_resource",
+            return_value=async_raising_generator(error),
+        ):
+            results = [
+                batch
+                async for batch in client._match_files_with_project_search(
+                    "group/bad-repo", "blobs", build_search_query("compose.y_")
+                )
+            ]
+
+        assert results == []
+
+    async def test_match_files_with_project_search_reraises_non_skippable_status(
+        self, client: GitLabClient
+    ) -> None:
+        """Non-skippable HTTP errors from project blob search still propagate."""
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.text = "Internal Server Error"
+        error = httpx.HTTPStatusError(
+            "500 Internal Server Error", request=MagicMock(), response=mock_response
+        )
+
+        with patch.object(
+            client.rest,
+            "get_paginated_resource",
+            return_value=async_raising_generator(error),
+        ):
+            with pytest.raises(httpx.HTTPStatusError):
+                async for _ in client._match_files_with_project_search(
+                    "group/project", "blobs", build_search_query("*.yml")
+                ):
+                    pass
+
+    async def test_search_files_in_repository_continues_when_project_search_returns_400(
+        self, client: GitLabClient
+    ) -> None:
+        """_search_files_in_repository yields nothing (and does not raise) on 400."""
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        mock_response.text = "Bad Request"
+        error = httpx.HTTPStatusError(
+            "400 Bad Request", request=MagicMock(), response=mock_response
+        )
+
+        with patch.object(
+            client.rest,
+            "get_paginated_resource",
+            return_value=async_raising_generator(error),
+        ):
+            results = [
+                batch
+                async for batch in client._search_files_in_repository(
+                    "group/bad-repo",
+                    "blobs",
+                    build_search_query("docker-compose.y_"),
+                )
+            ]
+
+        assert results == []
+
     async def test_search_files_in_groups(self, client: GitLabClient) -> None:
         """Test file search across all groups — search_files calls get_parent_groups (which calls get_groups) and params are forwarded"""
         mock_groups = [{"id": "1", "name": "Group1"}]

--- a/integrations/gitlab-v2/tests/clients/test_gitlab_client.py
+++ b/integrations/gitlab-v2/tests/clients/test_gitlab_client.py
@@ -791,6 +791,31 @@ class TestGitLabClient:
 
         assert results == []
 
+    async def test_match_files_with_project_search_skips_repo_on_301(
+        self, client: GitLabClient
+    ) -> None:
+        """A 301 from a renamed/deletion-scheduled repo is skipped like 400."""
+        mock_response = MagicMock()
+        mock_response.status_code = 301
+        mock_response.text = "Moved Permanently"
+        error = httpx.HTTPStatusError(
+            "301 Moved Permanently", request=MagicMock(), response=mock_response
+        )
+
+        with patch.object(
+            client.rest,
+            "get_paginated_resource",
+            return_value=async_raising_generator(error),
+        ):
+            results = [
+                batch
+                async for batch in client._match_files_with_project_search(
+                    "group/renamed-repo", "blobs", build_search_query("*.yml")
+                )
+            ]
+
+        assert results == []
+
     async def test_match_files_with_project_search_reraises_non_skippable_status(
         self, client: GitLabClient
     ) -> None:

--- a/integrations/gitlab-v2/tests/clients/test_gitlab_client.py
+++ b/integrations/gitlab-v2/tests/clients/test_gitlab_client.py
@@ -770,7 +770,7 @@ class TestGitLabClient:
         "status_code,response_text",
         [
             (400, "Bad Request"),
-            (301, "Moved Permanently"),
+            (404, "Not Found"),
         ],
     )
     async def test_match_files_with_project_search_skips_repo_on_skippable_status(

--- a/integrations/gitlab-v2/tests/clients/test_gitlab_client.py
+++ b/integrations/gitlab-v2/tests/clients/test_gitlab_client.py
@@ -766,15 +766,27 @@ class TestGitLabClient:
                     "group/project", "blobs", query, False
                 )
 
-    async def test_match_files_with_project_search_skips_repo_on_400(
-        self, client: GitLabClient
+    @pytest.mark.parametrize(
+        "status_code,response_text",
+        [
+            (400, "Bad Request"),
+            (301, "Moved Permanently"),
+        ],
+    )
+    async def test_match_files_with_project_search_skips_repo_on_skippable_status(
+        self,
+        client: GitLabClient,
+        status_code: int,
+        response_text: str,
     ) -> None:
-        """A 400 from project blob search skips that repo instead of aborting."""
+        """Skippable statuses from project blob search skip that repo instead of aborting."""
         mock_response = MagicMock()
-        mock_response.status_code = 400
-        mock_response.text = "Bad Request"
+        mock_response.status_code = status_code
+        mock_response.text = response_text
         error = httpx.HTTPStatusError(
-            "400 Bad Request", request=MagicMock(), response=mock_response
+            f"{status_code} {response_text}",
+            request=MagicMock(),
+            response=mock_response,
         )
 
         with patch.object(
@@ -786,31 +798,6 @@ class TestGitLabClient:
                 batch
                 async for batch in client._match_files_with_project_search(
                     "group/bad-repo", "blobs", build_search_query("compose.y_")
-                )
-            ]
-
-        assert results == []
-
-    async def test_match_files_with_project_search_skips_repo_on_301(
-        self, client: GitLabClient
-    ) -> None:
-        """A 301 from a renamed/deletion-scheduled repo is skipped like 400."""
-        mock_response = MagicMock()
-        mock_response.status_code = 301
-        mock_response.text = "Moved Permanently"
-        error = httpx.HTTPStatusError(
-            "301 Moved Permanently", request=MagicMock(), response=mock_response
-        )
-
-        with patch.object(
-            client.rest,
-            "get_paginated_resource",
-            return_value=async_raising_generator(error),
-        ):
-            results = [
-                batch
-                async for batch in client._match_files_with_project_search(
-                    "group/renamed-repo", "blobs", build_search_query("*.yml")
                 )
             ]
 
@@ -837,33 +824,6 @@ class TestGitLabClient:
                     "group/project", "blobs", build_search_query("*.yml")
                 ):
                     pass
-
-    async def test_search_files_in_repository_continues_when_project_search_returns_400(
-        self, client: GitLabClient
-    ) -> None:
-        """_search_files_in_repository yields nothing (and does not raise) on 400."""
-        mock_response = MagicMock()
-        mock_response.status_code = 400
-        mock_response.text = "Bad Request"
-        error = httpx.HTTPStatusError(
-            "400 Bad Request", request=MagicMock(), response=mock_response
-        )
-
-        with patch.object(
-            client.rest,
-            "get_paginated_resource",
-            return_value=async_raising_generator(error),
-        ):
-            results = [
-                batch
-                async for batch in client._search_files_in_repository(
-                    "group/bad-repo",
-                    "blobs",
-                    build_search_query("docker-compose.y_"),
-                )
-            ]
-
-        assert results == []
 
     async def test_search_files_in_groups(self, client: GitLabClient) -> None:
         """Test file search across all groups — search_files calls get_parent_groups (which calls get_groups) and params are forwarded"""


### PR DESCRIPTION
# Description
- Fix GitLab v2 `file` kind resync aborting when one repo returns `400` or `404` on project blob search
- Log a warning, skip that repo, and continue syncing remaining repositories
- Covers [PORT-18338](https://getport.atlassian.net/browse/PORT-18338) and [PORT-18267](https://getport.atlassian.net/browse/PORT-18267)

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow error-handling change in file discovery; only 400 responses are swallowed per repo, with tests and no auth or data-model changes.
> 
> **Overview**
> Fixes **file kind** resync failing when GitLab returns **HTTP 400** on `projects/:repo/search` (blob scope) for a single repository.
> 
> `_match_files_with_project_search` now catches `httpx.HTTPStatusError`, **logs a warning and skips that repo** on status 400, and still **re-raises** other errors. Remaining repositories in the same resync keep processing. Tests cover 400 skip behavior, non-400 propagation, and `_search_files_in_repository` completing without raising. Patch changelog entry added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02b359dcdef25df5de9d6d0f1ad65024d9628b9c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[PORT-18338]: https://getport.atlassian.net/browse/PORT-18338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PORT-18267]: https://getport.atlassian.net/browse/PORT-18267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ