### PR TITLE
[Core] Convert IntegrationEventsCallbacks To Class

### DIFF
--- a/.ocean-release/core/task_tk9lzk_convert_integrationeventscallbacks_to_class.yaml
+++ b/.ocean-release/core/task_tk9lzk_convert_integrationeventscallbacks_to_class.yaml
@@ -1,3 +1,7 @@
 bump: minor
 changelog-type: improvement
-changelog: Converted IntegrationEventsCallback from TypedDict to dataclass for easier IDE tracing
+changelog: >-
+  Converted IntegrationEventsCallbacks from TypedDict to dataclass for easier IDE tracing.
+  Breaking (internal): custom integrations that mutate `integration.event_strategy` as a dict
+  (e.g. `event_strategy["resync"][kind]`) must use attribute access instead
+  (e.g. `event_strategy.resync[kind]`); `@ocean.on_resync()` and other registration APIs are unchanged.

--- a/.ocean-release/core/task_tk9lzk_convert_integrationeventscallbacks_to_class.yaml
+++ b/.ocean-release/core/task_tk9lzk_convert_integrationeventscallbacks_to_class.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: improvement
+changelog: Converted IntegrationEventsCallback from TypedDict to dataclass for easier IDE tracing

--- a/.ocean-release/core/task_tk9lzk_convert_integrationeventscallbacks_to_class.yaml
+++ b/.ocean-release/core/task_tk9lzk_convert_integrationeventscallbacks_to_class.yaml
@@ -1,3 +1,3 @@
-bump: patch
+bump: minor
 changelog-type: improvement
 changelog: Converted IntegrationEventsCallback from TypedDict to dataclass for easier IDE tracing

--- a/port_ocean/core/integrations/base.py
+++ b/port_ocean/core/integrations/base.py
@@ -62,7 +62,7 @@ class BaseIntegration(SyncRawMixin, SyncMixin):
             raise IntegrationAlreadyStartedException("Integration already started")
 
         if (
-            not self.event_strategy["resync"]
+            not self.event_strategy.resync
             and self.__class__._on_resync == BaseIntegration._on_resync
             and self.context.config.event_listener.should_resync
         ):
@@ -72,7 +72,7 @@ class BaseIntegration(SyncRawMixin, SyncMixin):
 
         self.started = True
 
-        if self.event_strategy["start"]:
+        if self.event_strategy.start:
             async def run_on_start_tasks() -> None:
                 try:
                     async with event_context(
@@ -80,7 +80,7 @@ class BaseIntegration(SyncRawMixin, SyncMixin):
                         trigger_type="machine",
                     ):
                         await asyncio.gather(
-                            *(listener() for listener in self.event_strategy["start"])
+                            *(listener() for listener in self.event_strategy.start)
                         )
                 except Exception as e:
                     logger.exception("Error in start event listeners: %s", str(e))

--- a/port_ocean/core/integrations/mixins/events.py
+++ b/port_ocean/core/integrations/mixins/events.py
@@ -23,14 +23,6 @@ class EventsMixin:
     def __init__(self) -> None:
         self.event_strategy: IntegrationEventsCallbacks = IntegrationEventsCallbacks()
 
-    @property
-    def available_resync_kinds(self) -> list[str | None]:
-        return list(self.event_strategy.resync.keys())
-
-    @property
-    def available_incremental_kinds(self) -> list[str | None]:
-        return list(self.event_strategy.incremental.keys())
-
     def on_start(self, function: START_EVENT_LISTENER) -> START_EVENT_LISTENER:
         """Register a function as a listener for the "start" event."""
         logger.debug(f"Registering {function} as a start event listener")

