### PR TITLE
[Core] Use Lua scripts for atomic Redis stream operations in cluster mode

### DIFF
--- a/.ocean-release/core/redis-stream-lua-atomicity.yaml
+++ b/.ocean-release/core/redis-stream-lua-atomicity.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: bugfix
+changelog: Use Lua scripts for atomic Redis stream ack and PEL requeue operations so they work correctly with Redis Cluster, where redis-py transactional pipelines are not supported.

--- a/port_ocean/consumers/pel_requeue/worker.py
+++ b/port_ocean/consumers/pel_requeue/worker.py
@@ -15,7 +15,6 @@ actual processing.  When a message has been stuck in the PEL longer than
 """
 
 import asyncio
-from typing import Any, cast
 
 from loguru import logger
 from redis.exceptions import ResponseError
@@ -26,6 +25,7 @@ from port_ocean.consumers.redis_stream_utils import (
     ack_and_finalize_stream_entry,
     ensure_consumer_group,
     is_missing_stream_or_group_error,
+    requeue_stream_entry,
 )
 
 
@@ -218,9 +218,13 @@ class PELRequeueWorker:
         new_fields["requeue_count"] = str(requeue_count + 1)
 
         try:
-            await self._redis.xadd(self._stream_key, cast(Any, new_fields))
-            await self._redis.xack(self._stream_key, self._consumer_group, message_id)
-            await self._redis.xdel(self._stream_key, message_id)
+            await requeue_stream_entry(
+                self._redis,
+                stream_key=self._stream_key,
+                consumer_group=self._consumer_group,
+                message_id=message_id,
+                fields=new_fields,
+            )
         except ResponseError as error:
             if is_missing_stream_or_group_error(error):
                 await self._recover_missing_stream()

--- a/port_ocean/consumers/pel_requeue/worker.py
+++ b/port_ocean/consumers/pel_requeue/worker.py
@@ -218,11 +218,9 @@ class PELRequeueWorker:
         new_fields["requeue_count"] = str(requeue_count + 1)
 
         try:
-            async with self._redis.pipeline(transaction=True) as pipe:
-                await pipe.xadd(self._stream_key, cast(Any, new_fields))
-                await pipe.xack(self._stream_key, self._consumer_group, message_id)
-                await pipe.xdel(self._stream_key, message_id)
-                await pipe.execute()
+            await self._redis.xadd(self._stream_key, cast(Any, new_fields))
+            await self._redis.xack(self._stream_key, self._consumer_group, message_id)
+            await self._redis.xdel(self._stream_key, message_id)
         except ResponseError as error:
             if is_missing_stream_or_group_error(error):
                 await self._recover_missing_stream()

--- a/port_ocean/consumers/redis_stream_utils.py
+++ b/port_ocean/consumers/redis_stream_utils.py
@@ -80,6 +80,12 @@ async def _eval_lua_script(
     numkeys: int,
     *keys_and_args: str,
 ) -> Any:
+    """Run a Lua script on Redis so multiple commands execute atomically.
+
+    Stream ack/finalize and requeue paths issue several commands (e.g. XACK + XDEL).
+    Redis runs each EVAL script as a single atomic unit, so partial updates cannot
+    leave entries half-processed if another client or failure interleaves.
+    """
     return await cast(Awaitable[Any], redis.eval(script, numkeys, *keys_and_args))
 
 

--- a/port_ocean/consumers/redis_stream_utils.py
+++ b/port_ocean/consumers/redis_stream_utils.py
@@ -1,4 +1,6 @@
 import asyncio
+from collections.abc import Awaitable
+from typing import Any, cast
 
 from loguru import logger
 from redis.exceptions import ConnectionError as RedisConnectionError
@@ -72,6 +74,15 @@ return redis.call('XDEL', KEYS[1], ARGV[2])
 """
 
 
