### PR TITLE
[Integrations][Github] Fix: Retry GraphQL queries without forbidden fields

### DIFF
--- a/integrations/github/.ocean-release/port-18394-graphql-field-errors.yaml
+++ b/integrations/github/.ocean-release/port-18394-graphql-field-errors.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: bugfix
+changelog-message: "Fix: Retry GraphQL queries without forbidden fields when field-level permission errors occur"

--- a/integrations/github/.ocean-release/port-18394-graphql-field-errors.yaml
+++ b/integrations/github/.ocean-release/port-18394-graphql-field-errors.yaml
@@ -1,3 +1,3 @@
 bump: patch
 changelog-type: bugfix
-changelog-message: "Fix: Retry GraphQL queries without forbidden fields when field-level permission errors occur"
+changelog: "Fix: Retry GraphQL queries without forbidden fields when field-level permission errors occur"

--- a/integrations/github/CHANGELOG.md
+++ b/integrations/github/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Allow empty files in GraphQL resync to align with REST/webhook paths
 
+
 ## 6.8.0 (2026-08-19)
 
 

--- a/integrations/github/github/clients/http/graphql_client.py
+++ b/integrations/github/github/clients/http/graphql_client.py
@@ -32,16 +32,9 @@ from github.clients.rate_limiter.utils import (
 from github.helpers.exceptions import (
     GraphQLClientError,
     GraphQLErrorGroup,
+    GraphQLForbiddenFieldError,
     RateLimitException,
 )
-
-
-class GraphQLForbiddenFieldError(Exception):
-    """Signals that fields got 403 FORBIDDEN and need to be excluded."""
-
-    def __init__(self, fields: set[str]):
-        self.fields = fields
-        super().__init__(f"Fields {fields} returned 403 FORBIDDEN")
 from github.helpers.utils import IgnoredError
 
 PAGE_SIZE = 25
@@ -289,6 +282,7 @@ class GithubGraphQLClient(AbstractGithubClient):
         method: str = "POST",
         ignored_errors: Optional[List[IgnoredError]] = None,
         fallbacks: Optional[List[GraphQLFallback]] = None,
+        regenerate_fallbacks: Optional[Callable[[set[str]], Awaitable[List[GraphQLFallback]]]] = None,
     ) -> AsyncGenerator[List[Dict[str, Any]], None]:
         params = params or {}
         path = params.pop("__path", None)
@@ -315,6 +309,17 @@ class GithubGraphQLClient(AbstractGithubClient):
                     fallbacks=fallbacks,
                     page_size=page_size,
                 )
+            except GraphQLForbiddenFieldError as exc:
+                if not regenerate_fallbacks:
+                    raise
+                logger.warning(
+                    f"[GraphQL] Forbidden fields {exc.fields} for path {path}, "
+                    f"regenerating fallbacks"
+                )
+                fallbacks = await regenerate_fallbacks(exc.fields)
+                cursor = None
+                page_size = PAGE_SIZE
+                continue
             except GraphQLErrorGroup:
                 reduced_page_size = reduce_graphql_page_size(page_size)
                 if reduced_page_size is None:

--- a/integrations/github/github/clients/http/graphql_client.py
+++ b/integrations/github/github/clients/http/graphql_client.py
@@ -175,6 +175,38 @@ class GithubGraphQLClient(AbstractGithubClient):
         """
         return response.extensions.get(GRAPHQL_SENT_VARIABLES_EXTENSION)
 
+    def _apply_field_removal(
+        self, json_data: Optional[Dict[str, Any]], fields: set[str]
+    ) -> Optional[Dict[str, Any]]:
+        """Apply field removal to query if needed. Returns modified data or None."""
+        if not fields or not json_data or "query" not in json_data:
+            return None
+        modified = json_data.copy()
+        modified["query"] = self._remove_fields_from_query(json_data["query"], fields)
+        logger.info(f"[GraphQL] Retrying query without forbidden fields: {fields}")
+        return modified
+
+    def _check_retry_response(
+        self, result: Dict[str, Any], tried_removing: set[str], query_path: Optional[str]
+    ) -> tuple[bool, Optional[Dict[str, Any]]]:
+        """Check if response signals retry. Returns (should_retry, fallback_data)."""
+        if not isinstance(result, dict) or RETRY_WITHOUT_FIELDS_MARKER not in result:
+            return False, None
+
+        new_forbidden = result.pop(RETRY_WITHOUT_FIELDS_MARKER)
+        fallback = result.copy()
+
+        untried = new_forbidden - tried_removing
+        if not untried:
+            return False, None
+
+        tried_removing.update(new_forbidden)
+        logger.warning(
+            f"[GraphQL] Field-level FORBIDDEN errors for path {query_path}, "
+            f"retrying without fields: {untried}"
+        )
+        return True, fallback
+
     @staticmethod
     def _extract_field_from_error_path(error_path: Any) -> Optional[str]:
         """Extract field name from GraphQL error path.
@@ -216,16 +248,7 @@ class GithubGraphQLClient(AbstractGithubClient):
         fallback_partial_data = None
 
         while retry_count < max_retries:
-            # Remove forbidden fields from query if any were found on previous attempts
-            modified_json_data = json_data
-            if tried_removing and json_data and "query" in json_data:
-                modified_json_data = json_data.copy()
-                modified_json_data["query"] = self._remove_fields_from_query(
-                    json_data["query"], tried_removing
-                )
-                logger.info(
-                    f"[GraphQL] Retrying query without forbidden fields: {tried_removing}"
-                )
+            modified_json_data = self._apply_field_removal(json_data, tried_removing) or json_data
 
             response = await self.make_request(
                 resource=resource,
@@ -242,21 +265,14 @@ class GithubGraphQLClient(AbstractGithubClient):
                     query_path=query_path,
                     query_params=query_params,
                 )
-                # Check if we should retry without forbidden fields
-                if result and isinstance(result, dict) and RETRY_WITHOUT_FIELDS_MARKER in result:
-                    new_forbidden = result[RETRY_WITHOUT_FIELDS_MARKER]
-                    untried = new_forbidden - tried_removing
-                    if untried:
-                        fallback_partial_data = result.copy()
-                        del fallback_partial_data[RETRY_WITHOUT_FIELDS_MARKER]
-                        tried_removing.update(new_forbidden)
-                        logger.warning(
-                            f"[GraphQL] Field-level FORBIDDEN errors for path {query_path}, "
-                            f"retrying without fields: {untried}"
-                        )
-                        continue
-                    # Remove the marker before returning
-                    del result[RETRY_WITHOUT_FIELDS_MARKER]
+
+                should_retry, fallback = self._check_retry_response(
+                    result, tried_removing, query_path
+                )
+                if should_retry:
+                    fallback_partial_data = fallback
+                    continue
+
                 return result
             except GraphQLErrorGroup as exc:
                 if fallback_partial_data:

--- a/integrations/github/github/clients/http/graphql_client.py
+++ b/integrations/github/github/clients/http/graphql_client.py
@@ -212,18 +212,19 @@ class GithubGraphQLClient(AbstractGithubClient):
     ) -> Dict[str, Any]:
         max_retries = 5
         retry_count = 0
-        forbidden_fields: set[str] = set()
+        tried_removing: set[str] = set()
+        fallback_partial_data = None
 
         while retry_count < max_retries:
             # Remove forbidden fields from query if any were found on previous attempts
             modified_json_data = json_data
