### PR TITLE
[Preview] [IntegrationBump] Apply version and changelog for aikido, github

### DIFF
--- a/integrations/aikido/CHANGELOG.md
+++ b/integrations/aikido/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 0.3.40 (2026-08-23)
+
+
+### Bug Fixes
+
+- Describe the change
+- additional explanation on another line
+  - nested thingy
+- and back to base
+
+
 ## 0.3.39 (2026-08-18)
 
 

--- a/integrations/aikido/pyproject.toml
+++ b/integrations/aikido/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "aikido"
-version = "0.3.39"
+version = "0.3.40"
 description = "Aikido Ocean Integation"
 authors = ["Habib Nuhu <habib.nuhu@getport.io>"]
 

--- a/integrations/github/CHANGELOG.md
+++ b/integrations/github/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- towncrier release notes start -->
 
+## 6.8.3 (2026-08-23)
+
+
+### Improvements
+
+- Log an error when GitHub webhook signature verification fails (#87390356)
+
+
 ## 6.8.2 (2026-08-23)
 
 

--- a/integrations/github/pyproject.toml
+++ b/integrations/github/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "github-ocean"
-version = "6.8.2"
+version = "6.8.3"
 description = "This integration ingest data from github"
 authors = ["Chukwuemeka Nwaoma <joelchukks@gmail.com>", "Melody Anyaegbulam <melodyogonna@gmail.com>", "Michael Armah <mikeyarmah@gmail.com>"]
 


### PR DESCRIPTION
This is a **preview** of the ocean-release apply PR, generated from #3803. It applies that PR's `.ocean-release` files onto `main`. **Do not merge** — it updates on each push to the source PR.

**Triggered by:** @VenfiOranai
**Source:** 965aa69cc321335e62a5ad0967bd4ba902d478cb

Please review the version and changelog updates before merging. Publish workflows run after this PR is merged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only bumps with no application logic. Reviewers should confirm the aikido notes are not leftover placeholders before a real publish.
> 
> **Overview**
> Preview release apply for **aikido** (`0.3.39` → `0.3.40`) and **github** (`6.8.2` → `6.8.3`): version in `pyproject.toml` plus new changelog sections. No runtime code changes.
> 
> Aikido’s 0.3.40 notes are placeholder bugfix copy (`Describe the change`, nested bullets). GitHub 6.8.3 restates the webhook signature-failure log from 6.8.2 and adds Linear id `#87390356`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 483093d3681924340914b7699e0691175c9440ea. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->