### PR TITLE
[Integration][Aikido] Fixed premature pagination termination with blank pages

### DIFF
--- a/integrations/aikido/.ocean-release/fix-pagination-truncation.yaml
+++ b/integrations/aikido/.ocean-release/fix-pagination-truncation.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: bugfix
+changelog: Fixed pagination stopping early on empty pages when the Aikido API reported more results via X-Has-Next-Page, which could cause entities to be deleted during resync

--- a/integrations/aikido/clients/aikido_client.py
+++ b/integrations/aikido/clients/aikido_client.py
@@ -146,26 +146,24 @@ class AikidoClient:
 
             has_next = response.headers.get("x-has-next-page")
 
+            fetched_count = len(resources)
+
             if not resources:
                 logger.info(
                     f"No {resource_name} returned for page {params['page']} "
                     f"(x-has-next-page={has_next})"
                 )
-                if has_next is None or has_next.lower() != "true":
+            else:
+                logger.info(
+                    f"Fetched {fetched_count} {resource_name} from Aikido API "
+                    f"(page={params['page']}, x-has-next-page={has_next})"
+                )
+                yield resources
+
+            if has_next is not None:
+                if has_next.lower() != "true":
                     break
-                params["page"] += 1
-                continue
-
-            logger.info(
-                f"Fetched {len(resources)} {resource_name} from Aikido API "
-                f"(page={params['page']}, x-has-next-page={has_next})"
-            )
-            fetched_count = len(resources)
-            yield resources
-
-            if (has_next is not None and has_next.lower() != "true") or (
-                has_next is None and fetched_count < page_size
-            ):
+            elif fetched_count < page_size:
                 break
 
             params["page"] += 1

--- a/integrations/aikido/clients/aikido_client.py
+++ b/integrations/aikido/clients/aikido_client.py
@@ -144,18 +144,28 @@ class AikidoClient:
                 logger.error(f"Error fetching {resource_name}: {e}")
                 raise
 
-            if not resources:
-                logger.info(f"No {resource_name} returned for page {params['page']}")
-                break
+            has_next = response.headers.get("x-has-next-page")
 
-            logger.info(f"Fetched {len(resources)} {resource_name} from Aikido API")
+            if not resources:
+                logger.info(
+                    f"No {resource_name} returned for page {params['page']} "
+                    f"(x-has-next-page={has_next})"
+                )
+                if has_next is None or has_next.lower() != "true":
+                    break
+                params["page"] += 1
+                continue
+
+            logger.info(
+                f"Fetched {len(resources)} {resource_name} from Aikido API "
+                f"(page={params['page']}, x-has-next-page={has_next})"
+            )
             fetched_count = len(resources)
             yield resources
 
-            if (
-                (has_next := response.headers.get("x-has-next-page")) is not None
-                and has_next.lower() != "true"
-            ) or (has_next is None and fetched_count < page_size):
+            if (has_next is not None and has_next.lower() != "true") or (
+                has_next is None and fetched_count < page_size
+            ):
                 break
 
             params["page"] += 1

--- a/integrations/aikido/tests/clients/test_aikido_client.py
+++ b/integrations/aikido/tests/clients/test_aikido_client.py
@@ -369,6 +369,127 @@ async def test_get_paginated_resource_falls_back_to_count_heuristic_when_no_head
 
 
 @pytest.mark.asyncio
