### PR TITLE
[Core] Delete Redis stream entries on ack and refresh stream TTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.48.6 (2026-08-12)
+
+
+### Improvements
+
+- Redis stream consumer now deletes entries after acking and refreshes stream TTL in the same transactional pipeline (`XACK`, `XDEL`, `EXPIRE`). The PEL requeue worker uses the same ack-finalize flow for discard and tombstoned messages.
+
+
 ## 0.48.4 (2026-08-11)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,20 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
-## 0.48.7 (2026-08-13)
+## 0.48.6 (2026-08-13)
 
 
 ### Improvements
 
 - Redis stream consumer now deletes entries after acking in a transactional pipeline (`XACK`, `XDEL`). Default stream TTL is now one month and is applied only when the consumer creates the stream via MKSTREAM.
-
-
-## 0.48.6 (2026-08-12)
-
-
-### Improvements
-
-- Redis stream consumer now deletes entries after acking and refreshes stream TTL in the same transactional pipeline (`XACK`, `XDEL`, `EXPIRE`). The PEL requeue worker uses the same ack-finalize flow for discard and tombstoned messages.
 
 
 ## 0.48.5 (2026-08-11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- towncrier release notes start -->
+## 0.48.7 (2026-08-13)
+
+
+### Improvements
+
+- Redis stream consumer now deletes entries after acking in a transactional pipeline (`XACK`, `XDEL`). Default stream TTL is now one month and is applied only when the consumer creates the stream via MKSTREAM.
+
+
 ## 0.48.6 (2026-08-12)
 
 

--- a/port_ocean/config/settings.py
+++ b/port_ocean/config/settings.py
@@ -196,12 +196,11 @@ class LiveEventsRedisSettings(BaseOceanModel, extra=Extra.allow):
         description="Maximum number of stream entries to return per XREADGROUP call.",
     )
     stream_ttl_seconds: int | None = Field(
-        default=3600,
+        default=2_592_000,
         ge=1,
         description=(
             "TTL in seconds for the Redis stream. Set when the consumer creates "
-            "the stream via MKSTREAM and refreshed after each message ack. "
-            "Set to null to disable stream expiry."
+            "the stream via MKSTREAM. Set to null to disable stream expiry."
         ),
     )
     # PEL requeue worker settings

--- a/port_ocean/config/settings.py
+++ b/port_ocean/config/settings.py
@@ -199,8 +199,9 @@ class LiveEventsRedisSettings(BaseOceanModel, extra=Extra.allow):
         default=3600,
         ge=1,
         description=(
-            "TTL in seconds for the Redis stream when the consumer creates it "
-            "via MKSTREAM. Set to null to disable stream expiry."
+            "TTL in seconds for the Redis stream. Set when the consumer creates "
+            "the stream via MKSTREAM and refreshed after each message ack. "
+            "Set to null to disable stream expiry."
         ),
     )
     # PEL requeue worker settings

--- a/port_ocean/config/settings.py
+++ b/port_ocean/config/settings.py
@@ -196,7 +196,7 @@ class LiveEventsRedisSettings(BaseOceanModel, extra=Extra.allow):
         description="Maximum number of stream entries to return per XREADGROUP call.",
     )
     stream_ttl_seconds: int | None = Field(
-        default=2_592_000,
+        default=2_592_000,  # 30 days
         ge=1,
         description=(
             "TTL in seconds for the Redis stream. Set when the consumer creates "

--- a/port_ocean/consumers/pel_requeue/worker.py
+++ b/port_ocean/consumers/pel_requeue/worker.py
@@ -122,7 +122,6 @@ class PELRequeueWorker:
                         stream_key=self._stream_key,
                         consumer_group=self._consumer_group,
                         message_id=message_id,
-                        stream_ttl_seconds=self._redis_settings.stream_ttl_seconds,
                     )
                     continue
 
@@ -168,7 +167,6 @@ class PELRequeueWorker:
                 stream_key=self._stream_key,
                 consumer_group=self._consumer_group,
                 message_id=message_id,
-                stream_ttl_seconds=self._redis_settings.stream_ttl_seconds,
             )
             return
 
@@ -179,10 +177,6 @@ class PELRequeueWorker:
             await pipe.xadd(self._stream_key, cast(Any, new_fields))
             await pipe.xack(self._stream_key, self._consumer_group, message_id)
             await pipe.xdel(self._stream_key, message_id)