--- a/port_ocean/core/integrations/mixins/events.py
+++ b/port_ocean/core/integrations/mixins/events.py
@@ -1,5 +1,3 @@
-from collections import defaultdict
-
 from loguru import logger
 
 from port_ocean.core.ocean_types import (
@@ -19,30 +17,24 @@ class EventsMixin:
     It provides methods for attaching listeners to various lifecycle events.
 
     Attributes:
-        event_strategy: A dictionary storing event callbacks for different event types.
+        event_strategy: Event callbacks for different event types.
     """
 
     def __init__(self) -> None:
-        self.event_strategy: IntegrationEventsCallbacks = {
-            "start": [],
-            "resync": defaultdict(list),
-            "resync_start": [],
-            "resync_complete": [],
-            "incremental": defaultdict(list),
-        }
+        self.event_strategy: IntegrationEventsCallbacks = IntegrationEventsCallbacks()
 
     @property
-    def available_resync_kinds(self) -> list[str]:
-        return list(self.event_strategy["resync"].keys())
+    def available_resync_kinds(self) -> list[str | None]:
+        return list(self.event_strategy.resync.keys())
 
     @property
-    def available_incremental_kinds(self) -> list[str]:
-        return list(self.event_strategy["incremental"].keys())
+    def available_incremental_kinds(self) -> list[str | None]:
+        return list(self.event_strategy.incremental.keys())
 
     def on_start(self, function: START_EVENT_LISTENER) -> START_EVENT_LISTENER:
         """Register a function as a listener for the "start" event."""
         logger.debug(f"Registering {function} as a start event listener")
-        self.event_strategy["start"].append(function)
+        self.event_strategy.start.append(function)
         return function
 
     def on_resync(
@@ -54,7 +46,7 @@ class EventsMixin:
                 logger.debug("Registering resync event listener any kind")
             else:
                 logger.info(f"Registering resync event listener for kind {kind}")
-            self.event_strategy["resync"][kind].append(function)
+            self.event_strategy.resync[kind].append(function)
         return function
 
     def on_resync_start(
@@ -63,7 +55,7 @@ class EventsMixin:
         """Register a function to be called when a resync operation starts."""
         if function is not None:
             logger.debug(f"Registering {function} as a resync_start event listener")
-            self.event_strategy["resync_start"].append(function)
+            self.event_strategy.resync_start.append(function)
         return function
 
     def on_resync_complete(
@@ -72,7 +64,7 @@ class EventsMixin:
         """Register a function to be called when a resync operation completes."""
         if function is not None:
             logger.debug(f"Registering {function} as a resync_complete event listener")
-            self.event_strategy["resync_complete"].append(function)
+            self.event_strategy.resync_complete.append(function)
         return function
 
     def on_incremental_resync(
@@ -86,5 +78,5 @@ class EventsMixin:
         """
         if function is not None:
             logger.info(f"Registering incremental resync listener for kind {kind}")
-            self.event_strategy["incremental"][kind].append(function)
+            self.event_strategy.incremental[kind].append(function)
         return function

--- a/port_ocean/core/integrations/mixins/sync_raw.py
+++ b/port_ocean/core/integrations/mixins/sync_raw.py
@@ -86,17 +86,21 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
         logger.info(f"Fetching {resource_config.kind} resync results")
 
         is_incremental = event.event_type == EventType.INCREMENTAL_RESYNC
-        strategy_key = "incremental" if is_incremental else "resync"
-        available_kinds = (
-            self.available_incremental_kinds
+        event_mapping = (
+            self.event_strategy.incremental
             if is_incremental
-            else self.available_resync_kinds
+            else self.event_strategy.resync
         )
 
-        if resource_config.kind not in available_kinds and None not in available_kinds:
-            return unsupported_kind_response(resource_config.kind, cast(list[str], available_kinds))
+        if not (
+            event_mapping.get(resource_config.kind) or event_mapping.get(None)
+        ):
+            return unsupported_kind_response(
+                resource_config.kind,
+                cast(list[str], list(event_mapping.keys())),
+            )
 
-        fns = self._collect_resync_functions(resource_config, strategy_key)
+        fns = self._collect_resync_functions(resource_config, event_mapping)
         logger.info(f"Found {len(fns)} resync functions for {resource_config.kind}")
 
         results, errors = await self._execute_resync_tasks(
@@ -106,9 +110,10 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
         return results, errors
 
     def _collect_resync_functions(
-        self, resource_config: ResourceConfig, strategy_key: str = "resync"
+        self,
+        resource_config: ResourceConfig,
+        event_mapping: dict[str | None, list[Callable[[str], Awaitable[RAW_RESULT]]]],
     ) -> list[Callable[[str], Awaitable[RAW_RESULT]]]:
-        event_mapping = self.event_strategy.resync if strategy_key == "resync" else self.event_strategy.incremental
         fns = [
             *event_mapping[resource_config.kind],
             *event_mapping[None],

--- a/port_ocean/core/integrations/mixins/sync_raw.py
+++ b/port_ocean/core/integrations/mixins/sync_raw.py
@@ -95,7 +95,7 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
         )
 
         if not is_resource_supported(
-            resource_config.kind, self.event_strategy[strategy_key]
+            resource_config.kind, getattr(self.event_strategy, strategy_key)
         ):
             return unsupported_kind_response(resource_config.kind, available_kinds)
 
@@ -111,9 +111,10 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
     def _collect_resync_functions(
         self, resource_config: ResourceConfig, strategy_key: str = "resync"
     ) -> list[Callable[[str], Awaitable[RAW_RESULT]]]:
+        event_mapping = getattr(self.event_strategy, strategy_key)
         fns = [
-            *self.event_strategy[strategy_key][resource_config.kind],
-            *self.event_strategy[strategy_key][None],
+            *event_mapping[resource_config.kind],
+            *event_mapping[None],
         ]
 
         if self.__class__._on_resync != SyncRawMixin._on_resync:
@@ -1003,13 +1004,12 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
             logger.info("Resync finished successfully")
 
             # Execute resync_complete hooks
-            if "resync_complete" in self.event_strategy:
-                logger.info("Executing resync_complete hooks")
+            logger.info("Executing resync_complete hooks")
 
-                for resync_complete_fn in self.event_strategy["resync_complete"]:
-                    await resync_complete_fn()
+            for resync_complete_fn in self.event_strategy.resync_complete:
+                await resync_complete_fn()
 
-                logger.info("Finished executing resync_complete hooks")
+            logger.info("Finished executing resync_complete hooks")
 
             return True
 
@@ -1162,7 +1162,7 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
                 incremental_resources = [
                     (index, resource_cfg)
                     for index, resource_cfg in enumerate(app_config.resources)
-                    if self.event_strategy["incremental"].get(resource_cfg.kind)
+                    if self.event_strategy.incremental.get(resource_cfg.kind)
                 ]
 
                 if not incremental_resources:
@@ -1342,7 +1342,7 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
 
             try:
                 # Execute resync_start hooks
-                for resync_start_fn in self.event_strategy["resync_start"]:
+                for resync_start_fn in self.event_strategy.resync_start:
                     await resync_start_fn()
 
                 did_fetched_current_state = True

--- a/port_ocean/core/integrations/mixins/sync_raw.py
+++ b/port_ocean/core/integrations/mixins/sync_raw.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta, timezone
 from graphlib import CycleError
 import inspect
 import typing
-from typing import AsyncGenerator, Callable, Awaitable, Any
+from typing import AsyncGenerator, Callable, Awaitable, Any, cast
 import httpx
 import json
 from loguru import logger
@@ -21,7 +21,6 @@ from port_ocean.core.integrations.mixins.utils import (
     build_lakehouse_data_entry,
     is_dsp_mode_enabled,
     is_lakehouse_data_enabled,
-    is_resource_supported,
     selector_hash_from_resource,
     start_kind_tracking,
     stop_kind_tracking,
@@ -94,10 +93,8 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
             else self.available_resync_kinds
         )
 
-        if not is_resource_supported(
-            resource_config.kind, getattr(self.event_strategy, strategy_key)
-        ):
-            return unsupported_kind_response(resource_config.kind, available_kinds)
+        if resource_config.kind not in available_kinds and None not in available_kinds:
+            return unsupported_kind_response(resource_config.kind, cast(list[str], available_kinds))
 
         fns = self._collect_resync_functions(resource_config, strategy_key)
         logger.info(f"Found {len(fns)} resync functions for {resource_config.kind}")

--- a/port_ocean/core/integrations/mixins/sync_raw.py
+++ b/port_ocean/core/integrations/mixins/sync_raw.py
@@ -108,7 +108,7 @@ class SyncRawMixin(HandlerMixin, EventsMixin):
     def _collect_resync_functions(
         self, resource_config: ResourceConfig, strategy_key: str = "resync"
     ) -> list[Callable[[str], Awaitable[RAW_RESULT]]]:
-        event_mapping = getattr(self.event_strategy, strategy_key)
+        event_mapping = self.event_strategy.resync if strategy_key == "resync" else self.event_strategy.incremental
         fns = [
             *event_mapping[resource_config.kind],
             *event_mapping[None],

--- a/port_ocean/core/integrations/mixins/utils.py
+++ b/port_ocean/core/integrations/mixins/utils.py
@@ -16,7 +16,6 @@ from port_ocean.core.handlers.port_app_config.models import ResourceConfig
 from port_ocean.core.ocean_types import (
     ASYNC_GENERATOR_RESYNC_TYPE,
     RAW_RESULT,
-    RESYNC_EVENT_LISTENER,
     RESYNC_RESULT,
 )
 from port_ocean.core.utils.utils import validate_result
@@ -351,11 +350,6 @@ async def resync_generator_wrapper(
                 "At least one of the resync generator iterations failed", errors
             )
 
-
-def is_resource_supported(
-    kind: str, resync_event_mapping: dict[str | None, list[RESYNC_EVENT_LISTENER]]
-) -> bool:
-    return bool(resync_event_mapping[kind] or resync_event_mapping[None])
 
 def unsupported_kind_response(
     kind: str, available_resync_kinds: list[str]

--- a/port_ocean/core/ocean_types.py
+++ b/port_ocean/core/ocean_types.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+from dataclasses import dataclass, field
 from typing import (
     TypedDict,
     Any,
@@ -6,8 +8,6 @@ from typing import (
     Awaitable,
     NamedTuple,
 )
-
-from dataclasses import field
 from port_ocean.core.models import Entity
 
 RAW_ITEM = dict[Any, Any]
@@ -53,9 +53,14 @@ class ETLPhase:
     RECONCILIATION = "reconciliation"
 
 
-class IntegrationEventsCallbacks(TypedDict):
-    start: list[START_EVENT_LISTENER]
-    resync: dict[str | None, list[RESYNC_EVENT_LISTENER]]
-    resync_start: list[BEFORE_RESYNC_EVENT_LISTENER]
-    resync_complete: list[AFTER_RESYNC_EVENT_LISTENER]
-    incremental: dict[str | None, list[INCREMENTAL_EVENT_LISTENER]]
+@dataclass
+class IntegrationEventsCallbacks:
+    start: list[START_EVENT_LISTENER] = field(default_factory=list)
+    resync: dict[str | None, list[RESYNC_EVENT_LISTENER]] = field(
+        default_factory=lambda: defaultdict(list)
+    )
+    resync_start: list[BEFORE_RESYNC_EVENT_LISTENER] = field(default_factory=list)
+    resync_complete: list[AFTER_RESYNC_EVENT_LISTENER] = field(default_factory=list)
+    incremental: dict[str | None, list[INCREMENTAL_EVENT_LISTENER]] = field(
+        default_factory=lambda: defaultdict(list)
+    )

--- a/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
+++ b/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
@@ -5,7 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 from loguru import logger
 from port_ocean.core.utils.entity_topological_sorter import EntityTopologicalSorter
-from port_ocean.exceptions.core import OceanAbortException
+from port_ocean.exceptions.core import KindNotImplementedException, OceanAbortException
 import pytest
 from unittest.mock import MagicMock, AsyncMock, patch
 from port_ocean.ocean import Ocean
@@ -1499,6 +1499,130 @@ async def test_resync_reconciliation_sets_reconciliation_etl_phase_in_logger_con
     assert (
         len(reconciliation_records) >= 1
     ), "Expected at least 1 log with etl_phase=reconciliation"
+
+
+def _resource_config_for_kind(kind: str) -> ResourceConfig:
+    return ResourceConfig(
+        kind=kind,
+        selector=Selector(query="true"),
+        port=PortResourceConfig(
+            entity=MappingsConfig(
+                mappings=EntityMapping(
+                    identifier=".id",
+                    title=".name",
+                    blueprint='"service"',
+                    properties={"url": ".web_url"},
+                    relations={},
+                )
+            )
+        ),
+    )
+
+
+async def _resync_handler(kind: str) -> list[dict[str, str]]:
+    return [{"id": "1"}]
+
+
+@pytest.mark.asyncio
+async def test_get_resource_raw_results_returns_error_for_unregistered_kind(
+    mock_resource_config: ResourceConfig,
+) -> None:
+    # Arrange
+    mixin = SyncRawMixin()
+
+    # Act
+    async with event_context(EventType.RESYNC, trigger_type="machine"):
+        with patch.object(
+            mixin,
+            "_execute_resync_tasks",
+            new_callable=AsyncMock,
+        ) as mock_execute:
+            results, errors = await mixin._get_resource_raw_results(
+                mock_resource_config
+            )
+
+    # Assert
+    mock_execute.assert_not_awaited()
+    assert results == []
+    assert len(errors) == 1
+    assert isinstance(errors[0], KindNotImplementedException)
+    assert mock_resource_config.kind in str(errors[0])
+
+
+@pytest.mark.asyncio
+async def test_get_resource_raw_results_proceeds_when_specific_kind_registered(
+    mock_resource_config: ResourceConfig,
+) -> None:
+    # Arrange
+    mixin = SyncRawMixin()
+    mixin.on_resync(_resync_handler, kind=mock_resource_config.kind)
+
+    # Act
+    async with event_context(EventType.RESYNC, trigger_type="machine"):
+        with patch.object(
+            mixin,
+            "_execute_resync_tasks",
+            new_callable=AsyncMock,
+            return_value=([], []),
+        ) as mock_execute:
+            results, errors = await mixin._get_resource_raw_results(
+                mock_resource_config
+            )
+
+    # Assert
+    mock_execute.assert_awaited_once()
+    assert results == []
+    assert errors == []
+
+
+@pytest.mark.asyncio
+async def test_get_resource_raw_results_proceeds_when_catch_all_registered() -> None:
+    # Arrange
+    mixin = SyncRawMixin()
+    mixin.on_resync(_resync_handler, kind=None)
+    resource_config = _resource_config_for_kind("pull-request")
+
+    # Act
+    async with event_context(EventType.RESYNC, trigger_type="machine"):
+        with patch.object(
+            mixin,
+            "_execute_resync_tasks",
+            new_callable=AsyncMock,
+            return_value=([], []),
+        ) as mock_execute:
+            results, errors = await mixin._get_resource_raw_results(resource_config)
+
+    # Assert
+    mock_execute.assert_awaited_once()
+    assert results == []
+    assert errors == []
+
+
+@pytest.mark.asyncio
+async def test_get_resource_raw_results_proceeds_when_both_catch_all_and_specific_registered(
+    mock_resource_config: ResourceConfig,
+) -> None:
+    # Arrange
+    mixin = SyncRawMixin()
+    mixin.on_resync(_resync_handler, kind=mock_resource_config.kind)
+    mixin.on_resync(_resync_handler, kind=None)
+
+    # Act
+    async with event_context(EventType.RESYNC, trigger_type="machine"):
+        with patch.object(
+            mixin,
+            "_execute_resync_tasks",
+            new_callable=AsyncMock,
+            return_value=([], []),
+        ) as mock_execute:
+            results, errors = await mixin._get_resource_raw_results(
+                mock_resource_config
+            )
+
+    # Assert
+    mock_execute.assert_awaited_once()
+    assert results == []
+    assert errors == []
 
 
 @pytest.mark.asyncio

--- a/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
+++ b/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
@@ -1634,7 +1634,9 @@ async def test_collect_resync_functions_returns_functions_without_setting_logger
     Verify the removal doesn't break function collection and leaks no context."""
     records, sink_id = _capture_loguru_extras()
     try:
-        fns = mock_sync_raw_mixin._collect_resync_functions(mock_resource_config)
+        fns = mock_sync_raw_mixin._collect_resync_functions(
+            mock_resource_config, mock_sync_raw_mixin.event_strategy.resync
+        )
     finally:
         logger.remove(sink_id)
 

--- a/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
+++ b/port_ocean/tests/core/handlers/mixins/test_sync_raw.py
@@ -26,7 +26,7 @@ from port_ocean.core.handlers.entity_processor.jq_entity_processor import (
     JQEntityProcessor,
 )
 from port_ocean.core.models import Entity
-from port_ocean.core.ocean_types import ETLPhase
+from port_ocean.core.ocean_types import ETLPhase, RAW_RESULT
 from port_ocean.context.event import event_context, EventType
 from port_ocean.clients.port.types import UserAgentType
 from port_ocean.clients.dsp.lifecycle import GranularityType
@@ -1635,7 +1635,11 @@ async def test_collect_resync_functions_returns_functions_without_setting_logger
     records, sink_id = _capture_loguru_extras()
     try:
         fns = mock_sync_raw_mixin._collect_resync_functions(
-            mock_resource_config, mock_sync_raw_mixin.event_strategy.resync
+            mock_resource_config,
+            cast(
+                dict[str | None, list[Callable[[str], Awaitable[RAW_RESULT]]]],
+                mock_sync_raw_mixin.event_strategy.resync,
+            ),
         )
     finally:
         logger.remove(sink_id)

--- a/port_ocean/tests/core/incremental/test_sync_incremental.py
+++ b/port_ocean/tests/core/incremental/test_sync_incremental.py
@@ -84,7 +84,7 @@ def register_incremental_handler(
         yield [{"id": "1"}]
 
     handler.side_effect = gen
-    mixin.event_strategy["incremental"][kind].append(handler)
+    mixin.event_strategy.incremental[kind].append(handler)
     return handler
 
 
@@ -389,7 +389,7 @@ class TestEventsMixinIncrementalRegistration:
             yield [{"id": "1"}]
 
         mixin.on_incremental_resync(handler, kind="issue")
-        assert handler in mixin.event_strategy["incremental"]["issue"]
+        assert handler in mixin.event_strategy.incremental["issue"]
 
     def test_on_incremental_resync_registers_catch_all_handler(self) -> None:
         from port_ocean.core.integrations.mixins.events import EventsMixin
@@ -400,7 +400,7 @@ class TestEventsMixinIncrementalRegistration:
             yield [{"id": "1"}]
 
         mixin.on_incremental_resync(handler, kind=None)
-        assert handler in mixin.event_strategy["incremental"][None]
+        assert handler in mixin.event_strategy.incremental[None]
 
     def test_on_incremental_resync_ignores_none_function(self) -> None:
         from port_ocean.core.integrations.mixins.events import EventsMixin
@@ -408,7 +408,7 @@ class TestEventsMixinIncrementalRegistration:
         mixin = EventsMixin()
         result = mixin.on_incremental_resync(None, kind="issue")
         assert result is None
-        assert len(mixin.event_strategy["incremental"]["issue"]) == 0
+        assert len(mixin.event_strategy.incremental["issue"]) == 0
 
     def test_available_incremental_kinds_returns_registered_kinds(self) -> None:
         from port_ocean.core.integrations.mixins.events import EventsMixin

--- a/port_ocean/tests/core/incremental/test_sync_incremental.py
+++ b/port_ocean/tests/core/incremental/test_sync_incremental.py
@@ -409,15 +409,3 @@ class TestEventsMixinIncrementalRegistration:
         result = mixin.on_incremental_resync(None, kind="issue")
         assert result is None
         assert len(mixin.event_strategy.incremental["issue"]) == 0
-
-    def test_available_incremental_kinds_returns_registered_kinds(self) -> None:
-        from port_ocean.core.integrations.mixins.events import EventsMixin
-
-        mixin = EventsMixin()
-
-        async def handler(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
-            yield [{"id": "1"}]
-
-        mixin.on_incremental_resync(handler, kind="issue")
-        mixin.on_incremental_resync(handler, kind="pull-request")
-        assert set(mixin.available_incremental_kinds) == {"issue", "pull-request"}

--- a/port_ocean/tests/utils/test_async_iterators.py
+++ b/port_ocean/tests/utils/test_async_iterators.py
@@ -1,5 +1,6 @@
 import asyncio
 from collections.abc import AsyncGenerator
+from functools import partial
 from typing import Any
 
 import pytest
@@ -76,7 +77,7 @@ async def test_throttle_batch_operation_limits_concurrency() -> None:
         return value
 
     results = await throttle_batch_operation(
-        [lambda value=value: operation(value) for value in range(10)],
+        [partial(operation, value) for value in range(10)],
         max_concurrency,
     )
 


### PR DESCRIPTION
# Description

What - Converted IntegrationEventsCallbacks from typed dict to dataclass 

Why - Makes it significantly more traceable within the codebase

How -

## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core event registration and resync/start dispatch. Behavior should be equivalent, but any external code that treated `event_strategy` as a dict will break.
> 
> **Overview**
> Converts `IntegrationEventsCallbacks` from a `TypedDict` to a dataclass so event listeners are accessed as attributes (`event_strategy.resync`) instead of dict keys.
> 
> `EventsMixin` now constructs the dataclass (still using `defaultdict(list)` for kind maps). Call sites in `BaseIntegration` and `SyncRawMixin` use attribute access; dynamic `"resync"` / `"incremental"` lookup goes through `getattr`. `resync_complete` hooks always run (the old `"resync_complete" in ...` guard is gone). Tests are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22b9899f7c0d50b02be9060962891db9aeb5a9f8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->