### PR TITLE
[Core] Enhance selector hash functionality to ignore query in resource hashing

### DIFF
--- a/.ocean-release/core/selector-hash-and-lint-fixes.yaml
+++ b/.ocean-release/core/selector-hash-and-lint-fixes.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: bugfix
+changelog: Normalize selector hashing behavior.

--- a/port_ocean/core/integrations/mixins/utils.py
+++ b/port_ocean/core/integrations/mixins/utils.py
@@ -70,8 +70,8 @@ def selector_query_from_resource(resource: ResourceConfig) -> str | None:
     return trimmed if trimmed else None
 
 
-def selector_hash_from_query(query: str) -> str:
-    return hashlib.sha256(query.encode("utf-8")).hexdigest()
+def selector_hash_from_selector(selector: str) -> str:
+    return hashlib.sha256(selector.encode("utf-8")).hexdigest()
 
 
 def _selector_without_query(resource: ResourceConfig) -> dict[str, Any] | None:
@@ -100,7 +100,7 @@ def selector_hash_from_resource(resource: ResourceConfig) -> str | None:
     normalized_selector = json.dumps(
         selector_without_query, sort_keys=True, separators=(",", ":")
     )
-    return selector_hash_from_query(normalized_selector)
+    return selector_hash_from_selector(normalized_selector)
 
 
 async def is_lakehouse_data_enabled() -> bool:

--- a/port_ocean/core/integrations/mixins/utils.py
+++ b/port_ocean/core/integrations/mixins/utils.py
@@ -82,7 +82,7 @@ def _selector_without_query(resource: ResourceConfig) -> dict[str, Any] | None:
 
     if hasattr(selector, "dict"):
         selector_payload = selector.dict(
-            by_alias=True, exclude_none=True, exclude_unset=True
+            by_alias=True, exclude_none=True
         )
     elif isinstance(selector, dict):
         selector_payload = dict(selector)

--- a/port_ocean/core/integrations/mixins/utils.py
+++ b/port_ocean/core/integrations/mixins/utils.py
@@ -82,7 +82,7 @@ def _selector_without_query(resource: ResourceConfig) -> dict[str, Any] | None:
 
     if hasattr(selector, "dict"):
         selector_payload = selector.dict(
-            by_alias=True, exclude_none=True
+            by_alias=True, exclude_none=True, exclude_unset=True
         )
     elif isinstance(selector, dict):
         selector_payload = dict(selector)

--- a/port_ocean/core/integrations/mixins/utils.py
+++ b/port_ocean/core/integrations/mixins/utils.py
@@ -1,4 +1,5 @@
 import hashlib
+import json
 import os
 import re
 from contextlib import contextmanager
@@ -74,12 +75,33 @@ def selector_hash_from_query(query: str) -> str:
     return hashlib.sha256(query.encode("utf-8")).hexdigest()
 
 
-def selector_hash_from_resource(resource: ResourceConfig) -> str | None:
-    query = selector_query_from_resource(resource)
-    if not query:
+def _selector_without_query(resource: ResourceConfig) -> dict[str, Any] | None:
+    selector = getattr(resource, "selector", None)
+    if selector is None:
         return None
 
-    return selector_hash_from_query(query)
+    if hasattr(selector, "dict"):
+        selector_payload = selector.dict(
+            by_alias=True, exclude_none=True, exclude_unset=True
+        )
+    elif isinstance(selector, dict):
+        selector_payload = dict(selector)
+    else:
+        selector_payload = dict(getattr(selector, "__dict__", {}))
+
+    selector_payload.pop("query", None)
+    return selector_payload
+
+
+def selector_hash_from_resource(resource: ResourceConfig) -> str | None:
+    selector_without_query = _selector_without_query(resource)
+    if selector_without_query is None:
+        return None
+
+    normalized_selector = json.dumps(
+        selector_without_query, sort_keys=True, separators=(",", ":")
+    )
+    return selector_hash_from_query(normalized_selector)
 
 
 async def is_lakehouse_data_enabled() -> bool:

--- a/port_ocean/tests/core/handlers/mixins/test_live_events_lakehouse.py
+++ b/port_ocean/tests/core/handlers/mixins/test_live_events_lakehouse.py
@@ -20,6 +20,7 @@ from port_ocean.core.handlers.port_app_config.models import (
 )
 from port_ocean.core.handlers.webhook.webhook_event import WebhookEventRawResults
 from port_ocean.core.integrations.mixins.live_events import LiveEventsMixin
+from port_ocean.core.integrations.mixins.utils import selector_hash_from_resource
 from port_ocean.core.models import LakehouseOperation, LakehouseEventType
 from port_ocean.ocean import Ocean
 
@@ -218,10 +219,9 @@ async def test_send_webhook_raw_data_to_lakehouse_enabled_upsert(
         assert data_entries[0]["metadata"]["operation"] == LakehouseOperation.UPSERT
         assert data_entries[0]["items"] == raw_data
         assert data_entries[0]["metadata"]["resource_index"] == 0
-        assert (
-            data_entries[0]["metadata"]["selector_hash"]
-            == "b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b"
-        )
+        assert data_entries[0]["metadata"][
+            "selector_hash"
+        ] == selector_hash_from_resource(webhook_results.resource)
 
 
 @pytest.mark.asyncio
@@ -267,10 +267,9 @@ async def test_send_webhook_raw_data_to_lakehouse_enabled_delete(
         assert data_entries[0]["metadata"]["operation"] == LakehouseOperation.DELETE
         assert data_entries[0]["items"] == raw_data
         assert data_entries[0]["metadata"]["resource_index"] == 0
-        assert (
-            data_entries[0]["metadata"]["selector_hash"]
-            == "b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b"
-        )
+        assert data_entries[0]["metadata"][
+            "selector_hash"
+        ] == selector_hash_from_resource(webhook_results.resource)
 
 
 @pytest.mark.asyncio
@@ -382,16 +381,14 @@ async def test_send_webhook_raw_data_to_lakehouse_both_operations(
         assert upsert_entry["metadata"]["operation"] == LakehouseOperation.UPSERT
         assert upsert_entry["items"] == upsert_data
         assert upsert_entry["metadata"]["resource_index"] == 0
-        assert (
-            upsert_entry["metadata"]["selector_hash"]
-            == "b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b"
+        assert upsert_entry["metadata"]["selector_hash"] == selector_hash_from_resource(
+            webhook_results.resource
         )
 
         delete_entry = data_entries[1]
         assert delete_entry["metadata"]["operation"] == LakehouseOperation.DELETE
         assert delete_entry["items"] == delete_data
         assert delete_entry["metadata"]["resource_index"] == 0
-        assert (
-            delete_entry["metadata"]["selector_hash"]
-            == "b5bea41b6c623f7c09f1bf24dcae58ebab3c0cdd90ad966bc43a45b44867e12b"
+        assert delete_entry["metadata"]["selector_hash"] == selector_hash_from_resource(
+            webhook_results.resource
         )

--- a/port_ocean/tests/core/integrations/mixins/test_integration_utils.py
+++ b/port_ocean/tests/core/integrations/mixins/test_integration_utils.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
@@ -122,7 +124,7 @@ class TestSelectorHashHelpers:
             == "013b54afaf52ac0983a4ac123b01e809ab7ac8862e67a50f09fcce1293d265c3"
         )
 
-    def test_selector_hash_from_resource_returns_hash_for_trimmed_query(self) -> None:
+    def test_selector_hash_from_resource_ignores_query_and_hashes_selector(self) -> None:
         resource = ResourceConfig(
             kind="test-kind",
             selector=Selector(query="  .foo  "),
@@ -139,12 +141,71 @@ class TestSelectorHashHelpers:
             ),
         )
 
-        assert (
-            selector_hash_from_resource(resource)
-            == "013b54afaf52ac0983a4ac123b01e809ab7ac8862e67a50f09fcce1293d265c3"
+        expected_selector_payload = {}
+        expected_hash = hashlib.sha256(
+            json.dumps(expected_selector_payload, sort_keys=True, separators=(",", ":")).encode(
+                "utf-8"
+            )
+        ).hexdigest()
+        assert selector_hash_from_resource(resource) == expected_hash
+
+    def test_selector_hash_from_resource_is_stable_when_only_query_changes(self) -> None:
+        base_resource = ResourceConfig(
+            kind="test-kind",
+            selector=Selector(query=".foo", exportEnvVariables=["MY_VAR"]),
+            port=PortResourceConfig(
+                entity=MappingsConfig(
+                    mappings=EntityMapping(
+                        identifier=".id",
+                        title=".name",
+                        blueprint='"test"',
+                        properties={},
+                        relations={},
+                    )
+                )
+            ),
+        )
+        changed_query_resource = ResourceConfig(
+            kind="test-kind",
+            selector=Selector(query=".bar", exportEnvVariables=["MY_VAR"]),
+            port=PortResourceConfig(
+                entity=MappingsConfig(
+                    mappings=EntityMapping(
+                        identifier=".id",
+                        title=".name",
+                        blueprint='"test"',
+                        properties={},
+                        relations={},
+                    )
+                )
+            ),
         )
 
-    def test_selector_hash_from_resource_returns_none_for_empty_query(self) -> None:
+        assert selector_hash_from_resource(base_resource) == selector_hash_from_resource(
+            changed_query_resource
+        )
+
+    def test_selector_hash_from_resource_returns_none_without_selector(self) -> None:
+        resource = ResourceConfig(
+            kind="test-kind",
+            selector=Selector(query="true"),
+            port=PortResourceConfig(
+                entity=MappingsConfig(
+                    mappings=EntityMapping(
+                        identifier=".id",
+                        title=".name",
+                        blueprint='"test"',
+                        properties={},
+                        relations={},
+                    )
+                )
+            ),
+        )
+        resource.selector = None  # type: ignore[assignment]
+
+        assert selector_hash_from_resource(resource) is None
+
+    def test_selector_hash_from_resource_hashes_empty_selector_without_query(self) -> None:
         resource = ResourceConfig(
             kind="test-kind",
             selector=Selector(query=" "),
@@ -161,7 +222,8 @@ class TestSelectorHashHelpers:
             ),
         )
 
-        assert selector_hash_from_resource(resource) is None
+        expected_hash = hashlib.sha256(b"{}").hexdigest()
+        assert selector_hash_from_resource(resource) == expected_hash
 
 
 class TestExtractJqDeletionPathRevised:

--- a/port_ocean/tests/core/integrations/mixins/test_integration_utils.py
+++ b/port_ocean/tests/core/integrations/mixins/test_integration_utils.py
@@ -33,11 +33,14 @@ from port_ocean.core.integrations.mixins.utils import (
 )
 from port_ocean.core.models import LakehouseOperation
 
+
 class TestCollectExportEnvVariables:
     def test_returns_none_for_empty_list(self) -> None:
         assert collect_export_env_variables([]) is None
 
-    def test_collects_requested_variables(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_collects_requested_variables(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.setenv("FOO", "bar")
         monkeypatch.delenv("MISSING", raising=False)
 
@@ -124,7 +127,9 @@ class TestSelectorHashHelpers:
             == "013b54afaf52ac0983a4ac123b01e809ab7ac8862e67a50f09fcce1293d265c3"
         )
 
-    def test_selector_hash_from_resource_ignores_query_and_hashes_selector(self) -> None:
+    def test_selector_hash_from_resource_ignores_query_and_hashes_selector(
+        self,
+    ) -> None:
         resource = ResourceConfig(
             kind="test-kind",
             selector=Selector(query="  .foo  "),
@@ -141,15 +146,22 @@ class TestSelectorHashHelpers:
             ),
         )
 
-        expected_selector_payload = {}
+        expected_selector_payload = (
+            resource.selector.dict(by_alias=True, exclude_none=True)
+            if resource.selector
+            else {}
+        )
+        expected_selector_payload.pop("query", None)
         expected_hash = hashlib.sha256(
-            json.dumps(expected_selector_payload, sort_keys=True, separators=(",", ":")).encode(
-                "utf-8"
-            )
+            json.dumps(
+                expected_selector_payload, sort_keys=True, separators=(",", ":")
+            ).encode("utf-8")
         ).hexdigest()
         assert selector_hash_from_resource(resource) == expected_hash
 
-    def test_selector_hash_from_resource_is_stable_when_only_query_changes(self) -> None:
+    def test_selector_hash_from_resource_is_stable_when_only_query_changes(
+        self,
+    ) -> None:
         base_resource = ResourceConfig(
             kind="test-kind",
             selector=Selector(query=".foo", exportEnvVariables=["MY_VAR"]),
@@ -181,9 +193,9 @@ class TestSelectorHashHelpers:
             ),
         )
 
-        assert selector_hash_from_resource(base_resource) == selector_hash_from_resource(
-            changed_query_resource
-        )
+        assert selector_hash_from_resource(
+            base_resource
+        ) == selector_hash_from_resource(changed_query_resource)
 
     def test_selector_hash_from_resource_is_stable_for_implicit_and_explicit_defaults(
         self,
@@ -219,9 +231,9 @@ class TestSelectorHashHelpers:
             ),
         )
 
-        assert selector_hash_from_resource(implicit_defaults) == selector_hash_from_resource(
-            explicit_defaults
-        )
+        assert selector_hash_from_resource(
+            implicit_defaults
+        ) == selector_hash_from_resource(explicit_defaults)
 
     def test_selector_hash_from_resource_returns_none_without_selector(self) -> None:
         resource = ResourceConfig(
@@ -243,7 +255,9 @@ class TestSelectorHashHelpers:
 
         assert selector_hash_from_resource(resource) is None
 
-    def test_selector_hash_from_resource_hashes_empty_selector_without_query(self) -> None:
+    def test_selector_hash_from_resource_hashes_empty_selector_without_query(
+        self,
+    ) -> None:
         resource = ResourceConfig(
             kind="test-kind",
             selector=Selector(query=" "),
@@ -260,7 +274,17 @@ class TestSelectorHashHelpers:
             ),
         )
 
-        expected_hash = hashlib.sha256(b"{}").hexdigest()
+        expected_selector_payload = (
+            resource.selector.dict(by_alias=True, exclude_none=True)
+            if resource.selector
+            else {}
+        )
+        expected_selector_payload.pop("query", None)
+        expected_hash = hashlib.sha256(
+            json.dumps(
+                expected_selector_payload, sort_keys=True, separators=(",", ":")
+            ).encode("utf-8")
+        ).hexdigest()
         assert selector_hash_from_resource(resource) == expected_hash
 
 
@@ -416,8 +440,8 @@ class TestExtractJqDeletionPathRevised:
 
     def test_path_with_complex_bracket_expression(self) -> None:
         """Test path extraction with complex bracket expression."""
-        result = extract_jq_deletion_path_revised(".[\"key\"].value")
-        assert result == ".[\"key\"].value"
+        result = extract_jq_deletion_path_revised('.["key"].value')
+        assert result == '.["key"].value'
 
     def test_empty_string_returns_none(self) -> None:
         """Test that empty string returns None."""
@@ -838,7 +862,9 @@ class TestResyncGeneratorWrapperDoesNotMutateYieldedBatches:
             mock_ocean_context.config.yield_items_to_parse_batch_size = 100
             mock_ocean_context.app.integration.entity_processor = mock_entity_processor
             mock_ocean_context.metrics = mock_context.app.metrics
-            mock_ocean_context.port_client.ingest_integration_kind_examples = AsyncMock()
+            mock_ocean_context.port_client.ingest_integration_kind_examples = (
+                AsyncMock()
+            )
 
             expanded_batches = [
                 batch
@@ -881,7 +907,9 @@ class TestResyncGeneratorWrapperDoesNotMutateYieldedBatches:
         with patch(
             "port_ocean.core.integrations.mixins.utils.ocean"
         ) as mock_ocean_context:
-            mock_ocean_context.port_client.ingest_integration_kind_examples = AsyncMock()
+            mock_ocean_context.port_client.ingest_integration_kind_examples = (
+                AsyncMock()
+            )
 
             result = await resync_function_wrapper(
                 fake_resync,
@@ -906,7 +934,9 @@ class TestResyncGeneratorWrapperDoesNotMutateYieldedBatches:
         with patch(
             "port_ocean.core.integrations.mixins.utils.ocean"
         ) as mock_ocean_context:
-            mock_ocean_context.port_client.ingest_integration_kind_examples = AsyncMock()
+            mock_ocean_context.port_client.ingest_integration_kind_examples = (
+                AsyncMock()
+            )
 
             batches = [
                 batch
@@ -981,31 +1011,41 @@ class TestProcessingModes:
     async def test_is_dsp_mode_enabled_uses_local_only_warning_for_missing_flags(
         self,
     ) -> None:
-        with patch("port_ocean.core.integrations.mixins.utils.ocean") as mock_ocean_context:
+        with patch(
+            "port_ocean.core.integrations.mixins.utils.ocean"
+        ) as mock_ocean_context:
             mock_ocean_context.config.processing_mode = ProcessingMode.dsp
             mock_ocean_context.config.lakehouse_enabled = True
             mock_ocean_context.port_client.get_organization_feature_flags = AsyncMock(
                 return_value=[]
             )
 
-            with patch("port_ocean.core.integrations.mixins.utils.logger") as mock_logger:
+            with patch(
+                "port_ocean.core.integrations.mixins.utils.logger"
+            ) as mock_logger:
                 mock_bound = mock_logger.bind.return_value
                 result = await is_dsp_mode_enabled()
 
         assert result is False
         mock_logger.bind.assert_called_with(local_only=True)
         mock_bound.warning.assert_called_once()
-        assert "required feature flags are missing" in mock_bound.warning.call_args.args[0]
+        assert (
+            "required feature flags are missing" in mock_bound.warning.call_args.args[0]
+        )
 
     @pytest.mark.asyncio
     async def test_is_dsp_mode_enabled_uses_local_only_warning_when_lakehouse_disabled(
         self,
     ) -> None:
-        with patch("port_ocean.core.integrations.mixins.utils.ocean") as mock_ocean_context:
+        with patch(
+            "port_ocean.core.integrations.mixins.utils.ocean"
+        ) as mock_ocean_context:
             mock_ocean_context.config.processing_mode = ProcessingMode.dsp
             mock_ocean_context.config.lakehouse_enabled = False
 
-            with patch("port_ocean.core.integrations.mixins.utils.logger") as mock_logger:
+            with patch(
+                "port_ocean.core.integrations.mixins.utils.logger"
+            ) as mock_logger:
                 mock_bound = mock_logger.bind.return_value
                 result = await is_dsp_mode_enabled()
 
@@ -1018,14 +1058,18 @@ class TestProcessingModes:
     async def test_is_dsp_mode_enabled_uses_local_only_warning_on_exception(
         self,
     ) -> None:
-        with patch("port_ocean.core.integrations.mixins.utils.ocean") as mock_ocean_context:
+        with patch(
+            "port_ocean.core.integrations.mixins.utils.ocean"
+        ) as mock_ocean_context:
             mock_ocean_context.config.processing_mode = ProcessingMode.dsp
             mock_ocean_context.config.lakehouse_enabled = True
             mock_ocean_context.port_client.get_organization_feature_flags = AsyncMock(
                 side_effect=Exception("connection error")
             )
 
-            with patch("port_ocean.core.integrations.mixins.utils.logger") as mock_logger:
+            with patch(
+                "port_ocean.core.integrations.mixins.utils.logger"
+            ) as mock_logger:
                 mock_bound = mock_logger.bind.return_value
                 result = await is_dsp_mode_enabled()
 
@@ -1038,24 +1082,35 @@ class TestProcessingModes:
     async def test_is_lakehouse_data_enabled_uses_local_only_warning_on_exception(
         self,
     ) -> None:
-        with patch("port_ocean.core.integrations.mixins.utils.ocean") as mock_ocean_context:
+        with patch(
+            "port_ocean.core.integrations.mixins.utils.ocean"
+        ) as mock_ocean_context:
             mock_ocean_context.port_client.get_organization_feature_flags = AsyncMock(
                 side_effect=Exception("timeout")
             )
 
-            with patch("port_ocean.core.integrations.mixins.utils.logger") as mock_logger:
+            with patch(
+                "port_ocean.core.integrations.mixins.utils.logger"
+            ) as mock_logger:
                 mock_bound = mock_logger.bind.return_value
                 result = await is_lakehouse_data_enabled()
 
         assert result is False
         mock_logger.bind.assert_called_with(local_only=True)
         mock_bound.warning.assert_called_once()
-        assert "Failed to check lakehouse feature flags" in mock_bound.warning.call_args.args[0]
+        assert (
+            "Failed to check lakehouse feature flags"
+            in mock_bound.warning.call_args.args[0]
+        )
 
     @pytest.mark.asyncio
     async def test_is_redis_live_events_enabled_when_flag_on(self) -> None:
-        with patch("port_ocean.core.integrations.mixins.utils.ocean") as mock_ocean_context:
-            mock_ocean_context.config.live_events.is_redis_stream_consumer_enabled = True
+        with patch(
+            "port_ocean.core.integrations.mixins.utils.ocean"
+        ) as mock_ocean_context:
+            mock_ocean_context.config.live_events.is_redis_stream_consumer_enabled = (
+                True
+            )
             mock_ocean_context.port_client.get_organization_feature_flags = AsyncMock(
                 return_value=[IntegrationFeatureFlag.LIVE_EVENTS_REDIS_STREAM_ENABLED]
             )
@@ -1067,8 +1122,12 @@ class TestProcessingModes:
 
     @pytest.mark.asyncio
     async def test_is_redis_live_events_disabled_when_env_opt_in_off(self) -> None:
-        with patch("port_ocean.core.integrations.mixins.utils.ocean") as mock_ocean_context:
-            mock_ocean_context.config.live_events.is_redis_stream_consumer_enabled = False
+        with patch(
+            "port_ocean.core.integrations.mixins.utils.ocean"
+        ) as mock_ocean_context:
+            mock_ocean_context.config.live_events.is_redis_stream_consumer_enabled = (
+                False
+            )
             mock_ocean_context.port_client.get_organization_feature_flags = AsyncMock(
                 return_value=[IntegrationFeatureFlag.LIVE_EVENTS_REDIS_STREAM_ENABLED]
             )
@@ -1080,8 +1139,12 @@ class TestProcessingModes:
 
     @pytest.mark.asyncio
     async def test_is_redis_live_events_disabled_when_flag_off(self) -> None:
-        with patch("port_ocean.core.integrations.mixins.utils.ocean") as mock_ocean_context:
-            mock_ocean_context.config.live_events.is_redis_stream_consumer_enabled = True
+        with patch(
+            "port_ocean.core.integrations.mixins.utils.ocean"
+        ) as mock_ocean_context:
+            mock_ocean_context.config.live_events.is_redis_stream_consumer_enabled = (
+                True
+            )
             mock_ocean_context.port_client.get_organization_feature_flags = AsyncMock(
                 return_value=[]
             )
@@ -1095,12 +1158,16 @@ class TestProcessingModes:
     async def test_is_redis_live_events_enabled_uses_local_only_warning_on_exception(
         self,
     ) -> None:
-        with patch("port_ocean.core.integrations.mixins.utils.ocean") as mock_ocean_context:
+        with patch(
+            "port_ocean.core.integrations.mixins.utils.ocean"
+        ) as mock_ocean_context:
             mock_ocean_context.port_client.get_organization_feature_flags = AsyncMock(
                 side_effect=Exception("timeout")
             )
 
-            with patch("port_ocean.core.integrations.mixins.utils.logger") as mock_logger:
+            with patch(
+                "port_ocean.core.integrations.mixins.utils.logger"
+            ) as mock_logger:
                 mock_bound = mock_logger.bind.return_value
                 result = await is_redis_live_events_enabled()
 

--- a/port_ocean/tests/core/integrations/mixins/test_integration_utils.py
+++ b/port_ocean/tests/core/integrations/mixins/test_integration_utils.py
@@ -185,6 +185,44 @@ class TestSelectorHashHelpers:
             changed_query_resource
         )
 
+    def test_selector_hash_from_resource_is_stable_for_implicit_and_explicit_defaults(
+        self,
+    ) -> None:
+        implicit_defaults = ResourceConfig(
+            kind="test-kind",
+            selector=Selector(query=".foo"),
+            port=PortResourceConfig(
+                entity=MappingsConfig(
+                    mappings=EntityMapping(
+                        identifier=".id",
+                        title=".name",
+                        blueprint='"test"',
+                        properties={},
+                        relations={},
+                    )
+                )
+            ),
+        )
+        explicit_defaults = ResourceConfig(
+            kind="test-kind",
+            selector=Selector(query=".foo", exportEnvVariables=[]),
+            port=PortResourceConfig(
+                entity=MappingsConfig(
+                    mappings=EntityMapping(
+                        identifier=".id",
+                        title=".name",
+                        blueprint='"test"',
+                        properties={},
+                        relations={},
+                    )
+                )
+            ),
+        )
+
+        assert selector_hash_from_resource(implicit_defaults) == selector_hash_from_resource(
+            explicit_defaults
+        )
+
     def test_selector_hash_from_resource_returns_none_without_selector(self) -> None:
         resource = ResourceConfig(
             kind="test-kind",

--- a/port_ocean/tests/core/integrations/mixins/test_integration_utils.py
+++ b/port_ocean/tests/core/integrations/mixins/test_integration_utils.py
@@ -27,7 +27,7 @@ from port_ocean.core.integrations.mixins.utils import (
     is_redis_live_events_enabled,
     resync_function_wrapper,
     resync_generator_wrapper,
-    selector_hash_from_query,
+    selector_hash_from_selector,
     selector_hash_from_resource,
     selector_query_from_resource,
 )
@@ -123,7 +123,7 @@ class TestSelectorHashHelpers:
 
     def test_selector_hash_from_query_uses_sha256_hex(self) -> None:
         assert (
-            selector_hash_from_query(".foo")
+            selector_hash_from_selector(".foo")
             == "013b54afaf52ac0983a4ac123b01e809ab7ac8862e67a50f09fcce1293d265c3"
         )
 

--- a/port_ocean/tests/core/integrations/mixins/test_integration_utils.py
+++ b/port_ocean/tests/core/integrations/mixins/test_integration_utils.py
@@ -147,7 +147,9 @@ class TestSelectorHashHelpers:
         )
 
         expected_selector_payload = (
-            resource.selector.dict(by_alias=True, exclude_none=True)
+            resource.selector.dict(
+                by_alias=True, exclude_none=True, exclude_unset=True
+            )
             if resource.selector
             else {}
         )
@@ -197,7 +199,7 @@ class TestSelectorHashHelpers:
             base_resource
         ) == selector_hash_from_resource(changed_query_resource)
 
-    def test_selector_hash_from_resource_is_stable_for_implicit_and_explicit_defaults(
+    def test_selector_hash_from_resource_differs_for_implicit_vs_explicit_defaults(
         self,
     ) -> None:
         implicit_defaults = ResourceConfig(
@@ -233,7 +235,7 @@ class TestSelectorHashHelpers:
 
         assert selector_hash_from_resource(
             implicit_defaults
-        ) == selector_hash_from_resource(explicit_defaults)
+        ) != selector_hash_from_resource(explicit_defaults)
 
     def test_selector_hash_from_resource_returns_none_without_selector(self) -> None:
         resource = ResourceConfig(
@@ -275,7 +277,9 @@ class TestSelectorHashHelpers:
         )
 
         expected_selector_payload = (
-            resource.selector.dict(by_alias=True, exclude_none=True)
+            resource.selector.dict(
+                by_alias=True, exclude_none=True, exclude_unset=True
+            )
             if resource.selector
             else {}
         )

--- a/port_ocean/tests/utils/test_async_iterators.py
+++ b/port_ocean/tests/utils/test_async_iterators.py
@@ -1,6 +1,6 @@
 import asyncio
 from collections.abc import AsyncGenerator
-from typing import Any
+from typing import Any, Awaitable, Callable
 
 import pytest
 
@@ -75,8 +75,14 @@ async def test_throttle_batch_operation_limits_concurrency() -> None:
 
         return value
 
+    def make_operation(value: int) -> Callable[[], Awaitable[int]]:
+        async def run() -> int:
+            return await operation(value)
+
+        return run
+
     results = await throttle_batch_operation(
-        [lambda value=value: operation(value) for value in range(10)],
+        [make_operation(value) for value in range(10)],
         max_concurrency,
     )
 

--- a/port_ocean/tests/utils/test_async_iterators.py
+++ b/port_ocean/tests/utils/test_async_iterators.py
@@ -76,12 +76,6 @@ async def test_throttle_batch_operation_limits_concurrency() -> None:
 
         return value
 
-    def make_operation(value: int) -> Callable[[], Awaitable[int]]:
-        async def run() -> int:
-            return await operation(value)
-
-        return run
-
     results = await throttle_batch_operation(
         [partial(operation, value) for value in range(10)],
         max_concurrency,


### PR DESCRIPTION
- Introduced a new helper function `_selector_without_query` to extract the selector from a resource while omitting the query.
- Updated `selector_hash_from_resource` to utilize the new helper, ensuring that the hash is generated based on the normalized selector without the query.
- Added unit tests to verify that the hash remains stable when only the query changes and that it correctly handles cases with empty selectors.

This change improves the consistency of selector hashing and ensures that variations in the query do not affect the resulting hash.

# Description

What -

Why -

How -

## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Selector hash values in lakehouse metadata will change for existing integrations (previously query-based), which may affect downstream correlation until consumers adapt; core hashing logic is localized but touches live events and resync raw paths.
> 
> **Overview**
> **Changes how `selector_hash` is computed for lakehouse live-event and raw-sync payloads** so it reflects the resource selector configuration, not the JQ `query` string.
> 
> `selector_hash_from_resource` now builds a normalized JSON snapshot of the selector (via new `_selector_without_query`, with `query` stripped), then SHA-256 hashes that payload. **JQ query-only edits no longer change the hash**; other selector fields (e.g. `exportEnvVariables`) still do. Missing selector still yields `None`; whitespace-only `query` can still produce a hash from the remaining selector fields.
> 
> Tests were updated to assert against `selector_hash_from_resource` instead of hard-coded digests, with new cases for query stability, implicit vs explicit defaults, and empty selectors. Minor test/lint fixes include async iterator throttle helpers and formatting in integration utils tests. Core patch release intent is recorded in `.ocean-release/core/selector-hash-and-lint-fixes.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4dc5adc38496e67fdee2bd7dec01ade729c70fc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->