+async def _eval_lua_script(
+    redis: RedisClient,
+    script: str,
+    numkeys: int,
+    *keys_and_args: str,
+) -> Any:
+    return await cast(Awaitable[Any], redis.eval(script, numkeys, *keys_and_args))
+
+
 async def ack_and_finalize_stream_entry(
     redis: RedisClient,
     *,
@@ -81,7 +92,8 @@ async def ack_and_finalize_stream_entry(
 ) -> None:
     """Atomically ack a stream entry and delete it using a Lua script."""
     try:
-        await redis.eval(
+        await _eval_lua_script(
+            redis,
             ACK_AND_FINALIZE_STREAM_ENTRY_SCRIPT,
             1,
             stream_key,
@@ -113,7 +125,8 @@ async def requeue_stream_entry(
     for key, value in fields.items():
         field_items.extend((key, value))
 
-    await redis.eval(
+    await _eval_lua_script(
+        redis,
         REQUEUE_STREAM_ENTRY_SCRIPT,
         1,
         stream_key,

--- a/port_ocean/consumers/redis_stream_utils.py
+++ b/port_ocean/consumers/redis_stream_utils.py
@@ -77,8 +77,8 @@ return redis.call('XDEL', KEYS[1], ARGV[2])
 async def _eval_lua_script(
     redis: RedisClient,
     script: str,
-    numkeys: int,
-    *keys_and_args: str,
+    keys: list[str],
+    args: list[str],
 ) -> Any:
     """Run a Lua script on Redis so multiple commands execute atomically.
 
@@ -86,7 +86,10 @@ async def _eval_lua_script(
     Redis runs each EVAL script as a single atomic unit, so partial updates cannot
     leave entries half-processed if another client or failure interleaves.
     """
-    return await cast(Awaitable[Any], redis.eval(script, numkeys, *keys_and_args))
+    return await cast(
+        Awaitable[Any],
+        redis.eval(script, len(keys), *keys, *args),
+    )
 
 
 async def ack_and_finalize_stream_entry(
@@ -101,10 +104,8 @@ async def ack_and_finalize_stream_entry(
         await _eval_lua_script(
             redis,
             ACK_AND_FINALIZE_STREAM_ENTRY_SCRIPT,
-            1,
-            stream_key,
-            consumer_group,
-            message_id,
+            [stream_key],
+            [consumer_group, message_id],
         )
     except ResponseError as error:
         if not is_missing_stream_or_group_error(error):
@@ -134,9 +135,6 @@ async def requeue_stream_entry(
     await _eval_lua_script(
         redis,
         REQUEUE_STREAM_ENTRY_SCRIPT,
-        1,
-        stream_key,
-        consumer_group,
-        message_id,
-        *field_items,
+        [stream_key],
+        [consumer_group, message_id, *field_items],
     )

--- a/port_ocean/consumers/redis_stream_utils.py
+++ b/port_ocean/consumers/redis_stream_utils.py
@@ -60,6 +60,12 @@ async def ensure_consumer_group(
         )
 
 
+ACK_AND_FINALIZE_STREAM_ENTRY_SCRIPT = """
+redis.call('XACK', KEYS[1], ARGV[1], ARGV[2])
+return redis.call('XDEL', KEYS[1], ARGV[2])
+"""
+
+
 async def ack_and_finalize_stream_entry(
     redis: RedisClient,
     *,
@@ -67,10 +73,15 @@ async def ack_and_finalize_stream_entry(
     consumer_group: str,
     message_id: str,
 ) -> None:
-    """Ack a stream entry and delete it."""
+    """Atomically ack a stream entry and delete it using a Lua script."""
     try:
-        await redis.xack(stream_key, consumer_group, message_id)
-        await redis.xdel(stream_key, message_id)
+        await redis.eval(
+            ACK_AND_FINALIZE_STREAM_ENTRY_SCRIPT,
+            1,
+            stream_key,
+            consumer_group,
+            message_id,
+        )
     except ResponseError as error:
         if not is_missing_stream_or_group_error(error):
             raise

--- a/port_ocean/consumers/redis_stream_utils.py
+++ b/port_ocean/consumers/redis_stream_utils.py
@@ -67,12 +67,10 @@ async def ack_and_finalize_stream_entry(
     consumer_group: str,
     message_id: str,
 ) -> None:
-    """Ack a stream entry and delete it in one transaction."""
+    """Ack a stream entry and delete it."""
     try:
-        async with redis.pipeline(transaction=True) as pipe:
-            await pipe.xack(stream_key, consumer_group, message_id)
-            await pipe.xdel(stream_key, message_id)
-            await pipe.execute()
+        await redis.xack(stream_key, consumer_group, message_id)
+        await redis.xdel(stream_key, message_id)
     except ResponseError as error:
         if not is_missing_stream_or_group_error(error):
             raise

--- a/port_ocean/consumers/redis_stream_utils.py
+++ b/port_ocean/consumers/redis_stream_utils.py
@@ -65,6 +65,12 @@ redis.call('XACK', KEYS[1], ARGV[1], ARGV[2])
 return redis.call('XDEL', KEYS[1], ARGV[2])
 """
 
+REQUEUE_STREAM_ENTRY_SCRIPT = """
+redis.call('XADD', KEYS[1], '*', unpack(ARGV, 3))
+redis.call('XACK', KEYS[1], ARGV[1], ARGV[2])
+return redis.call('XDEL', KEYS[1], ARGV[2])
+"""
+
 
 async def ack_and_finalize_stream_entry(
     redis: RedisClient,
@@ -92,3 +98,26 @@ async def ack_and_finalize_stream_entry(
             message_id=message_id,
             error=str(error),
         )
+
+
+async def requeue_stream_entry(
+    redis: RedisClient,
+    *,
+    stream_key: str,
+    consumer_group: str,
+    message_id: str,
+    fields: dict[str, str],
+) -> None:
+    """Atomically re-enqueue a stream entry and finalize the original via Lua."""
+    field_items: list[str] = []
+    for key, value in fields.items():
+        field_items.extend((key, value))
+
+    await redis.eval(
+        REQUEUE_STREAM_ENTRY_SCRIPT,
+        1,
+        stream_key,
+        consumer_group,
+        message_id,
+        *field_items,
+    )

--- a/port_ocean/core/integrations/mixins/utils.py
+++ b/port_ocean/core/integrations/mixins/utils.py
@@ -157,6 +157,7 @@ async def is_redis_live_events_enabled() -> bool:
         bool: True when Redis stream consumption is enabled, False otherwise.
     """
     try:
+        return True
         if not ocean.config.live_events.is_redis_stream_consumer_enabled:
             return False
         flags = await ocean.port_client.get_organization_feature_flags()

--- a/port_ocean/core/integrations/mixins/utils.py
+++ b/port_ocean/core/integrations/mixins/utils.py
@@ -157,7 +157,6 @@ async def is_redis_live_events_enabled() -> bool:
         bool: True when Redis stream consumption is enabled, False otherwise.
     """
     try:
-        return True
         if not ocean.config.live_events.is_redis_stream_consumer_enabled:
             return False
         flags = await ocean.port_client.get_organization_feature_flags()

--- a/port_ocean/tests/consumers/pel_requeue/test_worker.py
+++ b/port_ocean/tests/consumers/pel_requeue/test_worker.py
@@ -1,8 +1,6 @@
 """Tests for PELRequeueWorker."""
 
 import asyncio
-from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -37,20 +35,6 @@ def _make_redis() -> AsyncMock:
     redis.xack = AsyncMock(return_value=1)
     redis.xdel = AsyncMock(return_value=1)
     redis.expire = AsyncMock(return_value=True)
-
-    @asynccontextmanager
-    async def fake_pipeline(
-        *_args: object, **_kwargs: object
-    ) -> AsyncIterator[AsyncMock]:
-        pipe = AsyncMock()
-        pipe.xadd = redis.xadd
-        pipe.xack = redis.xack
-        pipe.xdel = redis.xdel
-        pipe.expire = redis.expire
-        pipe.execute = AsyncMock(return_value=["1700000000001-0", 1, 1, True])
-        yield pipe
-
-    redis.pipeline = fake_pipeline
     return redis
 
 
@@ -100,31 +84,13 @@ class TestPELHandleStuckMessage:
         redis.xdel.assert_awaited_once_with(worker._stream_key, "1700000000000-0")
 
     @pytest.mark.asyncio
-    async def test_requeue_uses_transactional_pipeline(self) -> None:
+    async def test_requeue_calls_xadd_xack_and_xdel(self) -> None:
         redis = _make_redis()
         worker = _make_worker(redis, pel_max_requeue_count=3)
-
-        pipeline_calls: list[dict[str, Any]] = []
-
-        @asynccontextmanager
-        async def tracking_pipeline(
-            *_args: object, **kwargs: object
-        ) -> AsyncIterator[AsyncMock]:
-            pipeline_calls.append(kwargs)
-            pipe = AsyncMock()
-            pipe.xadd = redis.xadd
-            pipe.xack = redis.xack
-            pipe.xdel = redis.xdel
-            pipe.expire = redis.expire
-            pipe.execute = AsyncMock(return_value=["1700000000001-0", 1, 1, True])
-            yield pipe
-
-        redis.pipeline = tracking_pipeline
 
         fields = {"webhookPath": "/webhook", "payload": "{}", "headers": "{}"}
         await worker._handle_stuck_message("1700000000000-0", fields)
 
-        assert pipeline_calls == [{"transaction": True}]
         redis.xadd.assert_awaited_once()
         redis.xack.assert_awaited_once()
         redis.xdel.assert_awaited_once_with(worker._stream_key, "1700000000000-0")
@@ -479,28 +445,14 @@ class TestPELRecoverMissingStream:
         redis.xadd.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_requeue_recovers_when_pipeline_raises_nogroup(self) -> None:
+    async def test_requeue_recovers_when_xadd_raises_nogroup(self) -> None:
         redis = _make_redis()
         redis.exists = AsyncMock(return_value=0)
         redis.xgroup_create = AsyncMock()
         redis.expire = AsyncMock()
-
-        @asynccontextmanager
-        async def failing_pipeline(
-            *_args: object, **_kwargs: object
-        ) -> AsyncIterator[AsyncMock]:
-            pipe = AsyncMock()
-            pipe.xadd = redis.xadd
-            pipe.xack = redis.xack
-            pipe.xdel = redis.xdel
-            pipe.execute = AsyncMock(
-                side_effect=ResponseError(
-                    "NOGROUP No such key 'stream' or consumer group"
-                )
-            )
-            yield pipe
-
-        redis.pipeline = failing_pipeline
+        redis.xadd = AsyncMock(
+            side_effect=ResponseError("NOGROUP No such key 'stream' or consumer group")
+        )
 
         worker = _make_worker(redis, pel_max_requeue_count=3)
         fields = {"webhookPath": "/webhook", "payload": "{}", "headers": "{}"}
@@ -508,3 +460,5 @@ class TestPELRecoverMissingStream:
 
         redis.xgroup_create.assert_awaited_once()
         redis.xadd.assert_awaited_once()
+        redis.xack.assert_not_awaited()
+        redis.xdel.assert_not_awaited()

--- a/port_ocean/tests/consumers/pel_requeue/test_worker.py
+++ b/port_ocean/tests/consumers/pel_requeue/test_worker.py
@@ -12,6 +12,7 @@ from port_ocean.consumers.pel_requeue import PELRequeueWorker
 from port_ocean.consumers.pel_requeue.settings import PEL_CONSUMER_NAME
 from port_ocean.consumers.redis_stream_utils import (
     ACK_AND_FINALIZE_STREAM_ENTRY_SCRIPT,
+    REQUEUE_STREAM_ENTRY_SCRIPT,
 )
 
 # ---------------------------------------------------------------------------
@@ -34,12 +35,14 @@ _DEFAULT_REDIS_SETTINGS = LiveEventsRedisSettings(
 def _make_redis() -> AsyncMock:
     redis = AsyncMock()
     redis.xautoclaim = AsyncMock(return_value=("0-0", [], []))
-    redis.xadd = AsyncMock(return_value="1700000000001-0")
-    redis.xack = AsyncMock(return_value=1)
-    redis.xdel = AsyncMock(return_value=1)
-    redis.eval = AsyncMock(return_value=1)
+    redis.eval = AsyncMock(return_value="1700000000001-0")
     redis.expire = AsyncMock(return_value=True)
     return redis
+
+
+def _fields_from_requeue_eval_call(eval_call: Any) -> dict[str, str]:
+    field_pairs = eval_call.args[5:]
+    return dict(zip(field_pairs[0::2], field_pairs[1::2], strict=True))
 
 
 def _make_worker(
@@ -76,29 +79,35 @@ class TestPELHandleStuckMessage:
         }
         await worker._handle_stuck_message("1700000000000-0", fields)
 
-        redis.xadd.assert_awaited_once()
-        call_args = redis.xadd.await_args
-        sent_fields: dict[str, str] = call_args.args[1]
+        redis.eval.assert_awaited_once()
+        eval_call = redis.eval.await_args
+        assert eval_call is not None
+        assert eval_call.args[0] == REQUEUE_STREAM_ENTRY_SCRIPT
+        assert eval_call.args[2] == worker._stream_key
+        assert eval_call.args[3] == worker._consumer_group
+        assert eval_call.args[4] == "1700000000000-0"
+        sent_fields = _fields_from_requeue_eval_call(eval_call)
         assert sent_fields["requeue_count"] == "2"
         assert sent_fields["webhookPath"] == "/webhook"
 
-        redis.xack.assert_awaited_once_with(
-            worker._stream_key, worker._consumer_group, "1700000000000-0"
-        )
-        redis.xdel.assert_awaited_once_with(worker._stream_key, "1700000000000-0")
-
     @pytest.mark.asyncio
-    async def test_requeue_calls_xadd_xack_and_xdel(self) -> None:
+    async def test_requeue_uses_lua_script(self) -> None:
         redis = _make_redis()
         worker = _make_worker(redis, pel_max_requeue_count=3)
 
         fields = {"webhookPath": "/webhook", "payload": "{}", "headers": "{}"}
         await worker._handle_stuck_message("1700000000000-0", fields)
 
-        redis.xadd.assert_awaited_once()
-        redis.xack.assert_awaited_once()
-        redis.xdel.assert_awaited_once_with(worker._stream_key, "1700000000000-0")
-        assert redis.xadd.await_args_list[0].args[0] == worker._stream_key
+        redis.eval.assert_awaited_once()
+        eval_call = redis.eval.await_args
+        assert eval_call is not None
+        assert eval_call.args[0] == REQUEUE_STREAM_ENTRY_SCRIPT
+        assert eval_call.args[2] == worker._stream_key
+        assert eval_call.args[3] == worker._consumer_group
+        assert eval_call.args[4] == "1700000000000-0"
+        sent_fields = _fields_from_requeue_eval_call(eval_call)
+        assert sent_fields["requeue_count"] == "1"
+        assert sent_fields["webhookPath"] == "/webhook"
 
     @pytest.mark.asyncio
     async def test_increments_requeue_count_from_zero(self) -> None:
@@ -108,7 +117,9 @@ class TestPELHandleStuckMessage:
         fields = {"webhookPath": "/webhook", "payload": "{}", "headers": "{}"}
         await worker._handle_stuck_message("1700000000000-0", fields)
 
-        sent_fields: dict[str, str] = redis.xadd.await_args.args[1]
+        eval_call = redis.eval.await_args
+        assert eval_call is not None
+        sent_fields = _fields_from_requeue_eval_call(eval_call)
         assert sent_fields["requeue_count"] == "1"
 
     @pytest.mark.asyncio
@@ -132,8 +143,6 @@ class TestPELHandleStuckMessage:
             worker._consumer_group,
             "1700000000000-0",
         )
-        redis.xack.assert_not_awaited()
-        redis.xdel.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_discards_message_above_threshold(self) -> None:
@@ -145,8 +154,6 @@ class TestPELHandleStuckMessage:
 
         redis.xadd.assert_not_awaited()
         redis.eval.assert_awaited_once()
-        redis.xack.assert_not_awaited()
-        redis.xdel.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------
@@ -203,8 +210,7 @@ class TestPELScanAndRequeue:
         worker = _make_worker(redis)
         await worker._scan_and_requeue()
 
-        assert redis.xadd.await_count == 2
-        assert redis.xack.await_count == 2
+        assert redis.eval.await_count == 2
 
     @pytest.mark.asyncio
     async def test_paginates_through_non_zero_cursor_with_empty_batch(self) -> None:
@@ -231,10 +237,13 @@ class TestPELScanAndRequeue:
         await worker._scan_and_requeue()
 
         assert cursors_used == ["0-0", "1700000000002-0"]
-        redis.xadd.assert_awaited_once()
-        redis.xack.assert_awaited_once_with(
-            worker._stream_key, worker._consumer_group, "1700000000002-0"
-        )
+        redis.eval.assert_awaited_once()
+        eval_call = redis.eval.await_args
+        assert eval_call is not None
+        assert eval_call.args[0] == REQUEUE_STREAM_ENTRY_SCRIPT
+        assert eval_call.args[4] == "1700000000002-0"
+        sent_fields = _fields_from_requeue_eval_call(eval_call)
+        assert sent_fields["requeue_count"] == "1"
 
     @pytest.mark.asyncio
     async def test_paginates_when_next_cursor_is_not_zero(self) -> None:
@@ -267,18 +276,17 @@ class TestPELScanAndRequeue:
         await worker._scan_and_requeue()
 
         assert call_count == 2
-        assert redis.xadd.await_count == 2
+        assert redis.eval.await_count == 2
 
     @pytest.mark.asyncio
-    async def test_no_xadd_when_no_stuck_messages(self) -> None:
+    async def test_no_eval_when_no_stuck_messages(self) -> None:
         redis = _make_redis()
         redis.xautoclaim = AsyncMock(return_value=("0-0", [], []))
 
         worker = _make_worker(redis)
         await worker._scan_and_requeue()
 
-        redis.xadd.assert_not_awaited()
-        redis.xack.assert_not_awaited()
+        redis.eval.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_handles_two_element_xautoclaim_response(self) -> None:
@@ -295,10 +303,10 @@ class TestPELScanAndRequeue:
         worker = _make_worker(redis)
         await worker._scan_and_requeue()
 
-        redis.xadd.assert_awaited_once()
+        redis.eval.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_handles_deleted_ids_without_xack_or_requeue(self) -> None:
+    async def test_handles_deleted_ids_without_eval_or_requeue(self) -> None:
         """Redis 7.0+ returns ghost PEL entries in the third response element."""
         redis = _make_redis()
         redis.xautoclaim = AsyncMock(
@@ -308,8 +316,7 @@ class TestPELScanAndRequeue:
         worker = _make_worker(redis)
         await worker._scan_and_requeue()
 
-        redis.xadd.assert_not_awaited()
-        redis.xack.assert_not_awaited()
+        redis.eval.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_acknowledges_tombstoned_message_with_none_fields(self) -> None:
@@ -327,10 +334,12 @@ class TestPELScanAndRequeue:
         worker = _make_worker(redis)
         await worker._scan_and_requeue()
 
-        redis.eval.assert_awaited_once()
-        redis.xadd.assert_awaited_once()
-        redis.xack.assert_awaited_once()
-        redis.xdel.assert_awaited_once()
+        assert redis.eval.await_count == 2
+        assert (
+            redis.eval.await_args_list[0].args[0]
+            == ACK_AND_FINALIZE_STREAM_ENTRY_SCRIPT
+        )
+        assert redis.eval.await_args_list[1].args[0] == REQUEUE_STREAM_ENTRY_SCRIPT
 
     @pytest.mark.asyncio
     async def test_continues_scan_when_one_message_fails(self) -> None:
@@ -350,11 +359,12 @@ class TestPELScanAndRequeue:
         worker = _make_worker(redis)
         await worker._scan_and_requeue()
 
-        redis.xadd.assert_awaited_once()
-        assert redis.xadd.await_args.args[1]["requeue_count"] == "1"
-        redis.xack.assert_awaited_once_with(
-            worker._stream_key, worker._consumer_group, "1700000000002-0"
-        )
+        redis.eval.assert_awaited_once()
+        eval_call = redis.eval.await_args
+        assert eval_call is not None
+        sent_fields = _fields_from_requeue_eval_call(eval_call)
+        assert sent_fields["requeue_count"] == "1"
+        assert eval_call.args[4] == "1700000000002-0"
 
 
 # ---------------------------------------------------------------------------
@@ -449,14 +459,15 @@ class TestPELRecoverMissingStream:
 
         redis.xgroup_create.assert_awaited_once()
         redis.xadd.assert_not_awaited()
+        redis.eval.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_requeue_recovers_when_xadd_raises_nogroup(self) -> None:
+    async def test_requeue_recovers_when_eval_raises_nogroup(self) -> None:
         redis = _make_redis()
         redis.exists = AsyncMock(return_value=0)
         redis.xgroup_create = AsyncMock()
         redis.expire = AsyncMock()
-        redis.xadd = AsyncMock(
+        redis.eval = AsyncMock(
             side_effect=ResponseError("NOGROUP No such key 'stream' or consumer group")
         )
 
@@ -465,6 +476,4 @@ class TestPELRecoverMissingStream:
         await worker._handle_stuck_message("1700000000000-0", fields)
 
         redis.xgroup_create.assert_awaited_once()
-        redis.xadd.assert_awaited_once()
-        redis.xack.assert_not_awaited()
-        redis.xdel.assert_not_awaited()
+        redis.eval.assert_awaited_once()

--- a/port_ocean/tests/consumers/pel_requeue/test_worker.py
+++ b/port_ocean/tests/consumers/pel_requeue/test_worker.py
@@ -10,6 +10,9 @@ from redis.exceptions import ResponseError
 from port_ocean.config.settings import LiveEventsRedisSettings
 from port_ocean.consumers.pel_requeue import PELRequeueWorker
 from port_ocean.consumers.pel_requeue.settings import PEL_CONSUMER_NAME
+from port_ocean.consumers.redis_stream_utils import (
+    ACK_AND_FINALIZE_STREAM_ENTRY_SCRIPT,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -34,6 +37,7 @@ def _make_redis() -> AsyncMock:
     redis.xadd = AsyncMock(return_value="1700000000001-0")
     redis.xack = AsyncMock(return_value=1)
     redis.xdel = AsyncMock(return_value=1)
+    redis.eval = AsyncMock(return_value=1)
     redis.expire = AsyncMock(return_value=True)
     return redis
 
@@ -121,10 +125,15 @@ class TestPELHandleStuckMessage:
         await worker._handle_stuck_message("1700000000000-0", fields)
 
         redis.xadd.assert_not_awaited()
-        redis.xack.assert_awaited_once_with(
-            worker._stream_key, worker._consumer_group, "1700000000000-0"
+        redis.eval.assert_awaited_once_with(
+            ACK_AND_FINALIZE_STREAM_ENTRY_SCRIPT,
+            1,
+            worker._stream_key,
+            worker._consumer_group,
+            "1700000000000-0",
         )
-        redis.xdel.assert_awaited_once_with(worker._stream_key, "1700000000000-0")
+        redis.xack.assert_not_awaited()
+        redis.xdel.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_discards_message_above_threshold(self) -> None:
@@ -135,8 +144,9 @@ class TestPELHandleStuckMessage:
         await worker._handle_stuck_message("1700000000000-0", fields)
 
         redis.xadd.assert_not_awaited()
-        redis.xack.assert_awaited_once()
-        redis.xdel.assert_awaited_once()
+        redis.eval.assert_awaited_once()
+        redis.xack.assert_not_awaited()
+        redis.xdel.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------
@@ -317,14 +327,10 @@ class TestPELScanAndRequeue:
         worker = _make_worker(redis)
         await worker._scan_and_requeue()
 
+        redis.eval.assert_awaited_once()
         redis.xadd.assert_awaited_once()
-        assert redis.xack.await_count == 2
-        assert redis.xdel.await_count == 2
-        assert (
-            worker._stream_key,
-            worker._consumer_group,
-            "1700000000999-0",
-        ) in [call.args for call in redis.xack.await_args_list]
+        redis.xack.assert_awaited_once()
+        redis.xdel.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_continues_scan_when_one_message_fails(self) -> None:

--- a/port_ocean/tests/consumers/test_redis_stream_consumer.py
+++ b/port_ocean/tests/consumers/test_redis_stream_consumer.py
@@ -22,6 +22,7 @@ from port_ocean.consumers.pel_requeue import PELRequeueWorker
 from port_ocean.consumers.redis_stream_consumer import RedisStreamConsumer
 from port_ocean.consumers.redis_stream_utils import (
     ACK_AND_FINALIZE_STREAM_ENTRY_SCRIPT,
+    REQUEUE_STREAM_ENTRY_SCRIPT,
     ensure_consumer_group,
 )
 from port_ocean.core.handlers.webhook.webhook_event import WebhookRequestAdapter
@@ -777,9 +778,7 @@ class TestRedisStreamConsumerPelWorkerLifecycle:
         }
 
         mock_redis = AsyncMock()
-        mock_redis.xadd = AsyncMock(return_value="1700000000001-0")
-        mock_redis.xack = AsyncMock(return_value=1)
-        mock_redis.xdel = AsyncMock(return_value=1)
+        mock_redis.eval = AsyncMock(return_value="1700000000001-0")
         mock_redis.xautoclaim = AsyncMock(
             return_value=("0-0", [(message_id, fields)], [])
         )
@@ -808,15 +807,19 @@ class TestRedisStreamConsumerPelWorkerLifecycle:
             )
             await pel_worker._scan_and_requeue()
 
-            mock_redis.xadd.assert_awaited_once()
-            assert mock_redis.xadd.await_args is not None
-            requeued_fields: dict[str, str] = mock_redis.xadd.await_args.args[1]
+            mock_redis.eval.assert_awaited_once()
+            assert mock_redis.eval.await_args is not None
+            assert mock_redis.eval.await_args.args[0] == REQUEUE_STREAM_ENTRY_SCRIPT
+            field_pairs = mock_redis.eval.await_args.args[5:]
+            requeued_fields = dict(
+                zip(field_pairs[0::2], field_pairs[1::2], strict=True)
+            )
             assert requeued_fields["requeue_count"] == "1"
 
             release_handler.set()
             await handle_task
 
-            assert mock_redis.xack.await_count >= 1
+            assert mock_redis.eval.await_count >= 1
 
 
 class TestRedisStreamConsumer:

--- a/port_ocean/tests/consumers/test_redis_stream_consumer.py
+++ b/port_ocean/tests/consumers/test_redis_stream_consumer.py
@@ -20,7 +20,10 @@ from port_ocean.exceptions.live_events import (
 )
 from port_ocean.consumers.pel_requeue import PELRequeueWorker
 from port_ocean.consumers.redis_stream_consumer import RedisStreamConsumer
-from port_ocean.consumers.redis_stream_utils import ensure_consumer_group
+from port_ocean.consumers.redis_stream_utils import (
+    ACK_AND_FINALIZE_STREAM_ENTRY_SCRIPT,
+    ensure_consumer_group,
+)
 from port_ocean.core.handlers.webhook.webhook_event import WebhookRequestAdapter
 
 
@@ -561,14 +564,13 @@ class TestRedisStreamConsumerAck:
     @staticmethod
     def _mock_redis_for_ack(
         *,
-        xack_side_effect: Exception | None = None,
+        eval_side_effect: Exception | None = None,
     ) -> AsyncMock:
         mock_redis = AsyncMock()
-        if xack_side_effect is not None:
-            mock_redis.xack = AsyncMock(side_effect=xack_side_effect)
+        if eval_side_effect is not None:
+            mock_redis.eval = AsyncMock(side_effect=eval_side_effect)
         else:
-            mock_redis.xack = AsyncMock(return_value=1)
-        mock_redis.xdel = AsyncMock(return_value=1)
+            mock_redis.eval = AsyncMock(return_value=1)
         mock_redis.expire = AsyncMock(return_value=True)
         return mock_redis
 
@@ -594,10 +596,13 @@ class TestRedisStreamConsumerAck:
             consumer._redis = mock_redis
             await consumer._ack("1700000000000-0")
 
-        mock_redis.xack.assert_awaited_once_with(
-            "stream", "test.integration", "1700000000000-0"
+        mock_redis.eval.assert_awaited_once_with(
+            ACK_AND_FINALIZE_STREAM_ENTRY_SCRIPT,
+            1,
+            "stream",
+            "test.integration",
+            "1700000000000-0",
         )
-        mock_redis.xdel.assert_awaited_once_with("stream", "1700000000000-0")
         mock_redis.expire.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -622,7 +627,13 @@ class TestRedisStreamConsumerAck:
             consumer._redis = mock_redis
             await consumer._ack("1700000000000-0")
 
-        mock_redis.xdel.assert_awaited_once_with("stream", "1700000000000-0")
+        mock_redis.eval.assert_awaited_once_with(
+            ACK_AND_FINALIZE_STREAM_ENTRY_SCRIPT,
+            1,
+            "stream",
+            "test.integration",
+            "1700000000000-0",
+        )
         mock_redis.expire.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -635,7 +646,7 @@ class TestRedisStreamConsumerAck:
             stream_ttl_seconds=3600,
         )
         mock_redis = self._mock_redis_for_ack(
-            xack_side_effect=ResponseError(
+            eval_side_effect=ResponseError(
                 "NOGROUP No such key 'stream' or consumer group"
             )
         )

--- a/port_ocean/tests/consumers/test_redis_stream_consumer.py
+++ b/port_ocean/tests/consumers/test_redis_stream_consumer.py
@@ -2,8 +2,6 @@ import asyncio
 import base64
 import json
 import os
-from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
@@ -561,30 +559,17 @@ class TestRedisStreamConsumerGroupCreation:
 
 class TestRedisStreamConsumerAck:
     @staticmethod
-    def _mock_redis_with_ack_pipeline(
+    def _mock_redis_for_ack(
         *,
-        execute_side_effect: Exception | None = None,
+        xack_side_effect: Exception | None = None,
     ) -> AsyncMock:
         mock_redis = AsyncMock()
-        mock_redis.xack = AsyncMock(return_value=1)
+        if xack_side_effect is not None:
+            mock_redis.xack = AsyncMock(side_effect=xack_side_effect)
+        else:
+            mock_redis.xack = AsyncMock(return_value=1)
         mock_redis.xdel = AsyncMock(return_value=1)
         mock_redis.expire = AsyncMock(return_value=True)
-
-        @asynccontextmanager
-        async def fake_pipeline(
-            *_args: object, **_kwargs: object
-        ) -> AsyncIterator[AsyncMock]:
-            pipe = AsyncMock()
-            pipe.xack = mock_redis.xack
-            pipe.xdel = mock_redis.xdel
-            pipe.expire = mock_redis.expire
-            if execute_side_effect is not None:
-                pipe.execute = AsyncMock(side_effect=execute_side_effect)
-            else:
-                pipe.execute = AsyncMock(return_value=[1, 1, True])
-            yield pipe
-
-        mock_redis.pipeline = fake_pipeline
         return mock_redis
 
     @pytest.mark.asyncio
@@ -596,7 +581,7 @@ class TestRedisStreamConsumerAck:
             url="redis://localhost:6379",
             stream_ttl_seconds=3600,
         )
-        mock_redis = self._mock_redis_with_ack_pipeline()
+        mock_redis = self._mock_redis_for_ack()
 
         with patch(
             "port_ocean.consumers.redis_stream_consumer.ocean", mock_ocean_config
@@ -624,7 +609,7 @@ class TestRedisStreamConsumerAck:
             url="redis://localhost:6379",
             stream_ttl_seconds=None,
         )
-        mock_redis = self._mock_redis_with_ack_pipeline()
+        mock_redis = self._mock_redis_for_ack()
 
         with patch(
             "port_ocean.consumers.redis_stream_consumer.ocean", mock_ocean_config
@@ -649,8 +634,8 @@ class TestRedisStreamConsumerAck:
             url="redis://localhost:6379",
             stream_ttl_seconds=3600,
         )
-        mock_redis = self._mock_redis_with_ack_pipeline(
-            execute_side_effect=ResponseError(
+        mock_redis = self._mock_redis_for_ack(
+            xack_side_effect=ResponseError(
                 "NOGROUP No such key 'stream' or consumer group"
             )
         )
@@ -783,18 +768,7 @@ class TestRedisStreamConsumerPelWorkerLifecycle:
         mock_redis = AsyncMock()
         mock_redis.xadd = AsyncMock(return_value="1700000000001-0")
         mock_redis.xack = AsyncMock(return_value=1)
-
-        @asynccontextmanager
-        async def fake_pipeline(
-            *_args: object, **_kwargs: object
-        ) -> AsyncIterator[AsyncMock]:
-            pipe = AsyncMock()
-            pipe.xadd = mock_redis.xadd
-            pipe.xack = mock_redis.xack
-            pipe.execute = AsyncMock(return_value=["1700000000001-0", 1])
-            yield pipe
-
-        mock_redis.pipeline = fake_pipeline
+        mock_redis.xdel = AsyncMock(return_value=1)
         mock_redis.xautoclaim = AsyncMock(
             return_value=("0-0", [(message_id, fields)], [])
         )

--- a/port_ocean/tests/consumers/test_redis_stream_utils.py
+++ b/port_ocean/tests/consumers/test_redis_stream_utils.py
@@ -7,6 +7,7 @@ from redis.exceptions import ResponseError
 from redis.exceptions import TimeoutError as RedisTimeoutError
 
 from port_ocean.consumers.redis_stream_utils import (
+    ACK_AND_FINALIZE_STREAM_ENTRY_SCRIPT,
     ack_and_finalize_stream_entry,
     ensure_consumer_group,
     is_missing_stream_or_group_error,
@@ -16,8 +17,7 @@ from port_ocean.consumers.redis_stream_utils import (
 
 def _make_redis_for_ack_finalize() -> AsyncMock:
     redis = AsyncMock()
-    redis.xack = AsyncMock(return_value=1)
-    redis.xdel = AsyncMock(return_value=1)
+    redis.eval = AsyncMock(return_value=1)
     return redis
 
 
@@ -54,15 +54,18 @@ class TestAckAndFinalizeStreamEntry:
             message_id="1700000000000-0",
         )
 
-        redis.xack.assert_awaited_once_with(
-            "stream", "test.integration", "1700000000000-0"
+        redis.eval.assert_awaited_once_with(
+            ACK_AND_FINALIZE_STREAM_ENTRY_SCRIPT,
+            1,
+            "stream",
+            "test.integration",
+            "1700000000000-0",
         )
-        redis.xdel.assert_awaited_once_with("stream", "1700000000000-0")
 
     @pytest.mark.asyncio
-    async def test_swallows_missing_stream_error_from_xack(self) -> None:
+    async def test_swallows_missing_stream_error_from_eval(self) -> None:
         redis = _make_redis_for_ack_finalize()
-        redis.xack = AsyncMock(
+        redis.eval = AsyncMock(
             side_effect=ResponseError("NOGROUP No such key 'stream' or consumer group")
         )
 
@@ -73,8 +76,7 @@ class TestAckAndFinalizeStreamEntry:
             message_id="1700000000000-0",
         )
 
-        redis.xack.assert_awaited_once()
-        redis.xdel.assert_not_awaited()
+        redis.eval.assert_awaited_once()
 
 
 class TestEnsureConsumerGroup:

--- a/port_ocean/tests/consumers/test_redis_stream_utils.py
+++ b/port_ocean/tests/consumers/test_redis_stream_utils.py
@@ -1,6 +1,4 @@
 import asyncio
-from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock
 
 import pytest
@@ -16,22 +14,10 @@ from port_ocean.consumers.redis_stream_utils import (
 )
 
 
-def _make_redis_with_pipeline() -> AsyncMock:
+def _make_redis_for_ack_finalize() -> AsyncMock:
     redis = AsyncMock()
     redis.xack = AsyncMock(return_value=1)
     redis.xdel = AsyncMock(return_value=1)
-
-    @asynccontextmanager
-    async def fake_pipeline(
-        *_args: object, **_kwargs: object
-    ) -> AsyncIterator[AsyncMock]:
-        pipe = AsyncMock()
-        pipe.xack = redis.xack
-        pipe.xdel = redis.xdel
-        pipe.execute = AsyncMock(return_value=[1, 1])
-        yield pipe
-
-    redis.pipeline = fake_pipeline
     return redis
 
 
@@ -58,8 +44,8 @@ class TestIsMissingStreamOrGroupError:
 
 class TestAckAndFinalizeStreamEntry:
     @pytest.mark.asyncio
-    async def test_acks_and_deletes_entry_transactionally(self) -> None:
-        redis = _make_redis_with_pipeline()
+    async def test_acks_and_deletes_entry(self) -> None:
+        redis = _make_redis_for_ack_finalize()
 
         await ack_and_finalize_stream_entry(
             redis,
@@ -74,24 +60,11 @@ class TestAckAndFinalizeStreamEntry:
         redis.xdel.assert_awaited_once_with("stream", "1700000000000-0")
 
     @pytest.mark.asyncio
-    async def test_swallows_missing_stream_error_from_transaction(self) -> None:
-        redis = _make_redis_with_pipeline()
-
-        @asynccontextmanager
-        async def failing_pipeline(
-            *_args: object, **_kwargs: object
-        ) -> AsyncIterator[AsyncMock]:
-            pipe = AsyncMock()
-            pipe.xack = redis.xack
-            pipe.xdel = redis.xdel
-            pipe.execute = AsyncMock(
-                side_effect=ResponseError(
-                    "NOGROUP No such key 'stream' or consumer group"
-                )
-            )
-            yield pipe
-
-        redis.pipeline = failing_pipeline
+    async def test_swallows_missing_stream_error_from_xack(self) -> None:
+        redis = _make_redis_for_ack_finalize()
+        redis.xack = AsyncMock(
+            side_effect=ResponseError("NOGROUP No such key 'stream' or consumer group")
+        )
 
         await ack_and_finalize_stream_entry(
             redis,
@@ -101,6 +74,7 @@ class TestAckAndFinalizeStreamEntry:
         )
 
         redis.xack.assert_awaited_once()
+        redis.xdel.assert_not_awaited()
 
 
 class TestEnsureConsumerGroup:


### PR DESCRIPTION
# Description

Replaces transactional Redis pipelines (pipeline(transaction=True)) with Lua scripts for stream message finalization and PEL requeue operations.

We previously relied on transactional pipelines to make multi-step stream operations atomic.
redis-py explicitly does not support transactional pipelines in cluster mode. In redis.asyncio.cluster.RedisCluster.pipeline():
"Cluster implementation of pipeline does not support transaction or shard_hint."
So pipeline(transaction=True) is not a reliable way to get atomic MULTI/EXEC behavior when running against Redis Cluster.


## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core live-events message ack and PEL requeue paths; incorrect Lua or eval args could leave PEL entries stuck or duplicate deliveries, though behavior is intended to match the prior pipeline semantics.
> 
> **Overview**
> Replaces **transactional Redis pipelines** (`pipeline(transaction=True)`) with **Lua scripts** for live-events stream finalize and PEL requeue, because cluster clients do not support transactional pipelines for true atomic multi-step work.
> 
> `ack_and_finalize_stream_entry` now runs **XACK + XDEL** in one `EVAL` instead of a MULTI/EXEC pipeline. A new **`requeue_stream_entry`** helper atomically **XADDs** the updated fields (including incremented `requeue_count`), **ACKs**, and **XDELs** the original id; the PEL requeue worker calls this instead of building its own pipeline.
> 
> Consumer ack paths and PEL tests are updated to assert the correct script bodies and `eval` arguments rather than separate `xadd`/`xack`/`xdel` pipeline calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68d06730768d928c702f263f0c88be71e79b8f07. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->