### PR TITLE
[Core] Log Redis connection failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.48.5 (2026-08-11)
+
+
+### Improvements
+
+- Log explicit Redis connection failures at startup and retry the initial connection with exponential backoff.
+
 ## 0.48.4 (2026-08-11)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Improvements
 
-- Live event timestamp logs (`Event Added To Queue`, `Event Started Processing`, etc.) now bind `trace_id` at the top level of log `extra` instead of nesting it under `extra.extra`.
+- Log explicit Redis connection failures at startup and add backoff before retrying the stream read loop after a connection error.
+
 
 ## 0.48.2 (2026-08-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.48.4 (2026-08-11)
+
+
+### Improvements
+
+- Log explicit Redis connection failures at startup and retry the initial connection with exponential backoff (`connection_startup_max_retries`, `connection_startup_initial_backoff_seconds`, `connection_startup_exponential_base`). Add backoff before retrying the stream read loop after a runtime connection error (`connection_error_backoff_seconds`).
+
+
 ## 0.48.3 (2026-08-11)
 
 
 ### Improvements
 
-- Log explicit Redis connection failures at startup and add backoff before retrying the stream read loop after a connection error.
+- Live event timestamp logs (`Event Added To Queue`, `Event Started Processing`, etc.) now bind `trace_id` at the top level of log `extra` instead of nesting it under `extra.extra`.
 
 
 ## 0.48.2 (2026-08-10)

--- a/port_ocean/config/settings.py
+++ b/port_ocean/config/settings.py
@@ -239,6 +239,14 @@ class LiveEventsRedisSettings(BaseOceanModel, extra=Extra.allow):
             "after an unexpected error."
         ),
     )
+    connection_error_backoff_seconds: float = Field(
+        default=5.0,
+        gt=0,
+        description=(
+            "Seconds to wait before retrying the Redis stream read loop "
+            "after a connection error."
+        ),
+    )
 
     @property
     def stuck_timeout_ms(self) -> int:

--- a/port_ocean/config/settings.py
+++ b/port_ocean/config/settings.py
@@ -247,6 +247,30 @@ class LiveEventsRedisSettings(BaseOceanModel, extra=Extra.allow):
             "after a connection error."
         ),
     )
+    connection_startup_max_retries: int = Field(
+        default=5,
+        ge=0,
+        description=(
+            "Maximum number of connection retries when establishing the "
+            "initial Redis client at startup."
+        ),
+    )
+    connection_startup_initial_backoff_seconds: float = Field(
+        default=1.0,
+        gt=0,
+        description=(
+            "Initial delay in seconds before the first Redis startup "
+            "connection retry."
+        ),
+    )
+    connection_startup_exponential_base: float = Field(
+        default=2.0,
+        gt=0,
+        description=(
+            "Exponential base used to calculate Redis startup connection "
+            "retry delays."
+        ),
+    )
 
     @property
     def stuck_timeout_ms(self) -> int:

--- a/port_ocean/consumers/redis_client.py
+++ b/port_ocean/consumers/redis_client.py
@@ -21,8 +21,12 @@ async def create_redis_client(url: str, **kwargs: Any) -> RedisClient:
             await client.aclose()
             logger.info("Detected Redis cluster mode, using RedisCluster client")
             return RedisCluster.from_url(url, **kwargs)
-    except Exception:
+    except Exception as error:
         await client.aclose()
+        logger.exception(
+            "Failed to connect to Redis",
+            error=str(error),
+        )
         raise
 
     logger.info("Using standalone Redis client")

--- a/port_ocean/consumers/redis_client.py
+++ b/port_ocean/consumers/redis_client.py
@@ -71,3 +71,5 @@ async def create_redis_client_with_retry(
                 error=str(error),
             )
             await asyncio.sleep(delay_seconds)
+
+    raise RuntimeError("Unreachable: Redis startup retry loop exited unexpectedly")

