### PR TITLE
[Integration][Gitlab-v2] retry file fetch with default branch when search ref is stale

### DIFF
--- a/integrations/gitlab-v2/.ocean-release/fix-stale-search-ref.yaml
+++ b/integrations/gitlab-v2/.ocean-release/fix-stale-search-ref.yaml
@@ -1,3 +1,3 @@
 bump: patch
 changelog-type: bugfix
-changelog: Fetch file content from each project's default branch instead of stale refs returned by GitLab search, and reuse prefetched project data during repo enrichment to avoid duplicate API calls.
+changelog: Retry file content fetch with the project's default branch when a stale ref from GitLab search returns empty, fixing 404 errors on renamed or deleted branches.

--- a/integrations/gitlab-v2/.ocean-release/fix-stale-search-ref.yaml
+++ b/integrations/gitlab-v2/.ocean-release/fix-stale-search-ref.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: bugfix
+changelog: Fetch file content from each project's default branch instead of stale refs returned by GitLab search, and reuse prefetched project data during repo enrichment to avoid duplicate API calls.

--- a/integrations/gitlab-v2/gitlab/clients/gitlab_client.py
+++ b/integrations/gitlab-v2/gitlab/clients/gitlab_client.py
@@ -1021,7 +1021,12 @@ class GitLabClient:
     async def _get_file_content_with_ref_heal(
         self, project_id: str, file_path: str, ref: str
     ) -> tuple[dict[str, Any], str]:
-        """Fetch file content, retrying with default_branch if the ref is stale."""
+        """Fetch file content, retrying with default_branch when the ref fails.
+
+        Stale refs from GitLab blob search are a group-search issue; project
+        search and repository tree already use the default branch. Webhooks
+        use live commit SHAs from push events, not search-index refs.
+        """
         file_data = await self.rest.get_file_data(project_id, file_path, ref)
 
         if not file_data:

--- a/integrations/gitlab-v2/gitlab/clients/gitlab_client.py
+++ b/integrations/gitlab-v2/gitlab/clients/gitlab_client.py
@@ -1049,9 +1049,7 @@ class GitLabClient:
 
         return file_data
 
-    async def _resolve_refs_from_projects(
-        self, batch: list[dict[str, Any]]
-    ) -> None:
+    async def _resolve_refs_from_projects(self, batch: list[dict[str, Any]]) -> None:
         pids = list({str(f["project_id"]) for f in batch})
         fetched = await asyncio.gather(*(self.get_project(pid) for pid in pids))
         projects = {pid: proj for pid, proj in zip(pids, fetched) if proj}

--- a/integrations/gitlab-v2/gitlab/clients/gitlab_client.py
+++ b/integrations/gitlab-v2/gitlab/clients/gitlab_client.py
@@ -1052,11 +1052,6 @@ class GitLabClient:
     async def _resolve_refs_from_projects(
         self, batch: list[dict[str, Any]]
     ) -> None:
-        """Replace stale search-index refs with each project's default_branch.
-
-        Mutates *batch* in-place.  Also stamps ``__repo`` so the downstream
-        ``_enrich_file_with_repo`` can skip a duplicate ``get_project`` call.
-        """
         pids = list({str(f["project_id"]) for f in batch})
         fetched = await asyncio.gather(*(self.get_project(pid) for pid in pids))
         projects = {pid: proj for pid, proj in zip(pids, fetched) if proj}

--- a/integrations/gitlab-v2/gitlab/clients/gitlab_client.py
+++ b/integrations/gitlab-v2/gitlab/clients/gitlab_client.py
@@ -1023,9 +1023,10 @@ class GitLabClient:
     ) -> tuple[dict[str, Any], str]:
         """Fetch file content, retrying with default_branch when the ref fails.
 
-        Stale refs from GitLab blob search are a group-search issue; project
-        search and repository tree already use the default branch. Webhooks
-        use live commit SHAs from push events, not search-index refs.
+        Stale refs from GitLab blob search are mainly a group-search issue; project
+        search omits ref so GitLab searches the default branch, and repository tree
+        uses it explicitly. Webhooks use live commit SHAs from push events, not
+        search-index refs.
         """
         file_data = await self.rest.get_file_data(project_id, file_path, ref)
 

--- a/integrations/gitlab-v2/gitlab/clients/gitlab_client.py
+++ b/integrations/gitlab-v2/gitlab/clients/gitlab_client.py
@@ -877,6 +877,9 @@ class GitLabClient:
         self,
         file: dict[str, Any],
     ) -> dict[str, Any]:
