### PR TITLE
Add throttle_batch_operation util for bounded concurrent batch execution

### DIFF
--- a/.ocean-release/core/throttle-batch-operation.yaml
+++ b/.ocean-release/core/throttle-batch-operation.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: improvement
+changelog: Added `throttle_batch_operation` util for running multiple async callables with bounded concurrency.

--- a/port_ocean/tests/utils/test_async_iterators.py
+++ b/port_ocean/tests/utils/test_async_iterators.py
@@ -8,6 +8,7 @@ from port_ocean.utils import async_iterators
 from port_ocean.utils.async_iterators import (
     semaphore_async_iterator,
     stream_independent_async_iterators,
+    throttle_batch_operation,
 )
 
 
@@ -51,6 +52,43 @@ async def _slow_to_cancel() -> AsyncGenerator[int, None]:
         await asyncio.sleep(3600)
     except asyncio.CancelledError:
         await asyncio.sleep(0.1)
+
+
+@pytest.mark.asyncio
+async def test_throttle_batch_operation_limits_concurrency() -> None:
+    max_concurrency = 3
+    concurrent_tasks = 0
+    max_concurrent_tasks = 0
+    lock = asyncio.Lock()
+
+    async def operation(value: int) -> int:
+        nonlocal concurrent_tasks, max_concurrent_tasks
+
+        async with lock:
+            concurrent_tasks += 1
+            max_concurrent_tasks = max(max_concurrent_tasks, concurrent_tasks)
+
+        await asyncio.sleep(0.05)
+
+        async with lock:
+            concurrent_tasks -= 1
+
+        return value
+
+    results = await throttle_batch_operation(
+        [lambda value=value: operation(value) for value in range(10)],
+        max_concurrency,
+    )
+
+    assert results == list(range(10))
+    assert max_concurrent_tasks <= max_concurrency
+    assert concurrent_tasks == 0
+
+
+@pytest.mark.asyncio
+async def test_throttle_batch_operation_rejects_invalid_concurrency() -> None:
+    with pytest.raises(ValueError, match="concurrency must be at least 1"):
+        await throttle_batch_operation([], 0)
 
 
 @pytest.mark.asyncio

--- a/port_ocean/utils/async_iterators.py
+++ b/port_ocean/utils/async_iterators.py
@@ -10,6 +10,37 @@ CANCELLED_TASK_CLEANUP_TIMEOUT = 10
 T = typing.TypeVar("T")
 
 
+async def throttle_batch_operation(
+    operations: typing.Iterable[typing.Callable[[], typing.Awaitable[T]]],
+    concurrency: int,
+) -> list[T]:
+    """
+    Run multiple async operations with bounded concurrency.
+
+    Each operation is a nullary callable returning an awaitable. Apply arguments
+    with functools.partial or a lambda before passing it in.
+
+    Parameters:
+        operations: Callables to execute concurrently under the concurrency limit.
+        concurrency: Maximum number of operations running at the same time.
+
+    Returns:
+        Results in the same order as the provided operations.
+    """
+    if concurrency < 1:
+        raise ValueError("concurrency must be at least 1")
+
+    semaphore = asyncio.Semaphore(concurrency)
+
+    async def run_operation(operation: typing.Callable[[], typing.Awaitable[T]]) -> T:
+        async with semaphore:
+            return await operation()
+
+    return list(
+        await asyncio.gather(*(run_operation(operation) for operation in operations))
+    )
+
+
 @dataclass(slots=True)
 class _IteratorItem(typing.Generic[T]):
     item: T


### PR DESCRIPTION
## Summary
- Adds `throttle_batch_operation` to `port_ocean.utils.async_iterators` for running multiple async callables with a shared concurrency limit.
- Complements the existing `semaphore_async_iterator` helper, which targets streaming async iterators rather than one-shot `gather` workloads.
- Includes unit tests covering concurrency limiting and invalid concurrency validation.

## Motivation
GitHub bulk external custom properties actions need bounded concurrent HTTP calls. This pattern is currently duplicated inline across integrations; a small shared primitive keeps call sites simple:

```python
results = await throttle_batch_operation(
    [lambda item=item: do_work(item) for item in items],
    concurrency=5,
)
```

## Test plan
- [x] `pytest port_ocean/tests/utils/test_async_iterators.py -n0`


Made with [Cursor](https://cursor.com)