### PR TITLE
[Preview] [IntegrationBump] Apply version and changelog for aikido

### DIFF
--- a/integrations/aikido/CHANGELOG.md
+++ b/integrations/aikido/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.3.40 (2026-08-23)
+
+
+### Bug Fixes
+
+- Describe the change
+- additional explanation on another line
+
+
 ## 0.3.39 (2026-08-18)
 
 

--- a/integrations/aikido/pyproject.toml
+++ b/integrations/aikido/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aikido"
-version = "0.3.39"
+version = "0.3.40"
 description = "Aikido Ocean Integation"
 authors = ["Habib Nuhu <habib.nuhu@getport.io>"]
 


### PR DESCRIPTION
This is a **preview** of the ocean-release apply PR, generated from #3803. It applies that PR's `.ocean-release` files onto `main`. **Do not merge** — it updates on each push to the source PR.

**Triggered by:** @VenfiOranai
**Source:** f0c2ab96bdcba1cbf5ea283fdb48f1ab133609cf

Please review the version and changelog updates before merging. Publish workflows run after this PR is merged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only metadata; no runtime or security code changes. Placeholder notes should be reviewed before publish.
> 
> **Overview**
> Bumps the Aikido integration from `0.3.39` to `0.3.40` in `pyproject.toml` and records a **Bug Fixes** section in `CHANGELOG.md`.
> 
> The changelog text is still a placeholder (`Describe the change` / `additional explanation on another line`) and should be replaced before merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85c6ab1e96934290377c255efe2a9f3f2b4b3380. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->