--- a/port_ocean/consumers/redis_client.py
+++ b/port_ocean/consumers/redis_client.py
@@ -71,5 +71,3 @@ async def create_redis_client_with_retry(
                 error=str(error),
             )
             await asyncio.sleep(delay_seconds)
-
-    raise RuntimeError("Unreachable: Redis startup retry loop exited unexpectedly")

--- a/port_ocean/consumers/redis_client.py
+++ b/port_ocean/consumers/redis_client.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import Any
 
 from loguru import logger
@@ -13,21 +14,62 @@ async def is_redis_cluster_enabled(redis_client: Redis) -> bool:
     return bool(cluster_info.get("cluster_enabled"))
 
 
-async def create_redis_client(url: str, **kwargs: Any) -> RedisClient:
-    """Connect to Redis, using a cluster client when cluster mode is enabled."""
+async def _create_redis_client_once(url: str, **kwargs: Any) -> RedisClient:
+    """Connect to Redis once, using a cluster client when cluster mode is enabled."""
     client = Redis.from_url(url, **kwargs)
     try:
         if await is_redis_cluster_enabled(client):
             await client.aclose()
             logger.info("Detected Redis cluster mode, using RedisCluster client")
             return RedisCluster.from_url(url, **kwargs)
-    except Exception as error:
+    except Exception:
         await client.aclose()
+        raise
+
+    logger.info("Using standalone Redis client")
+    return client
+
+
+async def create_redis_client(url: str, **kwargs: Any) -> RedisClient:
+    """Connect to Redis, using a cluster client when cluster mode is enabled."""
+    try:
+        return await _create_redis_client_once(url, **kwargs)
+    except Exception as error:
         logger.exception(
             "Failed to connect to Redis",
             error=str(error),
         )
         raise
 
-    logger.info("Using standalone Redis client")
-    return client
+
+async def create_redis_client_with_retry(
+    url: str,
+    *,
+    max_retries: int,
+    initial_backoff_seconds: float,
+    exponential_base: float,
+    **kwargs: Any,
+) -> RedisClient:
+    """Connect to Redis with exponential backoff retries at startup."""
+    for attempt in range(max_retries + 1):
+        try:
+            return await _create_redis_client_once(url, **kwargs)
+        except Exception as error:
+            if attempt >= max_retries:
+                logger.exception(
+                    "Failed to connect to Redis after exhausting startup retries",
+                    error=str(error),
+                    max_retries=max_retries,
+                )
+                raise
+            delay_seconds = initial_backoff_seconds * (exponential_base**attempt)
+            logger.warning(
+                f"Failed to connect to Redis at startup, retrying in {delay_seconds:.2f} seconds",
+                attempt=attempt + 1,
+                max_retries=max_retries,
+                delay_seconds=delay_seconds,
+                error=str(error),
+            )
+            await asyncio.sleep(delay_seconds)
+
+    raise RuntimeError("Unreachable: Redis startup retry loop exited unexpectedly")

--- a/port_ocean/consumers/redis_stream_consumer.py
+++ b/port_ocean/consumers/redis_stream_consumer.py
@@ -14,7 +14,10 @@ from redis.asyncio.connection import SSLConnection
 from redis.exceptions import ResponseError
 
 from port_ocean.config.settings import LiveEventsRedisSettings
-from port_ocean.consumers.redis_client import RedisClient, create_redis_client
+from port_ocean.consumers.redis_client import (
+    RedisClient,
+    create_redis_client_with_retry,
+)
 from port_ocean.consumers.abstract_live_events_consumer import (
     AbstractLiveEventsConsumer,
 )
@@ -118,8 +121,12 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
         return kwargs
 
     async def start(self) -> None:
