### PR TITLE
[Infra] Split CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,82 +1,22 @@
-@port-labs/ecosystem-team
+# Default owner
+* @port-labs/connect-team
 
 # Ocean framework
-/port_ocean/** @port-labs/ecosystem-team
+/port_ocean/** @port-labs/connect-team
 
-# argocd integration
-/integrations/argocd/** @port-labs/ecosystem-team
+# DSP / lifecycle (lighthouse)
+/port_ocean/clients/dsp/** @port-labs/lighthouse-team
+/port_ocean/core/integrations/mixins/lakehouse_buffer.py @port-labs/lighthouse-team
+/port_ocean/tests/clients/test_lifecycle_client.py @port-labs/lighthouse-team
+/port_ocean/tests/core/integrations/mixins/test_lakehouse_buffer.py @port-labs/lighthouse-team
+/port_ocean/tests/core/handlers/mixins/test_live_events_lakehouse.py @port-labs/lighthouse-team
+/port_ocean/tests/clients/port/mixins/test_integrations_lakehouse.py @port-labs/lighthouse-team
+/port_ocean/tests/helpers/lakehouse_batch.py @port-labs/lighthouse-team
 
-# aws integration
-/integrations/aws/** @port-labs/ecosystem-team
+# sync_raw co-owned (both teams required as reviewers)
+/port_ocean/core/integrations/mixins/sync_raw.py @port-labs/connect-team @port-labs/lighthouse-team
+/port_ocean/tests/core/handlers/mixins/test_sync_raw.py @port-labs/connect-team @port-labs/lighthouse-team
 
-# azure-devops integration
-/integrations/azure-devops/** @port-labs/ecosystem-team
-
-# azure integration
-/integrations/azure/** @port-labs/ecosystem-team
-
-# datadog integration
-/integrations/datadog/** @port-labs/ecosystem-team
-
-# dynatrace integration
-/integrations/dynatrace/** @port-labs/ecosystem-team
-
-# firehydrant integration
-/integrations/firehydrant/** @port-labs/ecosystem-team
-
-# gcp integration
-/integrations/gcp/** @port-labs/ecosystem-team
-
-# gitlab integration
-/integrations/gitlab/** @port-labs/ecosystem-team
-
-# jenkins integration
-/integrations/jenkins/** @port-labs/ecosystem-team
-
-# jira integration
-/integrations/jira/** @port-labs/ecosystem-team
-
-# kafka integration
-/integrations/kafka/** @port-labs/ecosystem-team
-
-# kubecost integration
-/integrations/kubecost/** @port-labs/ecosystem-team
-
-# launchdarkly integration
-/integrations/launchdarkly/** @port-labs/ecosystem-team
-
-# linear integration
-/integrations/linear/** @port-labs/ecosystem-team
-
-# newrelic integration
-/integrations/newrelic/** @port-labs/ecosystem-team
-
-# opencost integration
-/integrations/opencost/** @port-labs/ecosystem-team
-
-# opsgenie integration
-/integrations/opsgenie/** @port-labs/ecosystem-team
-
-# pagerduty integration
-/integrations/pagerduty/** @port-labs/ecosystem-team
-
-# sentry integration
-/integrations/sentry/** @port-labs/ecosystem-team
-
-# servicenow integration
-/integrations/servicenow/** @port-labs/ecosystem-team
-
-# snyk integration
-/integrations/snyk/** @port-labs/ecosystem-team
-
-# sonarqube integration
-/integrations/sonarqube/** @port-labs/ecosystem-team
-
-# statuspage integration
-/integrations/statuspage/** @port-labs/ecosystem-team
-
-# terraform-cloud integration
-/integrations/terraform-cloud/** @port-labs/ecosystem-team
-
-# wiz integration
-/integrations/wiz/** @port-labs/ecosystem-team
+# Integrations: connect owns all, custom is lighthouse
+/integrations/** @port-labs/connect-team
+/integrations/custom/** @port-labs/lighthouse-team

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,9 +13,11 @@
 /port_ocean/tests/clients/port/mixins/test_integrations_lakehouse.py @port-labs/lighthouse-team
 /port_ocean/tests/helpers/lakehouse_batch.py @port-labs/lighthouse-team
 
-# sync_raw co-owned (both teams required as reviewers)
+# Shared ownership
 /port_ocean/core/integrations/mixins/sync_raw.py @port-labs/connect-team @port-labs/lighthouse-team
 /port_ocean/tests/core/handlers/mixins/test_sync_raw.py @port-labs/connect-team @port-labs/lighthouse-team
+/port_ocean/core/integrations/mixins/live_events.py @port-labs/connect-team @port-labs/lighthouse-team
+/port_ocean/tests/core/handlers/mixins/test_live_events.py @port-labs/connect-team @port-labs/lighthouse-team
 
 # Integrations: connect owns all, custom is lighthouse
 /integrations/** @port-labs/connect-team


### PR DESCRIPTION
# Description
- Replace `@port-labs/ecosystem-team` with ownership split between `@port-labs/connect-team` and `@port-labs/lighthouse-team`
- Connect owns core Ocean and all integrations by default; lighthouse owns DSP/lifecycle, lakehouse modules, and the custom integration
- Co-own sync_raw (and its tests) + live_events (and its tests) so both teams review shared sync changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only `.github/CODEOWNERS` changes; no runtime code, but PR review routing and required reviewers will change for affected paths.
> 
> **Overview**
> **Replaces** the single `@port-labs/ecosystem-team` default with a split between `@port-labs/connect-team` and `@port-labs/lighthouse-team`.
> 
> Connect becomes the default owner (`*`), owns `/port_ocean/**` and all `/integrations/**` except custom. Lighthouse owns DSP/lifecycle paths, lakehouse-related modules and tests, and `/integrations/custom/**`. `sync_raw.py` and its sync tests are **co-owned** by both teams so shared sync changes need dual review.
> 
> Per-integration CODEOWNERS entries are removed in favor of the broad integration rules above.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad107e4349d31825f4f67415e0c8ff370c126718. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->