+        prefetched_repo = file.get("__repo")
+        if prefetched_repo is not None:
+            return {"file": file, "repo": prefetched_repo}
         repo = await self.get_project(file["project_id"])
         return {"file": file, "repo": repo}
 
@@ -1023,7 +1026,7 @@ class GitLabClient:
     ) -> dict[str, Any]:
         file_path = file.get("path", "")
         project_id = str(file["project_id"])
-        ref = file.get("ref", "main")
+        ref = file.get("ref") or "main"
 
         file_data = await self.rest.get_file_data(project_id, file_path, ref)
         file_data["project_id"] = project_id
@@ -1043,6 +1046,23 @@ class GitLabClient:
             file_data["content"] = parsed_content
 
         return file_data
+
+    async def _resolve_refs_from_projects(
+        self, batch: list[dict[str, Any]]
+    ) -> None:
+        """Replace stale search-index refs with each project's default_branch.
+
+        Mutates *batch* in-place.  Also stamps ``__repo`` so the downstream
+        ``_enrich_file_with_repo`` can skip a duplicate ``get_project`` call.
+        """
+        pids = list({str(f["project_id"]) for f in batch})
+        fetched = await asyncio.gather(*(self.get_project(pid) for pid in pids))
+        projects = {pid: proj for pid, proj in zip(pids, fetched) if proj}
+
+        for file in batch:
+            if project := projects.get(str(file["project_id"])):
+                file["ref"] = project.get("default_branch") or file.get("ref") or "main"
+                file["__repo"] = project
 
     async def _process_file_batch(
         self,
@@ -1074,6 +1094,8 @@ class GitLabClient:
 
         async for file_batch in search_handler:
             logger.debug(f"Found {len(file_batch)} files in '{repo}'")
+            if not should_use_tree:
+                await self._resolve_refs_from_projects(file_batch)
             processed_batch = await self._process_file_batch(
                 file_batch, repo, skip_parsing
             )
@@ -1317,6 +1339,7 @@ class GitLabClient:
                 path, params=params
             ):
                 logger.info(f"Found {len(file_batch)} files in group {group_id} search")
+                await self._resolve_refs_from_projects(file_batch)
                 processed_batch = await self._process_file_batch(
                     file_batch, group_id, skip_parsing
                 )

--- a/integrations/gitlab-v2/gitlab/clients/gitlab_client.py
+++ b/integrations/gitlab-v2/gitlab/clients/gitlab_client.py
@@ -877,9 +877,6 @@ class GitLabClient:
         self,
         file: dict[str, Any],
     ) -> dict[str, Any]:
-        prefetched_repo = file.get("__repo")
-        if prefetched_repo is not None:
-            return {"file": file, "repo": prefetched_repo}
         repo = await self.get_project(file["project_id"])
         return {"file": file, "repo": repo}
 
@@ -1021,6 +1018,29 @@ class GitLabClient:
         project["__members"] = members
         return project
 
+    async def _get_file_content_with_ref_heal(
+        self, project_id: str, file_path: str, ref: str
+    ) -> tuple[dict[str, Any], str]:
+        """Fetch file content, retrying with default_branch if the ref is stale."""
+        file_data = await self.rest.get_file_data(project_id, file_path, ref)
+
+        if not file_data:
+            project = await self.get_project(project_id)
+            if project:
+                default_branch = project.get("default_branch")
+                if default_branch and default_branch != ref:
+                    logger.info(
+                        f"Retrying file fetch for '{file_path}' in project "
+                        f"'{project_id}' with default_branch '{default_branch}' "
+                        f"(original ref '{ref}' returned empty)"
+                    )
+                    ref = default_branch
+                    file_data = await self.rest.get_file_data(
+                        project_id, file_path, ref
+                    )
+
+        return file_data or {}, ref
+
     async def _process_file(
         self, file: dict[str, Any], context: str, skip_parsing: bool = False
     ) -> dict[str, Any]:
@@ -1028,11 +1048,11 @@ class GitLabClient:
         project_id = str(file["project_id"])
         ref = file.get("ref") or "main"
 
-        file_data = await self.rest.get_file_data(project_id, file_path, ref)
+        file_data, ref = await self._get_file_content_with_ref_heal(
+            project_id, file_path, ref
+        )
         file_data["project_id"] = project_id
         file_data["path"] = file_path