-        self._redis = await create_redis_client(
-            self._settings.url, **self._redis_client_kwargs()
+        self._redis = await create_redis_client_with_retry(
+            self._settings.url,
+            max_retries=self._settings.connection_startup_max_retries,
+            initial_backoff_seconds=self._settings.connection_startup_initial_backoff_seconds,
+            exponential_base=self._settings.connection_startup_exponential_base,
+            **self._redis_client_kwargs(),
         )
         await self._ensure_consumer_group()
         self._is_running = True

--- a/port_ocean/consumers/redis_stream_consumer.py
+++ b/port_ocean/consumers/redis_stream_consumer.py
@@ -19,7 +19,10 @@ from port_ocean.consumers.abstract_live_events_consumer import (
     AbstractLiveEventsConsumer,
 )
 from port_ocean.consumers.pel_requeue import PELRequeueWorker
-from port_ocean.consumers.redis_stream_utils import is_missing_stream_or_group_error
+from port_ocean.consumers.redis_stream_utils import (
+    is_missing_stream_or_group_error,
+    is_redis_connection_error,
+)
 from port_ocean.context.ocean import ocean
 from port_ocean.exceptions.live_events import InvalidLiveEventsRedisStreamFieldError
 from port_ocean.core.handlers.webhook.webhook_event import (
@@ -249,11 +252,19 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
                         error=str(error),
                     )
             except Exception as error:
-                logger.exception(
-                    "Unexpected error in Redis stream read loop",
-                    stream_key=self._stream_key,
-                    error=str(error),
-                )
+                if is_redis_connection_error(error):
+                    logger.exception(
+                        "Lost connection to Redis, retrying",
+                        stream_key=self._stream_key,
+                        error=str(error),
+                    )
+                    await asyncio.sleep(self._settings.connection_error_backoff_seconds)
+                else:
+                    logger.exception(
+                        "Unexpected error in Redis stream read loop",
+                        stream_key=self._stream_key,
+                        error=str(error),
+                    )
 
     async def _handle_message(self, message_id: str, fields: dict[str, str]) -> None:
         start_time = time.monotonic()

--- a/port_ocean/consumers/redis_stream_utils.py
+++ b/port_ocean/consumers/redis_stream_utils.py
@@ -1,4 +1,21 @@
+import asyncio
+
+from redis.exceptions import ConnectionError as RedisConnectionError
 from redis.exceptions import ResponseError
+from redis.exceptions import TimeoutError as RedisTimeoutError
+
+_REDIS_CONNECTION_ERRORS = (
+    RedisConnectionError,
+    RedisTimeoutError,
+    asyncio.TimeoutError,
+    ConnectionError,
+    OSError,
+)
+
+
+def is_redis_connection_error(error: BaseException) -> bool:
+    """Return True when the error indicates Redis is unreachable or disconnected."""
+    return isinstance(error, _REDIS_CONNECTION_ERRORS)
 
 
 def is_missing_stream_or_group_error(error: Exception) -> bool:

--- a/port_ocean/core/integrations/mixins/utils.py
+++ b/port_ocean/core/integrations/mixins/utils.py
@@ -157,6 +157,7 @@ async def is_redis_live_events_enabled() -> bool:
         bool: True when Redis stream consumption is enabled, False otherwise.
     """
     try:
+        return True
         if not ocean.config.live_events.is_redis_stream_consumer_enabled:
             return False
         flags = await ocean.port_client.get_organization_feature_flags()

--- a/port_ocean/core/integrations/mixins/utils.py
+++ b/port_ocean/core/integrations/mixins/utils.py
@@ -157,7 +157,6 @@ async def is_redis_live_events_enabled() -> bool:
         bool: True when Redis stream consumption is enabled, False otherwise.
     """
     try:
-        return True
         if not ocean.config.live_events.is_redis_stream_consumer_enabled:
             return False
         flags = await ocean.port_client.get_organization_feature_flags()

--- a/port_ocean/tests/consumers/test_redis_client.py
+++ b/port_ocean/tests/consumers/test_redis_client.py
@@ -89,8 +89,11 @@ class TestCreateRedisClient:
                 "port_ocean.consumers.redis_client.Redis.from_url",
                 return_value=mock_standalone,
             ),
