### PR TITLE
[Integration][Aws-v3] prevent credential provider crash when role ARN is missing on EKS

### DIFF
--- a/integrations/aws-v3/.ocean-release/fix-credential-provider-selection.yaml
+++ b/integrations/aws-v3/.ocean-release/fix-credential-provider-selection.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: bugfix
+changelog: Fixed credential provider selection crash on Port-hosted (EKS) deployments where AssumeRoleWithWebIdentity was incorrectly selected based solely on the presence of AWS_WEB_IDENTITY_TOKEN_FILE, without verifying a role ARN exists in config

--- a/integrations/aws-v3/aws/auth/session_factory.py
+++ b/integrations/aws-v3/aws/auth/session_factory.py
@@ -69,16 +69,17 @@ class AccountStrategyFactory:
     @staticmethod
     def _provider_is_applicable(provider_name: str, config: dict[str, Any]) -> bool:
         """Determine if a provider is applicable given the current environment and config."""
+        has_role_arn = bool(
+            config.get("account_role_arn") or config.get("account_role_arns")
+        )
         if provider_name == "AssumeRoleWithWebIdentity":
-            return bool(os.getenv("AWS_WEB_IDENTITY_TOKEN_FILE"))
+            return bool(os.getenv("AWS_WEB_IDENTITY_TOKEN_FILE")) and has_role_arn
         if provider_name == "StaticCredential":
             return bool(
                 config.get("aws_access_key_id") and config.get("aws_secret_access_key")
             )
         if provider_name == "AssumeRole":
-            return bool(
-                config.get("account_role_arn") or config.get("account_role_arns")
-            )
+            return has_role_arn
         return False
 
     @classmethod

--- a/integrations/aws-v3/tests/auth/test_session_factory.py
+++ b/integrations/aws-v3/tests/auth/test_session_factory.py
@@ -176,6 +176,33 @@ class TestAccountStrategyFactory:
             assert isinstance(strategy.provider, StaticCredentialProvider)
 
     @pytest.mark.asyncio
+    async def test_web_identity_not_applicable_without_role_arn(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When AWS_WEB_IDENTITY_TOKEN_FILE is set but no role ARN exists in config,
+        AssumeRoleWithWebIdentity should NOT be selected — it should fall through
+        to the fallback provider instead of crashing."""
+        config: dict[str, object] = {
+            "aws_access_key_id": None,
+            "aws_secret_access_key": None,
+            "aws_session_token": None,
+            "region": None,
+            "account_role_arn": None,
+            "account_role_arns": [],
+            "external_id": None,
+        }
+        monkeypatch.setenv("AWS_WEB_IDENTITY_TOKEN_FILE", "/var/run/secrets/token")
+        with patch("aws.auth.session_factory.ocean") as mock_ocean:
+            mock_ocean.integration_config = config
+
+            with patch.object(
+                SingleAccountStrategy, "healthcheck", new_callable=AsyncMock
+            ):
+                strategy = await AccountStrategyFactory.create()
+                assert isinstance(strategy.provider, AssumeRoleProvider)
+
+    @pytest.mark.asyncio
     async def test_provider_priority_unknown_and_not_applicable_fallbacks_to_assume_role(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary
- Fixed a bug where the `AssumeRoleWithWebIdentity` provider was incorrectly selected on Port-hosted (EKS) deployments based solely on the `AWS_WEB_IDENTITY_TOKEN_FILE` env var, without verifying a role ARN exists in config — causing a startup crash (`CredentialsProviderError`)
- The provider selection now checks for both the web identity token file **and** a role ARN before selecting `AssumeRoleWithWebIdentity`, allowing correct fallthrough to `AssumeRole`
- Refactored `_provider_is_applicable` to extract the role ARN check into a shared variable, removing duplication between the `AssumeRoleWithWebIdentity` and `AssumeRole` branches

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes AWS credential provider selection at integration startup; behavior is narrower and covered by a new test, but misconfiguration could still surface later via the AssumeRole fallback.
> 
> **Overview**
> Fixes a **startup crash** on Port-hosted (EKS) deployments where `AssumeRoleWithWebIdentity` was chosen only because `AWS_WEB_IDENTITY_TOKEN_FILE` is present, even when no `account_role_arn` / `account_role_arns` is configured.
> 
> `_provider_is_applicable` in `session_factory.py` now requires a role ARN for both **AssumeRoleWithWebIdentity** (token file **and** role ARN) and **AssumeRole**, via a shared `has_role_arn` check. Provider priority can fall through to the existing **AssumeRole** fallback instead of instantiating web identity without a role.
> 
> Adds a regression test for token file set with empty role config, and a patch changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38ee25497e48e214d59a3aab5383f0e5e789ac00. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->