### PR TITLE
[Core] Add Redis stream maintenance worker idle consumer cleanup and rename PEL worker

### DIFF
--- a/.ocean-release/core/redis-stream-maintenance-worker-rename.yaml
+++ b/.ocean-release/core/redis-stream-maintenance-worker-rename.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: improvement
+changelog: Rename the Redis PEL requeue worker to Redis stream maintenance worker to reflect PEL reclaim and idle consumer cleanup.

--- a/port_ocean/config/settings.py
+++ b/port_ocean/config/settings.py
@@ -203,40 +203,62 @@ class LiveEventsRedisSettings(BaseOceanModel, extra=Extra.allow):
             "the stream via MKSTREAM. Set to null to disable stream expiry."
         ),
     )
-    # PEL requeue worker settings
-    pel_requeue_worker_enabled: bool = Field(
+    # Redis stream maintenance worker settings
+    stream_maintenance_worker_enabled: bool = Field(
         default=True,
         description=(
             "When true, starts a background worker that reclaims stuck PEL "
-            "entries and re-enqueues them for reprocessing."
+            "entries, re-enqueues them for reprocessing, and removes idle "
+            "consumers from the group."
         ),
     )
     pel_stuck_timeout_seconds: int = Field(
         default=600,
         ge=1,
-        description="Seconds a PEL entry must be idle before the requeue worker reclaims it.",
+        description=(
+            "Seconds a PEL entry must be idle before the maintenance worker "
+            "reclaims it."
+        ),
     )
     pel_max_requeue_count: int = Field(
         default=3,
         ge=1,
         description="Maximum number of times a message is requeued before being discarded.",
     )
-    pel_scan_interval_seconds: float = Field(
+    stream_maintenance_scan_interval_seconds: float = Field(
         default=30.0,
         gt=0,
-        description="Seconds between successive PEL scans by the requeue worker.",
+        description=(
+            "Seconds between successive maintenance worker scans of the "
+            "consumer group."
+        ),
     )
     pel_xautoclaim_count: int = Field(
         default=100,
         ge=1,
         description="Maximum number of PEL entries to claim per XAUTOCLAIM call.",
     )
-    pel_lifecycle_error_backoff_seconds: float = Field(
+    stream_maintenance_error_backoff_seconds: float = Field(
         default=5.0,
         gt=0,
         description=(
-            "Seconds to wait before retrying the PEL worker lifecycle loop "
+            "Seconds to wait before retrying the stream maintenance worker loop "
             "after an unexpected error."
+        ),
+    )
+    stream_maintenance_consumer_cleanup_enabled: bool = Field(
+        default=True,
+        description=(
+            "When true, the stream maintenance worker periodically removes idle "
+            "consumers from the group that have no pending messages."
+        ),
+    )
+    stream_maintenance_consumer_cleanup_idle_seconds: int = Field(
+        default=86_400,  # 24 hours
+        ge=1,
+        description=(
+            "Seconds a consumer must be idle before the maintenance worker "
+            "removes it from the consumer group."
         ),
     )
     connection_error_backoff_seconds: float = Field(
@@ -275,6 +297,10 @@ class LiveEventsRedisSettings(BaseOceanModel, extra=Extra.allow):
     @property
     def stuck_timeout_ms(self) -> int:
         return self.pel_stuck_timeout_seconds * 1000
+
+    @property
+    def consumer_cleanup_idle_ms(self) -> int:
+        return self.stream_maintenance_consumer_cleanup_idle_seconds * 1000
 
     @root_validator
     def validate_tls_settings(cls, values: dict[str, Any]) -> dict[str, Any]:

--- a/port_ocean/consumers/pel_requeue/__init__.py
+++ b/port_ocean/consumers/pel_requeue/__init__.py
@@ -1,5 +1,0 @@
-from port_ocean.consumers.pel_requeue.worker import PELRequeueWorker
-
-__all__ = [
-    "PELRequeueWorker",
-]

--- a/port_ocean/consumers/pel_requeue/settings.py
+++ b/port_ocean/consumers/pel_requeue/settings.py
@@ -1,1 +1,0 @@
-PEL_CONSUMER_NAME = "pel-requeue-worker"

--- a/port_ocean/consumers/redis_stream_consumer.py
+++ b/port_ocean/consumers/redis_stream_consumer.py
@@ -21,7 +21,7 @@ from port_ocean.consumers.redis_client import (
 from port_ocean.consumers.abstract_live_events_consumer import (
     AbstractLiveEventsConsumer,
 )
-from port_ocean.consumers.pel_requeue import PELRequeueWorker
+from port_ocean.consumers.stream_maintenance import RedisStreamMaintenanceWorker
 from port_ocean.consumers.redis_stream_utils import (
     ack_and_finalize_stream_entry,
     ensure_consumer_group,
@@ -65,7 +65,7 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
         self._consumer_name = (
             f"{ocean.config.integration.identifier}-{socket.gethostname()}"
         )
-        self._pel_worker: PELRequeueWorker | None = None
+        self._stream_maintenance_worker: RedisStreamMaintenanceWorker | None = None
 
     def _resolve_consumer_group(self) -> str:
         integration = ocean.config.integration
@@ -139,15 +139,16 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
         self._is_running = True
         self._read_task = asyncio.create_task(self._read_loop())
 
-        if self._settings.pel_requeue_worker_enabled:
+        if self._settings.stream_maintenance_worker_enabled:
             assert self._redis is not None
-            self._pel_worker = PELRequeueWorker(
+            self._stream_maintenance_worker = RedisStreamMaintenanceWorker(
                 redis=self._redis,
                 redis_settings=self._settings,
                 stream_key=self._stream_key,
                 consumer_group=self._consumer_group,
+                stream_consumer_name=self._consumer_name,
             )
-            await self._pel_worker.start()
+            await self._stream_maintenance_worker.start()
 
         logger.info(
             "Started Redis stream consumer",
@@ -162,9 +163,9 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
             self._read_task.cancel()
             await asyncio.gather(self._read_task, return_exceptions=True)
             self._read_task = None
-        if self._pel_worker is not None:
-            await self._pel_worker.stop()
-            self._pel_worker = None
+        if self._stream_maintenance_worker is not None:
+            await self._stream_maintenance_worker.stop()
+            self._stream_maintenance_worker = None
         if self._redis is not None:
             await self._redis.aclose()
             self._redis = None

--- a/port_ocean/consumers/redis_stream_utils.py
+++ b/port_ocean/consumers/redis_stream_utils.py
@@ -97,21 +97,11 @@ async def cleanup_idle_consumers_from_group(
         if idle < idle_threshold_ms:
             continue
 
-        pending_before_delete = await redis.xgroup_delconsumer(
+        await redis.xgroup_delconsumer(
             stream_key,
             consumer_group,
             name,
         )
-        if pending_before_delete:
-            logger.warning(
-                "Redis consumer not removed because it still has pending messages",
-                stream_key=stream_key,
-                consumer_group=consumer_group,
-                consumer_name=name,
-                pending_count=pending_before_delete,
-            )
-            continue
-
         removed_count += 1
         logger.info(
             "Removed idle Redis stream consumer from group",

--- a/port_ocean/consumers/redis_stream_utils.py
+++ b/port_ocean/consumers/redis_stream_utils.py
@@ -62,6 +62,76 @@ async def ensure_consumer_group(
         )
 
 
+async def cleanup_idle_consumers_from_group(
+    redis: RedisClient,
+    *,
+    stream_key: str,
+    consumer_group: str,
+    idle_threshold_ms: int,
+    protected_consumer_names: frozenset[str],
+) -> int:
+    """Remove consumers idle beyond the threshold that have no pending messages."""
+    try:
+        consumers_info = await redis.xinfo_consumers(stream_key, consumer_group)
+    except ResponseError as error:
+        if not is_missing_stream_or_group_error(error):
+            raise
+        logger.warning(
+            "Redis stream or consumer group missing during idle consumer cleanup",
+            stream_key=stream_key,
+            consumer_group=consumer_group,
+            error=str(error),
+        )
+        return 0
+
+    removed_count = 0
+    for consumer in consumers_info:
+        name = str(consumer["name"])
+        pending = int(consumer["pending"])
+        idle = int(consumer["idle"])
+
+        if name in protected_consumer_names:
+            continue
+        if pending > 0:
+            continue
+        if idle < idle_threshold_ms:
+            continue
+
+        pending_before_delete = await redis.xgroup_delconsumer(
+            stream_key,
+            consumer_group,
+            name,
+        )
+        if pending_before_delete:
+            logger.warning(
+                "Redis consumer not removed because it still has pending messages",
+                stream_key=stream_key,
+                consumer_group=consumer_group,
+                consumer_name=name,
+                pending_count=pending_before_delete,
+            )
+            continue
+
+        removed_count += 1
+        logger.info(
+            "Removed idle Redis stream consumer from group",
+            stream_key=stream_key,
+            consumer_group=consumer_group,
+            consumer_name=name,
+            idle_ms=idle,
+        )
+
+    if removed_count:
+        logger.info(
+            "Idle Redis stream consumer cleanup complete",
+            stream_key=stream_key,
+            consumer_group=consumer_group,
+            removed_count=removed_count,
+        )
+
+    return removed_count
+
+
 ACK_AND_FINALIZE_STREAM_ENTRY_SCRIPT = """
 redis.call('XACK', KEYS[1], ARGV[1], ARGV[2])
 return redis.call('XDEL', KEYS[1], ARGV[2])

--- a/port_ocean/consumers/redis_stream_utils.py
+++ b/port_ocean/consumers/redis_stream_utils.py
@@ -90,11 +90,7 @@ async def cleanup_idle_consumers_from_group(
         pending = int(consumer["pending"])
         idle = int(consumer["idle"])
 
-        if name in protected_consumer_names:
-            continue
-        if pending > 0:
-            continue
-        if idle < idle_threshold_ms:
+        if name in protected_consumer_names or pending > 0 or idle < idle_threshold_ms:
             continue
 
         await redis.xgroup_delconsumer(

--- a/port_ocean/consumers/stream_maintenance/__init__.py
+++ b/port_ocean/consumers/stream_maintenance/__init__.py
@@ -1,0 +1,5 @@
+from port_ocean.consumers.stream_maintenance.worker import RedisStreamMaintenanceWorker
+
+__all__ = [
+    "RedisStreamMaintenanceWorker",
+]

--- a/port_ocean/consumers/stream_maintenance/settings.py
+++ b/port_ocean/consumers/stream_maintenance/settings.py
@@ -1,0 +1,1 @@
+STREAM_MAINTENANCE_CONSUMER_NAME = "stream-maintenance-worker"

--- a/port_ocean/consumers/stream_maintenance/worker.py
+++ b/port_ocean/consumers/stream_maintenance/worker.py
@@ -1,17 +1,20 @@
-"""PEL (Pending Entry List) requeue worker.
+"""Redis stream maintenance worker.
 
 All pods run the scan concurrently. XAUTOCLAIM is a single atomic Redis
 command, so only one pod will ever claim a given stuck message; redundant
 scans by other pods are harmless no-ops.
 
-The worker itself contains no processing logic — consumer pods handle all
-actual processing.  When a message has been stuck in the PEL longer than
-``stuck_timeout_ms`` the worker:
+The worker reclaims stuck PEL entries and performs consumer-group hygiene.
+Stream consumer pods handle all actual message processing. When a message has
+been stuck in the PEL longer than ``stuck_timeout_ms`` the worker:
 
 1. Claims it with XAUTOCLAIM.
 2. If ``requeue_count`` has reached ``max_requeue_count``, ACKs and discards it.
 3. Otherwise increments ``requeue_count``, re-enqueues via XADD, then ACKs the
    original entry to remove it from the PEL.
+
+After each scan, the worker may also remove idle consumers from the group that
+have no pending messages (see ``stream_maintenance_consumer_cleanup_enabled``).
 """
 
 import asyncio
@@ -20,17 +23,20 @@ from loguru import logger
 from redis.exceptions import ResponseError
 from port_ocean.config.settings import LiveEventsRedisSettings
 from port_ocean.consumers.redis_client import RedisClient
-from port_ocean.consumers.pel_requeue.settings import PEL_CONSUMER_NAME
+from port_ocean.consumers.stream_maintenance.settings import (
+    STREAM_MAINTENANCE_CONSUMER_NAME,
+)
 from port_ocean.consumers.redis_stream_utils import (
     ack_and_finalize_stream_entry,
+    cleanup_idle_consumers_from_group,
     ensure_consumer_group,
     is_missing_stream_or_group_error,
     requeue_stream_entry,
 )
 
 
-class PELRequeueWorker:
-    """Background worker that rescues messages stuck in the Redis PEL.
+class RedisStreamMaintenanceWorker:
+    """Background worker for Redis stream consumer-group maintenance.
 
     Every pod runs the scan independently on a fixed interval. XAUTOCLAIM
     atomicity ensures each stuck message is claimed and processed by exactly
@@ -43,11 +49,18 @@ class PELRequeueWorker:
         redis_settings: LiveEventsRedisSettings,
         stream_key: str,
         consumer_group: str,
+        *,
+        stream_consumer_name: str | None = None,
     ) -> None:
         self._redis = redis
         self._redis_settings = redis_settings
         self._stream_key = stream_key
         self._consumer_group = consumer_group
+        self._protected_consumer_names = frozenset(
+            name
+            for name in (STREAM_MAINTENANCE_CONSUMER_NAME, stream_consumer_name)
+            if name
+        )
         self._is_running = False
         self._lifecycle_task: asyncio.Task[None] | None = None
 
@@ -55,7 +68,7 @@ class PELRequeueWorker:
         self._is_running = True
         self._lifecycle_task = asyncio.create_task(self._worker_loop())
         logger.info(
-            "PEL requeue worker started",
+            "Redis stream maintenance worker started",
             stream_key=self._stream_key,
             consumer_group=self._consumer_group,
         )
@@ -70,7 +83,7 @@ class PELRequeueWorker:
     async def _recover_missing_stream(self) -> None:
         try:
             logger.warning(
-                "Redis stream or consumer group missing in PEL requeue worker, recreating",
+                "Redis stream or consumer group missing in stream maintenance worker, recreating",
                 stream_key=self._stream_key,
                 consumer_group=self._consumer_group,
             )
@@ -83,7 +96,7 @@ class PELRequeueWorker:
         except Exception as recovery_error:
             logger.exception(
                 "Failed to recreate Redis stream consumer group "
-                "from PEL requeue worker",
+                "from stream maintenance worker",
                 stream_key=self._stream_key,
                 error=str(recovery_error),
             )
@@ -92,7 +105,11 @@ class PELRequeueWorker:
         while self._is_running:
             try:
                 await self._scan_and_requeue()
-                await asyncio.sleep(self._redis_settings.pel_scan_interval_seconds)
+                if self._redis_settings.stream_maintenance_consumer_cleanup_enabled:
+                    await self._cleanup_idle_consumers()
+                await asyncio.sleep(
+                    self._redis_settings.stream_maintenance_scan_interval_seconds
+                )
             except asyncio.CancelledError:
                 break
             except ResponseError as error:
@@ -100,20 +117,20 @@ class PELRequeueWorker:
                     await self._recover_missing_stream()
                 else:
                     logger.exception(
-                        "Unexpected Redis error in PEL requeue worker loop",
+                        "Unexpected Redis error in stream maintenance worker loop",
                         stream_key=self._stream_key,
                         error=str(error),
                     )
                 await asyncio.sleep(
-                    self._redis_settings.pel_lifecycle_error_backoff_seconds
+                    self._redis_settings.stream_maintenance_error_backoff_seconds
                 )
             except Exception as error:
                 logger.exception(
-                    "Unexpected error in PEL requeue worker loop",
+                    "Unexpected error in stream maintenance worker loop",
                     error=str(error),
                 )
                 await asyncio.sleep(
-                    self._redis_settings.pel_lifecycle_error_backoff_seconds
+                    self._redis_settings.stream_maintenance_error_backoff_seconds
                 )
 
     async def _scan_and_requeue(self) -> None:
@@ -126,7 +143,7 @@ class PELRequeueWorker:
                 result = await self._redis.xautoclaim(
                     self._stream_key,
                     self._consumer_group,
-                    PEL_CONSUMER_NAME,
+                    STREAM_MAINTENANCE_CONSUMER_NAME,
                     self._redis_settings.stuck_timeout_ms,
                     cursor,
                     count=self._redis_settings.pel_xautoclaim_count,
@@ -191,6 +208,21 @@ class PELRequeueWorker:
                 total_processed=total_processed,
                 stream_key=self._stream_key,
             )
+
+    async def _cleanup_idle_consumers(self) -> None:
+        try:
+            await cleanup_idle_consumers_from_group(
+                self._redis,
+                stream_key=self._stream_key,
+                consumer_group=self._consumer_group,
+                idle_threshold_ms=self._redis_settings.consumer_cleanup_idle_ms,
+                protected_consumer_names=self._protected_consumer_names,
+            )
+        except ResponseError as error:
+            if is_missing_stream_or_group_error(error):
+                await self._recover_missing_stream()
+            else:
+                raise
 
     async def _handle_stuck_message(
         self, message_id: str, fields: dict[str, str]

--- a/port_ocean/consumers/stream_maintenance/worker.py
+++ b/port_ocean/consumers/stream_maintenance/worker.py
@@ -56,10 +56,10 @@ class RedisStreamMaintenanceWorker:
         self._redis_settings = redis_settings
         self._stream_key = stream_key
         self._consumer_group = consumer_group
-        self._protected_consumer_names = frozenset(
-            name
-            for name in (STREAM_MAINTENANCE_CONSUMER_NAME, stream_consumer_name)
-            if name
+        self._protected_consumer_names = (
+            frozenset({STREAM_MAINTENANCE_CONSUMER_NAME, stream_consumer_name})
+            if stream_consumer_name
+            else frozenset({STREAM_MAINTENANCE_CONSUMER_NAME})
         )
         self._is_running = False
         self._lifecycle_task: asyncio.Task[None] | None = None
@@ -219,10 +219,9 @@ class RedisStreamMaintenanceWorker:
                 protected_consumer_names=self._protected_consumer_names,
             )
         except ResponseError as error:
-            if is_missing_stream_or_group_error(error):
-                await self._recover_missing_stream()
-            else:
+            if not is_missing_stream_or_group_error(error):
                 raise
+            await self._recover_missing_stream()
 
     async def _handle_stuck_message(
         self, message_id: str, fields: dict[str, str]

--- a/port_ocean/tests/config/test_live_events_redis_settings.py
+++ b/port_ocean/tests/config/test_live_events_redis_settings.py
@@ -9,7 +9,7 @@ class TestLiveEventsRedisSettingsValidation:
         settings = LiveEventsRedisSettings(url="redis://localhost:6379")
 
         assert settings.enable_tls is False
-        assert settings.pel_requeue_worker_enabled is True
+        assert settings.stream_maintenance_worker_enabled is True
         assert settings.stream_ttl_seconds == 2_592_000
 
     def test_is_redis_stream_consumer_enabled_from_env(
@@ -29,13 +29,13 @@ class TestLiveEventsRedisSettingsValidation:
 
         assert config.live_events.is_redis_stream_consumer_enabled is True
 
-    def test_pel_requeue_worker_enabled_from_env(
+    def test_stream_maintenance_worker_enabled_from_env(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         from port_ocean.config.settings import IntegrationConfiguration
 
         monkeypatch.setenv(
-            "OCEAN__LIVE_EVENTS__REDIS__PEL_REQUEUE_WORKER_ENABLED", "true"
+            "OCEAN__LIVE_EVENTS__REDIS__STREAM_MAINTENANCE_WORKER_ENABLED", "true"
         )
         monkeypatch.setenv("OCEAN__PORT__CLIENT_ID", "test-client-id")
         monkeypatch.setenv("OCEAN__PORT__CLIENT_SECRET", "test-client-secret")
@@ -44,7 +44,7 @@ class TestLiveEventsRedisSettingsValidation:
 
         config = IntegrationConfiguration()
 
-        assert config.live_events.redis.pel_requeue_worker_enabled is True
+        assert config.live_events.redis.stream_maintenance_worker_enabled is True
 
     def test_stream_ttl_seconds_from_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
         from port_ocean.config.settings import IntegrationConfiguration

--- a/port_ocean/tests/consumers/stream_maintenance/test_worker.py
+++ b/port_ocean/tests/consumers/stream_maintenance/test_worker.py
@@ -1,4 +1,4 @@
-"""Tests for PELRequeueWorker."""
+"""Tests for RedisStreamMaintenanceWorker."""
 
 import asyncio
 from typing import Any
@@ -8,8 +8,10 @@ import pytest
 from redis.exceptions import ResponseError
 
 from port_ocean.config.settings import LiveEventsRedisSettings
-from port_ocean.consumers.pel_requeue import PELRequeueWorker
-from port_ocean.consumers.pel_requeue.settings import PEL_CONSUMER_NAME
+from port_ocean.consumers.stream_maintenance import RedisStreamMaintenanceWorker
+from port_ocean.consumers.stream_maintenance.settings import (
+    STREAM_MAINTENANCE_CONSUMER_NAME,
+)
 from port_ocean.consumers.redis_stream_utils import (
     ACK_AND_FINALIZE_STREAM_ENTRY_SCRIPT,
     REQUEUE_STREAM_ENTRY_SCRIPT,
@@ -26,15 +28,16 @@ _DEFAULT_REDIS_SETTINGS = LiveEventsRedisSettings(
     url="redis://localhost:6379",
     pel_stuck_timeout_seconds=60,
     pel_max_requeue_count=3,
-    pel_scan_interval_seconds=30.0,
+    stream_maintenance_scan_interval_seconds=30.0,
     pel_xautoclaim_count=100,
-    pel_lifecycle_error_backoff_seconds=5.0,
+    stream_maintenance_error_backoff_seconds=5.0,
 )
 
 
 def _make_redis() -> AsyncMock:
     redis = AsyncMock()
     redis.xautoclaim = AsyncMock(return_value=("0-0", [], []))
+    redis.xinfo_consumers = AsyncMock(return_value=[])
     redis.eval = AsyncMock(return_value="1700000000001-0")
     redis.expire = AsyncMock(return_value=True)
     return redis
@@ -49,19 +52,21 @@ def _make_worker(
     redis: AsyncMock,
     stream_key: str = _STREAM_KEY,
     consumer_group: str = _CONSUMER_GROUP,
+    stream_consumer_name: str | None = None,
     **settings_overrides: Any,
-) -> PELRequeueWorker:
+) -> RedisStreamMaintenanceWorker:
     redis_settings = _DEFAULT_REDIS_SETTINGS.copy(update=settings_overrides)
-    return PELRequeueWorker(
+    return RedisStreamMaintenanceWorker(
         redis,
         redis_settings=redis_settings,
         stream_key=stream_key,
         consumer_group=consumer_group,
+        stream_consumer_name=stream_consumer_name,
     )
 
 
 # ---------------------------------------------------------------------------
-# PELRequeueWorker — _handle_stuck_message
+# RedisStreamMaintenanceWorker — _handle_stuck_message
 # ---------------------------------------------------------------------------
 
 
@@ -157,7 +162,7 @@ class TestPELHandleStuckMessage:
 
 
 # ---------------------------------------------------------------------------
-# PELRequeueWorker — _scan_and_requeue
+# RedisStreamMaintenanceWorker — _scan_and_requeue
 # ---------------------------------------------------------------------------
 
 
@@ -175,7 +180,7 @@ class TestPELScanAndRequeue:
         redis.xautoclaim.assert_awaited_once_with(
             worker._stream_key,
             worker._consumer_group,
-            PEL_CONSUMER_NAME,
+            STREAM_MAINTENANCE_CONSUMER_NAME,
             60_000,
             "0-0",
             count=100,
@@ -368,11 +373,11 @@ class TestPELScanAndRequeue:
 
 
 # ---------------------------------------------------------------------------
-# PELRequeueWorker — worker loop
+# RedisStreamMaintenanceWorker — worker loop
 # ---------------------------------------------------------------------------
 
 
-class TestPELWorkerLoop:
+class TestStreamMaintenanceWorkerLoop:
     @pytest.mark.asyncio
     async def test_worker_stops_cleanly(self) -> None:
         redis = _make_redis()
@@ -381,7 +386,7 @@ class TestPELWorkerLoop:
         async def fake_scan() -> None:
             scan_calls.append(1)
 
-        worker = _make_worker(redis, pel_scan_interval_seconds=0.05)
+        worker = _make_worker(redis, stream_maintenance_scan_interval_seconds=0.05)
         worker._scan_and_requeue = fake_scan  # type: ignore[method-assign]
         await worker.start()
         await asyncio.sleep(0.25)
@@ -397,8 +402,8 @@ class TestPELWorkerLoop:
         redis = _make_redis()
         scan_counts: dict[str, int] = {"a": 0, "b": 0}
 
-        worker_a = _make_worker(redis, pel_scan_interval_seconds=0.05)
-        worker_b = _make_worker(redis, pel_scan_interval_seconds=0.05)
+        worker_a = _make_worker(redis, stream_maintenance_scan_interval_seconds=0.05)
+        worker_b = _make_worker(redis, stream_maintenance_scan_interval_seconds=0.05)
 
         async def fake_scan_a() -> None:
             scan_counts["a"] += 1
@@ -429,8 +434,8 @@ class TestPELWorkerLoop:
 
         worker = _make_worker(
             redis,
-            pel_scan_interval_seconds=0.01,
-            pel_lifecycle_error_backoff_seconds=0.05,
+            stream_maintenance_scan_interval_seconds=0.01,
+            stream_maintenance_error_backoff_seconds=0.05,
         )
         worker._scan_and_requeue = failing_scan  # type: ignore[method-assign]
         await worker.start()
@@ -441,7 +446,89 @@ class TestPELWorkerLoop:
         assert len(scan_calls) >= 2, "Expected retries after error backoff"
 
 
-class TestPELRecoverMissingStream:
+class TestStreamMaintenanceIdleConsumerCleanup:
+    @pytest.mark.asyncio
+    async def test_cleanup_removes_idle_consumers_after_scan(self) -> None:
+        redis = _make_redis()
+        redis.xinfo_consumers = AsyncMock(
+            return_value=[
+                {
+                    "name": "integration-dead-pod",
+                    "pending": 0,
+                    "idle": 5_000_000,
+                }
+            ]
+        )
+        redis.xgroup_delconsumer = AsyncMock(return_value=0)
+
+        worker = _make_worker(
+            redis,
+            stream_consumer_name="integration-live-pod",
+            stream_maintenance_consumer_cleanup_idle_seconds=60,
+        )
+        await worker._cleanup_idle_consumers()
+
+        redis.xgroup_delconsumer.assert_awaited_once_with(
+            _STREAM_KEY,
+            _CONSUMER_GROUP,
+            "integration-dead-pod",
+        )
+
+    @pytest.mark.asyncio
+    async def test_cleanup_skips_protected_stream_consumer_name(self) -> None:
+        redis = _make_redis()
+        redis.xinfo_consumers = AsyncMock(
+            return_value=[
+                {
+                    "name": "integration-live-pod",
+                    "pending": 0,
+                    "idle": 5_000_000,
+                },
+                {
+                    "name": STREAM_MAINTENANCE_CONSUMER_NAME,
+                    "pending": 0,
+                    "idle": 5_000_000,
+                },
+            ]
+        )
+        redis.xgroup_delconsumer = AsyncMock(return_value=0)
+
+        worker = _make_worker(
+            redis,
+            stream_consumer_name="integration-live-pod",
+            stream_maintenance_consumer_cleanup_idle_seconds=60,
+        )
+        await worker._cleanup_idle_consumers()
+
+        redis.xgroup_delconsumer.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_worker_loop_skips_cleanup_when_disabled(self) -> None:
+        redis = _make_redis()
+        cleanup_calls: list[int] = []
+
+        async def fake_scan() -> None:
+            return None
+
+        async def fake_cleanup() -> None:
+            cleanup_calls.append(1)
+
+        worker = _make_worker(
+            redis,
+            stream_maintenance_scan_interval_seconds=0.05,
+            stream_maintenance_consumer_cleanup_enabled=False,
+        )
+        worker._scan_and_requeue = fake_scan  # type: ignore[method-assign]
+        worker._cleanup_idle_consumers = fake_cleanup  # type: ignore[method-assign]
+
+        await worker.start()
+        await asyncio.sleep(0.15)
+        await worker.stop()
+
+        assert cleanup_calls == []
+
+
+class TestStreamMaintenanceRecoverMissingStream:
     @pytest.mark.asyncio
     async def test_scan_recovers_when_xautoclaim_raises_nogroup(self) -> None:
         redis = _make_redis()

--- a/port_ocean/tests/consumers/test_redis_stream_consumer.py
+++ b/port_ocean/tests/consumers/test_redis_stream_consumer.py
@@ -18,7 +18,7 @@ from port_ocean.exceptions.live_events import (
     LiveEventsUuidNotFoundError,
     MissingLiveEventsBaseUrlError,
 )
-from port_ocean.consumers.pel_requeue import PELRequeueWorker
+from port_ocean.consumers.stream_maintenance import RedisStreamMaintenanceWorker
 from port_ocean.consumers.redis_stream_consumer import RedisStreamConsumer
 from port_ocean.consumers.redis_stream_utils import (
     ACK_AND_FINALIZE_STREAM_ENTRY_SCRIPT,
@@ -668,19 +668,19 @@ class TestRedisStreamConsumerAck:
         mock_redis.xgroup_create.assert_not_awaited()
 
 
-class TestRedisStreamConsumerPelWorkerLifecycle:
+class TestRedisStreamConsumerMaintenanceWorkerLifecycle:
     @pytest.mark.asyncio
-    async def test_start_starts_pel_worker_when_enabled(
+    async def test_start_starts_stream_maintenance_worker_when_enabled(
         self,
         mock_ocean_config: MagicMock,
     ) -> None:
         settings = LiveEventsRedisSettings(
             url="redis://localhost:6379",
-            pel_requeue_worker_enabled=True,
+            stream_maintenance_worker_enabled=True,
         )
         mock_redis = AsyncMock()
         mock_redis.xgroup_create = AsyncMock()
-        mock_pel_worker = AsyncMock()
+        mock_maintenance_worker = AsyncMock()
 
         with (
             patch(
@@ -691,9 +691,9 @@ class TestRedisStreamConsumerPelWorkerLifecycle:
                 new=AsyncMock(return_value=mock_redis),
             ),
             patch(
-                "port_ocean.consumers.redis_stream_consumer.PELRequeueWorker",
-                return_value=mock_pel_worker,
-            ) as mock_pel_worker_cls,
+                "port_ocean.consumers.redis_stream_consumer.RedisStreamMaintenanceWorker",
+                return_value=mock_maintenance_worker,
+            ) as mock_maintenance_worker_cls,
         ):
             consumer = RedisStreamConsumer(
                 redis_settings=settings,
@@ -702,24 +702,26 @@ class TestRedisStreamConsumerPelWorkerLifecycle:
             )
             await consumer.start()
 
-            mock_pel_worker_cls.assert_called_once()
-            mock_pel_worker.start.assert_awaited_once()
-            assert consumer._pel_worker is mock_pel_worker
+            mock_maintenance_worker_cls.assert_called_once()
+            call_kwargs = mock_maintenance_worker_cls.call_args.kwargs
+            assert call_kwargs["stream_consumer_name"] == consumer._consumer_name
+            mock_maintenance_worker.start.assert_awaited_once()
+            assert consumer._stream_maintenance_worker is mock_maintenance_worker
 
             await consumer.stop()
 
-            mock_pel_worker.stop.assert_awaited_once()
-            assert consumer._pel_worker is None
+            mock_maintenance_worker.stop.assert_awaited_once()
+            assert consumer._stream_maintenance_worker is None
             mock_redis.aclose.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_start_skips_pel_worker_when_disabled(
+    async def test_start_skips_stream_maintenance_worker_when_disabled(
         self,
         mock_ocean_config: MagicMock,
     ) -> None:
         settings = LiveEventsRedisSettings(
             url="redis://localhost:6379",
-            pel_requeue_worker_enabled=False,
+            stream_maintenance_worker_enabled=False,
         )
         mock_redis = AsyncMock()
         mock_redis.xgroup_create = AsyncMock()
@@ -733,8 +735,8 @@ class TestRedisStreamConsumerPelWorkerLifecycle:
                 new=AsyncMock(return_value=mock_redis),
             ),
             patch(
-                "port_ocean.consumers.redis_stream_consumer.PELRequeueWorker",
-            ) as mock_pel_worker_cls,
+                "port_ocean.consumers.redis_stream_consumer.RedisStreamMaintenanceWorker",
+            ) as mock_maintenance_worker_cls,
         ):
             consumer = RedisStreamConsumer(
                 redis_settings=settings,
@@ -743,21 +745,21 @@ class TestRedisStreamConsumerPelWorkerLifecycle:
             )
             await consumer.start()
 
-            mock_pel_worker_cls.assert_not_called()
-            assert consumer._pel_worker is None
+            mock_maintenance_worker_cls.assert_not_called()
+            assert consumer._stream_maintenance_worker is None
 
             await consumer.stop()
 
-            assert consumer._pel_worker is None
+            assert consumer._stream_maintenance_worker is None
             mock_redis.aclose.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_pel_worker_requeues_while_handler_still_processing(
+    async def test_stream_maintenance_worker_requeues_while_handler_still_processing(
         self,
         mock_ocean_config: MagicMock,
     ) -> None:
-        """If processing exceeds stuck_timeout, PEL worker can requeue while the
-        original handler is still in flight — enabling duplicate delivery."""
+        """If processing exceeds stuck_timeout, the maintenance worker can requeue
+        while the original handler is still in flight — enabling duplicate delivery."""
         handler_entered = asyncio.Event()
         release_handler = asyncio.Event()
 
@@ -799,13 +801,13 @@ class TestRedisStreamConsumerPelWorkerLifecycle:
             )
             await handler_entered.wait()
 
-            pel_worker = PELRequeueWorker(
+            maintenance_worker = RedisStreamMaintenanceWorker(
                 mock_redis,
                 redis_settings=settings,
                 stream_key="stream",
                 consumer_group=consumer._consumer_group,
             )
-            await pel_worker._scan_and_requeue()
+            await maintenance_worker._scan_and_requeue()
 
             mock_redis.eval.assert_awaited_once()
             assert mock_redis.eval.await_args is not None

--- a/port_ocean/tests/consumers/test_redis_stream_utils.py
+++ b/port_ocean/tests/consumers/test_redis_stream_utils.py
@@ -9,6 +9,7 @@ from redis.exceptions import TimeoutError as RedisTimeoutError
 from port_ocean.consumers.redis_stream_utils import (
     ACK_AND_FINALIZE_STREAM_ENTRY_SCRIPT,
     ack_and_finalize_stream_entry,
+    cleanup_idle_consumers_from_group,
     ensure_consumer_group,
     is_missing_stream_or_group_error,
     is_redis_connection_error,
@@ -129,6 +130,137 @@ class TestEnsureConsumerGroup:
         )
 
         redis.expire.assert_not_awaited()
+
+
+class TestCleanupIdleConsumersFromGroup:
+    @pytest.mark.asyncio
+    async def test_removes_idle_consumer_with_no_pending_messages(self) -> None:
+        redis = AsyncMock()
+        redis.xinfo_consumers = AsyncMock(
+            return_value=[
+                {
+                    "name": "integration-dead-pod",
+                    "pending": 0,
+                    "idle": 5_000_000,
+                }
+            ]
+        )
+        redis.xgroup_delconsumer = AsyncMock(return_value=0)
+
+        removed = await cleanup_idle_consumers_from_group(
+            redis,
+            stream_key="stream",
+            consumer_group="test.integration",
+            idle_threshold_ms=3600_000,
+            protected_consumer_names=frozenset(),
+        )
+
+        assert removed == 1
+        redis.xgroup_delconsumer.assert_awaited_once_with(
+            "stream",
+            "test.integration",
+            "integration-dead-pod",
+        )
+
+    @pytest.mark.asyncio
+    async def test_skips_protected_consumer_names(self) -> None:
+        redis = AsyncMock()
+        redis.xinfo_consumers = AsyncMock(
+            return_value=[
+                {
+                    "name": "stream-maintenance-worker",
+                    "pending": 0,
+                    "idle": 5_000_000,
+                },
+                {
+                    "name": "integration-live-pod",
+                    "pending": 0,
+                    "idle": 5_000_000,
+                },
+            ]
+        )
+        redis.xgroup_delconsumer = AsyncMock(return_value=0)
+
+        removed = await cleanup_idle_consumers_from_group(
+            redis,
+            stream_key="stream",
+            consumer_group="test.integration",
+            idle_threshold_ms=3600_000,
+            protected_consumer_names=frozenset(
+                {"stream-maintenance-worker", "integration-live-pod"}
+            ),
+        )
+
+        assert removed == 0
+        redis.xgroup_delconsumer.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_skips_consumers_with_pending_messages(self) -> None:
+        redis = AsyncMock()
+        redis.xinfo_consumers = AsyncMock(
+            return_value=[
+                {
+                    "name": "integration-dead-pod",
+                    "pending": 2,
+                    "idle": 5_000_000,
+                }
+            ]
+        )
+        redis.xgroup_delconsumer = AsyncMock(return_value=0)
+
+        removed = await cleanup_idle_consumers_from_group(
+            redis,
+            stream_key="stream",
+            consumer_group="test.integration",
+            idle_threshold_ms=3600_000,
+            protected_consumer_names=frozenset(),
+        )
+
+        assert removed == 0
+        redis.xgroup_delconsumer.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_skips_consumers_below_idle_threshold(self) -> None:
+        redis = AsyncMock()
+        redis.xinfo_consumers = AsyncMock(
+            return_value=[
+                {
+                    "name": "integration-recent-pod",
+                    "pending": 0,
+                    "idle": 1000,
+                }
+            ]
+        )
+        redis.xgroup_delconsumer = AsyncMock(return_value=0)
+
+        removed = await cleanup_idle_consumers_from_group(
+            redis,
+            stream_key="stream",
+            consumer_group="test.integration",
+            idle_threshold_ms=3600_000,
+            protected_consumer_names=frozenset(),
+        )
+
+        assert removed == 0
+        redis.xgroup_delconsumer.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_swallows_missing_stream_error(self) -> None:
+        redis = AsyncMock()
+        redis.xinfo_consumers = AsyncMock(
+            side_effect=ResponseError("NOGROUP No such key 'stream' or consumer group")
+        )
+
+        removed = await cleanup_idle_consumers_from_group(
+            redis,
+            stream_key="stream",
+            consumer_group="test.integration",
+            idle_threshold_ms=3600_000,
+            protected_consumer_names=frozenset(),
+        )
+
+        assert removed == 0
+        redis.xgroup_delconsumer.assert_not_awaited()
 
 
 class TestIsRedisConnectionError:


### PR DESCRIPTION
# Description

- Renames the Redis **PEL requeue worker** to **`RedisStreamMaintenanceWorker`** (`port_ocean/consumers/stream_maintenance/`) to reflect its broader role: stuck PEL reclaim plus consumer-group hygiene.
- Adds periodic removal of **stale consumers** from the Redis stream consumer group via `XINFO CONSUMERS` + `XGROUP DELCONSUMER`.
- Reclaim stuck PEL messages first (`XAUTOCLAIM`), then clean up idle consumers so dead pods don’t leave unclaimed pending entries blocking deletion.


## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live-events Redis consumer-group behavior and renames configuration keys (breaking for anyone still using old env names); idle consumer deletion is guarded but still affects production stream groups.
> 
> **Overview**
> Renames the Redis **PEL requeue worker** to **`RedisStreamMaintenanceWorker`** (`port_ocean/consumers/stream_maintenance/`) and removes `port_ocean/consumers/pel_requeue/`. Several `LiveEventsRedisSettings` fields are renamed (e.g. `pel_requeue_worker_enabled` → `stream_maintenance_worker_enabled`, `pel_scan_interval_seconds` → `stream_maintenance_scan_interval_seconds`); deployments must use the new `OCEAN__LIVE_EVENTS__REDIS__*` env names.
> 
> **New behavior:** after each PEL reclaim scan, the maintenance worker can remove **idle consumers** with zero pending messages via `XINFO CONSUMERS` and `XGROUP DELCONSUMER`, implemented in `cleanup_idle_consumers_from_group`. Cleanup is on by default (24h idle threshold), can be disabled with `stream_maintenance_consumer_cleanup_enabled`, and never deletes the maintenance worker name or the live pod’s `stream_consumer_name` passed from `RedisStreamConsumer`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f14564cf35f1607bcd26d20922864cca8a66b5d9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->