-        if repo := file.get("__repo"):
-            file_data["__repo"] = repo
 
         if (
             not skip_parsing
@@ -1048,16 +1068,6 @@ class GitLabClient:
             file_data["content"] = parsed_content
 
         return file_data
-
-    async def _resolve_refs_from_projects(self, batch: list[dict[str, Any]]) -> None:
-        pids = list({str(f["project_id"]) for f in batch})
-        fetched = await asyncio.gather(*(self.get_project(pid) for pid in pids))
-        projects = {pid: proj for pid, proj in zip(pids, fetched) if proj}
-
-        for file in batch:
-            if project := projects.get(str(file["project_id"])):
-                file["ref"] = project.get("default_branch") or file.get("ref") or "main"
-                file["__repo"] = project
 
     async def _process_file_batch(
         self,
@@ -1089,8 +1099,6 @@ class GitLabClient:
 
         async for file_batch in search_handler:
             logger.debug(f"Found {len(file_batch)} files in '{repo}'")
-            if not should_use_tree:
-                await self._resolve_refs_from_projects(file_batch)
             processed_batch = await self._process_file_batch(
                 file_batch, repo, skip_parsing
             )
@@ -1334,7 +1342,6 @@ class GitLabClient:
                 path, params=params
             ):
                 logger.info(f"Found {len(file_batch)} files in group {group_id} search")
-                await self._resolve_refs_from_projects(file_batch)
                 processed_batch = await self._process_file_batch(
                     file_batch, group_id, skip_parsing
                 )

--- a/integrations/gitlab-v2/gitlab/clients/gitlab_client.py
+++ b/integrations/gitlab-v2/gitlab/clients/gitlab_client.py
@@ -1031,6 +1031,8 @@ class GitLabClient:
         file_data = await self.rest.get_file_data(project_id, file_path, ref)
         file_data["project_id"] = project_id
         file_data["path"] = file_path
+        if repo := file.get("__repo"):
+            file_data["__repo"] = repo
 
         if (
             not skip_parsing

--- a/integrations/gitlab-v2/tests/clients/test_gitlab_client.py
+++ b/integrations/gitlab-v2/tests/clients/test_gitlab_client.py
@@ -1,5 +1,5 @@
 from typing import Any, AsyncGenerator
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import httpx
 import pytest
@@ -1384,56 +1384,83 @@ class TestGitLabClient:
                 "123", "other_file.txt", "main"
             )
 
-    async def test_resolve_refs_replaces_stale_ref_with_default_branch(
+    async def test_process_file_retries_with_default_branch_on_empty_response(
         self, client: GitLabClient
     ) -> None:
-        batch = [
-            {"path": "a.yml", "project_id": "111", "ref": "deadbeef"},
-            {"path": "b.yml", "project_id": "111", "ref": "deadbeef"},
-            {"path": "a.yml", "project_id": "222", "ref": "old-branch"},
-        ]
-        projects = {
-            "111": {"id": 111, "default_branch": "main"},
-            "222": {"id": 222, "default_branch": "develop"},
-        }
-
-        with patch.object(
-            client,
-            "get_project",
-            AsyncMock(side_effect=lambda pid: projects[str(pid)]),
-        ) as mock_get_project:
-            await client._resolve_refs_from_projects(batch)
-
-        assert mock_get_project.call_count == 2
-        assert batch[0]["ref"] == "main"
-        assert batch[2]["ref"] == "develop"
-        assert batch[0]["__repo"] == projects["111"]
-
-    async def test_search_batch_resolves_ref_and_reuses_project(
-        self, client: GitLabClient
-    ) -> None:
-        batch = [{"path": "a.yml", "project_id": "111", "ref": "deadbeef"}]
         project = {"id": 111, "default_branch": "main"}
 
         with (
             patch.object(
-                client, "get_project", AsyncMock(return_value=project)
+                client,
+                "get_project",
+                AsyncMock(return_value=project),
             ) as mock_get_project,
             patch.object(
                 client.rest,
                 "get_file_data",
-                AsyncMock(return_value={"content": "x", "path": "a.yml"}),
+                AsyncMock(
+                    side_effect=[
+                        {},
+                        {"content": "hello", "path": "a.yml"},
+                    ]
+                ),
             ) as mock_get_file_data,
         ):
-            await client._resolve_refs_from_projects(batch)
-            processed = await client._process_file_batch(
-                batch, "g-1", skip_parsing=True
+            result = await client._process_file(
+                {"path": "a.yml", "project_id": "111", "ref": "deadbeef"},
+                "ctx",
+                skip_parsing=True,
             )
-            enriched = await client._enrich_files_with_repos(processed)
 
+        assert result["content"] == "hello"
         mock_get_project.assert_called_once_with("111")
+        assert mock_get_file_data.call_args_list == [
+            call("111", "a.yml", "deadbeef"),
+            call("111", "a.yml", "main"),
+        ]
+
+    async def test_process_file_no_retry_when_ref_matches_default_branch(
+        self, client: GitLabClient
+    ) -> None:
+        project = {"id": 111, "default_branch": "main"}
+
+        with (
+            patch.object(
+                client,
+                "get_project",
+                AsyncMock(return_value=project),
+            ),
+            patch.object(
+                client.rest,
+                "get_file_data",
+                AsyncMock(return_value={}),
+            ) as mock_get_file_data,
+        ):
+            result = await client._process_file(
+                {"path": "a.yml", "project_id": "111", "ref": "main"},
+                "ctx",
+                skip_parsing=True,
+            )
+
+        assert "content" not in result
         mock_get_file_data.assert_called_once_with("111", "a.yml", "main")
-        assert enriched[0]["repo"] == project
+
+    async def test_process_file_no_retry_when_first_fetch_succeeds(
+        self, client: GitLabClient
+    ) -> None:
+        with patch.object(
+            client.rest,
+            "get_file_data",
+            AsyncMock(return_value={"content": "ok", "path": "a.yml"}),
+        ) as mock_get_file_data:
+            result = await client._process_file(
+                {"path": "a.yml", "project_id": "111", "ref": "deadbeef"},
+                "ctx",
+                skip_parsing=True,
+            )
+
+        assert result["content"] == "ok"
+        mock_get_file_data.assert_called_once_with("111", "a.yml", "deadbeef")
 
     async def test_resolve_file_references_relative_reference(
         self, client: GitLabClient

--- a/integrations/gitlab-v2/tests/clients/test_gitlab_client.py
+++ b/integrations/gitlab-v2/tests/clients/test_gitlab_client.py
@@ -1387,12 +1387,10 @@ class TestGitLabClient:
     async def test_resolve_refs_replaces_stale_ref_with_default_branch(
         self, client: GitLabClient
     ) -> None:
-        """_resolve_refs_from_projects fetches each unique project once,
-        stamps default_branch as ref, and attaches __repo for later reuse."""
         batch = [
-            {"path": "port-service.yml", "project_id": "111", "ref": "deadbeef"},
-            {"path": "other.yml", "project_id": "111", "ref": "deadbeef"},
-            {"path": "port-service.yml", "project_id": "222", "ref": "old-branch"},
+            {"path": "a.yml", "project_id": "111", "ref": "deadbeef"},
+            {"path": "b.yml", "project_id": "111", "ref": "deadbeef"},
+            {"path": "a.yml", "project_id": "222", "ref": "old-branch"},
         ]
         projects = {
             "111": {"id": 111, "default_branch": "main"},
@@ -1402,51 +1400,40 @@ class TestGitLabClient:
         with patch.object(
             client,
             "get_project",
-            AsyncMock(side_effect=lambda pid: projects.get(str(pid))),
+            AsyncMock(side_effect=lambda pid: projects[str(pid)]),
         ) as mock_get_project:
             await client._resolve_refs_from_projects(batch)
 
         assert mock_get_project.call_count == 2
         assert batch[0]["ref"] == "main"
-        assert batch[1]["ref"] == "main"
         assert batch[2]["ref"] == "develop"
         assert batch[0]["__repo"] == projects["111"]
-        assert batch[2]["__repo"] == projects["222"]
 
-    async def test_process_file_carries_prefetched_repo(
+    async def test_search_batch_resolves_ref_and_reuses_project(
         self, client: GitLabClient
     ) -> None:
-        prefetched = {"id": 123, "default_branch": "main"}
-        file = {
-            "path": "config.yaml",
-            "project_id": "123",
-            "ref": "main",
-            "__repo": prefetched,
-        }
+        batch = [{"path": "a.yml", "project_id": "111", "ref": "deadbeef"}]
+        project = {"id": 111, "default_branch": "main"}
 
-        with patch.object(
-            client.rest,
-            "get_file_data",
-            AsyncMock(return_value={"content": "key: value", "path": "config.yaml"}),
+        with (
+            patch.object(
+                client, "get_project", AsyncMock(return_value=project)
+            ) as mock_get_project,
+            patch.object(
+                client.rest,
+                "get_file_data",
+                AsyncMock(return_value={"content": "x", "path": "a.yml"}),
+            ) as mock_get_file_data,
         ):
-            result = await client._process_file(
-                file, context="test", skip_parsing=True
+            await client._resolve_refs_from_projects(batch)
+            processed = await client._process_file_batch(
+                batch, "g-1", skip_parsing=True
             )
+            enriched = await client._enrich_files_with_repos(processed)
 
-        assert result["__repo"] == prefetched
-
-    async def test_enrich_file_with_repo_reuses_prefetched_repo(
-        self, client: GitLabClient
-    ) -> None:
-        """When _resolve_refs stamps __repo, enrich skips the duplicate GET."""
-        prefetched = {"id": 123, "default_branch": "main"}
-        file = {"path": "x.yaml", "project_id": "123", "__repo": prefetched}
-
-        with patch.object(client, "get_project", AsyncMock()) as mock:
-            result = await client._enrich_file_with_repo(file)
-
-        assert result == {"file": file, "repo": prefetched}
-        mock.assert_not_called()
+        mock_get_project.assert_called_once_with("111")
+        mock_get_file_data.assert_called_once_with("111", "a.yml", "main")
+        assert enriched[0]["repo"] == project
 
     async def test_resolve_file_references_relative_reference(
         self, client: GitLabClient

--- a/integrations/gitlab-v2/tests/clients/test_gitlab_client.py
+++ b/integrations/gitlab-v2/tests/clients/test_gitlab_client.py
@@ -1384,6 +1384,48 @@ class TestGitLabClient:
                 "123", "other_file.txt", "main"
             )
 
+    async def test_resolve_refs_replaces_stale_ref_with_default_branch(
+        self, client: GitLabClient
+    ) -> None:
+        """_resolve_refs_from_projects fetches each unique project once,
+        stamps default_branch as ref, and attaches __repo for later reuse."""
+        batch = [
+            {"path": "port-service.yml", "project_id": "111", "ref": "deadbeef"},
+            {"path": "other.yml", "project_id": "111", "ref": "deadbeef"},
+            {"path": "port-service.yml", "project_id": "222", "ref": "old-branch"},
+        ]
+        projects = {
+            "111": {"id": 111, "default_branch": "main"},
+            "222": {"id": 222, "default_branch": "develop"},
+        }
+
+        with patch.object(
+            client,
+            "get_project",
+            AsyncMock(side_effect=lambda pid: projects.get(str(pid))),
+        ) as mock_get_project:
+            await client._resolve_refs_from_projects(batch)
+
+        assert mock_get_project.call_count == 2
+        assert batch[0]["ref"] == "main"
+        assert batch[1]["ref"] == "main"
+        assert batch[2]["ref"] == "develop"
+        assert batch[0]["__repo"] == projects["111"]
+        assert batch[2]["__repo"] == projects["222"]
+
+    async def test_enrich_file_with_repo_reuses_prefetched_repo(
+        self, client: GitLabClient
+    ) -> None:
+        """When _resolve_refs stamps __repo, enrich skips the duplicate GET."""
+        prefetched = {"id": 123, "default_branch": "main"}
+        file = {"path": "x.yaml", "project_id": "123", "__repo": prefetched}
+
+        with patch.object(client, "get_project", AsyncMock()) as mock:
+            result = await client._enrich_file_with_repo(file)
+
+        assert result == {"file": file, "repo": prefetched}
+        mock.assert_not_called()
+
     async def test_resolve_file_references_relative_reference(
         self, client: GitLabClient
     ) -> None:

--- a/integrations/gitlab-v2/tests/clients/test_gitlab_client.py
+++ b/integrations/gitlab-v2/tests/clients/test_gitlab_client.py
@@ -1413,6 +1413,28 @@ class TestGitLabClient:
         assert batch[0]["__repo"] == projects["111"]
         assert batch[2]["__repo"] == projects["222"]
 
+    async def test_process_file_carries_prefetched_repo(
+        self, client: GitLabClient
+    ) -> None:
+        prefetched = {"id": 123, "default_branch": "main"}
+        file = {
+            "path": "config.yaml",
+            "project_id": "123",
+            "ref": "main",
+            "__repo": prefetched,
+        }
+
+        with patch.object(
+            client.rest,
+            "get_file_data",
+            AsyncMock(return_value={"content": "key: value", "path": "config.yaml"}),
+        ):
+            result = await client._process_file(
+                file, context="test", skip_parsing=True
+            )
+
+        assert result["__repo"] == prefetched
+
     async def test_enrich_file_with_repo_reuses_prefetched_repo(
         self, client: GitLabClient
     ) -> None:


### PR DESCRIPTION
## Description
- Fix file content fetches failing when GitLab blob search returns a stale `ref` (e.g. renamed/deleted branch), which previously surfaced as empty file data and could lead to entities being deleted.
- Add `_get_file_content_with_ref_heal()` to retry the fetch with the project's `default_branch` only when the initial fetch returns empty.
- `_process_file` is called by many search methods, but the bug's issue will only happen for group search, since project search searches on default branches by default, and repository tree fetches all matching file in the default branch

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.