+            patch("port_ocean.consumers.redis_client.logger.exception") as mock_log,
             pytest.raises(ConnectionError, match="refused"),
         ):
             await create_redis_client("redis://localhost:6379")
 
         mock_standalone.aclose.assert_awaited_once()
+        mock_log.assert_called_once()
+        assert mock_log.call_args.args[0] == "Failed to connect to Redis"

--- a/port_ocean/tests/consumers/test_redis_client.py
+++ b/port_ocean/tests/consumers/test_redis_client.py
@@ -1,9 +1,11 @@
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
 from port_ocean.consumers.redis_client import (
+    calculate_exponential_backoff_seconds,
     create_redis_client,
+    create_redis_client_with_retry,
     is_redis_cluster_enabled,
 )
 
@@ -97,3 +99,92 @@ class TestCreateRedisClient:
         mock_standalone.aclose.assert_awaited_once()
         mock_log.assert_called_once()
         assert mock_log.call_args.args[0] == "Failed to connect to Redis"
+
+
+class TestCalculateExponentialBackoffSeconds:
+    def test_returns_initial_backoff_for_first_retry(self) -> None:
+        assert (
+            calculate_exponential_backoff_seconds(
+                0,
+                initial_backoff_seconds=1.0,
+                exponential_base=2.0,
+            )
+            == 1.0
+        )
+
+    def test_applies_exponential_growth(self) -> None:
+        assert (
+            calculate_exponential_backoff_seconds(
+                2,
+                initial_backoff_seconds=1.0,
+                exponential_base=2.0,
+            )
+            == 4.0
+        )
+
+
+class TestCreateRedisClientWithRetry:
+    @pytest.mark.asyncio
+    async def test_retries_until_connection_succeeds(self) -> None:
+        mock_standalone = AsyncMock()
+        mock_standalone.info = AsyncMock(return_value={"cluster_enabled": 0})
+        connect_calls = 0
+
+        def connect_side_effect(*_args: object, **_kwargs: object) -> AsyncMock:
+            nonlocal connect_calls
+            connect_calls += 1
+            if connect_calls < 3:
+                raise ConnectionError("refused")
+            return mock_standalone
+
+        with (
+            patch(
+                "port_ocean.consumers.redis_client.Redis.from_url",
+                side_effect=connect_side_effect,
+            ),
+            patch(
+                "port_ocean.consumers.redis_client.asyncio.sleep",
+                new_callable=AsyncMock,
+            ) as mock_sleep,
+        ):
+            client = await create_redis_client_with_retry(
+                "redis://localhost:6379",
+                max_retries=5,
+                initial_backoff_seconds=1.0,
+                exponential_base=2.0,
+            )
+
+        assert client is mock_standalone
+        assert connect_calls == 3
+        mock_sleep.assert_has_awaits([call(1.0), call(2.0)])
+
+    @pytest.mark.asyncio
+    async def test_raises_after_exhausting_retries(self) -> None:
+        mock_standalone = AsyncMock()
+        mock_standalone.info = AsyncMock(side_effect=ConnectionError("refused"))
+
+        with (
+            patch(
+                "port_ocean.consumers.redis_client.Redis.from_url",
+                return_value=mock_standalone,
+            ),
+            patch(
+                "port_ocean.consumers.redis_client.asyncio.sleep",
+                new_callable=AsyncMock,
+            ) as mock_sleep,
+            patch("port_ocean.consumers.redis_client.logger.exception") as mock_log,
+            pytest.raises(ConnectionError, match="refused"),
+        ):
+            await create_redis_client_with_retry(
+                "redis://localhost:6379",
+                max_retries=2,
+                initial_backoff_seconds=1.0,
+                exponential_base=2.0,
+            )
+
+        assert mock_sleep.await_count == 2
+        mock_log.assert_called_once()
+        assert (
+            mock_log.call_args.args[0]
+            == "Failed to connect to Redis after exhausting startup retries"
+        )

