### PR TITLE
[Integration][cursor-cloud-agents] disable saas live events due to unsupported dynamic webhook path 

### DIFF
--- a/integrations/cursor-cloud-agents/.port/spec.yaml
+++ b/integrations/cursor-cloud-agents/.port/spec.yaml
@@ -13,7 +13,7 @@ features:
 saas:
   enabled: true
   liveEvents:
-    enabled: true
+    enabled: false
 configurations:
   - name: cursorApiKey
     type: string


### PR DESCRIPTION
# Description

Cursor Cloud Agents uses a dynamic webhook path (/webhook/{run_id}).
Current Redis live-events dispatch in Ocean performs exact path matching and does not resolve templated routes to concrete paths.
In Redis mode, request path params are also not reconstructed for webhook auth logic that expects run_id so events are silently acknowledged-but-unprocessed.


## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single configuration flag change; SaaS remains enabled and exporter/resync behavior is unchanged—only SaaS live-event routing is disabled.
> 
> **Overview**
> **Disables SaaS live events** for the Cursor Cloud Agents integration by setting `saas.liveEvents.enabled` to `false` in the Port spec.
> 
> Cursor webhooks use a dynamic path (`/webhook/{run_id}`). Ocean’s Redis live-events layer matches routes exactly and does not resolve templated paths or reconstruct `run_id` for webhook auth, so events were acknowledged but not processed. Turning off SaaS live events avoids advertising broken webhook delivery until dispatch supports this pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6a3efddfa439a32289484ab68ea877c77581416. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->