### PR TITLE
[CI] Fix Bash Early Exit In Apply Release

### DIFF
--- a/.github/workflows/apply-ocean-release.yml
+++ b/.github/workflows/apply-ocean-release.yml
@@ -94,7 +94,8 @@ jobs:
                   labels.append(path.split("/")[1])
 
           prefix = "[CoreBump]" if has_core else "[IntegrationBump]"
-          print(f"{prefix} Apply version and changelog for {', '.join(labels)}")
+          labels_text = ", ".join(labels)
+          print(f"{prefix} Apply version and changelog for {labels_text}")
           '
           )
           echo "pr_title=${PR_TITLE}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
# Description

What -

Why -

How -

## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to PR title generation in apply-ocean-release; no runtime or release logic is modified.
> 
> **Overview**
> Fixes the **Apply ocean release** workflow step that builds auto-PR titles from changed `pyproject.toml` paths.
> 
> The inline Python used `', '.join(labels)` inside a bash single-quoted `python3 -c` block, so the embedded `'` characters ended the shell string early and could break the step. Label joining is now done in a `labels_text` variable with double-quoted Python strings, and the print only interpolates `{labels_text}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da5081f0cafab56fba648b0a2ab63c192b093446. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->