### PR TITLE
[Core] Fix Live Event Deletes for Selector-excluded Entities

### DIFF
--- a/.ocean-release/core/fix-live-event-delete-selector.yaml
+++ b/.ocean-release/core/fix-live-event-delete-selector.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: bugfix
+changelog: Fix live event deletes for entities whose raw payload no longer passes the selector

--- a/port_ocean/core/integrations/mixins/live_events.py
+++ b/port_ocean/core/integrations/mixins/live_events.py
@@ -86,7 +86,10 @@ class LiveEventsMixin(HandlerMixin):
                     deletion_results = await self.entity_processor.parse_items(
                         resource, batch, parse_all=True
                     )
-                    entities_to_delete.extend(deletion_results.entity_selector_diff.passed)
+                    entities_to_delete.extend(
+                        deletion_results.entity_selector_diff.passed
+                        + deletion_results.entity_selector_diff.failed
+                    )
 
         entities_to_remove = []
         for entity in entities_to_delete + entities_not_passed:

--- a/port_ocean/tests/core/handlers/mixins/test_live_events.py
+++ b/port_ocean/tests/core/handlers/mixins/test_live_events.py
@@ -388,6 +388,34 @@ async def test_parse_raw_event_results_to_entities_deletion(
 
 
 @pytest.mark.asyncio
+async def test_parse_raw_event_results_to_entities_deletion_when_selector_fails(
+    mock_live_events_mixin: LiveEventsMixin,
+) -> None:
+    """Delete events should remove entities even when the raw item fails the selector."""
+    mock_live_events_mixin.entity_processor.parse_items = AsyncMock()  # type: ignore
+
+    calculation_result = CalculationResult(
+        entity_selector_diff=EntitySelectorDiff(passed=[], failed=[entity]),
+        errors=[],
+        misconfigured_entity_keys={},
+    )
+    mock_live_events_mixin.entity_processor.parse_items.return_value = (
+        calculation_result
+    )
+
+    (
+        entities_to_create,
+        entities_to_delete,
+    ) = await mock_live_events_mixin._parse_raw_event_results_to_entities(
+        [one_webhook_event_raw_results_for_deletion]
+    )
+
+    assert entities_to_create == []
+    assert entities_to_delete == [entity]
+    mock_live_events_mixin.entity_processor.parse_items.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_parse_raw_event_results_to_entities_skips_results_without_resource(
     mock_live_events_mixin: LiveEventsMixin,
 ) -> None:


### PR DESCRIPTION
# Description

What - Fix Ocean core live-event delete handling so explicit delete events remove entities even when the raw payload no longer passes the selector.

Why - Archived/disabled/out-of-scope resources can fail their selector at delete time, causing Ocean to drop the delete candidate and leave stale entities in Port.

How - Include both selector-passed and selector-failed mapped entities when processing `deleted_raw_results`, and add a regression test for delete events where the selector fails.


## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [x] Integration able to create all default resources from scratch
- [x] Resync finishes successfully
- [x] Resync able to create entities
- [x] Resync able to update entities
- [x] Resync able to detect and delete entities
- [x] Scheduled resync able to abort existing resync and start a new one
- [x] Tested with at least 2 integrations from scratch
- [x] Tested with Kafka and Polling event listeners
- [x] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [x] Integration able to create all default resources from scratch
- [x] Completed a full resync from a freshly installed integration and it completed successfully
- [x] Resync able to create entities
- [x] Resync able to update entities
- [x] Resync able to detect and delete entities
- [x] Resync finishes successfully
- [x] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core live-event deletion, so incorrect mapping could delete extra entities or still miss deletes. Scope is a small, well-tested change to candidate collection only.
> 
> **Overview**
> Live-event **delete** handling now removes entities even when the raw payload no longer matches the selector (e.g. archived or out-of-scope resources). Previously only selector-passed mapped entities were queued for delete, which left stale Port entities.
> 
> `_parse_raw_event_results_to_entities` now unions `passed` and `failed` from `deleted_raw_results`. A regression test covers selector-fail deletes. Patch release intent is included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f39df58f6e4484b97d0573ac601f89248dab4d2d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->