### PR TITLE
[Integration][fake-integration] Add PortAppConfig for schema generation

### DIFF
--- a/integrations/fake-integration/.ocean-release/add-portappconfig.yaml
+++ b/integrations/fake-integration/.ocean-release/add-portappconfig.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: improvement
+changelog: Add a PortAppConfig class so ocean port-app-config schema can load fake-integration.

--- a/integrations/fake-integration/integration.py
+++ b/integrations/fake-integration/integration.py
@@ -1,0 +1,73 @@
+from enum import StrEnum
+from typing import Literal
+
+from pydantic.v1 import Field
+
+from port_ocean.core.handlers.port_app_config.api import APIPortAppConfig
+from port_ocean.core.handlers.port_app_config.models import (
+    PortAppConfig,
+    ResourceConfig,
+)
+from port_ocean.core.integrations.base import BaseIntegration
+
+
+class ObjectKind(StrEnum):
+    DEPARTMENT = "fake-department"
+    PERSON = "fake-person"
+    OFFICE = "fake-office"
+    TEAM = "fake-team"
+    PROJECT = "fake-project"
+
+
+class FakeDepartmentResourceConfig(ResourceConfig):
+    kind: Literal[ObjectKind.DEPARTMENT] = Field(
+        title="Fake Department",
+        description="Fake department resource kind used in Ocean core smoke tests.",
+    )
+
+
+class FakePersonResourceConfig(ResourceConfig):
+    kind: Literal[ObjectKind.PERSON] = Field(
+        title="Fake Person",
+        description="Fake person resource kind used in Ocean core smoke tests.",
+    )
+
+
+class FakeOfficeResourceConfig(ResourceConfig):
+    kind: Literal[ObjectKind.OFFICE] = Field(
+        title="Fake Office",
+        description="Fake office resource kind used in Ocean core smoke tests.",
+    )
+
+
+class FakeTeamResourceConfig(ResourceConfig):
+    kind: Literal[ObjectKind.TEAM] = Field(
+        title="Fake Team",
+        description="Fake team resource kind used in Ocean core smoke tests.",
+    )
+
+
+class FakeProjectResourceConfig(ResourceConfig):
+    kind: Literal[ObjectKind.PROJECT] = Field(
+        title="Fake Project",
+        description="Fake project resource kind used in Ocean core smoke tests.",
+    )
+
+
+class FakePortAppConfig(PortAppConfig):
+    resources: list[
+        FakeDepartmentResourceConfig
+        | FakePersonResourceConfig
+        | FakeOfficeResourceConfig
+        | FakeTeamResourceConfig
+        | FakeProjectResourceConfig
+    ] = Field(
+        default_factory=list,
+        title="Resources",
+        description="The list of resource configurations for the fake integration.",
+    )  # type: ignore[assignment]
+
+
+class FakeIntegration(BaseIntegration):
+    class AppConfigHandlerClass(APIPortAppConfig):
+        CONFIG_CLASS = FakePortAppConfig


### PR DESCRIPTION
## Summary
- fake-integration had no `integration.py`, so `ocean port-app-config schema` failed in core schema CI ([job](https://github.com/port-labs/ocean/actions/runs/31942530992/job/95153743899?pr=3754)).
- Add typed `PortAppConfig` / `ResourceConfig` kinds matching the existing fake resync kinds.

https://app.getport.io/taskEntity?identifier=task_tjuzi4

Depends on / unblocks https://github.com/port-labs/ocean/pull/3754

## Test plan
- [ ] `cd integrations/fake-integration && make install/local-core && ocean port-app-config schema`
- [ ] `ocean port-app-config schema -f ui`
- [ ] Re-run schema CI on PR 3754 after this merges


Made with [Cursor](https://cursor.com)