+async def test_get_paginated_resource_continues_on_empty_page_when_has_next_header_true(
+    aikido_client: AikidoClient,
+) -> None:
+    """An empty page must not end pagination while x-has-next-page is true.
+
+    Aikido documents that a filtered request (e.g. filter_team_id) can return an empty
+    body while the header still reports another page. Stopping here truncates the
+    extract and lets reconciliation delete live entities.
+    """
+    populated_page = [{"id": "1"}, {"id": "2"}]
+    responses: list[list[dict[str, Any]]] = [[], populated_page]
+    headers_per_call = [{"x-has-next-page": "true"}, {"x-has-next-page": "false"}]
+    captured_params: list[dict[str, Any]] = []
+
+    with patch.object(
+        aikido_client, "_execute_request", new_callable=AsyncMock
+    ) as mock_exec:
+
+        async def _side_effect(
+            endpoint: str,
+            method: str = "GET",
+            params: dict[str, Any] | None = None,
+            **_kwargs: Any,
+        ) -> MagicMock:
+            if params is not None:
+                captured_params.append(params.copy())
+            mock_resp = MagicMock(spec=Response)
+            mock_resp.json.return_value = responses.pop(0)
+            mock_resp.headers = headers_per_call.pop(0)
+            return mock_resp
+
+        mock_exec.side_effect = _side_effect
+
+        batches: list[list[dict[str, Any]]] = []
+        async for batch in aikido_client.get_paginated_resource(
+            endpoint="api/public/v1/open-issue-groups",
+            resource_name="open issue groups",
+            page_size=20,
+        ):
+            batches.append(batch)
+
+    assert batches == [populated_page]
+    assert mock_exec.call_count == 2
+    assert captured_params == [
+        {"per_page": 20, "page": 0},
+        {"per_page": 20, "page": 1},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_paginated_resource_stops_on_empty_page_when_has_next_header_false(
+    aikido_client: AikidoClient,
+) -> None:
+    """An empty page with x-has-next-page: false ends pagination without yielding."""
+
+    with patch.object(
+        aikido_client, "_execute_request", new_callable=AsyncMock
+    ) as mock_exec:
+
+        async def _side_effect(
+            endpoint: str,
+            method: str = "GET",
+            params: dict[str, Any] | None = None,
+            **_kwargs: Any,
+        ) -> MagicMock:
+            mock_resp = MagicMock(spec=Response)
+            mock_resp.json.return_value = []
+            mock_resp.headers = {"x-has-next-page": "false"}
+            return mock_resp
+
+        mock_exec.side_effect = _side_effect
+
+        batches: list[list[dict[str, Any]]] = []
+        async for batch in aikido_client.get_paginated_resource(
+            endpoint="api/public/v1/open-issue-groups",
+            resource_name="open issue groups",
+            page_size=20,
+        ):
+            batches.append(batch)
+
+    assert batches == []
+    assert mock_exec.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_get_paginated_resource_stops_on_empty_page_when_no_header(
+    aikido_client: AikidoClient,
+) -> None:
+    """Endpoints that send no header (/teams, /repositories/code, /containers,
+    /issues/export) must still stop on an empty page."""
+
+    with patch.object(
+        aikido_client, "_execute_request", new_callable=AsyncMock
+    ) as mock_exec:
+
+        async def _side_effect(
+            endpoint: str,
+            method: str = "GET",
+            params: dict[str, Any] | None = None,
+            **_kwargs: Any,
+        ) -> MagicMock:
+            mock_resp = MagicMock(spec=Response)
+            mock_resp.json.return_value = []
+            mock_resp.headers = {}
+            return mock_resp
+
+        mock_exec.side_effect = _side_effect
+
+        batches: list[list[dict[str, Any]]] = []
+        async for batch in aikido_client.get_paginated_resource(
+            endpoint="api/public/v1/teams",
+            resource_name="teams",
+            page_size=20,
+        ):
+            batches.append(batch)
+
+    assert batches == []
+    assert mock_exec.call_count == 1
+
+
+@pytest.mark.asyncio
 async def test_get_open_issue_groups_paginates(aikido_client: AikidoClient) -> None:
     page1 = [{"id": str(i)} for i in range(1, 21)]
     page2 = [{"id": "21"}]


### PR DESCRIPTION
# Description

What - Pagination terminated prematurely on a blank page, even when `x-has-next-page` was `true`.

Why - #3480 added the header check after the blank-page guard, so it never ran on blank pages. Aikido returns blank or short pages for filtered `/open-issue-groups` requests, so team-scoped resyncs truncated silently and reconciliation deleted the unreached teams' entities.

How - Moved the header read above the blank-page guard and gated its `break` on it. Behaviour unchanged for `/teams`, `/repositories/code`, `/containers` and `/issues/export`, which send no header.

## Release (integrations / ocean core)

`integrations/aikido/.ocean-release/fix-pagination-truncation.yaml` (`bump: patch`, `changelog-type: bugfix`).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [x] Handled pagination
- [x] Implemented the code in async
- [ ] Support Multi account

## Screenshots

N/A

## API Documentation

https://apidocs.aikido.dev/reference/listopenissuegroups

`X-Has-Next-Page`: "Indicates whether there is another page of results. Due to filtering, the response body may contain fewer items than `per_page`."

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 22e9e1cd2592aefc3dbbf90bc45e79da8406fdaa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->