### PR TITLE
[Integrations][Gitlab][Gitlab-v2][Azure-Devops][Claude][Opencost] Add missing titles and descriptions on integration config fields.

### DIFF
--- a/integrations/azure-devops/.ocean-release/config-field-metadata.yaml
+++ b/integrations/azure-devops/.ocean-release/config-field-metadata.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: improvement
+changelog: Add title and description metadata to the Azure DevOps specPath config field.

--- a/integrations/azure-devops/integration.py
+++ b/integrations/azure-devops/integration.py
@@ -657,7 +657,12 @@ class AzureDevopsGroupMemberResourceConfig(ResourceConfig):
 
 
 class GitPortAppConfig(PortAppConfig):
-    spec_path: List[str] | str = Field(alias="specPath", default="port.yml")
+    spec_path: List[str] | str = Field(
+        alias="specPath",
+        default="port.yml",
+        title="Spec Path",
+        description="Path to Port spec files in the repository. Default is 'port.yml'.",
+    )
     use_default_branch: bool | None = Field(
         default=None,
         alias="useDefaultBranch",

--- a/integrations/claude/.ocean-release/config-field-metadata.yaml
+++ b/integrations/claude/.ocean-release/config-field-metadata.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: improvement
+changelog: Split deprecated Claude kind aliases onto dedicated ResourceConfig classes.

--- a/integrations/claude/integration.py
+++ b/integrations/claude/integration.py
@@ -246,31 +246,49 @@ class ClaudeAIUserReportSelector(Selector):
 
 
 class ClaudePlatformUsageRecordResourceConfig(ResourceConfig):
-    # "claude-usage-record" is the deprecated alias kept for backwards
-    # compatibility with existing installations.
-    kind: Literal["claude-platform-usage-record", "claude-usage-record"] = Field(
+    kind: Literal["claude-platform-usage-record"] = Field(
         description="Claude Platform usage record resource kind",
         title="Claude Platform Usage Record",
     )
     selector: ClaudePlatformUsageSelector
 
 
+class ClaudeUsageRecordResourceConfig(ResourceConfig):
+    kind: Literal["claude-usage-record"] = Field(
+        description="Deprecated alias for Claude Platform usage record.",
+        title="Claude Usage Record",
+    )
+    selector: ClaudePlatformUsageSelector
+
+
 class ClaudePlatformCostRecordResourceConfig(ResourceConfig):
-    # "claude-cost-record" is the deprecated alias kept for backwards
-    # compatibility with existing installations.
-    kind: Literal["claude-platform-cost-record", "claude-cost-record"] = Field(
+    kind: Literal["claude-platform-cost-record"] = Field(
         description="Claude Platform cost record resource kind",
         title="Claude Platform Cost Record",
     )
     selector: ClaudePlatformCostSelector
 
 
+class ClaudeCostRecordResourceConfig(ResourceConfig):
+    kind: Literal["claude-cost-record"] = Field(
+        description="Deprecated alias for Claude Platform cost record.",
+        title="Claude Cost Record",
+    )
+    selector: ClaudePlatformCostSelector
+
+
 class ClaudePlatformCodeAnalyticsResourceConfig(ResourceConfig):
-    # "claude-code-analytics" is the deprecated alias kept for backwards
-    # compatibility with existing installations.
-    kind: Literal["claude-platform-code-analytics", "claude-code-analytics"] = Field(
+    kind: Literal["claude-platform-code-analytics"] = Field(
         description="Claude Platform code analytics resource kind",
         title="Claude Platform Code Analytics",
+    )
+    selector: ClaudePlatformCodeAnalyticsSelector
+
+
+class ClaudeCodeAnalyticsResourceConfig(ResourceConfig):
+    kind: Literal["claude-code-analytics"] = Field(
+        description="Deprecated alias for Claude Platform code analytics.",
+        title="Claude Code Analytics",
     )
     selector: ClaudePlatformCodeAnalyticsSelector
 
@@ -305,8 +323,11 @@ class ClaudePortAppConfig(PortAppConfig):
         | ClaudeAIUserUsageResourceConfig
         | ClaudeAIUserCostResourceConfig
         | ClaudePlatformUsageRecordResourceConfig
+        | ClaudeUsageRecordResourceConfig
         | ClaudePlatformCostRecordResourceConfig
+        | ClaudeCostRecordResourceConfig
         | ClaudePlatformCodeAnalyticsResourceConfig
+        | ClaudeCodeAnalyticsResourceConfig
     ] = Field(
         description="Resources for claude",
         title="Resources",

--- a/integrations/claude/tests/test_integration.py
+++ b/integrations/claude/tests/test_integration.py
@@ -4,10 +4,13 @@ from pydantic.v1 import ValidationError
 from integration import (
     ClaudeAIUserActivitySelector,
     ClaudeAIUserReportSelector,
+    ClaudeCodeAnalyticsResourceConfig,
+    ClaudeCostRecordResourceConfig,
     ClaudePlatformCodeAnalyticsResourceConfig,
     ClaudePlatformCodeAnalyticsSelector,
     ClaudePlatformCostRecordResourceConfig,
     ClaudePlatformUsageRecordResourceConfig,
+    ClaudeUsageRecordResourceConfig,
 )
 
 _MINIMAL_PORT = {"entity": {"mappings": {"identifier": ".id", "blueprint": '"bp"'}}}
@@ -103,31 +106,42 @@ def test_user_report_selector_rejects_malformed_starting_at() -> None:
 
 
 @pytest.mark.parametrize(
-    "config_cls,new_kind,legacy_kind,selector",
+    "config_cls,kind,selector",
     [
         (
             ClaudePlatformUsageRecordResourceConfig,
             "claude-platform-usage-record",
+            {"query": "true"},
+        ),
+        (
+            ClaudeUsageRecordResourceConfig,
             "claude-usage-record",
             {"query": "true"},
         ),
         (
             ClaudePlatformCostRecordResourceConfig,
             "claude-platform-cost-record",
+            {"query": "true"},
+        ),
+        (
+            ClaudeCostRecordResourceConfig,
             "claude-cost-record",
             {"query": "true"},
         ),
         (
             ClaudePlatformCodeAnalyticsResourceConfig,
             "claude-platform-code-analytics",
+            {"query": "true", "timeFrame": 30},
+        ),
+        (
+            ClaudeCodeAnalyticsResourceConfig,
             "claude-code-analytics",
             {"query": "true", "timeFrame": 30},
         ),
     ],
 )
 def test_platform_config_accepts_new_and_legacy_kinds(
-    config_cls: type, new_kind: str, legacy_kind: str, selector: dict[str, object]
+    config_cls: type, kind: str, selector: dict[str, object]
 ) -> None:
-    for kind in (new_kind, legacy_kind):
-        config = config_cls(kind=kind, selector=selector, port=_MINIMAL_PORT)
-        assert config.kind == kind
+    config = config_cls(kind=kind, selector=selector, port=_MINIMAL_PORT)
+    assert config.kind == kind

--- a/integrations/gitlab-v2/.ocean-release/config-field-metadata.yaml
+++ b/integrations/gitlab-v2/.ocean-release/config-field-metadata.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: improvement
+changelog: Add title and description metadata to the GitLab v2 file selector.

--- a/integrations/gitlab-v2/integration.py
+++ b/integrations/gitlab-v2/integration.py
@@ -361,7 +361,10 @@ class FilesSelector(BaseModel):
 
 
 class GitLabFilesSelector(GroupSelector):
-    files: FilesSelector
+    files: FilesSelector = Field(
+        title="Files",
+        description="File matching configuration for GitLab file resources.",
+    )
     included_files: list[str] = Field(
         alias="includedFiles",
         title="Included Files",

--- a/integrations/gitlab/.ocean-release/config-field-metadata.yaml
+++ b/integrations/gitlab/.ocean-release/config-field-metadata.yaml
@@ -1,3 +1,3 @@
 bump: patch
 changelog-type: improvement
-changelog: Add title and description metadata to GitLab PortAppConfig and selector fields.
+changelog: Add title and description metadata to GitLab PortAppConfig fields, and split member kinds onto one Literal each.

--- a/integrations/gitlab/.ocean-release/config-field-metadata.yaml
+++ b/integrations/gitlab/.ocean-release/config-field-metadata.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: improvement
+changelog: Add title and description metadata to GitLab PortAppConfig and selector fields.

--- a/integrations/gitlab/gitlab_integration/git_integration.py
+++ b/integrations/gitlab/gitlab_integration/git_integration.py
@@ -169,9 +169,25 @@ class GitlabMemberSelector(Selector):
     )
 
 
-class GitlabObjectWithMembersResourceConfig(ResourceConfig):
-    kind: Literal["project-with-members", "group-with-members"]
+class GitlabGroupWithMembersResourceConfig(ResourceConfig):
+    kind: Literal["group-with-members"] = Field(
+        title="GitLab Group With Members",
+        description="GitLab group resource kind including group members.",
+    )
     selector: GitlabMemberSelector
+
+
+class GitlabProjectWithMembersResourceConfig(ResourceConfig):
+    kind: Literal["project-with-members"] = Field(
+        title="GitLab Project With Members",
+        description="GitLab project resource kind including project members.",
+    )
+    selector: GitlabMemberSelector
+
+
+GitlabObjectWithMembersResourceConfig = (
+    GitlabGroupWithMembersResourceConfig | GitlabProjectWithMembersResourceConfig
+)
 
 
 class FilesSelector(BaseModel):
@@ -231,7 +247,7 @@ class GitlabPortAppConfig(PortAppConfig):
         title="Project Visibility Filter",
         description="Optional GitLab visibility filter for projects (e.g. public, internal, private).",
     )
-    resources: list[GitlabObjectWithMembersResourceConfig | GitLabFilesResourceConfig | GitLabProjectResourceConfig | GitlabResourceConfig] = Field(default_factory=list)  # type: ignore
+    resources: list[GitlabGroupWithMembersResourceConfig | GitlabProjectWithMembersResourceConfig | GitLabFilesResourceConfig | GitLabProjectResourceConfig | GitlabResourceConfig] = Field(default_factory=list)  # type: ignore
 
 
 def _get_project_from_cache(project_id: int) -> Project | None:

--- a/integrations/gitlab/gitlab_integration/git_integration.py
+++ b/integrations/gitlab/gitlab_integration/git_integration.py
@@ -134,7 +134,11 @@ class FoldersSelector(BaseModel):
 
 
 class GitlabSelector(Selector):
-    folders: List[FoldersSelector] = Field(default_factory=list)
+    folders: List[FoldersSelector] = Field(
+        default_factory=list,
+        title="Folders",
+        description="Folders to export as monorepo-style resources.",
+    )
 
 
 class GitlabResourceConfig(ResourceConfig):
@@ -145,16 +149,19 @@ class GitlabMemberSelector(Selector):
     include_inherited_members: bool = Field(
         alias="includeInheritedMembers",
         default=False,
+        title="Include Inherited Members",
         description="If set to true, the integration will include inherited members in the group members list. Default value is false",
     )
     include_bot_members: bool = Field(
         alias="includeBotMembers",
         default=False,
+        title="Include Bot Members",
         description="If set to false, bots will be filtered out from the members list. Default value is true",
     )
     include_verbose_member_object: bool = Field(
         alias="includeVerboseMemberObject",
         default=False,
+        title="Include Verbose Member Object",
         description=(
             "If set to true, the integration will include the verbose/entire member object in the members list. Default value is false, "
             "this will reduce the memory footprint of the integration"
@@ -177,13 +184,17 @@ class FilesSelector(BaseModel):
 class GitLabProjectSelector(Selector):
     include_labels: bool = Field(
         alias="includeLabels",
+        title="Include Labels",
         description="Whether to enrich projects with labels",
         default=False,
     )
 
 
 class GitLabFilesSelector(Selector):
-    files: FilesSelector
+    files: FilesSelector = Field(
+        title="Files",
+        description="File matching configuration for GitLab file resources.",
+    )
 
 
 class GitLabFilesResourceConfig(ResourceConfig):
@@ -197,13 +208,28 @@ class GitLabProjectResourceConfig(ResourceConfig):
 
 
 class GitlabPortAppConfig(PortAppConfig):
-    spec_path: str | List[str] = Field(alias="specPath", default="**/port.yml")
-    branch: str | None
+    spec_path: str | List[str] = Field(
+        alias="specPath",
+        default="**/port.yml",
+        title="Spec Path",
+        description="Path glob for Port spec files to sync from GitLab repositories.",
+    )
+    branch: str | None = Field(
+        default=None,
+        title="Branch",
+        description="Git branch to use when syncing spec files. Defaults to the repository default branch.",
+    )
     filter_owned_projects: bool | None = Field(
-        alias="filterOwnedProjects", default=True
+        alias="filterOwnedProjects",
+        default=True,
+        title="Filter Owned Projects",
+        description="If true, only projects owned by the authenticated user or group are synced.",
     )
     project_visibility_filter: str | None = Field(
-        alias="projectVisibilityFilter", default=None
+        alias="projectVisibilityFilter",
+        default=None,
+        title="Project Visibility Filter",
+        description="Optional GitLab visibility filter for projects (e.g. public, internal, private).",
     )
     resources: list[GitlabObjectWithMembersResourceConfig | GitLabFilesResourceConfig | GitLabProjectResourceConfig | GitlabResourceConfig] = Field(default_factory=list)  # type: ignore
 

--- a/integrations/opencost/.ocean-release/config-field-metadata.yaml
+++ b/integrations/opencost/.ocean-release/config-field-metadata.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: improvement
+changelog: Add title and description metadata to OpenCost allocation and cloud-cost selector fields.

--- a/integrations/opencost/integration.py
+++ b/integrations/opencost/integration.py
@@ -93,14 +93,21 @@ class OpencostSelector(Selector):
         ]
         | DatePairField
         | UnixtimePairField
-    ) = Field(default="today")
+    ) = Field(
+        default="today",
+        title="Window",
+        description="Time window for the OpenCost allocation query.",
+    )
     aggregate: AggregationField | None = Field(
+        title="Aggregate",
         description="Field by which to aggregate the results.",
     )
     step: DurationField | None = Field(
+        title="Step",
         description="Duration of a single allocation set (e.g., '30m', '2h', '1d'). Default is window.",
     )
     resolution: ResolutionField | None = Field(
+        title="Resolution",
         description="Duration to use as resolution in Prometheus queries",
     )
 
@@ -126,16 +133,23 @@ class CloudCostSelector(Selector):
         ]
         | DatePairField
         | UnixtimePairField
-    ) = Field(default="today")
+    ) = Field(
+        default="today",
+        title="Window",
+        description="Time window for the OpenCost cloud cost query.",
+    )
     aggregate: CloudCostAggregateField | None = Field(
+        title="Aggregate",
         description="Field by which to aggregate the results of cloudcost",
     )
     accumulate: Literal["all", "hour", "day", "week", "month", "quarter"] | None = (
         Field(
+            title="Accumulate",
             description="Step size of the accumulation.",
         )
     )
     filter: str | None = Field(
+        title="Filter",
         description=(
             "Filter results by any category which that can be aggregated by,"
             " can support multiple filterable items in the same category in"


### PR DESCRIPTION
These fields would fail the PortAppConfig metadata enforcer once it is enabled in core.

# Description

What -

Why -

How -

## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-metadata-only changes with no validation or sync logic modifications; low risk aside from ensuring enforcer expectations match the new metadata.
> 
> **Overview**
> Adds **Pydantic `title` and `description` metadata** on integration `PortAppConfig` and selector models so they satisfy the upcoming **PortAppConfig metadata enforcer** in Ocean core. Runtime behavior and defaults are unchanged.
> 
> **Azure DevOps** documents `specPath` on `GitPortAppConfig`. **GitLab v2** documents the nested `files` selector on file resources. **GitLab (legacy)** fills gaps on folder/member/file selectors and on app-level fields (`specPath`, `branch`, `filterOwnedProjects`, `projectVisibilityFilter`). **OpenCost** adds display titles (and clarifies descriptions where needed) on allocation and cloud-cost selector fields such as `window`, `aggregate`, `step`, `resolution`, `accumulate`, and `filter`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5a3660b85485aee8604b67f1924823d178a2ad3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->