### PR TITLE
[Integration][AWS-v3] removed le key from spec

### DIFF
--- a/integrations/aws-v3/.ocean-release/remove-live-events-api-key-spec.yaml
+++ b/integrations/aws-v3/.ocean-release/remove-live-events-api-key-spec.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: bugfix
+changelog: Remove liveEventsApiKey from spec.yaml so it is not shown in the UI while live events are behind a feature flag

--- a/integrations/aws-v3/.port/spec.yaml
+++ b/integrations/aws-v3/.port/spec.yaml
@@ -81,13 +81,6 @@ configurations:
     sensitive: false
     description: AWS Partition, defaults to "aws" which is the standard global one (optional).
     enum: ["aws", "aws-us-gov", "aws-cn"]
-  - name: liveEventsApiKey
-    required: false
-    type: string
-    sensitive: true
-    description: >-
-      Shared secret expected on the `x-port-aws-ocean-api-key` header of incoming
-      live event webhook requests (e.g. from an EventBridge API Destination).
 disableDefaultInstallationMethods: true
 installationDocs:
   saas:

--- a/integrations/aws-v3/aws/config/live_events.py
+++ b/integrations/aws-v3/aws/config/live_events.py
@@ -1,0 +1,20 @@
+import os
+
+from port_ocean.context.ocean import ocean
+
+LIVE_EVENTS_API_KEY_ENV = "OCEAN__INTEGRATION__CONFIG__LIVE_EVENTS_API_KEY"
+
+
+def get_live_events_api_key() -> str | None:
+    """Return the live-events API key from integration config or local env fallback.
+
+    ``liveEventsApiKey`` is intentionally omitted from ``spec.yaml`` (hidden from Port UI
+    while live events are not released yet). The dynamic config model built from spec
+    may therefore drop the key when parsing env vars on older Ocean versions; read the env
+    var directly as a fallback for local development.
+    """
+    configured_key = ocean.integration_config.get("live_events_api_key")
+    if configured_key:
+        return str(configured_key)
+    env_key = os.environ.get(LIVE_EVENTS_API_KEY_ENV)
+    return env_key if env_key else None

--- a/integrations/aws-v3/aws/webhook/registry.py
+++ b/integrations/aws-v3/aws/webhook/registry.py
@@ -1,6 +1,8 @@
 from loguru import logger
 from port_ocean.context.ocean import ocean
 
