### PR TITLE
[Infra] Task tjnpb3/rule to default to changesets in ocean

### DIFF
--- a/.cursor/rules/core-development.mdc
+++ b/.cursor/rules/core-development.mdc
@@ -91,9 +91,9 @@ Core Development Guidelines
     - Include performance tests
 
 12. Release intent (changesets)
-    - Every PR that changes `port_ocean/` MUST declare how to release using a release intent file
-    - Add `.ocean-release/core/<unique-name>.yaml` alongside your code changes (use a unique filename per PR)
-    - Do NOT manually bump `pyproject.toml` or `CHANGELOG.md` in the feature PR — CI applies those after merge
+    - Every PR that changes `port_ocean/` MUST declare how to release
+    - **Prefer** a release intent file: add `.ocean-release/core/<feature-related-name>.yaml` alongside your code changes (use a short filename related to the feature or change, e.g. `retry-transport-fix.yaml`)
+    - Only bump `pyproject.toml` or `CHANGELOG.md` manually when explicitly asked — if both a release file and manual bumps are present, manual changes take priority
     - Example:
 
       ```yaml
@@ -102,14 +102,14 @@ Core Development Guidelines
       changelog: Describe the change
       ```
 
+    - Write a clear, user-facing `changelog` entry; use `changelog-type: breaking` for breaking changes
     - `bump` must be `patch`, `minor`, or `major` — use `patch` for fixes and minor improvements, `minor` for new features, `major` for breaking changes
     - `changelog-type` must be `breaking`, `deprecation`, `feature`, `improvement`, `bugfix`, or `doc`
     - After the PR merges to `main`, the Apply ocean release workflow opens a follow-up PR with the version bump and changelog updates; review and merge that PR to publish
 
 13. Versioning
-    - Use declarative release intent files (section 12) — do not bump versions manually in feature branches
+    - Prefer declarative release intent files (section 12) over manual version bumps in feature branches
     - Do not edit version in any integration `pyproject.toml` when changing core only
-    - Manual `pyproject.toml` + `CHANGELOG.md` bumps are supported but discouraged; if both a release file and manual bumps are present, manual changes take priority
 
 14. Code Quality
     - run `make lint` command on the port_ocean folder before any commit

--- a/.cursor/rules/core-development.mdc
+++ b/.cursor/rules/core-development.mdc
@@ -90,17 +90,26 @@ Core Development Guidelines
     - Add linting checks
     - Include performance tests
 
-12. Changelog Management
-    - Document all changes
-    - Include version numbers
-    - Describe new features
-    - Note breaking changes
+12. Release intent (changesets)
+    - Every PR that changes `port_ocean/` MUST declare how to release using a release intent file
+    - Add `.ocean-release/core/<unique-name>.yaml` alongside your code changes (use a unique filename per PR)
+    - Do NOT manually bump `pyproject.toml` or `CHANGELOG.md` in the feature PR — CI applies those after merge
+    - Example:
+
+      ```yaml
+      bump: patch
+      changelog-type: bugfix
+      changelog: Describe the change
+      ```
+
+    - `bump` must be `patch`, `minor`, or `major` — use `patch` for fixes and minor improvements, `minor` for new features, `major` for breaking changes
+    - `changelog-type` must be `breaking`, `deprecation`, `feature`, `improvement`, `bugfix`, or `doc`
+    - After the PR merges to `main`, the Apply ocean release workflow opens a follow-up PR with the version bump and changelog updates; review and merge that PR to publish
 
 13. Versioning
-    - Each feature branch need to bump the latest version
-    - In case of merge conflict take the version from the merged branch and bump it
-    - Don't merge versions! existing version need to remain as it is and each branch creates its own version
-    - Don't bump the version on the integrations pyproject.toml
+    - Use declarative release intent files (section 12) — do not bump versions manually in feature branches
+    - Do not edit version in any integration `pyproject.toml` when changing core only
+    - Manual `pyproject.toml` + `CHANGELOG.md` bumps are supported but discouraged; if both a release file and manual bumps are present, manual changes take priority
 
 14. Code Quality
     - run `make lint` command on the port_ocean folder before any commit

--- a/.cursor/rules/integration-development.mdc
+++ b/.cursor/rules/integration-development.mdc
@@ -80,12 +80,21 @@ Integration Development Guidelines
     - Maintain consistent naming conventions
     - Organize code logically
 