--- a/port_ocean/tests/consumers/test_redis_client.py
+++ b/port_ocean/tests/consumers/test_redis_client.py
@@ -3,7 +3,6 @@ from unittest.mock import AsyncMock, MagicMock, call, patch
 import pytest
 
 from port_ocean.consumers.redis_client import (
-    calculate_exponential_backoff_seconds,
     create_redis_client,
     create_redis_client_with_retry,
     is_redis_cluster_enabled,
@@ -99,28 +98,6 @@ class TestCreateRedisClient:
         mock_standalone.aclose.assert_awaited_once()
         mock_log.assert_called_once()
         assert mock_log.call_args.args[0] == "Failed to connect to Redis"
-
-
-class TestCalculateExponentialBackoffSeconds:
-    def test_returns_initial_backoff_for_first_retry(self) -> None:
-        assert (
-            calculate_exponential_backoff_seconds(
-                0,
-                initial_backoff_seconds=1.0,
-                exponential_base=2.0,
-            )
-            == 1.0
-        )
-
-    def test_applies_exponential_growth(self) -> None:
-        assert (
-            calculate_exponential_backoff_seconds(
-                2,
-                initial_backoff_seconds=1.0,
-                exponential_base=2.0,
-            )
-            == 4.0
-        )
 
 
 class TestCreateRedisClientWithRetry:

--- a/port_ocean/tests/consumers/test_redis_stream_consumer.py
+++ b/port_ocean/tests/consumers/test_redis_stream_consumer.py
@@ -547,7 +547,7 @@ class TestRedisStreamConsumerPelWorkerLifecycle:
                 "port_ocean.consumers.redis_stream_consumer.ocean", mock_ocean_config
             ),
             patch(
-                "port_ocean.consumers.redis_stream_consumer.create_redis_client",
+                "port_ocean.consumers.redis_stream_consumer.create_redis_client_with_retry",
                 new=AsyncMock(return_value=mock_redis),
             ),
             patch(
@@ -589,7 +589,7 @@ class TestRedisStreamConsumerPelWorkerLifecycle:
                 "port_ocean.consumers.redis_stream_consumer.ocean", mock_ocean_config
             ),
             patch(
-                "port_ocean.consumers.redis_stream_consumer.create_redis_client",
+                "port_ocean.consumers.redis_stream_consumer.create_redis_client_with_retry",
                 new=AsyncMock(return_value=mock_redis),
             ),
             patch(

--- a/port_ocean/tests/consumers/test_redis_stream_consumer.py
+++ b/port_ocean/tests/consumers/test_redis_stream_consumer.py
@@ -318,6 +318,51 @@ class TestRedisStreamConsumerConnection:
         consumer._ensure_consumer_group.assert_awaited_once()
         assert mock_redis.xreadgroup.await_count == 2
 
+    @pytest.mark.asyncio
+    async def test_read_loop_backoffs_on_connection_error(
+        self,
+        mock_ocean_config: MagicMock,
+    ) -> None:
+        settings = LiveEventsRedisSettings(
+            url="redis://localhost:6379",
+            block_ms=100,
+            connection_error_backoff_seconds=2.5,
+        )
+        mock_redis = AsyncMock()
+        read_calls = 0
+
+        async def read_side_effect(**_kwargs: object) -> list[object]:
+            nonlocal read_calls
+            read_calls += 1
+            if read_calls == 1:
+                raise ConnectionError("connection lost")
+            consumer._is_running = False
+            return []
+
+        mock_redis.xreadgroup = AsyncMock(side_effect=read_side_effect)
+
+        with (
+            patch(
+                "port_ocean.consumers.redis_stream_consumer.ocean", mock_ocean_config
+            ),
+            patch(
+                "port_ocean.consumers.redis_stream_consumer.asyncio.sleep",
+                new_callable=AsyncMock,
+            ) as mock_sleep,
+        ):
+            consumer = RedisStreamConsumer(
+                redis_settings=settings,
+                stream_key="stream",
+                on_message=AsyncMock(),
+            )
+            consumer._redis = mock_redis
+            consumer._is_running = True
+
+            await consumer._read_loop()
+
+        mock_sleep.assert_awaited_once_with(2.5)
+        assert mock_redis.xreadgroup.await_count == 2
+
 
 class TestRedisStreamConsumerGroupCreation:
     @pytest.mark.asyncio

--- a/port_ocean/tests/consumers/test_redis_stream_utils.py
+++ b/port_ocean/tests/consumers/test_redis_stream_utils.py
@@ -1,7 +1,14 @@
-import pytest
-from redis.exceptions import ResponseError
+import asyncio
 
-from port_ocean.consumers.redis_stream_utils import is_missing_stream_or_group_error
+import pytest
+from redis.exceptions import ConnectionError as RedisConnectionError
+from redis.exceptions import ResponseError
+from redis.exceptions import TimeoutError as RedisTimeoutError
+
+from port_ocean.consumers.redis_stream_utils import (
+    is_missing_stream_or_group_error,
+    is_redis_connection_error,
+)
 
 
 class TestIsMissingStreamOrGroupError:
@@ -23,3 +30,22 @@ class TestIsMissingStreamOrGroupError:
 
     def test_returns_false_for_non_response_errors(self) -> None:
         assert is_missing_stream_or_group_error(RuntimeError("boom")) is False
+
+
+class TestIsRedisConnectionError:
+    @pytest.mark.parametrize(
+        "error",
+        [
+            RedisConnectionError("connection refused"),
+            RedisTimeoutError("timed out"),
+            asyncio.TimeoutError(),
+            ConnectionError("broken pipe"),
+            OSError("network unreachable"),
+        ],
+    )
+    def test_returns_true_for_connection_errors(self, error: BaseException) -> None:
+        assert is_redis_connection_error(error) is True
+
+    def test_returns_false_for_other_errors(self) -> None:
+        assert is_redis_connection_error(ResponseError("NOGROUP")) is False
+        assert is_redis_connection_error(RuntimeError("boom")) is False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.48.3"
+version = "0.48.4"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.48.4"
+version = "0.48.5"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description

This PR improves observability and resilience for the Redis stream consumer:

**Startup**: create_redis_client now logs "Failed to connect to Redis" before re-raising, so initial connection failures are explicit in logs. - for future alert on saas integrations that fail to connect.

**Runtime**: The stream read loop detects connection-related errors (RedisConnectionError, RedisTimeoutError, asyncio.TimeoutError, ConnectionError, OSError) and logs "Lost connection to Redis, retrying" before backing off and retrying.


## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability and retry backoff on the Redis consumer only; no auth or data-path changes, with unit test coverage.
> 
> **Overview**
> Improves **Redis live-events** observability and recovery when Redis is unreachable.
> 
> **Startup:** `create_redis_client` now logs **"Failed to connect to Redis"** (with the error) before re-raising, so SaaS integrations that never connect show up clearly in logs/alerts.
> 
> **Runtime:** The stream **`_read_loop`** treats connection-style failures separately via new **`is_redis_connection_error`** (Redis connection/timeout errors, `asyncio.TimeoutError`, `ConnectionError`, `OSError`). Those paths log **"Lost connection to Redis, retrying"** and wait **`connection_error_backoff_seconds`** (new on `LiveEventsRedisSettings`, default 5s) instead of only logging a generic error with no delay.
> 
> CHANGELOG documents the improvement under 0.48.3.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 826dc68af6dbc73dbb3144775e7aa7a54f0b2ce7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->