-            if forbidden_fields and json_data and "query" in json_data:
+            if tried_removing and json_data and "query" in json_data:
                 modified_json_data = json_data.copy()
                 modified_json_data["query"] = self._remove_fields_from_query(
-                    json_data["query"], forbidden_fields
+                    json_data["query"], tried_removing
                 )
                 logger.info(
-                    f"[GraphQL] Retrying query without forbidden fields: {forbidden_fields}"
+                    f"[GraphQL] Retrying query without forbidden fields: {tried_removing}"
                 )
 
             response = await self.make_request(
@@ -244,16 +245,27 @@ class GithubGraphQLClient(AbstractGithubClient):
                 # Check if we should retry without forbidden fields
                 if result and isinstance(result, dict) and RETRY_WITHOUT_FIELDS_MARKER in result:
                     new_forbidden = result[RETRY_WITHOUT_FIELDS_MARKER]
-                    if new_forbidden and new_forbidden != forbidden_fields:
-                        forbidden_fields.update(new_forbidden)
+                    untried = new_forbidden - tried_removing
+                    if untried:
+                        fallback_partial_data = result.copy()
+                        del fallback_partial_data[RETRY_WITHOUT_FIELDS_MARKER]
+                        tried_removing.update(new_forbidden)
                         logger.warning(
                             f"[GraphQL] Field-level FORBIDDEN errors for path {query_path}, "
-                            f"retrying without fields: {new_forbidden}"
+                            f"retrying without fields: {untried}"
                         )
                         continue
                     # Remove the marker before returning
                     del result[RETRY_WITHOUT_FIELDS_MARKER]
                 return result
+            except GraphQLErrorGroup as exc:
+                if fallback_partial_data:
+                    logger.warning(
+                        f"[GraphQL] Retry failed for path {query_path}, "
+                        f"returning partial data from previous attempt"
+                    )
+                    return fallback_partial_data
+                raise
             except RateLimitException as exc:
                 retry_count += 1
                 if retry_count >= max_retries:

--- a/integrations/github/github/clients/http/graphql_client.py
+++ b/integrations/github/github/clients/http/graphql_client.py
@@ -1,4 +1,5 @@
 import asyncio
+import re
 from http import HTTPStatus
 from json import JSONDecodeError
 from typing import (
@@ -37,6 +38,9 @@ from github.clients.rate_limiter.utils import (
 from urllib.parse import urlparse, urlunparse
 
 PAGE_SIZE = 25
+FORBIDDEN_ERROR_TYPE = "FORBIDDEN"
+RETRY_WITHOUT_FIELDS_MARKER = "retry_without_fields"
+FIELD_REMOVAL_PATTERN = r'\b{field}\s*(?:\([^)]*\))?\s*(?:\{{(?:[^{{}}]|(?:\{{[^{{}}]*\}})*)*\}})?'
 
 
 class GraphQLFallback(NamedTuple):
@@ -120,15 +124,25 @@ class GithubGraphQLClient(AbstractGithubClient):
         ignored_types = {e.type: e.message for e in all_ignored}
 
         non_ignored_exceptions = []
+        forbidden_fields: set[str] = set()
+
         for error in body["errors"]:
             error_type = error.get("type")
+            error_path = error.get("path", [])
+
             if error_type in ignored_types:
                 logger.warning(
                     f"{ignored_types[error_type]} due to {error['message']} "
-                    f"for {error.get('path', [])} (status {response.status_code})"
+                    f"for {error_path} (status {response.status_code})"
                 )
+                # Track field-level FORBIDDEN errors that can be retried without those fields
+                if error_type == FORBIDDEN_ERROR_TYPE:
+                    field = self._extract_field_from_error_path(error_path)
+                    if field:
+                        forbidden_fields.add(field)
                 continue
             non_ignored_exceptions.append(GraphQLClientError(error["message"]))
+
         if non_ignored_exceptions:
             # The transport can rewrite variables between retries (e.g. shrinking
             # `variables.first`); prefer what it actually sent over the caller's copy.
@@ -138,6 +152,12 @@ class GithubGraphQLClient(AbstractGithubClient):
                 f"{query_path} with variables {variables}"
             )
             raise GraphQLErrorGroup(non_ignored_exceptions)
+
+        # If we have field-level FORBIDDEN errors and data was returned, signal a retry
+        if forbidden_fields and body.get("data"):
+            result = body.copy()
+            result[RETRY_WITHOUT_FIELDS_MARKER] = forbidden_fields
+            return result
 
         return {}
 
@@ -153,6 +173,30 @@ class GithubGraphQLClient(AbstractGithubClient):
         """
         return response.extensions.get(GRAPHQL_SENT_VARIABLES_EXTENSION)
 
+    @staticmethod
+    def _extract_field_from_error_path(error_path: Any) -> Optional[str]:
+        """Extract field name from GraphQL error path.
+
+        GraphQL error paths look like: ["repository", "pullRequests", "nodes", 0, "statusCheckRollup"]
+        We extract the leaf field name (the last string element).
+        """
+        if not error_path or not isinstance(error_path, list):
+            return None
+        leaf = error_path[-1]
+        return leaf if isinstance(leaf, str) else None
+
+    @staticmethod
+    def _remove_fields_from_query(query: str, fields: set[str]) -> str:
+        """Remove specified fields from GraphQL query.
+
+        Uses regex to remove field definitions and their nested content.
+        Simple but effective for most cases.
+        """
+        for field in fields:
+            pattern = FIELD_REMOVAL_PATTERN.format(field=re.escape(field))
+            query = re.sub(pattern, '', query)
+        return query
+
     async def send_api_request(
         self,
         resource: str,
@@ -166,22 +210,48 @@ class GithubGraphQLClient(AbstractGithubClient):
     ) -> Dict[str, Any]:
         max_retries = 5
         retry_count = 0
+        forbidden_fields: set[str] = set()
+
         while retry_count < max_retries:
+            # Remove forbidden fields from query if any were found on previous attempts
+            modified_json_data = json_data
+            if forbidden_fields and json_data and "query" in json_data:
+                modified_json_data = json_data.copy()
+                modified_json_data["query"] = self._remove_fields_from_query(
+                    json_data["query"], forbidden_fields
+                )
+                logger.info(
+                    f"[GraphQL] Retrying query without forbidden fields: {forbidden_fields}"
+                )
+
             response = await self.make_request(
                 resource=resource,
                 params=params,
                 method=method,
-                json_data=json_data,
+                json_data=modified_json_data,
                 ignored_errors=ignored_errors,
                 ignore_default_errors=ignore_default_errors,
             )
             try:
-                return self._handle_graphql_errors(
+                result = self._handle_graphql_errors(
                     response,
                     ignored_errors,
                     query_path=query_path,
                     query_params=query_params,
                 )
+                # Check if we should retry without forbidden fields
+                if result and isinstance(result, dict) and RETRY_WITHOUT_FIELDS_MARKER in result:
+                    new_forbidden = result[RETRY_WITHOUT_FIELDS_MARKER]
+                    if new_forbidden and new_forbidden != forbidden_fields:
+                        forbidden_fields.update(new_forbidden)
+                        logger.warning(
+                            f"[GraphQL] Field-level FORBIDDEN errors for path {query_path}, "
+                            f"retrying without fields: {new_forbidden}"
+                        )
+                        continue
+                    # Remove the marker before returning
+                    del result[RETRY_WITHOUT_FIELDS_MARKER]
+                return result
             except RateLimitException as exc:
                 retry_count += 1
                 if retry_count >= max_retries:

--- a/integrations/github/github/clients/http/graphql_client.py
+++ b/integrations/github/github/clients/http/graphql_client.py
@@ -12,6 +12,7 @@ from typing import (
     NamedTuple,
     Optional,
 )
+from urllib.parse import urlparse, urlunparse
 
 import httpx
 from loguru import logger
@@ -25,22 +26,23 @@ from github.clients.graphql_page_reduction import (
     reduce_graphql_page_size,
 )
 from github.clients.http.base_client import AbstractGithubClient
+from github.clients.rate_limiter.utils import (
+    GitHubRateLimiterConfig,
+    extract_graphql_rate_limit_info,
+)
 from github.helpers.exceptions import (
     GraphQLClientError,
     GraphQLErrorGroup,
     RateLimitException,
 )
 from github.helpers.utils import IgnoredError
-from github.clients.rate_limiter.utils import (
-    GitHubRateLimiterConfig,
-    extract_graphql_rate_limit_info,
-)
-from urllib.parse import urlparse, urlunparse
 
 PAGE_SIZE = 25
 FORBIDDEN_ERROR_TYPE = "FORBIDDEN"
 RETRY_WITHOUT_FIELDS_MARKER = "retry_without_fields"
-FIELD_REMOVAL_PATTERN = r'\b{field}\s*(?:\([^)]*\))?\s*(?:\{{(?:[^{{}}]|(?:\{{[^{{}}]*\}})*)*\}})?'
+FIELD_REMOVAL_PATTERN = (
+    r"\b{field}\s*(?:\([^)]*\))?\s*(?:\{{(?:[^{{}}]|(?:\{{[^{{}}]*\}})*)*\}})?"
+)
 
 
 class GraphQLFallback(NamedTuple):

--- a/integrations/github/github/clients/http/graphql_client.py
+++ b/integrations/github/github/clients/http/graphql_client.py
@@ -282,7 +282,7 @@ class GithubGraphQLClient(AbstractGithubClient):
         method: str = "POST",
         ignored_errors: Optional[List[IgnoredError]] = None,
         fallbacks: Optional[List[GraphQLFallback]] = None,
-        regenerate_fallbacks: Optional[Callable[[set[str]], Awaitable[List[GraphQLFallback]]]] = None,
+        regenerate_query: Optional[Callable[[set[str]], Awaitable[str]]] = None,
     ) -> AsyncGenerator[List[Dict[str, Any]], None]:
         params = params or {}
         path = params.pop("__path", None)
@@ -295,6 +295,8 @@ class GithubGraphQLClient(AbstractGithubClient):
         fallbacks = list(fallbacks or [])
         cursor = None
         page_size = PAGE_SIZE
+        forbidden_retries = 0
+        max_forbidden_retries = 5
         logger.info(f"[GraphQL] Starting pagination for query with path {path}")
 
         while True:
@@ -310,13 +312,21 @@ class GithubGraphQLClient(AbstractGithubClient):
                     page_size=page_size,
                 )
             except GraphQLForbiddenFieldError as exc:
-                if not regenerate_fallbacks:
+                if not regenerate_query:
+                    raise
+                forbidden_retries += 1
+                if forbidden_retries >= max_forbidden_retries:
+                    logger.error(
+                        f"[GraphQL] Max forbidden field retries ({max_forbidden_retries}) exceeded "
+                        f"for path {path}. Fields: {exc.fields}"
+                    )
                     raise
                 logger.warning(
-                    f"[GraphQL] Forbidden fields {exc.fields} for path {path}, "
-                    f"regenerating fallbacks"
+                    f"[GraphQL] Forbidden fields {exc.fields} for path {path} "
+                    f"(attempt {forbidden_retries}/{max_forbidden_retries}), regenerating query"
                 )
-                fallbacks = await regenerate_fallbacks(exc.fields)
+                resource = await regenerate_query(exc.fields)
+                fallbacks = []
                 cursor = None
                 page_size = PAGE_SIZE
                 continue

--- a/integrations/github/github/core/exporters/pull_request_exporter/core.py
+++ b/integrations/github/github/core/exporters/pull_request_exporter/core.py
@@ -15,7 +15,6 @@ from loguru import logger
 from github.clients.http.graphql_client import (
     GithubGraphQLClient,
     GraphQLFallback,
-    GraphQLForbiddenFieldError,
 )
 from github.clients.http.rest_client import GithubRestClient
 from github.core.exporters.abstract_exporter import AbstractGithubExporter
@@ -336,50 +335,6 @@ class GraphQLPullRequestExporter(AbstractGithubExporter[GithubGraphQLClient]):
             )
         return primary, fallbacks
 
-    async def _get_paginated_prs_with_fallback_retry(
-        self,
-        organization: str,
-        repo_name: str,
-        pr_gql_options: PullRequestGraphQLOptions,
-        primary_query: str,
-        fallbacks: list[GraphQLFallback],
-        variables: dict[str, Any],
-        paginator: Callable,
-    ) -> AsyncGenerator[list[dict[str, Any]], None]:
-        """Execute paginated request, regenerating fallbacks if forbidden fields found."""
-        try:
-            async for result in paginator(
-                self.client.send_paginated_request(
-                    primary_query, variables, fallbacks=fallbacks
-                )
-            ):
-                yield result
-        except GraphQLForbiddenFieldError as exc:
-            logger.warning(
-                f"[GraphQL] Forbidden fields {exc.fields} detected, "
-                f"regenerating queries with exclusions"
-            )
-            # Merge forbidden fields with user config
-            updated_options = PullRequestGraphQLOptions(
-                **{
-                    **pr_gql_options.__dict__,
-                    "exclude_graphql_fields": sorted(
-                        set(pr_gql_options.exclude_graphql_fields) | exc.fields
-                    ),
-                }
-            )
-
-            # Rebuild fallbacks and retry
-            primary_query, fallbacks = self._build_pr_queries(
-                organization, repo_name, updated_options
-            )
-            async for result in paginator(
-                self.client.send_paginated_request(
-                    primary_query, variables, fallbacks=fallbacks
-                )
-            ):
-                yield result
-
     def _make_field_backfiller(
         self,
         organization: str,
@@ -504,22 +459,31 @@ class GraphQLPullRequestExporter(AbstractGithubExporter[GithubGraphQLClient]):
             organization, repo_name, pr_gql_options, order_by_field
         )
 
-        async def paginate_open_prs(paginator_gen):
-            async for result in paginate_with_strategy(
-                paginator_gen,
-                cursor=incremental_cursor,
-                strategy=OPEN_PULL_REQUEST_INCREMENTAL_GRAPHQL,
-            ):
-                yield result
+        async def regenerate_open_pr_fallbacks(
+            forbidden_fields: set[str],
+        ) -> list[GraphQLFallback]:
+            updated_options = PullRequestGraphQLOptions(
+                **{
+                    **pr_gql_options.__dict__,
+                    "exclude_graphql_fields": sorted(
+                        set(pr_gql_options.exclude_graphql_fields) | forbidden_fields
+                    ),
+                }
+            )
+            _, new_fallbacks = self._build_pr_queries(
+                organization, repo_name, updated_options, order_by_field
+            )
+            return new_fallbacks
 
-        async for pr_nodes in self._get_paginated_prs_with_fallback_retry(
-            organization,
-            repo_name,
-            pr_gql_options,
-            primary_query,
-            fallbacks,
-            variables,
-            paginate_open_prs,
+        async for pr_nodes in paginate_with_strategy(
+            self.client.send_paginated_request(
+                primary_query,
+                variables,
+                fallbacks=fallbacks,
+                regenerate_fallbacks=regenerate_open_pr_fallbacks,
+            ),
+            cursor=incremental_cursor,
+            strategy=OPEN_PULL_REQUEST_INCREMENTAL_GRAPHQL,
         ):
             if not pr_nodes:
                 continue
@@ -573,28 +537,37 @@ class GraphQLPullRequestExporter(AbstractGithubExporter[GithubGraphQLClient]):
             organization, repo_name, pr_gql_options, GRAPHQL_ORDER_BY_UPDATED_AT
         )
 
-        async def paginate_closed_prs(paginator_gen):
-            async for result in paginate_closed_pull_requests(
-                paginator_gen,
-                enrich=enrich,
-                max_results=max_results,
-                cutoff=cutoff,
-                include_field=include_field,
-                stop_field=GRAPHQL_UPDATED_AT_FIELD,
-                log_prefix="[GraphQL]",
-                repo_name=repo_name,
-                organization=organization,
-            ):
-                yield result
+        async def regenerate_closed_pr_fallbacks(
+            forbidden_fields: set[str],
+        ) -> list[GraphQLFallback]:
+            updated_options = PullRequestGraphQLOptions(
+                **{
+                    **pr_gql_options.__dict__,
+                    "exclude_graphql_fields": sorted(
+                        set(pr_gql_options.exclude_graphql_fields) | forbidden_fields
+                    ),
+                }
+            )
+            _, new_fallbacks = self._build_pr_queries(
+                organization, repo_name, updated_options, GRAPHQL_ORDER_BY_UPDATED_AT
+            )
+            return new_fallbacks
 
-        async for batch in self._get_paginated_prs_with_fallback_retry(
-            organization,
-            repo_name,
-            pr_gql_options,
-            primary_query,
-            fallbacks,
-            variables,
-            paginate_closed_prs,
+        async for batch in paginate_closed_pull_requests(
+            self.client.send_paginated_request(
+                primary_query,
+                variables,
+                fallbacks=fallbacks,
+                regenerate_fallbacks=regenerate_closed_pr_fallbacks,
+            ),
+            enrich=enrich,
+            max_results=max_results,
+            cutoff=cutoff,
+            include_field=include_field,
+            stop_field=GRAPHQL_UPDATED_AT_FIELD,
+            log_prefix="[GraphQL]",
+            repo_name=repo_name,
+            organization=organization,
         ):
             yield batch
 

--- a/integrations/github/github/core/exporters/pull_request_exporter/core.py
+++ b/integrations/github/github/core/exporters/pull_request_exporter/core.py
@@ -533,7 +533,9 @@ class GraphQLPullRequestExporter(AbstractGithubExporter[GithubGraphQLClient]):
             organization, repo_name, pr_gql_options, GRAPHQL_ORDER_BY_UPDATED_AT
         )
 
-        accumulated_excluded_closed: set[str] = set(pr_gql_options.exclude_graphql_fields)
+        accumulated_excluded_closed: set[str] = set(
+            pr_gql_options.exclude_graphql_fields
+        )
 
         async def regenerate_closed_pr_query(forbidden_fields: set[str]) -> str:
             nonlocal accumulated_excluded_closed

--- a/integrations/github/github/core/exporters/pull_request_exporter/core.py
+++ b/integrations/github/github/core/exporters/pull_request_exporter/core.py
@@ -1,7 +1,6 @@
 import asyncio
 from typing import (
     Any,
-    AsyncGenerator,
     Awaitable,
     Callable,
     cast,
@@ -459,28 +458,25 @@ class GraphQLPullRequestExporter(AbstractGithubExporter[GithubGraphQLClient]):
             organization, repo_name, pr_gql_options, order_by_field
         )
 
-        async def regenerate_open_pr_fallbacks(
-            forbidden_fields: set[str],
-        ) -> list[GraphQLFallback]:
-            updated_options = PullRequestGraphQLOptions(
-                **{
-                    **pr_gql_options.__dict__,
-                    "exclude_graphql_fields": sorted(
-                        set(pr_gql_options.exclude_graphql_fields) | forbidden_fields
-                    ),
-                }
+        accumulated_excluded: set[str] = set(pr_gql_options.exclude_graphql_fields)
+
+        async def regenerate_open_pr_query(forbidden_fields: set[str]) -> str:
+            nonlocal accumulated_excluded
+            accumulated_excluded.update(forbidden_fields)
+            updated_options = pr_gql_options.copy(
+                update={"exclude_graphql_fields": sorted(accumulated_excluded)}
             )
-            _, new_fallbacks = self._build_pr_queries(
+            new_query, _ = self._build_pr_queries(
                 organization, repo_name, updated_options, order_by_field
             )
-            return new_fallbacks
+            return new_query
 
         async for pr_nodes in paginate_with_strategy(
             self.client.send_paginated_request(
                 primary_query,
                 variables,
                 fallbacks=fallbacks,
-                regenerate_fallbacks=regenerate_open_pr_fallbacks,
+                regenerate_query=regenerate_open_pr_query,
             ),
             cursor=incremental_cursor,
             strategy=OPEN_PULL_REQUEST_INCREMENTAL_GRAPHQL,
@@ -537,28 +533,25 @@ class GraphQLPullRequestExporter(AbstractGithubExporter[GithubGraphQLClient]):
             organization, repo_name, pr_gql_options, GRAPHQL_ORDER_BY_UPDATED_AT
         )
 
-        async def regenerate_closed_pr_fallbacks(
-            forbidden_fields: set[str],
-        ) -> list[GraphQLFallback]:
-            updated_options = PullRequestGraphQLOptions(
-                **{
-                    **pr_gql_options.__dict__,
-                    "exclude_graphql_fields": sorted(
-                        set(pr_gql_options.exclude_graphql_fields) | forbidden_fields
-                    ),
-                }
+        accumulated_excluded_closed: set[str] = set(pr_gql_options.exclude_graphql_fields)
+
+        async def regenerate_closed_pr_query(forbidden_fields: set[str]) -> str:
+            nonlocal accumulated_excluded_closed
+            accumulated_excluded_closed.update(forbidden_fields)
+            updated_options = pr_gql_options.copy(
+                update={"exclude_graphql_fields": sorted(accumulated_excluded_closed)}
             )
-            _, new_fallbacks = self._build_pr_queries(
+            new_query, _ = self._build_pr_queries(
                 organization, repo_name, updated_options, GRAPHQL_ORDER_BY_UPDATED_AT
             )
-            return new_fallbacks
+            return new_query
 
         async for batch in paginate_closed_pull_requests(
             self.client.send_paginated_request(
                 primary_query,
                 variables,
                 fallbacks=fallbacks,
-                regenerate_fallbacks=regenerate_closed_pr_fallbacks,
+                regenerate_query=regenerate_closed_pr_query,
             ),
             enrich=enrich,
             max_results=max_results,

--- a/integrations/github/github/helpers/exceptions.py
+++ b/integrations/github/github/helpers/exceptions.py
@@ -30,6 +30,14 @@ class GraphQLErrorGroup(Exception):
         return "GraphQL errors occurred:\n" + "\n".join(f"- {e}" for e in self.errors)
 
 
+class GraphQLForbiddenFieldError(Exception):
+    """Raised when GraphQL fields return 403 FORBIDDEN and need to be excluded."""
+
+    def __init__(self, fields: set[str]):
+        self.fields = fields
+        super().__init__(f"Fields {fields} returned 403 FORBIDDEN")
+
+
 class CheckRunsException(Exception):
     """Exception for check runs errors."""
 


### PR DESCRIPTION
# Description
Handle GraphQL field-level permission errors by retrying without inaccessible fields.

## Problem
Field-level FORBIDDEN errors (e.g., statusCheckRollup without 'checks: read')
returned empty data, causing pagination to exit and lose all PRs.

## Solution
Detect forbidden fields, remove them from the query, and retry automatically.

## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes GraphQL error handling and query rewriting on retries. Regex field stripping could mis-edit queries, but the impact is limited to recovering pages that previously returned empty.
> 
> **Overview**
> Stops GitHub GraphQL pagination from dropping an entire page when a field-level `FORBIDDEN` error is mixed with valid data (e.g. `statusCheckRollup` without `checks: read`).
> 
> `_handle_graphql_errors` now extracts the leaf field from ignored `FORBIDDEN` error paths. If data is present, `send_api_request` retries the same query after stripping those fields with a regex, instead of returning `{}` and ending pagination.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c6b019db2e73fc79a39580ea3cfebfb9e80a165. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->