### PR TITLE
[Preview] [IntegrationBump] Apply version and changelog for aikido

### DIFF
--- a/integrations/aikido/CHANGELOG.md
+++ b/integrations/aikido/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.3.40 (2026-08-23)
+
+
+### Bug Fixes
+
+- Describe the change
+- additional explanation on another line
+  - nested thingy
+- and back to base
+
+
 ## 0.3.39 (2026-08-18)
 
 

--- a/integrations/aikido/pyproject.toml
+++ b/integrations/aikido/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aikido"
-version = "0.3.39"
+version = "0.3.40"
 description = "Aikido Ocean Integation"
 authors = ["Habib Nuhu <habib.nuhu@getport.io>"]
 


### PR DESCRIPTION
This is a **preview** of the ocean-release apply PR, generated from #3803. It applies that PR's `.ocean-release` files onto `main`. **Do not merge** — it updates on each push to the source PR.

**Triggered by:** @VenfiOranai
**Source:** ccc9fef587feff6721c2ff518608819f24d8d01b

Please review the version and changelog updates before merging. Publish workflows run after this PR is merged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only; no code, auth, or data-path changes. Placeholder notes are the main review concern.
> 
> **Overview**
> Bumps the Aikido Ocean integration from `0.3.39` to `0.3.40` in `pyproject.toml` and adds a `0.3.40` changelog section.
> 
> The new notes are placeholder **Bug Fixes** text (`Describe the change`, nested bullets). No runtime or dependency changes. Preview apply PR — changelog copy should be reviewed before merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c8fbdab1bbbf68bb355ded9a99e32f19addc76a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->