### PR TITLE
[Integrations][Gitlab] Split catch-all kinds onto one Literal each.

### DIFF
--- a/integrations/gitlab/.ocean-release/split-kind-literals.yaml
+++ b/integrations/gitlab/.ocean-release/split-kind-literals.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: improvement
+changelog: Split GitLab catch-all resource kinds onto one Literal each so schema generation can enumerate kinds.

--- a/integrations/gitlab/gitlab_integration/events/hooks/base.py
+++ b/integrations/gitlab/gitlab_integration/events/hooks/base.py
@@ -48,13 +48,12 @@ class HookHandler(ABC):
             return
 
         for resource_config in matching_resource_configs:
-            include_bot_members = resource_config.selector.include_bot_members
-            include_inherited_members = (
-                resource_config.selector.include_inherited_members
-            )
-            include_verbose_member_object = (
-                resource_config.selector.include_verbose_member_object
-            )
+            selector = resource_config.selector
+            if not isinstance(selector, GitlabMemberSelector):
+                continue
+            include_bot_members = selector.include_bot_members
+            include_inherited_members = selector.include_inherited_members
+            include_verbose_member_object = selector.include_verbose_member_object
 
             object_result: RESTObject = (
                 await self.gitlab_service.enrich_object_with_members(

--- a/integrations/gitlab/gitlab_integration/git_integration.py
+++ b/integrations/gitlab/gitlab_integration/git_integration.py
@@ -141,7 +141,7 @@ class GitlabSelector(Selector):
     )
 
 
-class GitlabResourceConfig(ResourceConfig):
+class GitlabFolderResourceConfig(ResourceConfig):
     kind: Literal["folder"] = Field(
         title="GitLab Folder",
         description="GitLab folder resource kind for monorepo-style folder export.",
@@ -291,7 +291,7 @@ class GitlabPortAppConfig(PortAppConfig):
         | GitlabProjectWithMembersResourceConfig
         | GitLabFilesResourceConfig
         | GitLabProjectResourceConfig
-        | GitlabResourceConfig
+        | GitlabFolderResourceConfig
         | GitlabGroupResourceConfig
         | GitlabIssueResourceConfig
         | GitlabJobResourceConfig

--- a/integrations/gitlab/gitlab_integration/git_integration.py
+++ b/integrations/gitlab/gitlab_integration/git_integration.py
@@ -297,7 +297,9 @@ class GitlabPortAppConfig(PortAppConfig):
         | GitlabJobResourceConfig
         | GitlabMergeRequestResourceConfig
         | GitlabPipelineResourceConfig
-    ] = Field(default_factory=list)  # type: ignore
+    ] = Field(
+        default_factory=list
+    )  # type: ignore
 
 
 def _get_project_from_cache(project_id: int) -> Project | None:

--- a/integrations/gitlab/gitlab_integration/git_integration.py
+++ b/integrations/gitlab/gitlab_integration/git_integration.py
@@ -142,7 +142,46 @@ class GitlabSelector(Selector):
 
 
 class GitlabResourceConfig(ResourceConfig):
+    kind: Literal["folder"] = Field(
+        title="GitLab Folder",
+        description="GitLab folder resource kind for monorepo-style folder export.",
+    )
     selector: GitlabSelector
+
+
+class GitlabGroupResourceConfig(ResourceConfig):
+    kind: Literal["group"] = Field(
+        title="GitLab Group",
+        description="GitLab group resource kind.",
+    )
+
+
+class GitlabIssueResourceConfig(ResourceConfig):
+    kind: Literal["issue"] = Field(
+        title="GitLab Issue",
+        description="GitLab issue resource kind.",
+    )
+
+
+class GitlabJobResourceConfig(ResourceConfig):
+    kind: Literal["job"] = Field(
+        title="GitLab Job",
+        description="GitLab job resource kind.",
+    )
+
+
+class GitlabMergeRequestResourceConfig(ResourceConfig):
+    kind: Literal["merge-request"] = Field(
+        title="GitLab Merge Request",
+        description="GitLab merge request resource kind.",
+    )
+
+
+class GitlabPipelineResourceConfig(ResourceConfig):
+    kind: Literal["pipeline"] = Field(
+        title="GitLab Pipeline",
+        description="GitLab pipeline resource kind.",
+    )
 
 
 class GitlabMemberSelector(Selector):
@@ -247,7 +286,18 @@ class GitlabPortAppConfig(PortAppConfig):
         title="Project Visibility Filter",
         description="Optional GitLab visibility filter for projects (e.g. public, internal, private).",
     )
-    resources: list[GitlabGroupWithMembersResourceConfig | GitlabProjectWithMembersResourceConfig | GitLabFilesResourceConfig | GitLabProjectResourceConfig | GitlabResourceConfig] = Field(default_factory=list)  # type: ignore
+    resources: list[
+        GitlabGroupWithMembersResourceConfig
+        | GitlabProjectWithMembersResourceConfig
+        | GitLabFilesResourceConfig
+        | GitLabProjectResourceConfig
+        | GitlabResourceConfig
+        | GitlabGroupResourceConfig
+        | GitlabIssueResourceConfig
+        | GitlabJobResourceConfig
+        | GitlabMergeRequestResourceConfig
+        | GitlabPipelineResourceConfig
+    ] = Field(default_factory=list)  # type: ignore
 
 
 def _get_project_from_cache(project_id: int) -> Project | None:

--- a/integrations/gitlab/gitlab_integration/ocean.py
+++ b/integrations/gitlab/gitlab_integration/ocean.py
@@ -13,7 +13,7 @@ from gitlab_integration.models.webhook_groups_override_config import (
 )
 from gitlab_integration.events.setup import setup_application
 from gitlab_integration.git_integration import (
-    GitlabResourceConfig,
+    GitlabFolderResourceConfig,
     GitLabFilesResourceConfig,
     GitlabObjectWithMembersResourceConfig,
     GitLabProjectResourceConfig,
@@ -261,10 +261,10 @@ async def resync_project_with_members(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
 @ocean.on_resync(ObjectKind.FOLDER)
 async def resync_folders(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
     for service in get_cached_all_services():
-        gitlab_resource_config: GitlabResourceConfig = typing.cast(
-            "GitlabResourceConfig", event.resource_config
+        gitlab_resource_config: GitlabFolderResourceConfig = typing.cast(
+            "GitlabFolderResourceConfig", event.resource_config
         )
-        if not isinstance(gitlab_resource_config, GitlabResourceConfig):
+        if not isinstance(gitlab_resource_config, GitlabFolderResourceConfig):
             return
         selector = gitlab_resource_config.selector
         async for projects_batch in service.get_all_projects():


### PR DESCRIPTION
## Summary
- GitLab schema generation fails on core PR 3754 because `GitlabResourceConfig` inherits `kind: str` (`custom kinds are not allowed when allow_custom_kinds is False`).
- Pin `GitlabResourceConfig` to `Literal["folder"]` (keeps the folders selector) and add one ResourceConfig per remaining kind: `group`, `issue`, `job`, `merge-request`, `pipeline`.

Task: https://app.getport.io/taskEntity?identifier=task_tjuzwm

## Test plan
- [ ] Confirm GitLab `ocean port-app-config schema` succeeds against core schema enforcements
- [ ] Existing folder resync still uses `GitlabResourceConfig` / `GitlabSelector.folders`
- [ ] Merge before re-running schema CI on https://github.com/port-labs/ocean/pull/3754


Made with [Cursor](https://cursor.com)