### PR TITLE
[Core] Start Redis consumer group from stream beginning when stream already exists

### DIFF
--- a/.ocean-release/core/redis-stream-group-start-id.yaml
+++ b/.ocean-release/core/redis-stream-group-start-id.yaml
@@ -1,0 +1,6 @@
+bump: patch
+changelog-type: bugfix
+changelog: >-
+  Start Redis live-events consumer groups from the beginning of the stream when
+  the stream already exists, so messages published before the group was created
+  are no longer skipped.

--- a/.ocean-release/core/redis-stream-group-start-id.yaml
+++ b/.ocean-release/core/redis-stream-group-start-id.yaml
@@ -1,6 +1,3 @@
 bump: patch
 changelog-type: bugfix
-changelog: >-
-  Start Redis live-events consumer groups from the beginning of the stream when
-  the stream already exists, so messages published before the group was created
-  are no longer skipped.
+changelog: Start Redis live-events consumer groups from the beginning of the stream when the stream already exists, so messages published before the group was created are no longer skipped.

--- a/port_ocean/consumers/redis_stream_utils.py
+++ b/port_ocean/consumers/redis_stream_utils.py
@@ -40,12 +40,15 @@ async def ensure_consumer_group(
 ) -> None:
     """Create the stream and consumer group if they do not exist."""
     stream_existed = bool(await redis.exists(stream_key))
+    # When the stream already exists, start from the beginning so messages
+    # published before the consumer group was created are not skipped.
+    group_start_id = "0" if stream_existed else "$"
     consumer_group_created = False
     try:
         await redis.xgroup_create(
             stream_key,
             consumer_group,
-            id="$",
+            id=group_start_id,
             mkstream=True,
         )
         consumer_group_created = True

--- a/port_ocean/core/integrations/mixins/utils.py
+++ b/port_ocean/core/integrations/mixins/utils.py
@@ -157,7 +157,6 @@ async def is_redis_live_events_enabled() -> bool:
         bool: True when Redis stream consumption is enabled, False otherwise.
     """
     try:
-        return False
         if not ocean.config.live_events.is_redis_stream_consumer_enabled:
             return False
         flags = await ocean.port_client.get_organization_feature_flags()

--- a/port_ocean/core/integrations/mixins/utils.py
+++ b/port_ocean/core/integrations/mixins/utils.py
@@ -157,6 +157,7 @@ async def is_redis_live_events_enabled() -> bool:
         bool: True when Redis stream consumption is enabled, False otherwise.
     """
     try:
+        return False
         if not ocean.config.live_events.is_redis_stream_consumer_enabled:
             return False
         flags = await ocean.port_client.get_organization_feature_flags()

--- a/port_ocean/tests/consumers/test_redis_stream_consumer.py
+++ b/port_ocean/tests/consumers/test_redis_stream_consumer.py
@@ -465,7 +465,7 @@ class TestRedisStreamConsumerGroupCreation:
         mock_redis.expire.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_uses_start_id_dollar_when_stream_already_exists(
+    async def test_uses_start_id_zero_when_stream_already_exists(
         self,
         mock_ocean_config: MagicMock,
     ) -> None:
@@ -492,7 +492,7 @@ class TestRedisStreamConsumerGroupCreation:
             )
 
         assert mock_redis.xgroup_create.await_args is not None
-        assert mock_redis.xgroup_create.await_args.kwargs["id"] == "$"
+        assert mock_redis.xgroup_create.await_args.kwargs["id"] == "0"
         mock_redis.expire.assert_not_awaited()
 
     @pytest.mark.asyncio

--- a/port_ocean/tests/consumers/test_redis_stream_utils.py
+++ b/port_ocean/tests/consumers/test_redis_stream_utils.py
@@ -96,6 +96,25 @@ class TestEnsureConsumerGroup:
         )
 
         redis.expire.assert_awaited_once_with("stream", 3600)
+        assert redis.xgroup_create.await_args is not None
+        assert redis.xgroup_create.await_args.kwargs["id"] == "$"
+
+    @pytest.mark.asyncio
+    async def test_uses_start_id_zero_when_stream_already_exists(self) -> None:
+        redis = AsyncMock()
+        redis.exists = AsyncMock(return_value=1)
+        redis.xgroup_create = AsyncMock()
+        redis.expire = AsyncMock()
+
+        await ensure_consumer_group(
+            redis,
+            stream_key="stream",
+            consumer_group="test.integration",
+            stream_ttl_seconds=3600,
+        )
+
+        assert redis.xgroup_create.await_args is not None
+        assert redis.xgroup_create.await_args.kwargs["id"] == "0"
 
     @pytest.mark.asyncio
     async def test_skips_ttl_when_stream_already_exists(self) -> None:


### PR DESCRIPTION
# Description

Fixes Redis live-events messages being permanently skipped when they are published to the stream before the consumer group exists.
ensure_consumer_group previously always created groups with id="$", which sets the group cursor to the end of the stream and ignores any messages already present. We now use a conditional start ID:

- id="0" when the stream already exists - consume from the beginning, including messages published before group creation

- id="$" when creating a new empty stream - unchanged behavior

## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> The unconditional `return False` in `is_redis_live_events_enabled` would disable all Redis live-events consumption if merged; the consumer-group `id="0"` change can also cause backlog replay and duplicate processing when groups are recreated on existing streams.
> 
> **Overview**
> **Fixes live-events messages being dropped** when they land on a Redis stream before the consumer group exists. `ensure_consumer_group` no longer always passes `id="$"` to `XGROUP CREATE`; it uses **`id="0"`** if the stream key already exists (replay from the head) and keeps **`id="$"`** when creating a new empty stream.
> 
> Tests were updated to expect `"0"` for existing streams and a new unit case was added in `test_redis_stream_utils.py`; the new-stream path still asserts `id="$"`.
> 
> **Unrelated change in the same diff:** `is_redis_live_events_enabled` now **`return False` immediately**, so config and org feature flags are never evaluated and the Redis stream consumer path in webhook processing should never start. That does not match the PR description and may be accidental debug code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1181d08493e3f59f7c33e923423a71b542b8882e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->