-            if self._redis_settings.stream_ttl_seconds is not None:
-                await pipe.expire(
-                    self._stream_key, self._redis_settings.stream_ttl_seconds
-                )
             await pipe.execute()
 
         logger.info(

--- a/port_ocean/consumers/pel_requeue/worker.py
+++ b/port_ocean/consumers/pel_requeue/worker.py
@@ -18,10 +18,15 @@ import asyncio
 from typing import Any, cast
 
 from loguru import logger
+from redis.exceptions import ResponseError
 from port_ocean.config.settings import LiveEventsRedisSettings
 from port_ocean.consumers.redis_client import RedisClient
 from port_ocean.consumers.pel_requeue.settings import PEL_CONSUMER_NAME
-from port_ocean.consumers.redis_stream_utils import ack_and_finalize_stream_entry
+from port_ocean.consumers.redis_stream_utils import (
+    ack_and_finalize_stream_entry,
+    ensure_consumer_group,
+    is_missing_stream_or_group_error,
+)
 
 
 class PELRequeueWorker:
@@ -62,6 +67,19 @@ class PELRequeueWorker:
             await asyncio.gather(self._lifecycle_task, return_exceptions=True)
             self._lifecycle_task = None
 
+    async def _recover_missing_stream(self) -> None:
+        logger.warning(
+            "Redis stream or consumer group missing in PEL requeue worker, recreating",
+            stream_key=self._stream_key,
+            consumer_group=self._consumer_group,
+        )
+        await ensure_consumer_group(
+            self._redis,
+            stream_key=self._stream_key,
+            consumer_group=self._consumer_group,
+            stream_ttl_seconds=self._redis_settings.stream_ttl_seconds,
+        )
+
     async def _worker_loop(self) -> None:
         while self._is_running:
             try:
@@ -69,6 +87,26 @@ class PELRequeueWorker:
                 await asyncio.sleep(self._redis_settings.pel_scan_interval_seconds)
             except asyncio.CancelledError:
                 break
+            except ResponseError as error:
+                if is_missing_stream_or_group_error(error):
+                    try:
+                        await self._recover_missing_stream()
+                    except Exception as recovery_error:
+                        logger.exception(
+                            "Failed to recreate Redis stream consumer group "
+                            "from PEL requeue worker",
+                            stream_key=self._stream_key,
+                            error=str(recovery_error),
+                        )
+                else:
+                    logger.exception(
+                        "Unexpected Redis error in PEL requeue worker loop",
+                        stream_key=self._stream_key,
+                        error=str(error),
+                    )
+                await asyncio.sleep(
+                    self._redis_settings.pel_lifecycle_error_backoff_seconds
+                )
             except Exception as error:
                 logger.exception(
                     "Unexpected error in PEL requeue worker loop",
@@ -84,14 +122,20 @@ class PELRequeueWorker:
         total_processed = 0
 
         while True:
-            result = await self._redis.xautoclaim(
-                self._stream_key,
-                self._consumer_group,
-                PEL_CONSUMER_NAME,
-                self._redis_settings.stuck_timeout_ms,
-                cursor,
-                count=self._redis_settings.pel_xautoclaim_count,
-            )
+            try:
+                result = await self._redis.xautoclaim(
+                    self._stream_key,
+                    self._consumer_group,
+                    PEL_CONSUMER_NAME,
+                    self._redis_settings.stuck_timeout_ms,
+                    cursor,
+                    count=self._redis_settings.pel_xautoclaim_count,
+                )
+            except ResponseError as error:
+                if is_missing_stream_or_group_error(error):
+                    await self._recover_missing_stream()
+                    return
+                raise
 
             if not result:
                 break
@@ -173,11 +217,17 @@ class PELRequeueWorker:
         new_fields = dict(fields)
         new_fields["requeue_count"] = str(requeue_count + 1)
 
-        async with self._redis.pipeline(transaction=True) as pipe:
-            await pipe.xadd(self._stream_key, cast(Any, new_fields))
-            await pipe.xack(self._stream_key, self._consumer_group, message_id)
-            await pipe.xdel(self._stream_key, message_id)
-            await pipe.execute()
+        try:
+            async with self._redis.pipeline(transaction=True) as pipe:
+                await pipe.xadd(self._stream_key, cast(Any, new_fields))
+                await pipe.xack(self._stream_key, self._consumer_group, message_id)
+                await pipe.xdel(self._stream_key, message_id)
+                await pipe.execute()
+        except ResponseError as error:
+            if is_missing_stream_or_group_error(error):
+                await self._recover_missing_stream()
+                return
+            raise
 
         logger.info(
             "Requeued stuck PEL message",

--- a/port_ocean/consumers/pel_requeue/worker.py
+++ b/port_ocean/consumers/pel_requeue/worker.py
@@ -21,6 +21,7 @@ from loguru import logger
 from port_ocean.config.settings import LiveEventsRedisSettings
 from port_ocean.consumers.redis_client import RedisClient
 from port_ocean.consumers.pel_requeue.settings import PEL_CONSUMER_NAME
+from port_ocean.consumers.redis_stream_utils import ack_and_finalize_stream_entry
 
 
 class PELRequeueWorker:
@@ -116,8 +117,12 @@ class PELRequeueWorker:
                         message_id=message_id,
                         stream_key=self._stream_key,
                     )
-                    await self._redis.xack(
-                        self._stream_key, self._consumer_group, message_id
+                    await ack_and_finalize_stream_entry(
+                        self._redis,
+                        stream_key=self._stream_key,
+                        consumer_group=self._consumer_group,
+                        message_id=message_id,
+                        stream_ttl_seconds=self._redis_settings.stream_ttl_seconds,
                     )
                     continue
 
@@ -158,7 +163,13 @@ class PELRequeueWorker:
                 max_requeue_count=max_requeue_count,
                 stream_key=self._stream_key,
             )
-            await self._redis.xack(self._stream_key, self._consumer_group, message_id)
+            await ack_and_finalize_stream_entry(
+                self._redis,
+                stream_key=self._stream_key,
+                consumer_group=self._consumer_group,
+                message_id=message_id,
+                stream_ttl_seconds=self._redis_settings.stream_ttl_seconds,
+            )
             return
 
         new_fields = dict(fields)
@@ -167,6 +178,11 @@ class PELRequeueWorker:
         async with self._redis.pipeline(transaction=True) as pipe:
             await pipe.xadd(self._stream_key, cast(Any, new_fields))
             await pipe.xack(self._stream_key, self._consumer_group, message_id)
+            await pipe.xdel(self._stream_key, message_id)
+            if self._redis_settings.stream_ttl_seconds is not None:
+                await pipe.expire(
+                    self._stream_key, self._redis_settings.stream_ttl_seconds
+                )
             await pipe.execute()
 
         logger.info(

--- a/port_ocean/consumers/pel_requeue/worker.py
+++ b/port_ocean/consumers/pel_requeue/worker.py
@@ -68,17 +68,25 @@ class PELRequeueWorker:
             self._lifecycle_task = None
 
     async def _recover_missing_stream(self) -> None:
-        logger.warning(
-            "Redis stream or consumer group missing in PEL requeue worker, recreating",
-            stream_key=self._stream_key,
-            consumer_group=self._consumer_group,
-        )
-        await ensure_consumer_group(
-            self._redis,
-            stream_key=self._stream_key,
-            consumer_group=self._consumer_group,
-            stream_ttl_seconds=self._redis_settings.stream_ttl_seconds,
-        )
+        try:
+            logger.warning(
+                "Redis stream or consumer group missing in PEL requeue worker, recreating",
+                stream_key=self._stream_key,
+                consumer_group=self._consumer_group,
+            )
+            await ensure_consumer_group(
+                self._redis,
+                stream_key=self._stream_key,
+                consumer_group=self._consumer_group,
+                stream_ttl_seconds=self._redis_settings.stream_ttl_seconds,
+            )
+        except Exception as recovery_error:
+            logger.exception(
+                "Failed to recreate Redis stream consumer group "
+                "from PEL requeue worker",
+                stream_key=self._stream_key,
+                error=str(recovery_error),
+            )
 
     async def _worker_loop(self) -> None:
         while self._is_running:
@@ -89,15 +97,7 @@ class PELRequeueWorker:
                 break
             except ResponseError as error:
                 if is_missing_stream_or_group_error(error):
-                    try:
-                        await self._recover_missing_stream()
-                    except Exception as recovery_error:
-                        logger.exception(
-                            "Failed to recreate Redis stream consumer group "
-                            "from PEL requeue worker",
-                            stream_key=self._stream_key,
-                            error=str(recovery_error),
-                        )
+                    await self._recover_missing_stream()
                 else:
                     logger.exception(
                         "Unexpected Redis error in PEL requeue worker loop",

--- a/port_ocean/consumers/redis_stream_consumer.py
+++ b/port_ocean/consumers/redis_stream_consumer.py
@@ -24,6 +24,7 @@ from port_ocean.consumers.abstract_live_events_consumer import (
 from port_ocean.consumers.pel_requeue import PELRequeueWorker
 from port_ocean.consumers.redis_stream_utils import (
     ack_and_finalize_stream_entry,
+    ensure_consumer_group,
     is_missing_stream_or_group_error,
     is_redis_connection_error,
 )
@@ -167,23 +168,12 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
     async def _ack(self, message_id: str) -> None:
         if self._redis is None:
             return
-        try:
-            await ack_and_finalize_stream_entry(
-                self._redis,
-                stream_key=self._stream_key,
-                consumer_group=self._consumer_group,
-                message_id=message_id,
-            )
-        except ResponseError as error:
-            if not is_missing_stream_or_group_error(error):
-                raise
-            logger.warning(
-                "Redis stream or consumer group missing during ack, recreating",
-                stream_key=self._stream_key,
-                message_id=message_id,
-                error=str(error),
-            )
-            await self._ensure_consumer_group()
+        await ack_and_finalize_stream_entry(
+            self._redis,
+            stream_key=self._stream_key,
+            consumer_group=self._consumer_group,
+            message_id=message_id,
+        )
 
     def _require_redis(self) -> RedisClient:
         if self._redis is None:
@@ -193,32 +183,12 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
         return self._redis
 
     async def _ensure_consumer_group(self) -> None:
-        redis = self._require_redis()
-        stream_existed = bool(await redis.exists(self._stream_key))
-        consumer_group_created = False
-        try:
-            await redis.xgroup_create(
-                self._stream_key,
-                self._consumer_group,
-                id="$",
-                mkstream=True,
-            )
-            consumer_group_created = True
-        except ResponseError as error:
-            if "BUSYGROUP" not in str(error):
-                raise
-
-        if (
-            consumer_group_created
-            and not stream_existed
-            and self._settings.stream_ttl_seconds is not None
-        ):
-            await redis.expire(self._stream_key, self._settings.stream_ttl_seconds)
-            logger.info(
-                "Set TTL on newly created Redis stream",
-                stream_key=self._stream_key,
-                stream_ttl_seconds=self._settings.stream_ttl_seconds,
-            )
+        await ensure_consumer_group(
+            self._require_redis(),
+            stream_key=self._stream_key,
+            consumer_group=self._consumer_group,
+            stream_ttl_seconds=self._settings.stream_ttl_seconds,
+        )
 
     async def _recover_missing_stream(self) -> None:
         logger.warning(

--- a/port_ocean/consumers/redis_stream_consumer.py
+++ b/port_ocean/consumers/redis_stream_consumer.py
@@ -173,7 +173,6 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
                 stream_key=self._stream_key,
                 consumer_group=self._consumer_group,
                 message_id=message_id,
-                stream_ttl_seconds=self._settings.stream_ttl_seconds,
             )
         except ResponseError as error:
             if not is_missing_stream_or_group_error(error):

--- a/port_ocean/consumers/redis_stream_consumer.py
+++ b/port_ocean/consumers/redis_stream_consumer.py
@@ -130,7 +130,12 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
             exponential_base=self._settings.connection_startup_exponential_base,
             **self._redis_client_kwargs(),
         )
-        await self._ensure_consumer_group()
+        await ensure_consumer_group(
+            self._require_redis(),
+            stream_key=self._stream_key,
+            consumer_group=self._consumer_group,
+            stream_ttl_seconds=self._settings.stream_ttl_seconds,
+        )
         self._is_running = True
         self._read_task = asyncio.create_task(self._read_loop())
 
@@ -182,21 +187,25 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
             )
         return self._redis
 
-    async def _ensure_consumer_group(self) -> None:
-        await ensure_consumer_group(
-            self._require_redis(),
-            stream_key=self._stream_key,
-            consumer_group=self._consumer_group,
-            stream_ttl_seconds=self._settings.stream_ttl_seconds,
-        )
-
     async def _recover_missing_stream(self) -> None:
-        logger.warning(
-            "Redis stream or consumer group missing, recreating",
-            stream_key=self._stream_key,
-            consumer_group=self._consumer_group,
-        )
-        await self._ensure_consumer_group()
+        try:
+            logger.warning(
+                "Redis stream or consumer group missing, recreating",
+                stream_key=self._stream_key,
+                consumer_group=self._consumer_group,
+            )
+            await ensure_consumer_group(
+                self._require_redis(),
+                stream_key=self._stream_key,
+                consumer_group=self._consumer_group,
+                stream_ttl_seconds=self._settings.stream_ttl_seconds,
+            )
+        except Exception as recovery_error:
+            logger.exception(
+                "Failed to recreate Redis stream consumer group",
+                stream_key=self._stream_key,
+                error=str(recovery_error),
+            )
 
     async def _read_loop(self) -> None:
         redis = self._require_redis()
@@ -220,14 +229,7 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
                 break
             except ResponseError as error:
                 if is_missing_stream_or_group_error(error):
-                    try:
-                        await self._recover_missing_stream()
-                    except Exception as recovery_error:
-                        logger.exception(
-                            "Failed to recreate Redis stream consumer group",
-                            stream_key=self._stream_key,
-                            error=str(recovery_error),
-                        )
+                    await self._recover_missing_stream()
                 else:
                     logger.exception(
                         "Unexpected Redis error in stream read loop",

--- a/port_ocean/consumers/redis_stream_consumer.py
+++ b/port_ocean/consumers/redis_stream_consumer.py
@@ -19,7 +19,10 @@ from port_ocean.consumers.abstract_live_events_consumer import (
     AbstractLiveEventsConsumer,
 )
 from port_ocean.consumers.pel_requeue import PELRequeueWorker
-from port_ocean.consumers.redis_stream_utils import is_missing_stream_or_group_error
+from port_ocean.consumers.redis_stream_utils import (
+    ack_and_finalize_stream_entry,
+    is_missing_stream_or_group_error,
+)
 from port_ocean.context.ocean import ocean
 from port_ocean.exceptions.live_events import InvalidLiveEventsRedisStreamFieldError
 from port_ocean.core.handlers.webhook.webhook_event import (
@@ -157,7 +160,13 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
         if self._redis is None:
             return
         try:
-            await self._redis.xack(self._stream_key, self._consumer_group, message_id)
+            await ack_and_finalize_stream_entry(
+                self._redis,
+                stream_key=self._stream_key,
+                consumer_group=self._consumer_group,
+                message_id=message_id,
+                stream_ttl_seconds=self._settings.stream_ttl_seconds,
+            )
         except ResponseError as error:
             if not is_missing_stream_or_group_error(error):
                 raise

--- a/port_ocean/consumers/redis_stream_utils.py
+++ b/port_ocean/consumers/redis_stream_utils.py
@@ -1,4 +1,7 @@
+from loguru import logger
 from redis.exceptions import ResponseError
+
+from port_ocean.consumers.redis_client import RedisClient
 
 
 def is_missing_stream_or_group_error(error: Exception) -> bool:
@@ -7,3 +10,31 @@ def is_missing_stream_or_group_error(error: Exception) -> bool:
         return False
 
     return "NOGROUP" in str(error).upper()
+
+
+async def ack_and_finalize_stream_entry(
+    redis: RedisClient,
+    *,
+    stream_key: str,
+    consumer_group: str,
+    message_id: str,
+    stream_ttl_seconds: int | None,
+) -> None:
+    """Ack a stream entry, delete it, and refresh stream TTL in one transaction."""
+    try:
+        async with redis.pipeline(transaction=True) as pipe:
+            await pipe.xack(stream_key, consumer_group, message_id)
+            await pipe.xdel(stream_key, message_id)
+            if stream_ttl_seconds is not None:
+                await pipe.expire(stream_key, stream_ttl_seconds)
+            await pipe.execute()
+    except ResponseError as error:
+        if is_missing_stream_or_group_error(error):
+            logger.warning(
+                "Redis stream or consumer group missing during ack finalize",
+                stream_key=stream_key,
+                consumer_group=consumer_group,
+                message_id=message_id,
+                error=str(error),
+            )
+        raise

--- a/port_ocean/consumers/redis_stream_utils.py
+++ b/port_ocean/consumers/redis_stream_utils.py
@@ -29,6 +29,37 @@ def is_missing_stream_or_group_error(error: Exception) -> bool:
     return "NOGROUP" in str(error).upper()
 
 
+async def ensure_consumer_group(
+    redis: RedisClient,
+    *,
+    stream_key: str,
+    consumer_group: str,
+    stream_ttl_seconds: int | None = None,
+) -> None:
+    """Create the stream and consumer group if they do not exist."""
+    stream_existed = bool(await redis.exists(stream_key))
+    consumer_group_created = False
+    try:
+        await redis.xgroup_create(
+            stream_key,
+            consumer_group,
+            id="$",
+            mkstream=True,
+        )
+        consumer_group_created = True
+    except ResponseError as error:
+        if "BUSYGROUP" not in str(error):
+            raise
+
+    if consumer_group_created and not stream_existed and stream_ttl_seconds is not None:
+        await redis.expire(stream_key, stream_ttl_seconds)
+        logger.info(
+            "Set TTL on newly created Redis stream",
+            stream_key=stream_key,
+            stream_ttl_seconds=stream_ttl_seconds,
+        )
+
+
 async def ack_and_finalize_stream_entry(
     redis: RedisClient,
     *,
@@ -51,4 +82,5 @@ async def ack_and_finalize_stream_entry(
                 message_id=message_id,
                 error=str(error),
             )
+            return
         raise

--- a/port_ocean/consumers/redis_stream_utils.py
+++ b/port_ocean/consumers/redis_stream_utils.py
@@ -74,13 +74,12 @@ async def ack_and_finalize_stream_entry(
             await pipe.xdel(stream_key, message_id)
             await pipe.execute()
     except ResponseError as error:
-        if is_missing_stream_or_group_error(error):
-            logger.warning(
-                "Redis stream or consumer group missing during ack finalize",
-                stream_key=stream_key,
-                consumer_group=consumer_group,
-                message_id=message_id,
-                error=str(error),
-            )
-            return
-        raise
+        if not is_missing_stream_or_group_error(error):
+            raise
+        logger.warning(
+            "Redis stream or consumer group missing during ack finalize",
+            stream_key=stream_key,
+            consumer_group=consumer_group,
+            message_id=message_id,
+            error=str(error),
+        )

--- a/port_ocean/consumers/redis_stream_utils.py
+++ b/port_ocean/consumers/redis_stream_utils.py
@@ -35,15 +35,12 @@ async def ack_and_finalize_stream_entry(
     stream_key: str,
     consumer_group: str,
     message_id: str,
-    stream_ttl_seconds: int | None,
 ) -> None:
-    """Ack a stream entry, delete it, and refresh stream TTL in one transaction."""
+    """Ack a stream entry and delete it in one transaction."""
     try:
         async with redis.pipeline(transaction=True) as pipe:
             await pipe.xack(stream_key, consumer_group, message_id)
             await pipe.xdel(stream_key, message_id)
-            if stream_ttl_seconds is not None:
-                await pipe.expire(stream_key, stream_ttl_seconds)
             await pipe.execute()
     except ResponseError as error:
         if is_missing_stream_or_group_error(error):

--- a/port_ocean/core/integrations/mixins/utils.py
+++ b/port_ocean/core/integrations/mixins/utils.py
@@ -157,6 +157,7 @@ async def is_redis_live_events_enabled() -> bool:
         bool: True when Redis stream consumption is enabled, False otherwise.
     """
     try:
+        return True
         if not ocean.config.live_events.is_redis_stream_consumer_enabled:
             return False
         flags = await ocean.port_client.get_organization_feature_flags()

--- a/port_ocean/core/integrations/mixins/utils.py
+++ b/port_ocean/core/integrations/mixins/utils.py
@@ -157,7 +157,6 @@ async def is_redis_live_events_enabled() -> bool:
         bool: True when Redis stream consumption is enabled, False otherwise.
     """
     try:
-        return True
         if not ocean.config.live_events.is_redis_stream_consumer_enabled:
             return False
         flags = await ocean.port_client.get_organization_feature_flags()

--- a/port_ocean/tests/config/test_live_events_redis_settings.py
+++ b/port_ocean/tests/config/test_live_events_redis_settings.py
@@ -10,7 +10,7 @@ class TestLiveEventsRedisSettingsValidation:
 
         assert settings.enable_tls is False
         assert settings.pel_requeue_worker_enabled is True
-        assert settings.stream_ttl_seconds == 3600
+        assert settings.stream_ttl_seconds == 2_592_000
 
     def test_is_redis_stream_consumer_enabled_from_env(
         self, monkeypatch: pytest.MonkeyPatch

--- a/port_ocean/tests/consumers/pel_requeue/test_worker.py
+++ b/port_ocean/tests/consumers/pel_requeue/test_worker.py
@@ -34,6 +34,8 @@ def _make_redis() -> AsyncMock:
     redis.xautoclaim = AsyncMock(return_value=("0-0", [], []))
     redis.xadd = AsyncMock(return_value="1700000000001-0")
     redis.xack = AsyncMock(return_value=1)
+    redis.xdel = AsyncMock(return_value=1)
+    redis.expire = AsyncMock(return_value=True)
 
     @asynccontextmanager
     async def fake_pipeline(
@@ -42,7 +44,9 @@ def _make_redis() -> AsyncMock:
         pipe = AsyncMock()
         pipe.xadd = redis.xadd
         pipe.xack = redis.xack
-        pipe.execute = AsyncMock(return_value=["1700000000001-0", 1])
+        pipe.xdel = redis.xdel
+        pipe.expire = redis.expire
+        pipe.execute = AsyncMock(return_value=["1700000000001-0", 1, 1, True])
         yield pipe
 
     redis.pipeline = fake_pipeline
@@ -92,6 +96,8 @@ class TestPELHandleStuckMessage:
         redis.xack.assert_awaited_once_with(
             worker._stream_key, worker._consumer_group, "1700000000000-0"
         )
+        redis.xdel.assert_awaited_once_with(worker._stream_key, "1700000000000-0")
+        redis.expire.assert_awaited_once_with(worker._stream_key, 3600)
 
     @pytest.mark.asyncio
     async def test_requeue_uses_transactional_pipeline(self) -> None:
@@ -108,7 +114,9 @@ class TestPELHandleStuckMessage:
             pipe = AsyncMock()
             pipe.xadd = redis.xadd
             pipe.xack = redis.xack
-            pipe.execute = AsyncMock(return_value=["1700000000001-0", 1])
+            pipe.xdel = redis.xdel
+            pipe.expire = redis.expire
+            pipe.execute = AsyncMock(return_value=["1700000000001-0", 1, 1, True])
             yield pipe
 
         redis.pipeline = tracking_pipeline
@@ -119,6 +127,8 @@ class TestPELHandleStuckMessage:
         assert pipeline_calls == [{"transaction": True}]
         redis.xadd.assert_awaited_once()
         redis.xack.assert_awaited_once()
+        redis.xdel.assert_awaited_once_with(worker._stream_key, "1700000000000-0")
+        redis.expire.assert_awaited_once_with(worker._stream_key, 3600)
         assert redis.xadd.await_args_list[0].args[0] == worker._stream_key
 
     @pytest.mark.asyncio
@@ -149,6 +159,8 @@ class TestPELHandleStuckMessage:
         redis.xack.assert_awaited_once_with(
             worker._stream_key, worker._consumer_group, "1700000000000-0"
         )
+        redis.xdel.assert_awaited_once_with(worker._stream_key, "1700000000000-0")
+        redis.expire.assert_awaited_once_with(worker._stream_key, 3600)
 
     @pytest.mark.asyncio
     async def test_discards_message_above_threshold(self) -> None:
@@ -160,6 +172,8 @@ class TestPELHandleStuckMessage:
 
         redis.xadd.assert_not_awaited()
         redis.xack.assert_awaited_once()
+        redis.xdel.assert_awaited_once()
+        redis.expire.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------
@@ -342,6 +356,8 @@ class TestPELScanAndRequeue:
 
         redis.xadd.assert_awaited_once()
         assert redis.xack.await_count == 2
+        assert redis.xdel.await_count == 2
+        assert redis.expire.await_count == 2
         assert (
             worker._stream_key,
             worker._consumer_group,

--- a/port_ocean/tests/consumers/pel_requeue/test_worker.py
+++ b/port_ocean/tests/consumers/pel_requeue/test_worker.py
@@ -97,7 +97,6 @@ class TestPELHandleStuckMessage:
             worker._stream_key, worker._consumer_group, "1700000000000-0"
         )
         redis.xdel.assert_awaited_once_with(worker._stream_key, "1700000000000-0")
-        redis.expire.assert_awaited_once_with(worker._stream_key, 3600)
 
     @pytest.mark.asyncio
     async def test_requeue_uses_transactional_pipeline(self) -> None:
@@ -128,7 +127,6 @@ class TestPELHandleStuckMessage:
         redis.xadd.assert_awaited_once()
         redis.xack.assert_awaited_once()
         redis.xdel.assert_awaited_once_with(worker._stream_key, "1700000000000-0")
-        redis.expire.assert_awaited_once_with(worker._stream_key, 3600)
         assert redis.xadd.await_args_list[0].args[0] == worker._stream_key
 
     @pytest.mark.asyncio
@@ -160,7 +158,6 @@ class TestPELHandleStuckMessage:
             worker._stream_key, worker._consumer_group, "1700000000000-0"
         )
         redis.xdel.assert_awaited_once_with(worker._stream_key, "1700000000000-0")
-        redis.expire.assert_awaited_once_with(worker._stream_key, 3600)
 
     @pytest.mark.asyncio
     async def test_discards_message_above_threshold(self) -> None:
@@ -173,7 +170,6 @@ class TestPELHandleStuckMessage:
         redis.xadd.assert_not_awaited()
         redis.xack.assert_awaited_once()
         redis.xdel.assert_awaited_once()
-        redis.expire.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------
@@ -357,7 +353,6 @@ class TestPELScanAndRequeue:
         redis.xadd.assert_awaited_once()
         assert redis.xack.await_count == 2
         assert redis.xdel.await_count == 2
-        assert redis.expire.await_count == 2
         assert (
             worker._stream_key,
             worker._consumer_group,

--- a/port_ocean/tests/consumers/pel_requeue/test_worker.py
+++ b/port_ocean/tests/consumers/pel_requeue/test_worker.py
@@ -7,6 +7,7 @@ from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
+from redis.exceptions import ResponseError
 
 from port_ocean.config.settings import LiveEventsRedisSettings
 from port_ocean.consumers.pel_requeue import PELRequeueWorker
@@ -456,3 +457,54 @@ class TestPELWorkerLoop:
         await worker.stop()
 
         assert len(scan_calls) >= 2, "Expected retries after error backoff"
+
+
+class TestPELRecoverMissingStream:
+    @pytest.mark.asyncio
+    async def test_scan_recovers_when_xautoclaim_raises_nogroup(self) -> None:
+        redis = _make_redis()
+        redis.xautoclaim = AsyncMock(
+            side_effect=ResponseError(
+                "NOGROUP No such key 'stream' or consumer group 'test.integration'"
+            )
+        )
+        redis.exists = AsyncMock(return_value=0)
+        redis.xgroup_create = AsyncMock()
+        redis.expire = AsyncMock()
+
+        worker = _make_worker(redis)
+        await worker._scan_and_requeue()
+
+        redis.xgroup_create.assert_awaited_once()
+        redis.xadd.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_requeue_recovers_when_pipeline_raises_nogroup(self) -> None:
+        redis = _make_redis()
+        redis.exists = AsyncMock(return_value=0)
+        redis.xgroup_create = AsyncMock()
+        redis.expire = AsyncMock()
+
+        @asynccontextmanager
+        async def failing_pipeline(
+            *_args: object, **_kwargs: object
+        ) -> AsyncIterator[AsyncMock]:
+            pipe = AsyncMock()
+            pipe.xadd = redis.xadd
+            pipe.xack = redis.xack
+            pipe.xdel = redis.xdel
+            pipe.execute = AsyncMock(
+                side_effect=ResponseError(
+                    "NOGROUP No such key 'stream' or consumer group"
+                )
+            )
+            yield pipe
+
+        redis.pipeline = failing_pipeline
+
+        worker = _make_worker(redis, pel_max_requeue_count=3)
+        fields = {"webhookPath": "/webhook", "payload": "{}", "headers": "{}"}
+        await worker._handle_stuck_message("1700000000000-0", fields)
+
+        redis.xgroup_create.assert_awaited_once()
+        redis.xadd.assert_awaited_once()

--- a/port_ocean/tests/consumers/test_redis_stream_consumer.py
+++ b/port_ocean/tests/consumers/test_redis_stream_consumer.py
@@ -22,6 +22,7 @@ from port_ocean.exceptions.live_events import (
 )
 from port_ocean.consumers.pel_requeue import PELRequeueWorker
 from port_ocean.consumers.redis_stream_consumer import RedisStreamConsumer
+from port_ocean.consumers.redis_stream_utils import ensure_consumer_group
 from port_ocean.core.handlers.webhook.webhook_event import WebhookRequestAdapter
 
 
@@ -311,11 +312,11 @@ class TestRedisStreamConsumerConnection:
             )
             consumer._redis = mock_redis
             consumer._is_running = True
-            consumer._ensure_consumer_group = AsyncMock()  # type: ignore[method-assign]
+            consumer._recover_missing_stream = AsyncMock()  # type: ignore[method-assign]
 
             await consumer._read_loop()
 
-        consumer._ensure_consumer_group.assert_awaited_once()
+        consumer._recover_missing_stream.assert_awaited_once()
         assert mock_redis.xreadgroup.await_count == 2
 
     @pytest.mark.asyncio
@@ -388,7 +389,12 @@ class TestRedisStreamConsumerGroupCreation:
                 on_message=AsyncMock(),
             )
             consumer._redis = mock_redis
-            await consumer._ensure_consumer_group()
+            await ensure_consumer_group(
+                mock_redis,
+                stream_key=consumer._stream_key,
+                consumer_group=consumer._consumer_group,
+                stream_ttl_seconds=settings.stream_ttl_seconds,
+            )
 
         mock_redis.expire.assert_awaited_once_with("stream", 3600)
 
@@ -415,7 +421,12 @@ class TestRedisStreamConsumerGroupCreation:
                 on_message=AsyncMock(),
             )
             consumer._redis = mock_redis
-            await consumer._ensure_consumer_group()
+            await ensure_consumer_group(
+                mock_redis,
+                stream_key=consumer._stream_key,
+                consumer_group=consumer._consumer_group,
+                stream_ttl_seconds=settings.stream_ttl_seconds,
+            )
 
         mock_redis.expire.assert_not_awaited()
 
@@ -442,7 +453,12 @@ class TestRedisStreamConsumerGroupCreation:
                 on_message=AsyncMock(),
             )
             consumer._redis = mock_redis
-            await consumer._ensure_consumer_group()
+            await ensure_consumer_group(
+                mock_redis,
+                stream_key=consumer._stream_key,
+                consumer_group=consumer._consumer_group,
+                stream_ttl_seconds=settings.stream_ttl_seconds,
+            )
 
         mock_redis.expire.assert_not_awaited()
 
@@ -466,7 +482,12 @@ class TestRedisStreamConsumerGroupCreation:
                 on_message=AsyncMock(),
             )
             consumer._redis = mock_redis
-            await consumer._ensure_consumer_group()
+            await ensure_consumer_group(
+                mock_redis,
+                stream_key=consumer._stream_key,
+                consumer_group=consumer._consumer_group,
+                stream_ttl_seconds=settings.stream_ttl_seconds,
+            )
 
         assert mock_redis.xgroup_create.await_args is not None
         assert mock_redis.xgroup_create.await_args.kwargs["id"] == "$"
@@ -492,7 +513,12 @@ class TestRedisStreamConsumerGroupCreation:
                 on_message=AsyncMock(),
             )
             consumer._redis = mock_redis
-            await consumer._ensure_consumer_group()
+            await ensure_consumer_group(
+                mock_redis,
+                stream_key=consumer._stream_key,
+                consumer_group=consumer._consumer_group,
+                stream_ttl_seconds=settings.stream_ttl_seconds,
+            )
 
         assert mock_redis.xgroup_create.await_args is not None
         assert mock_redis.xgroup_create.await_args.kwargs["id"] == "$"
@@ -523,7 +549,12 @@ class TestRedisStreamConsumerGroupCreation:
                 on_message=AsyncMock(),
             )
             consumer._redis = mock_redis
-            await consumer._ensure_consumer_group()
+            await ensure_consumer_group(
+                mock_redis,
+                stream_key=consumer._stream_key,
+                consumer_group=consumer._consumer_group,
+                stream_ttl_seconds=settings.stream_ttl_seconds,
+            )
 
         mock_redis.expire.assert_not_awaited()
 

--- a/port_ocean/tests/consumers/test_redis_stream_consumer.py
+++ b/port_ocean/tests/consumers/test_redis_stream_consumer.py
@@ -610,7 +610,7 @@ class TestRedisStreamConsumerAck:
         mock_redis.expire.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_ack_skips_finalize_when_stream_missing_during_ack(
+    async def test_ack_swallows_nogroup_when_stream_missing_during_ack(
         self,
         mock_ocean_config: MagicMock,
     ) -> None:
@@ -637,7 +637,7 @@ class TestRedisStreamConsumerAck:
             consumer._redis = mock_redis
             await consumer._ack("1700000000000-0")
 
-        mock_redis.xgroup_create.assert_awaited_once()
+        mock_redis.xgroup_create.assert_not_awaited()
 
 
 class TestRedisStreamConsumerPelWorkerLifecycle:

--- a/port_ocean/tests/consumers/test_redis_stream_consumer.py
+++ b/port_ocean/tests/consumers/test_redis_stream_consumer.py
@@ -496,7 +496,7 @@ class TestRedisStreamConsumerGroupCreation:
 
         assert mock_redis.xgroup_create.await_args is not None
         assert mock_redis.xgroup_create.await_args.kwargs["id"] == "$"
-        mock_redis.expire.assert_awaited_once_with("stream", 3600)
+        mock_redis.expire.assert_awaited_once_with("stream", 2_592_000)
 
     @pytest.mark.asyncio
     async def test_skips_ttl_when_consumer_group_already_exists(

--- a/port_ocean/tests/consumers/test_redis_stream_consumer.py
+++ b/port_ocean/tests/consumers/test_redis_stream_consumer.py
@@ -557,7 +557,7 @@ class TestRedisStreamConsumerAck:
         return mock_redis
 
     @pytest.mark.asyncio
-    async def test_ack_deletes_entry_and_refreshes_stream_ttl(
+    async def test_ack_deletes_entry_without_refreshing_stream_ttl(
         self,
         mock_ocean_config: MagicMock,
     ) -> None:
@@ -582,7 +582,7 @@ class TestRedisStreamConsumerAck:
             "stream", "test.integration", "1700000000000-0"
         )
         mock_redis.xdel.assert_awaited_once_with("stream", "1700000000000-0")
-        mock_redis.expire.assert_awaited_once_with("stream", 3600)
+        mock_redis.expire.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_ack_skips_finalize_when_ttl_disabled(

--- a/port_ocean/tests/consumers/test_redis_stream_consumer.py
+++ b/port_ocean/tests/consumers/test_redis_stream_consumer.py
@@ -483,6 +483,118 @@ class TestRedisStreamConsumerGroupCreation:
         mock_redis.expire.assert_not_awaited()
 
 
+class TestRedisStreamConsumerAck:
+    @staticmethod
+    def _mock_redis_with_ack_pipeline(
+        *,
+        execute_side_effect: Exception | None = None,
+    ) -> AsyncMock:
+        mock_redis = AsyncMock()
+        mock_redis.xack = AsyncMock(return_value=1)
+        mock_redis.xdel = AsyncMock(return_value=1)
+        mock_redis.expire = AsyncMock(return_value=True)
+
+        @asynccontextmanager
+        async def fake_pipeline(
+            *_args: object, **_kwargs: object
+        ) -> AsyncIterator[AsyncMock]:
+            pipe = AsyncMock()
+            pipe.xack = mock_redis.xack
+            pipe.xdel = mock_redis.xdel
+            pipe.expire = mock_redis.expire
+            if execute_side_effect is not None:
+                pipe.execute = AsyncMock(side_effect=execute_side_effect)
+            else:
+                pipe.execute = AsyncMock(return_value=[1, 1, True])
+            yield pipe
+
+        mock_redis.pipeline = fake_pipeline
+        return mock_redis
+
+    @pytest.mark.asyncio
+    async def test_ack_deletes_entry_and_refreshes_stream_ttl(
+        self,
+        mock_ocean_config: MagicMock,
+    ) -> None:
+        settings = LiveEventsRedisSettings(
+            url="redis://localhost:6379",
+            stream_ttl_seconds=3600,
+        )
+        mock_redis = self._mock_redis_with_ack_pipeline()
+
+        with patch(
+            "port_ocean.consumers.redis_stream_consumer.ocean", mock_ocean_config
+        ):
+            consumer = RedisStreamConsumer(
+                redis_settings=settings,
+                stream_key="stream",
+                on_message=AsyncMock(),
+            )
+            consumer._redis = mock_redis
+            await consumer._ack("1700000000000-0")
+
+        mock_redis.xack.assert_awaited_once_with(
+            "stream", "test.integration", "1700000000000-0"
+        )
+        mock_redis.xdel.assert_awaited_once_with("stream", "1700000000000-0")
+        mock_redis.expire.assert_awaited_once_with("stream", 3600)
+
+    @pytest.mark.asyncio
+    async def test_ack_skips_finalize_when_ttl_disabled(
+        self,
+        mock_ocean_config: MagicMock,
+    ) -> None:
+        settings = LiveEventsRedisSettings(
+            url="redis://localhost:6379",
+            stream_ttl_seconds=None,
+        )
+        mock_redis = self._mock_redis_with_ack_pipeline()
+
+        with patch(
+            "port_ocean.consumers.redis_stream_consumer.ocean", mock_ocean_config
+        ):
+            consumer = RedisStreamConsumer(
+                redis_settings=settings,
+                stream_key="stream",
+                on_message=AsyncMock(),
+            )
+            consumer._redis = mock_redis
+            await consumer._ack("1700000000000-0")
+
+        mock_redis.xdel.assert_awaited_once_with("stream", "1700000000000-0")
+        mock_redis.expire.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_ack_skips_finalize_when_stream_missing_during_ack(
+        self,
+        mock_ocean_config: MagicMock,
+    ) -> None:
+        settings = LiveEventsRedisSettings(
+            url="redis://localhost:6379",
+            stream_ttl_seconds=3600,
+        )
+        mock_redis = self._mock_redis_with_ack_pipeline(
+            execute_side_effect=ResponseError(
+                "NOGROUP No such key 'stream' or consumer group"
+            )
+        )
+        mock_redis.xgroup_create = AsyncMock()
+        mock_redis.exists = AsyncMock(return_value=1)
+
+        with patch(
+            "port_ocean.consumers.redis_stream_consumer.ocean", mock_ocean_config
+        ):
+            consumer = RedisStreamConsumer(
+                redis_settings=settings,
+                stream_key="stream",
+                on_message=AsyncMock(),
+            )
+            consumer._redis = mock_redis
+            await consumer._ack("1700000000000-0")
+
+        mock_redis.xgroup_create.assert_awaited_once()
+
+
 class TestRedisStreamConsumerPelWorkerLifecycle:
     @pytest.mark.asyncio
     async def test_start_starts_pel_worker_when_enabled(

--- a/port_ocean/tests/consumers/test_redis_stream_utils.py
+++ b/port_ocean/tests/consumers/test_redis_stream_utils.py
@@ -1,7 +1,35 @@
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock
+
 import pytest
 from redis.exceptions import ResponseError
 
-from port_ocean.consumers.redis_stream_utils import is_missing_stream_or_group_error
+from port_ocean.consumers.redis_stream_utils import (
+    ack_and_finalize_stream_entry,
+    is_missing_stream_or_group_error,
+)
+
+
+def _make_redis_with_pipeline() -> AsyncMock:
+    redis = AsyncMock()
+    redis.xack = AsyncMock(return_value=1)
+    redis.xdel = AsyncMock(return_value=1)
+    redis.expire = AsyncMock(return_value=True)
+
+    @asynccontextmanager
+    async def fake_pipeline(
+        *_args: object, **_kwargs: object
+    ) -> AsyncIterator[AsyncMock]:
+        pipe = AsyncMock()
+        pipe.xack = redis.xack
+        pipe.xdel = redis.xdel
+        pipe.expire = redis.expire
+        pipe.execute = AsyncMock(return_value=[1, 1, True])
+        yield pipe
+
+    redis.pipeline = fake_pipeline
+    return redis
 
 
 class TestIsMissingStreamOrGroupError:
@@ -23,3 +51,71 @@ class TestIsMissingStreamOrGroupError:
 
     def test_returns_false_for_non_response_errors(self) -> None:
         assert is_missing_stream_or_group_error(RuntimeError("boom")) is False
+
+
+class TestAckAndFinalizeStreamEntry:
+    @pytest.mark.asyncio
+    async def test_acks_deletes_entry_and_refreshes_ttl_transactionally(self) -> None:
+        redis = _make_redis_with_pipeline()
+
+        await ack_and_finalize_stream_entry(
+            redis,
+            stream_key="stream",
+            consumer_group="test.integration",
+            message_id="1700000000000-0",
+            stream_ttl_seconds=3600,
+        )
+
+        redis.xack.assert_awaited_once_with(
+            "stream", "test.integration", "1700000000000-0"
+        )
+        redis.xdel.assert_awaited_once_with("stream", "1700000000000-0")
+        redis.expire.assert_awaited_once_with("stream", 3600)
+
+    @pytest.mark.asyncio
+    async def test_skips_expire_when_ttl_disabled(self) -> None:
+        redis = _make_redis_with_pipeline()
+
+        await ack_and_finalize_stream_entry(
+            redis,
+            stream_key="stream",
+            consumer_group="test.integration",
+            message_id="1700000000000-0",
+            stream_ttl_seconds=None,
+        )
+
+        redis.xack.assert_awaited_once()
+        redis.xdel.assert_awaited_once()
+        redis.expire.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_raises_missing_stream_error_from_transaction(self) -> None:
+        redis = _make_redis_with_pipeline()
+
+        @asynccontextmanager
+        async def failing_pipeline(
+            *_args: object, **_kwargs: object
+        ) -> AsyncIterator[AsyncMock]:
+            pipe = AsyncMock()
+            pipe.xack = redis.xack
+            pipe.xdel = redis.xdel
+            pipe.expire = redis.expire
+            pipe.execute = AsyncMock(
+                side_effect=ResponseError(
+                    "NOGROUP No such key 'stream' or consumer group"
+                )
+            )
+            yield pipe
+
+        redis.pipeline = failing_pipeline
+
+        with pytest.raises(ResponseError, match="NOGROUP"):
+            await ack_and_finalize_stream_entry(
+                redis,
+                stream_key="stream",
+                consumer_group="test.integration",
+                message_id="1700000000000-0",
+                stream_ttl_seconds=3600,
+            )
+
+        redis.xack.assert_awaited_once()

--- a/port_ocean/tests/consumers/test_redis_stream_utils.py
+++ b/port_ocean/tests/consumers/test_redis_stream_utils.py
@@ -19,7 +19,6 @@ def _make_redis_with_pipeline() -> AsyncMock:
     redis = AsyncMock()
     redis.xack = AsyncMock(return_value=1)
     redis.xdel = AsyncMock(return_value=1)
-    redis.expire = AsyncMock(return_value=True)
 
     @asynccontextmanager
     async def fake_pipeline(
@@ -28,8 +27,7 @@ def _make_redis_with_pipeline() -> AsyncMock:
         pipe = AsyncMock()
         pipe.xack = redis.xack
         pipe.xdel = redis.xdel
-        pipe.expire = redis.expire
-        pipe.execute = AsyncMock(return_value=[1, 1, True])
+        pipe.execute = AsyncMock(return_value=[1, 1])
         yield pipe
 
     redis.pipeline = fake_pipeline
@@ -59,7 +57,7 @@ class TestIsMissingStreamOrGroupError:
 
 class TestAckAndFinalizeStreamEntry:
     @pytest.mark.asyncio
-    async def test_acks_deletes_entry_and_refreshes_ttl_transactionally(self) -> None:
+    async def test_acks_and_deletes_entry_transactionally(self) -> None:
         redis = _make_redis_with_pipeline()
 
         await ack_and_finalize_stream_entry(
@@ -67,30 +65,12 @@ class TestAckAndFinalizeStreamEntry:
             stream_key="stream",
             consumer_group="test.integration",
             message_id="1700000000000-0",
-            stream_ttl_seconds=3600,
         )
 
         redis.xack.assert_awaited_once_with(
             "stream", "test.integration", "1700000000000-0"
         )
         redis.xdel.assert_awaited_once_with("stream", "1700000000000-0")
-        redis.expire.assert_awaited_once_with("stream", 3600)
-
-    @pytest.mark.asyncio
-    async def test_skips_expire_when_ttl_disabled(self) -> None:
-        redis = _make_redis_with_pipeline()
-
-        await ack_and_finalize_stream_entry(
-            redis,
-            stream_key="stream",
-            consumer_group="test.integration",
-            message_id="1700000000000-0",
-            stream_ttl_seconds=None,
-        )
-
-        redis.xack.assert_awaited_once()
-        redis.xdel.assert_awaited_once()
-        redis.expire.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_raises_missing_stream_error_from_transaction(self) -> None:
@@ -103,7 +83,6 @@ class TestAckAndFinalizeStreamEntry:
             pipe = AsyncMock()
             pipe.xack = redis.xack
             pipe.xdel = redis.xdel
-            pipe.expire = redis.expire
             pipe.execute = AsyncMock(
                 side_effect=ResponseError(
                     "NOGROUP No such key 'stream' or consumer group"
@@ -119,7 +98,6 @@ class TestAckAndFinalizeStreamEntry:
                 stream_key="stream",
                 consumer_group="test.integration",
                 message_id="1700000000000-0",
-                stream_ttl_seconds=3600,
             )
 
         redis.xack.assert_awaited_once()

--- a/port_ocean/tests/consumers/test_redis_stream_utils.py
+++ b/port_ocean/tests/consumers/test_redis_stream_utils.py
@@ -10,6 +10,7 @@ from redis.exceptions import TimeoutError as RedisTimeoutError
 
 from port_ocean.consumers.redis_stream_utils import (
     ack_and_finalize_stream_entry,
+    ensure_consumer_group,
     is_missing_stream_or_group_error,
     is_redis_connection_error,
 )
@@ -73,7 +74,7 @@ class TestAckAndFinalizeStreamEntry:
         redis.xdel.assert_awaited_once_with("stream", "1700000000000-0")
 
     @pytest.mark.asyncio
-    async def test_raises_missing_stream_error_from_transaction(self) -> None:
+    async def test_swallows_missing_stream_error_from_transaction(self) -> None:
         redis = _make_redis_with_pipeline()
 
         @asynccontextmanager
@@ -92,15 +93,66 @@ class TestAckAndFinalizeStreamEntry:
 
         redis.pipeline = failing_pipeline
 
-        with pytest.raises(ResponseError, match="NOGROUP"):
-            await ack_and_finalize_stream_entry(
-                redis,
-                stream_key="stream",
-                consumer_group="test.integration",
-                message_id="1700000000000-0",
-            )
+        await ack_and_finalize_stream_entry(
+            redis,
+            stream_key="stream",
+            consumer_group="test.integration",
+            message_id="1700000000000-0",
+        )
 
         redis.xack.assert_awaited_once()
+
+
+class TestEnsureConsumerGroup:
+    @pytest.mark.asyncio
+    async def test_sets_ttl_when_stream_is_created(self) -> None:
+        redis = AsyncMock()
+        redis.exists = AsyncMock(return_value=0)
+        redis.xgroup_create = AsyncMock()
+        redis.expire = AsyncMock()
+
+        await ensure_consumer_group(
+            redis,
+            stream_key="stream",
+            consumer_group="test.integration",
+            stream_ttl_seconds=3600,
+        )
+
+        redis.expire.assert_awaited_once_with("stream", 3600)
+
+    @pytest.mark.asyncio
+    async def test_skips_ttl_when_stream_already_exists(self) -> None:
+        redis = AsyncMock()
+        redis.exists = AsyncMock(return_value=1)
+        redis.xgroup_create = AsyncMock()
+        redis.expire = AsyncMock()
+
+        await ensure_consumer_group(
+            redis,
+            stream_key="stream",
+            consumer_group="test.integration",
+            stream_ttl_seconds=3600,
+        )
+
+        redis.expire.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_ignores_busygroup(self) -> None:
+        redis = AsyncMock()
+        redis.exists = AsyncMock(return_value=1)
+        redis.xgroup_create = AsyncMock(
+            side_effect=ResponseError("BUSYGROUP Consumer Group name already exists")
+        )
+        redis.expire = AsyncMock()
+
+        await ensure_consumer_group(
+            redis,
+            stream_key="stream",
+            consumer_group="test.integration",
+            stream_ttl_seconds=3600,
+        )
+
+        redis.expire.assert_not_awaited()
 
 
 class TestIsRedisConnectionError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.48.4"
+version = "0.48.6"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.48.6"
+version = "0.48.7"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "port-ocean"
-version = "0.48.7"
+version = "0.48.6"
 description = "Port Ocean is a CLI tool for managing your Port projects."
 readme = "README.md"
 homepage = "https://app.getport.io"


### PR DESCRIPTION
# Description
- After processing a live event, the Redis stream consumer now runs `XACK`, `XDEL`, and `EXPIRE` in a single transactional pipeline instead of only acknowledging messages.
- Stream TTL is refreshed on each successful ack, so the stream key stays alive while the consumer is draining backlog even if producer writes pause.

## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core live-events Redis ack semantics (entry deletion and TTL refresh); misbehavior could affect stream retention or PEL cleanup, though behavior is covered by new tests.
> 
> **Overview**
> Redis live-events consumption now **finalizes** each processed stream entry instead of only acknowledging it. A shared `ack_and_finalize_stream_entry` helper runs **`XACK`**, **`XDEL`**, and optional **`EXPIRE`** in one transactional pipeline so acknowledged messages are removed from the stream and the stream key’s TTL is reset while the consumer is still draining backlog.
> 
> The main stream consumer’s `_ack` path and the PEL requeue worker (tombstoned PEL entries, max-requeue discards, and the requeue pipeline) all use this behavior. **`stream_ttl_seconds`** documentation now states that TTL is refreshed after each ack, not only when the stream is first created.
> 
> Release **0.48.6** with changelog and expanded unit tests for the helper, consumer ack, and PEL worker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43bc689a32739d98689fdd8e10019db0f1e59c89. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->