-11. Changelog Management
-    - Document all changes clearly
-    - Include version numbers
-    - Describe new features and fixes
-    - Note breaking changes
-    - Every PR that modifies an integration MUST add an entry to `integrations/<name>/CHANGELOG.md` under a new version heading immediately after the `<!-- towncrier release notes start -->` comment, using Keep a Changelog format (`### Features`, `### Improvements`, or `### Bug Fixes`)
+11. Release intent (changesets)
+    - Every PR that modifies an integration MUST declare how to release using a release intent file
+    - Add `integrations/<name>/.ocean-release/<unique-name>.yaml` alongside your code changes (use a unique filename per PR)
+    - Do NOT manually bump `integrations/<name>/pyproject.toml` or `integrations/<name>/CHANGELOG.md` in the feature PR — CI applies those after merge
+    - Example:
+
+      ```yaml
+      bump: patch
+      changelog-type: bugfix
+      changelog: Describe the change
+      ```
+
+    - `bump` must be `patch`, `minor`, or `major` — use `patch` for fixes and minor improvements, `minor` for new features, `major` for breaking changes
+    - `changelog-type` must be `breaking`, `deprecation`, `feature`, `improvement`, `bugfix`, or `doc`
+    - After the PR merges to `main`, the Apply ocean release workflow opens a follow-up PR with the version bump and changelog updates; review and merge that PR to publish
 
 12. Testing Requirements
     - Write unit tests for new code
@@ -94,11 +103,8 @@ Integration Development Guidelines
     - Maintain test coverage
 
 13. Versioning
-    - Each feature branch need to bump the latest version in `integrations/<name>/pyproject.toml`
-    - Apply a patch bump (e.g. 0.1.1 → 0.1.2) for fixes and minor improvements; a minor bump (e.g. 0.1.x → 0.2.0) for new features
-    - In case of merge conflict take the version from the merged branch and bump it
-    - Don't merge versions! existing version need to remain as it is and each branch creates its own version
-    - The version in `pyproject.toml` and the new `CHANGELOG.md` heading MUST match
+    - Use declarative release intent files (section 11) — do not bump versions manually in feature branches
+    - Manual `pyproject.toml` + `CHANGELOG.md` bumps are supported but discouraged; if both a release file and manual bumps are present, manual changes take priority
 
 14. Code Quality
     - run `make lint` command on the integration folder before any commit

--- a/.cursor/rules/integration-development.mdc
+++ b/.cursor/rules/integration-development.mdc
@@ -81,9 +81,9 @@ Integration Development Guidelines
     - Organize code logically
 
 11. Release intent (changesets)
-    - Every PR that modifies an integration MUST declare how to release using a release intent file
-    - Add `integrations/<name>/.ocean-release/<unique-name>.yaml` alongside your code changes (use a unique filename per PR)
-    - Do NOT manually bump `integrations/<name>/pyproject.toml` or `integrations/<name>/CHANGELOG.md` in the feature PR — CI applies those after merge
+    - Every PR that modifies an integration MUST declare how to release
+    - **Prefer** a release intent file: add `integrations/<name>/.ocean-release/<feature-related-name>.yaml` alongside your code changes (use a short filename related to the feature or change, e.g. `fix-pagination.yaml`)
+    - Only bump `integrations/<name>/pyproject.toml` or `integrations/<name>/CHANGELOG.md` manually when explicitly asked — if both a release file and manual bumps are present, manual changes take priority
     - Example:
 
       ```yaml
@@ -92,6 +92,7 @@ Integration Development Guidelines
       changelog: Describe the change
       ```
 
+    - Write a clear, user-facing `changelog` entry; use `changelog-type: breaking` for breaking changes
     - `bump` must be `patch`, `minor`, or `major` — use `patch` for fixes and minor improvements, `minor` for new features, `major` for breaking changes
     - `changelog-type` must be `breaking`, `deprecation`, `feature`, `improvement`, `bugfix`, or `doc`
     - After the PR merges to `main`, the Apply ocean release workflow opens a follow-up PR with the version bump and changelog updates; review and merge that PR to publish
@@ -103,8 +104,7 @@ Integration Development Guidelines
     - Maintain test coverage
 
 13. Versioning
-    - Use declarative release intent files (section 11) — do not bump versions manually in feature branches
-    - Manual `pyproject.toml` + `CHANGELOG.md` bumps are supported but discouraged; if both a release file and manual bumps are present, manual changes take priority
+    - Prefer declarative release intent files (section 11) over manual version bumps in feature branches
 
 14. Code Quality
     - run `make lint` command on the integration folder before any commit


### PR DESCRIPTION
# Description

What -

Why -

How -

## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to Cursor rule files; no runtime, release automation, or product code is modified.
> 
> **Overview**
> Updates Cursor development rules so core and integration PRs **prefer declarative `.ocean-release` intent files** instead of manually editing `CHANGELOG.md` / `pyproject.toml`.
> 
> In `core-development.mdc` and `integration-development.mdc`, the old changelog/versioning guidance is replaced with release-intent instructions: required YAML fields (`bump`, `changelog-type`, `changelog`), allowed values, and that the Apply ocean release workflow opens the follow-up version/changelog PR after merge. Manual bumps remain allowed and take priority when both are present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e15d571d902a71557f8b0452426b9c8bcbd7f80c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->