+from aws.config.live_events import get_live_events_api_key
+
 from aws.webhook.consts import CLOUDTRAIL_WEBHOOK_PATH
 from aws.webhook.webhook_processors.cloudtrail_webhook_processor import (
     CloudTrailWebhookProcessor,
@@ -9,7 +11,7 @@ from aws.webhook.webhook_processors.cloudtrail_webhook_processor import (
 
 def register_cloudtrail_live_events() -> None:
     """Register the CloudTrail live-events processor when this instance is configured for LE."""
-    if not ocean.integration_config.get("live_events_api_key"):
+    if not get_live_events_api_key():
         logger.info(
             "Skipping CloudTrail live events — live_events_api_key is not configured"
         )

--- a/integrations/aws-v3/aws/webhook/webhook_processors/cloudtrail_webhook_processor.py
+++ b/integrations/aws-v3/aws/webhook/webhook_processors/cloudtrail_webhook_processor.py
@@ -10,7 +10,6 @@ from typing import Any, cast
 import hmac
 
 from loguru import logger
-from port_ocean.context.ocean import ocean
 from port_ocean.core.handlers.port_app_config.models import ResourceConfig
 from port_ocean.core.handlers.webhook.abstract_webhook_processor import (
     AbstractWebhookProcessor,
@@ -41,6 +40,7 @@ from aws.webhook.cloudtrail_parser import (
     is_supported_cloudtrail_event,
     parse_cloudtrail_event,
 )
+from aws.config.live_events import get_live_events_api_key
 from aws.webhook.consts import LIVE_EVENTS_API_KEY_HEADER
 from aws.utils.feature_flags import is_aws_v3_live_events_enabled
 
@@ -68,7 +68,7 @@ class CloudTrailWebhookProcessor(AbstractWebhookProcessor):
             logger.debug("AWS-v3 live events are disabled by organization feature flag")
             return False
 
-        expected_api_key = ocean.integration_config.get("live_events_api_key")
+        expected_api_key = get_live_events_api_key()
         if not expected_api_key:
             logger.warning(
                 "live_events_api_key is not configured, rejecting all live events"

--- a/integrations/aws-v3/tests/config/test_live_events.py
+++ b/integrations/aws-v3/tests/config/test_live_events.py
@@ -1,0 +1,27 @@
+import os
+from unittest.mock import patch
+
+from aws.config.live_events import LIVE_EVENTS_API_KEY_ENV, get_live_events_api_key
+
+
+def test_get_live_events_api_key_from_integration_config() -> None:
+    with patch("aws.config.live_events.ocean") as mock_ocean:
+        mock_ocean.integration_config = {"live_events_api_key": "from-config"}
+        with patch.dict(os.environ, {}, clear=True):
+            assert get_live_events_api_key() == "from-config"
+
+
+def test_get_live_events_api_key_from_env_when_missing_from_config() -> None:
+    with patch("aws.config.live_events.ocean") as mock_ocean:
+        mock_ocean.integration_config = {}
+        with patch.dict(
+            os.environ, {LIVE_EVENTS_API_KEY_ENV: "from-env"}, clear=True
+        ):
+            assert get_live_events_api_key() == "from-env"
+
+
+def test_get_live_events_api_key_returns_none_when_unset() -> None:
+    with patch("aws.config.live_events.ocean") as mock_ocean:
+        mock_ocean.integration_config = {}
+        with patch.dict(os.environ, {}, clear=True):
+            assert get_live_events_api_key() is None

--- a/integrations/aws-v3/tests/config/test_live_events.py
+++ b/integrations/aws-v3/tests/config/test_live_events.py
@@ -14,9 +14,7 @@ def test_get_live_events_api_key_from_integration_config() -> None:
 def test_get_live_events_api_key_from_env_when_missing_from_config() -> None:
     with patch("aws.config.live_events.ocean") as mock_ocean:
         mock_ocean.integration_config = {}
-        with patch.dict(
-            os.environ, {LIVE_EVENTS_API_KEY_ENV: "from-env"}, clear=True
-        ):
+        with patch.dict(os.environ, {LIVE_EVENTS_API_KEY_ENV: "from-env"}, clear=True):
             assert get_live_events_api_key() == "from-env"
 
 

--- a/integrations/aws-v3/tests/webhook/test_registry.py
+++ b/integrations/aws-v3/tests/webhook/test_registry.py
@@ -11,9 +11,11 @@ MODULE = "aws.webhook.registry"
 
 def test_register_cloudtrail_live_events_when_configured() -> None:
     mock_ocean = MagicMock()
-    mock_ocean.integration_config = {"live_events_api_key": "secret"}
 
-    with patch(f"{MODULE}.ocean", mock_ocean):
+    with (
+        patch(f"{MODULE}.ocean", mock_ocean),
+        patch(f"{MODULE}.get_live_events_api_key", return_value="secret"),
+    ):
         register_cloudtrail_live_events()
 
     mock_ocean.add_webhook_processor.assert_called_once_with(
@@ -23,9 +25,11 @@ def test_register_cloudtrail_live_events_when_configured() -> None:
 
 def test_skips_registration_when_api_key_missing() -> None:
     mock_ocean = MagicMock()
-    mock_ocean.integration_config = {}
 
-    with patch(f"{MODULE}.ocean", mock_ocean):
+    with (
+        patch(f"{MODULE}.ocean", mock_ocean),
+        patch(f"{MODULE}.get_live_events_api_key", return_value=None),
+    ):
         register_cloudtrail_live_events()
 
     mock_ocean.add_webhook_processor.assert_not_called()

--- a/integrations/aws-v3/tests/webhook/webhook_processors/test_cloudtrail_webhook_processor.py
+++ b/integrations/aws-v3/tests/webhook/webhook_processors/test_cloudtrail_webhook_processor.py
@@ -155,11 +155,8 @@ async def test_authenticate_succeeds_with_matching_api_key(
         patch(
             f"{MODULE}.is_aws_v3_live_events_enabled", new=AsyncMock(return_value=True)
         ),
-        patch(
-            "aws.webhook.webhook_processors.cloudtrail_webhook_processor.ocean"
-        ) as mock_ocean,
+        patch(f"{MODULE}.get_live_events_api_key", return_value="secret"),
     ):
-        mock_ocean.integration_config = {"live_events_api_key": "secret"}
         result = await processor.authenticate(
             {}, {LIVE_EVENTS_API_KEY_HEADER: "secret"}
         )
@@ -174,11 +171,8 @@ async def test_authenticate_fails_with_wrong_api_key(
         patch(
             f"{MODULE}.is_aws_v3_live_events_enabled", new=AsyncMock(return_value=True)
         ),
-        patch(
-            "aws.webhook.webhook_processors.cloudtrail_webhook_processor.ocean"
-        ) as mock_ocean,
+        patch(f"{MODULE}.get_live_events_api_key", return_value="secret"),
     ):
-        mock_ocean.integration_config = {"live_events_api_key": "secret"}
         result = await processor.authenticate({}, {LIVE_EVENTS_API_KEY_HEADER: "wrong"})
     assert result is False
 
@@ -191,11 +185,8 @@ async def test_authenticate_fails_when_not_configured(
         patch(
             f"{MODULE}.is_aws_v3_live_events_enabled", new=AsyncMock(return_value=True)
         ),
-        patch(
-            "aws.webhook.webhook_processors.cloudtrail_webhook_processor.ocean"
-        ) as mock_ocean,
+        patch(f"{MODULE}.get_live_events_api_key", return_value=None),
     ):
-        mock_ocean.integration_config = {}
         result = await processor.authenticate(
             {}, {LIVE_EVENTS_API_KEY_HEADER: "anything"}
         )


### PR DESCRIPTION
# Description

What -

Why -

How -

## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI/spec cleanup for a feature-flagged, disabled live-events path; auth comparison logic is unchanged and still gated.
> 
> **Overview**
> Hides the unfinished **live events** API key from the Port UI by removing `liveEventsApiKey` from `spec.yaml`, while keeping local/dev configuration working.
> 
> Adds `get_live_events_api_key()`, which reads from integration config and falls back to `OCEAN__INTEGRATION__CONFIG__LIVE_EVENTS_API_KEY` when the dynamic config model drops the key. Webhook registration and CloudTrail auth now use this helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fac7784f2a82b4585d34c27dbbd6fd896f835ced. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->