### PR TITLE
[Preview] [IntegrationBump] Apply version and changelog for aikido

### DIFF
--- a/integrations/aikido/CHANGELOG.md
+++ b/integrations/aikido/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.3.40 (2026-08-23)
+
+
+### Bug Fixes
+
+- Describe the change
+  - additional explanation on another line
+
+
 ## 0.3.39 (2026-08-18)
 
 

--- a/integrations/aikido/pyproject.toml
+++ b/integrations/aikido/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aikido"
-version = "0.3.39"
+version = "0.3.40"
 description = "Aikido Ocean Integation"
 authors = ["Habib Nuhu <habib.nuhu@getport.io>"]
 


### PR DESCRIPTION
This is a **preview** of the ocean-release apply PR, generated from #3803. It applies that PR's `.ocean-release` files onto `main`. **Do not merge** — it updates on each push to the source PR.

**Triggered by:** @VenfiOranai
**Source:** 7b3328a19cecfe055877a0f05f9e1a898384bed4

Please review the version and changelog updates before merging. Publish workflows run after this PR is merged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only change with no code, auth, or data-handling updates. Placeholder changelog text is the main review concern.
> 
> **Overview**
> Bumps the Aikido Ocean integration from `0.3.39` to `0.3.40` and adds a changelog entry under **Bug Fixes**.
> 
> The new notes are still placeholder text (`Describe the change`), so they should be replaced before merge. No runtime or dependency changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac39fb1403935812218f082563d1d96ed1a856c4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->