### PR TITLE
[Integrations][Azure-Devops][Gcp][Github][Gitlab][Gitlab-v2][Opencost] Add missing Field titles and descriptions for schema enforcements

### DIFF
--- a/integrations/azure-devops/.ocean-release/config-field-metadata.yaml
+++ b/integrations/azure-devops/.ocean-release/config-field-metadata.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: improvement
+changelog: Add missing Field titles and descriptions required by PortAppConfig schema validation.

--- a/integrations/azure-devops/azure_devops/misc.py
+++ b/integrations/azure-devops/azure_devops/misc.py
@@ -90,14 +90,17 @@ def extract_org_name_from_url(url: str) -> str:
 
 
 class RepositoryBranchMapping(BaseModel):
-    name: str = Field(description="Repository name")
-    branch: str | None = Field(default=None, description="Branch to scan")
+    name: str = Field(title="Name", description="Repository name")
+    branch: str | None = Field(
+        default=None, title="Branch", description="Branch to scan"
+    )
 
 
 class FolderPattern(BaseModel):
     path: str = Field(
         ...,
         alias="path",
+        title="Path",
         description="""Specify the repositories and folders to include under this relative path.
         Supports glob pattern (*) for matching within a path segment:
         - Use * to match any characters within a path segment
@@ -111,6 +114,7 @@ class FolderPattern(BaseModel):
     repos: list[RepositoryBranchMapping] = Field(
         default_factory=list,
         alias="repos",
+        title="Repositories",
         description="Specify the repositories and branches to include under this relative path",
     )
 

--- a/integrations/gcp/.ocean-release/config-field-metadata.yaml
+++ b/integrations/gcp/.ocean-release/config-field-metadata.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: improvement
+changelog: Add missing Field titles and descriptions required by PortAppConfig schema validation.

--- a/integrations/gcp/gcp_core/overrides.py
+++ b/integrations/gcp/gcp_core/overrides.py
@@ -124,7 +124,6 @@ class GCPCloudFunctionSelector(Selector):
 
 class GCPCloudFunctionResourceConfig(ResourceConfig):
     kind: Literal["gcpCloudFunction"] = Field(
-        "gcpCloudFunction",
         title="GCP Cloud Function",
         description="GCP cloud-function sync protocol resource kind.",
     )

--- a/integrations/gcp/gcp_core/overrides.py
+++ b/integrations/gcp/gcp_core/overrides.py
@@ -123,7 +123,11 @@ class GCPCloudFunctionSelector(Selector):
 
 
 class GCPCloudFunctionResourceConfig(ResourceConfig):
-    kind: Literal["gcpCloudFunction"] = "gcpCloudFunction"
+    kind: Literal["gcpCloudFunction"] = Field(
+        "gcpCloudFunction",
+        title="GCP Cloud Function",
+        description="GCP cloud-function sync protocol resource kind.",
+    )
     selector: GCPCloudFunctionSelector = Field(
         title="Cloud Function Selector",
         description="Selector for a resource served by the cloud-function sync protocol.",

--- a/integrations/github/.ocean-release/config-field-metadata.yaml
+++ b/integrations/github/.ocean-release/config-field-metadata.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: improvement
+changelog: Add missing Field titles and descriptions required by PortAppConfig schema validation.

--- a/integrations/github/integration.py
+++ b/integrations/github/integration.py
@@ -223,7 +223,11 @@ class RepositorySourceModel(BaseModel):
 
 
 class FolderSelector(RepositorySourceModel, IncludedFilesConfig):
-    path: str = Field(default="*")
+    path: str = Field(
+        default="*",
+        title="Path",
+        description="Relative folder path to sync. Supports glob (*) within a path segment.",
+    )
 
     class Config:
         extra = "forbid"

--- a/integrations/gitlab-v2/.ocean-release/config-field-metadata.yaml
+++ b/integrations/gitlab-v2/.ocean-release/config-field-metadata.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: improvement
+changelog: Add missing Field titles and descriptions required by PortAppConfig schema validation.

--- a/integrations/gitlab-v2/integration.py
+++ b/integrations/gitlab-v2/integration.py
@@ -38,13 +38,16 @@ class SearchQuery(BaseModel):
     """A search query to execute against a GitLab project during enrichment."""
 
     name: str = Field(
+        title="Name",
         description="A unique name for this search query, used as the key in __searchQueries",
     )
     scope: str = Field(
         default="blobs",
+        title="Scope",
         description="The GitLab search scope (e.g. blobs, commits, wiki_blobs, etc.)",
     )
     query: str = Field(
+        title="Query",
         description="The search query string (e.g. filename:port.yml)",
     )
 

--- a/integrations/gitlab/.ocean-release/config-field-metadata.yaml
+++ b/integrations/gitlab/.ocean-release/config-field-metadata.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: improvement
+changelog: Add missing Field titles and descriptions required by PortAppConfig schema validation.

--- a/integrations/gitlab/gitlab_integration/git_integration.py
+++ b/integrations/gitlab/gitlab_integration/git_integration.py
@@ -128,9 +128,20 @@ class GitManipulationHandler(JQEntityProcessor):
 
 
 class FoldersSelector(BaseModel):
-    path: str
-    repos: List[str] = Field(default_factory=list)
-    branch: str | None = None
+    path: str = Field(
+        title="Path",
+        description="Relative folder path to export under the repository.",
+    )
+    repos: List[str] = Field(
+        default_factory=list,
+        title="Repositories",
+        description="Optional list of repository names to limit folder export to.",
+    )
+    branch: str | None = Field(
+        default=None,
+        title="Branch",
+        description="Branch to use for folder export. Defaults to the repository default branch.",
+    )
 
 
 class GitlabSelector(Selector):
@@ -230,9 +241,14 @@ GitlabObjectWithMembersResourceConfig = (
 
 
 class FilesSelector(BaseModel):
-    path: str = Field(description="The path to get the files from")
+    path: str = Field(
+        title="Path",
+        description="The path to get the files from",
+    )
     repos: List[str] = Field(
-        description="A list of repositories to search files in", default_factory=list
+        default_factory=list,
+        title="Repositories",
+        description="A list of repositories to search files in",
     )
 
 
@@ -254,12 +270,18 @@ class GitLabFilesSelector(Selector):
 
 class GitLabFilesResourceConfig(ResourceConfig):
     selector: GitLabFilesSelector
-    kind: Literal["file"]
+    kind: Literal["file"] = Field(
+        title="GitLab File",
+        description="GitLab file resource kind.",
+    )
 
 
 class GitLabProjectResourceConfig(ResourceConfig):
     selector: GitLabProjectSelector
-    kind: Literal["project"]
+    kind: Literal["project"] = Field(
+        title="GitLab Project",
+        description="GitLab project resource kind.",
+    )
 
 
 class GitlabPortAppConfig(PortAppConfig):

--- a/integrations/opencost/.ocean-release/config-field-metadata.yaml
+++ b/integrations/opencost/.ocean-release/config-field-metadata.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: improvement
+changelog: Add missing Field titles and descriptions required by PortAppConfig schema validation.

--- a/integrations/opencost/integration.py
+++ b/integrations/opencost/integration.py
@@ -114,7 +114,10 @@ class OpencostSelector(Selector):
 
 class OpencostResourceConfig(ResourceConfig):
 
-    kind: Literal["cost"]
+    kind: Literal["cost"] = Field(
+        title="OpenCost Cost",
+        description="OpenCost allocation cost resource kind.",
+    )
     selector: OpencostSelector
 
 
@@ -160,7 +163,10 @@ class CloudCostSelector(Selector):
 
 class CloudCostResourceConfig(ResourceConfig):
 
-    kind: Literal["cloudcost"]
+    kind: Literal["cloudcost"] = Field(
+        title="OpenCost Cloud Cost",
+        description="OpenCost cloud cost resource kind.",
+    )
     selector: CloudCostSelector
 
 


### PR DESCRIPTION
## Summary
- Add missing Pydantic `Field` `title`/`description` metadata on azure-devops, gcp, github, gitlab, gitlab-v2, and opencost so PortAppConfig schema validation passes under the core enforcements in #3754.
- Declare patch release intents for each touched integration.

## Test plan
- [ ] Confirm schema CI jobs for azure-devops, gcp, github, gitlab, gitlab-v2, and opencost pass on this PR (or on #3754 after merge)
- [ ] Spot-check generated UI schema still includes the updated kind/selector titles

Port task: https://app.getport.io/taskEntity?identifier=task_tjwsu1


Made with [Cursor](https://cursor.com)