### PR TITLE
[Integration][AWS-v3] Add CloudTrail live events for ECR repositories, ECS clusters, and EKS clusters

### DIFF
--- a/integrations/aws-v3/.ocean-release/ecr-ecs-eks-live-events.yaml
+++ b/integrations/aws-v3/.ocean-release/ecr-ecs-eks-live-events.yaml
@@ -1,0 +1,3 @@
+bump: minor
+changelog-type: feature
+changelog: Add CloudTrail live events for ECR repositories, ECS clusters, and EKS clusters

--- a/integrations/aws-v3/aws/core/exporters/aws_lambda/function/live_events.py
+++ b/integrations/aws-v3/aws/core/exporters/aws_lambda/function/live_events.py
@@ -8,6 +8,8 @@ from aws.core.helpers.metadata.types import (
 )
 from aws.utils import RegionHelper
 
+CLOUDTRAIL_EVENT_SOURCE = "lambda.amazonaws.com"
+
 
 def _function_arn(context: LiveEventContext) -> str:
     partition = RegionHelper.get_partition()
@@ -45,16 +47,24 @@ LAMBDA_FUNCTION_LIVE_EVENTS = LiveEventFactories(
     deletion_identifier_properties_factory=_deletion_identifier_properties,
     cloudtrail_mappings={
         "CreateFunction20150331": CloudTrailEventMapping(
-            CloudTrailEventAction.UPSERT, _extract_lambda_function_name
+            CloudTrailEventAction.UPSERT,
+            _extract_lambda_function_name,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
         ),
         "UpdateFunctionConfiguration20150331v2": CloudTrailEventMapping(
-            CloudTrailEventAction.UPSERT, _extract_lambda_function_name
+            CloudTrailEventAction.UPSERT,
+            _extract_lambda_function_name,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
         ),
         "UpdateFunctionCode20150331v2": CloudTrailEventMapping(
-            CloudTrailEventAction.UPSERT, _extract_lambda_function_name
+            CloudTrailEventAction.UPSERT,
+            _extract_lambda_function_name,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
         ),
         "DeleteFunction20150331": CloudTrailEventMapping(
-            CloudTrailEventAction.DELETE, _extract_lambda_function_name
+            CloudTrailEventAction.DELETE,
+            _extract_lambda_function_name,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
         ),
     },
 )

--- a/integrations/aws-v3/aws/core/exporters/dynamodb/table/live_events.py
+++ b/integrations/aws-v3/aws/core/exporters/dynamodb/table/live_events.py
@@ -8,6 +8,8 @@ from aws.core.helpers.metadata.types import (
 )
 from aws.utils import RegionHelper
 
+CLOUDTRAIL_EVENT_SOURCE = "dynamodb.amazonaws.com"
+
 
 def _table_arn(context: LiveEventContext) -> str:
     partition = RegionHelper.get_partition()
@@ -45,13 +47,19 @@ DYNAMODB_TABLE_LIVE_EVENTS = LiveEventFactories(
     deletion_identifier_properties_factory=_deletion_identifier_properties,
     cloudtrail_mappings={
         "CreateTable": CloudTrailEventMapping(
-            CloudTrailEventAction.UPSERT, _extract_table_name
+            CloudTrailEventAction.UPSERT,
+            _extract_table_name,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
         ),
         "UpdateTable": CloudTrailEventMapping(
-            CloudTrailEventAction.UPSERT, _extract_table_name
+            CloudTrailEventAction.UPSERT,
+            _extract_table_name,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
         ),
         "DeleteTable": CloudTrailEventMapping(
-            CloudTrailEventAction.DELETE, _extract_table_name
+            CloudTrailEventAction.DELETE,
+            _extract_table_name,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
         ),
     },
 )

--- a/integrations/aws-v3/aws/core/exporters/ecr/repository/exporter.py
+++ b/integrations/aws-v3/aws/core/exporters/ecr/repository/exporter.py
@@ -32,7 +32,14 @@ class EcrRepositoryExporter(IResourceExporter[list[dict[str, Any]]]):
             if not repositories:
                 return {}
 
-            result = await inspector.inspect(repositories, options.include)
+            result = await inspector.inspect(
+                repositories,
+                options.include,
+                extra_context={
+                    "AccountId": options.account_id,
+                    "Region": options.region,
+                },
+            )
             return result[0] if result else {}
 
     async def get_paginated_resources(

--- a/integrations/aws-v3/aws/core/exporters/ecr/repository/live_events.py
+++ b/integrations/aws-v3/aws/core/exporters/ecr/repository/live_events.py
@@ -8,6 +8,8 @@ from aws.core.helpers.metadata.types import (
 )
 from aws.utils import RegionHelper
 
+CLOUDTRAIL_EVENT_SOURCE = "ecr.amazonaws.com"
+
 
 def _repository_arn(context: LiveEventContext) -> str:
     partition = RegionHelper.get_partition()
@@ -47,12 +49,12 @@ ECR_REPOSITORY_LIVE_EVENTS = LiveEventFactories(
         "CreateRepository": CloudTrailEventMapping(
             CloudTrailEventAction.UPSERT,
             _extract_repository_name,
-            event_source="ecr.amazonaws.com",
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
         ),
         "DeleteRepository": CloudTrailEventMapping(
             CloudTrailEventAction.DELETE,
             _extract_repository_name,
-            event_source="ecr.amazonaws.com",
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
         ),
     },
 )

--- a/integrations/aws-v3/aws/core/exporters/ecr/repository/live_events.py
+++ b/integrations/aws-v3/aws/core/exporters/ecr/repository/live_events.py
@@ -1,0 +1,58 @@
+from aws.core.exporters.ecr.repository.models import SingleRepositoryRequest
+from aws.core.helpers.metadata.types import (
+    CloudTrailDetail,
+    CloudTrailEventAction,
+    CloudTrailEventMapping,
+    LiveEventContext,
+    LiveEventFactories,
+)
+from aws.utils import RegionHelper
+
+
+def _repository_arn(context: LiveEventContext) -> str:
+    partition = RegionHelper.get_partition()
+    return (
+        f"arn:{partition}:ecr:{context.region}:{context.account_id}:"
+        f"repository/{context.identifier}"
+    )
+
+
+def _extract_repository_name(detail: CloudTrailDetail) -> str | None:
+    repository_name = detail.get("requestParameters", {}).get("repositoryName")
+    return repository_name if isinstance(repository_name, str) else None
+
+
+def _request_factory(
+    context: LiveEventContext, include_actions: list[str]
+) -> SingleRepositoryRequest:
+    return SingleRepositoryRequest(
+        repository_name=context.identifier,
+        region=context.region,
+        account_id=context.account_id,
+        include=include_actions,
+    )
+
+
+def _deletion_identifier_properties(context: LiveEventContext) -> dict[str, str]:
+    return {
+        "RepositoryArn": _repository_arn(context),
+        "RepositoryName": context.identifier,
+    }
+
+
+ECR_REPOSITORY_LIVE_EVENTS = LiveEventFactories(
+    request_factory=_request_factory,
+    deletion_identifier_properties_factory=_deletion_identifier_properties,
+    cloudtrail_mappings={
+        "CreateRepository": CloudTrailEventMapping(
+            CloudTrailEventAction.UPSERT,
+            _extract_repository_name,
+            event_source="ecr.amazonaws.com",
+        ),
+        "DeleteRepository": CloudTrailEventMapping(
+            CloudTrailEventAction.DELETE,
+            _extract_repository_name,
+            event_source="ecr.amazonaws.com",
+        ),
+    },
+)

--- a/integrations/aws-v3/aws/core/exporters/ecs/cluster/exporter.py
+++ b/integrations/aws-v3/aws/core/exporters/ecs/cluster/exporter.py
@@ -1,5 +1,7 @@
 from typing import Any, AsyncGenerator, Type
 
+from botocore.exceptions import ClientError
+
 from aws.core.client.proxy import AioBaseClientProxy
 from aws.core.exporters.ecs.cluster.actions import EcsClusterActionsMap
 from aws.core.exporters.ecs.cluster.models import Cluster
@@ -23,11 +25,36 @@ class EcsClusterExporter(IResourceExporter[list[str]]):
         async with AioBaseClientProxy(
             self.session, options.region, self._service_name
         ) as proxy:
+            # Live-event single-cluster fetch only has a cluster name from CloudTrail.
+            # describe_clusters returns an empty list when the cluster is gone instead
+            # of raising, and the inspector would still build a stub from that name.
+            # Confirm it exists so a missing cluster raises and the live-event handler
+            # can treat the update as a delete instead.
+            response = await proxy.client.describe_clusters(  # type: ignore[attr-defined]
+                clusters=[options.cluster_name]
+            )
+            if not response.get("clusters"):
+                raise ClientError(
+                    {
+                        "Error": {
+                            "Code": "ClusterNotFoundException",
+                            "Message": f"Cluster not found: {options.cluster_name}",
+                        }
+                    },
+                    "DescribeClusters",
+                )
 
             inspector = ResourceInspector(
                 proxy.client, self._actions_map(), lambda: self._model_cls()
             )
-            response = await inspector.inspect([options.cluster_name], options.include)
+            response = await inspector.inspect(
+                [options.cluster_name],
+                options.include,
+                extra_context={
+                    "AccountId": options.account_id,
+                    "Region": options.region,
+                },
+            )
 
             return response[0] if response else {}
 

--- a/integrations/aws-v3/aws/core/exporters/ecs/cluster/live_events.py
+++ b/integrations/aws-v3/aws/core/exporters/ecs/cluster/live_events.py
@@ -8,6 +8,8 @@ from aws.core.helpers.metadata.types import (
 )
 from aws.utils import RegionHelper
 
+CLOUDTRAIL_EVENT_SOURCE = "ecs.amazonaws.com"
+
 
 def _cluster_arn(context: LiveEventContext) -> str:
     partition = RegionHelper.get_partition()
@@ -53,17 +55,17 @@ ECS_CLUSTER_LIVE_EVENTS = LiveEventFactories(
         "CreateCluster": CloudTrailEventMapping(
             CloudTrailEventAction.UPSERT,
             _extract_cluster_name,
-            event_source="ecs.amazonaws.com",
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
         ),
         "PutClusterCapacityProviders": CloudTrailEventMapping(
             CloudTrailEventAction.UPSERT,
             _extract_cluster_name,
-            event_source="ecs.amazonaws.com",
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
         ),
         "DeleteCluster": CloudTrailEventMapping(
             CloudTrailEventAction.DELETE,
             _extract_cluster_name,
-            event_source="ecs.amazonaws.com",
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
         ),
     },
 )

--- a/integrations/aws-v3/aws/core/exporters/ecs/cluster/live_events.py
+++ b/integrations/aws-v3/aws/core/exporters/ecs/cluster/live_events.py
@@ -21,13 +21,14 @@ def _cluster_arn(context: LiveEventContext) -> str:
 
 def _extract_cluster_name(detail: CloudTrailDetail) -> str | None:
     request_parameters = detail.get("requestParameters", {})
-    for key in ("clusterName", "cluster"):
-        identifier = request_parameters.get(key)
-        if isinstance(identifier, str):
-            if ":cluster/" in identifier:
-                return identifier.rsplit("/", 1)[-1]
-            return identifier
-    return None
+    identifier = request_parameters.get("clusterName") or request_parameters.get(
+        "cluster"
+    )
+    if not isinstance(identifier, str):
+        return None
+    if ":cluster/" in identifier:
+        return identifier.rsplit("/", 1)[-1]
+    return identifier
 
 
 def _request_factory(

--- a/integrations/aws-v3/aws/core/exporters/ecs/cluster/live_events.py
+++ b/integrations/aws-v3/aws/core/exporters/ecs/cluster/live_events.py
@@ -1,0 +1,69 @@
+from aws.core.exporters.ecs.cluster.models import SingleClusterRequest
+from aws.core.helpers.metadata.types import (
+    CloudTrailDetail,
+    CloudTrailEventAction,
+    CloudTrailEventMapping,
+    LiveEventContext,
+    LiveEventFactories,
+)
+from aws.utils import RegionHelper
+
+
+def _cluster_arn(context: LiveEventContext) -> str:
+    partition = RegionHelper.get_partition()
+    return (
+        f"arn:{partition}:ecs:{context.region}:{context.account_id}:"
+        f"cluster/{context.identifier}"
+    )
+
+
+def _extract_cluster_name(detail: CloudTrailDetail) -> str | None:
+    request_parameters = detail.get("requestParameters", {})
+    for key in ("clusterName", "cluster"):
+        identifier = request_parameters.get(key)
+        if isinstance(identifier, str):
+            if ":cluster/" in identifier:
+                return identifier.rsplit("/", 1)[-1]
+            return identifier
+    return None
+
+
+def _request_factory(
+    context: LiveEventContext, include_actions: list[str]
+) -> SingleClusterRequest:
+    return SingleClusterRequest(
+        cluster_name=context.identifier,
+        region=context.region,
+        account_id=context.account_id,
+        include=include_actions,
+    )
+
+
+def _deletion_identifier_properties(context: LiveEventContext) -> dict[str, str]:
+    return {
+        "ClusterArn": _cluster_arn(context),
+        "ClusterName": context.identifier,
+    }
+
+
+ECS_CLUSTER_LIVE_EVENTS = LiveEventFactories(
+    request_factory=_request_factory,
+    deletion_identifier_properties_factory=_deletion_identifier_properties,
+    cloudtrail_mappings={
+        "CreateCluster": CloudTrailEventMapping(
+            CloudTrailEventAction.UPSERT,
+            _extract_cluster_name,
+            event_source="ecs.amazonaws.com",
+        ),
+        "PutClusterCapacityProviders": CloudTrailEventMapping(
+            CloudTrailEventAction.UPSERT,
+            _extract_cluster_name,
+            event_source="ecs.amazonaws.com",
+        ),
+        "DeleteCluster": CloudTrailEventMapping(
+            CloudTrailEventAction.DELETE,
+            _extract_cluster_name,
+            event_source="ecs.amazonaws.com",
+        ),
+    },
+)

--- a/integrations/aws-v3/aws/core/exporters/eks/cluster/exporter.py
+++ b/integrations/aws-v3/aws/core/exporters/eks/cluster/exporter.py
@@ -23,11 +23,26 @@ class EksClusterExporter(IResourceExporter[list[str]]):
         async with AioBaseClientProxy(
             self.session, options.region, self._service_name
         ) as proxy:
+            # Live-event single-cluster fetch only has a cluster name from CloudTrail.
+            # DescribeClusterAction swallows ResourceNotFoundException as recoverable,
+            # so the inspector would return an empty payload for a deleted cluster.
+            # Confirm it exists so a missing cluster raises and the live-event handler
+            # can treat the update as a delete instead.
+            await proxy.client.describe_cluster(  # type: ignore[attr-defined]
+                name=options.cluster_name
+            )
 
             inspector = ResourceInspector(
                 proxy.client, self._actions_map(), lambda: self._model_cls()
             )
-            response = await inspector.inspect([options.cluster_name], options.include)
+            response = await inspector.inspect(
+                [options.cluster_name],
+                options.include,
+                extra_context={
+                    "AccountId": options.account_id,
+                    "Region": options.region,
+                },
+            )
 
             return response[0] if response else {}
 

--- a/integrations/aws-v3/aws/core/exporters/eks/cluster/live_events.py
+++ b/integrations/aws-v3/aws/core/exporters/eks/cluster/live_events.py
@@ -21,9 +21,7 @@ def _cluster_arn(context: LiveEventContext) -> str:
 
 def _extract_cluster_name(detail: CloudTrailDetail) -> str | None:
     request_parameters = detail.get("requestParameters", {})
-    identifier = request_parameters.get("name") or request_parameters.get(
-        "clusterName"
-    )
+    identifier = request_parameters.get("name") or request_parameters.get("clusterName")
     return identifier if isinstance(identifier, str) else None
 
 

--- a/integrations/aws-v3/aws/core/exporters/eks/cluster/live_events.py
+++ b/integrations/aws-v3/aws/core/exporters/eks/cluster/live_events.py
@@ -1,0 +1,72 @@
+from aws.core.exporters.eks.cluster.models import SingleEksClusterRequest
+from aws.core.helpers.metadata.types import (
+    CloudTrailDetail,
+    CloudTrailEventAction,
+    CloudTrailEventMapping,
+    LiveEventContext,
+    LiveEventFactories,
+)
+from aws.utils import RegionHelper
+
+
+def _cluster_arn(context: LiveEventContext) -> str:
+    partition = RegionHelper.get_partition()
+    return (
+        f"arn:{partition}:eks:{context.region}:{context.account_id}:"
+        f"cluster/{context.identifier}"
+    )
+
+
+def _extract_cluster_name(detail: CloudTrailDetail) -> str | None:
+    request_parameters = detail.get("requestParameters", {})
+    for key in ("name", "clusterName"):
+        identifier = request_parameters.get(key)
+        if isinstance(identifier, str):
+            return identifier
+    return None
+
+
+def _request_factory(
+    context: LiveEventContext, include_actions: list[str]
+) -> SingleEksClusterRequest:
+    return SingleEksClusterRequest(
+        cluster_name=context.identifier,
+        region=context.region,
+        account_id=context.account_id,
+        include=include_actions,
+    )
+
+
+def _deletion_identifier_properties(context: LiveEventContext) -> dict[str, str]:
+    return {
+        "Arn": _cluster_arn(context),
+        "Name": context.identifier,
+    }
+
+
+EKS_CLUSTER_LIVE_EVENTS = LiveEventFactories(
+    request_factory=_request_factory,
+    deletion_identifier_properties_factory=_deletion_identifier_properties,
+    cloudtrail_mappings={
+        "CreateCluster": CloudTrailEventMapping(
+            CloudTrailEventAction.UPSERT,
+            _extract_cluster_name,
+            event_source="eks.amazonaws.com",
+        ),
+        "UpdateClusterConfig": CloudTrailEventMapping(
+            CloudTrailEventAction.UPSERT,
+            _extract_cluster_name,
+            event_source="eks.amazonaws.com",
+        ),
+        "UpdateClusterVersion": CloudTrailEventMapping(
+            CloudTrailEventAction.UPSERT,
+            _extract_cluster_name,
+            event_source="eks.amazonaws.com",
+        ),
+        "DeleteCluster": CloudTrailEventMapping(
+            CloudTrailEventAction.DELETE,
+            _extract_cluster_name,
+            event_source="eks.amazonaws.com",
+        ),
+    },
+)

--- a/integrations/aws-v3/aws/core/exporters/eks/cluster/live_events.py
+++ b/integrations/aws-v3/aws/core/exporters/eks/cluster/live_events.py
@@ -21,11 +21,10 @@ def _cluster_arn(context: LiveEventContext) -> str:
 
 def _extract_cluster_name(detail: CloudTrailDetail) -> str | None:
     request_parameters = detail.get("requestParameters", {})
-    for key in ("name", "clusterName"):
-        identifier = request_parameters.get(key)
-        if isinstance(identifier, str):
-            return identifier
-    return None
+    identifier = request_parameters.get("name") or request_parameters.get(
+        "clusterName"
+    )
+    return identifier if isinstance(identifier, str) else None
 
 
 def _request_factory(

--- a/integrations/aws-v3/aws/core/exporters/eks/cluster/live_events.py
+++ b/integrations/aws-v3/aws/core/exporters/eks/cluster/live_events.py
@@ -8,6 +8,8 @@ from aws.core.helpers.metadata.types import (
 )
 from aws.utils import RegionHelper
 
+CLOUDTRAIL_EVENT_SOURCE = "eks.amazonaws.com"
+
 
 def _cluster_arn(context: LiveEventContext) -> str:
     partition = RegionHelper.get_partition()
@@ -51,22 +53,22 @@ EKS_CLUSTER_LIVE_EVENTS = LiveEventFactories(
         "CreateCluster": CloudTrailEventMapping(
             CloudTrailEventAction.UPSERT,
             _extract_cluster_name,
-            event_source="eks.amazonaws.com",
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
         ),
         "UpdateClusterConfig": CloudTrailEventMapping(
             CloudTrailEventAction.UPSERT,
             _extract_cluster_name,
-            event_source="eks.amazonaws.com",
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
         ),
         "UpdateClusterVersion": CloudTrailEventMapping(
             CloudTrailEventAction.UPSERT,
             _extract_cluster_name,
-            event_source="eks.amazonaws.com",
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
         ),
         "DeleteCluster": CloudTrailEventMapping(
             CloudTrailEventAction.DELETE,
             _extract_cluster_name,
-            event_source="eks.amazonaws.com",
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
         ),
     },
 )

--- a/integrations/aws-v3/aws/core/exporters/exporter_metadata.py
+++ b/integrations/aws-v3/aws/core/exporters/exporter_metadata.py
@@ -41,14 +41,17 @@ from aws.core.exporters.ec2.instance import (
 from aws.core.exporters.ec2.volume import EbsVolumeExporter
 from aws.core.exporters.ec2.volume.models import PaginatedEbsVolumeRequest
 from aws.core.exporters.ecr import EcrRepositoryExporter
+from aws.core.exporters.ecr.repository.live_events import ECR_REPOSITORY_LIVE_EVENTS
 from aws.core.exporters.ecr.repository.models import PaginatedRepositoryRequest
 from aws.core.exporters.ecs.cluster.exporter import EcsClusterExporter
+from aws.core.exporters.ecs.cluster.live_events import ECS_CLUSTER_LIVE_EVENTS
 from aws.core.exporters.ecs.cluster.models import PaginatedClusterRequest
 from aws.core.exporters.ecs.service.exporter import EcsServiceExporter
 from aws.core.exporters.ecs.service.models import PaginatedServiceRequest
 from aws.core.exporters.ecs.task_definition.exporter import EcsTaskDefinitionExporter
 from aws.core.exporters.ecs.task_definition.models import PaginatedTaskDefinitionRequest
 from aws.core.exporters.eks.cluster.exporter import EksClusterExporter
+from aws.core.exporters.eks.cluster.live_events import EKS_CLUSTER_LIVE_EVENTS
 from aws.core.exporters.eks.cluster.models import PaginatedEksClusterRequest
 from aws.core.exporters.elasticache import ElastiCacheClusterExporter
 from aws.core.exporters.elasticache.cluster.models import PaginatedCacheClusterRequest
@@ -89,10 +92,14 @@ kind_to_export_metadata: dict[ObjectKind, ExporterMetadata] = {
         EC2InstanceExporter, PaginatedEC2InstanceRequest
     ),
     ObjectKind.ECS_CLUSTER: ExporterMetadata(
-        EcsClusterExporter, PaginatedClusterRequest
+        EcsClusterExporter,
+        PaginatedClusterRequest,
+        live_events=ECS_CLUSTER_LIVE_EVENTS,
     ),
     ObjectKind.EKS_CLUSTER: ExporterMetadata(
-        EksClusterExporter, PaginatedEksClusterRequest
+        EksClusterExporter,
+        PaginatedEksClusterRequest,
+        live_events=EKS_CLUSTER_LIVE_EVENTS,
     ),
     ObjectKind.RDS_DB_INSTANCE: ExporterMetadata(
         RdsDbInstanceExporter,
@@ -115,7 +122,9 @@ kind_to_export_metadata: dict[ObjectKind, ExporterMetadata] = {
     ),
     ObjectKind.SQS_QUEUE: ExporterMetadata(SqsQueueExporter, PaginatedQueueRequest),
     ObjectKind.ECR_REPOSITORY: ExporterMetadata(
-        EcrRepositoryExporter, PaginatedRepositoryRequest
+        EcrRepositoryExporter,
+        PaginatedRepositoryRequest,
+        live_events=ECR_REPOSITORY_LIVE_EVENTS,
     ),
     ObjectKind.MSK_SERVERLESS_CLUSTER: ExporterMetadata(
         MskServerlessClusterExporter, PaginatedMskServerlessClusterRequest

--- a/integrations/aws-v3/aws/core/exporters/rds/db_instance/live_events.py
+++ b/integrations/aws-v3/aws/core/exporters/rds/db_instance/live_events.py
@@ -8,6 +8,8 @@ from aws.core.helpers.metadata.types import (
 )
 from aws.utils import RegionHelper
 
+CLOUDTRAIL_EVENT_SOURCE = "rds.amazonaws.com"
+
 
 def _db_instance_arn(context: LiveEventContext) -> str:
     partition = RegionHelper.get_partition()
@@ -49,13 +51,19 @@ RDS_DB_INSTANCE_LIVE_EVENTS = LiveEventFactories(
     deletion_identifier_properties_factory=_deletion_identifier_properties,
     cloudtrail_mappings={
         "CreateDBInstance": CloudTrailEventMapping(
-            CloudTrailEventAction.UPSERT, _extract_db_instance_identifier
+            CloudTrailEventAction.UPSERT,
+            _extract_db_instance_identifier,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
         ),
         "ModifyDBInstance": CloudTrailEventMapping(
-            CloudTrailEventAction.UPSERT, _extract_db_instance_identifier
+            CloudTrailEventAction.UPSERT,
+            _extract_db_instance_identifier,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
         ),
         "DeleteDBInstance": CloudTrailEventMapping(
-            CloudTrailEventAction.DELETE, _extract_db_instance_identifier
+            CloudTrailEventAction.DELETE,
+            _extract_db_instance_identifier,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
         ),
     },
 )

--- a/integrations/aws-v3/aws/core/exporters/s3/bucket/live_events.py
+++ b/integrations/aws-v3/aws/core/exporters/s3/bucket/live_events.py
@@ -8,6 +8,8 @@ from aws.core.helpers.metadata.types import (
 from aws.core.exporters.s3.bucket.models import SingleBucketRequest
 from aws.utils import RegionHelper
 
+CLOUDTRAIL_EVENT_SOURCE = "s3.amazonaws.com"
+
 
 def _bucket_arn(bucket_name: str) -> str:
     partition = RegionHelper.get_partition()
@@ -42,10 +44,14 @@ S3_BUCKET_LIVE_EVENTS = LiveEventFactories(
     deletion_identifier_properties_factory=_deletion_identifier_properties,
     cloudtrail_mappings={
         "CreateBucket": CloudTrailEventMapping(
-            CloudTrailEventAction.UPSERT, _extract_s3_bucket_name
+            CloudTrailEventAction.UPSERT,
+            _extract_s3_bucket_name,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
         ),
         "DeleteBucket": CloudTrailEventMapping(
-            CloudTrailEventAction.DELETE, _extract_s3_bucket_name
+            CloudTrailEventAction.DELETE,
+            _extract_s3_bucket_name,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
         ),
     },
 )

--- a/integrations/aws-v3/aws/core/helpers/metadata/cloudtrail_event_mappings.py
+++ b/integrations/aws-v3/aws/core/helpers/metadata/cloudtrail_event_mappings.py
@@ -2,13 +2,20 @@ from aws.core.exporters.exporter_metadata import kind_to_export_metadata
 from aws.core.helpers.metadata.types import EventNameMapping
 
 
+def cloudtrail_mapping_key(event_name: str, event_source: str | None = None) -> str:
+    if event_source:
+        return f"{event_source}:{event_name}"
+    return event_name
+
+
 def build_event_name_mappings() -> dict[str, EventNameMapping]:
     mappings: dict[str, EventNameMapping] = {}
     for kind, metadata in kind_to_export_metadata.items():
         if metadata.live_events is None:
             continue
         for event_name, mapping in metadata.live_events.cloudtrail_mappings.items():
-            mappings[event_name] = EventNameMapping(
+            key = cloudtrail_mapping_key(event_name, mapping.event_source)
+            mappings[key] = EventNameMapping(
                 kind=kind,
                 action=mapping.action,
                 extract_identifier=mapping.extract_identifier,

--- a/integrations/aws-v3/aws/core/helpers/metadata/types.py
+++ b/integrations/aws-v3/aws/core/helpers/metadata/types.py
@@ -36,7 +36,7 @@ class CloudTrailEventAction(StrEnum):
 class CloudTrailEventMapping:
     action: CloudTrailEventAction
     extract_identifier: Callable[[CloudTrailDetail], str | None]
-    event_source: str | None = None
+    event_source: str
 
 
 @dataclass(frozen=True)

--- a/integrations/aws-v3/aws/core/helpers/metadata/types.py
+++ b/integrations/aws-v3/aws/core/helpers/metadata/types.py
@@ -11,6 +11,7 @@ class CloudTrailDetail(TypedDict, total=False):
     """CloudTrail record nested inside an EventBridge envelope."""
 
     eventName: str
+    eventSource: str
     errorCode: str
     errorMessage: str
     awsRegion: str
@@ -35,6 +36,7 @@ class CloudTrailEventAction(StrEnum):
 class CloudTrailEventMapping:
     action: CloudTrailEventAction
     extract_identifier: Callable[[CloudTrailDetail], str | None]
+    event_source: str | None = None
 
 
 @dataclass(frozen=True)

--- a/integrations/aws-v3/aws/core/helpers/utils.py
+++ b/integrations/aws-v3/aws/core/helpers/utils.py
@@ -25,6 +25,8 @@ def is_resource_not_found_exception(e: Exception) -> bool:
         "ResourceNotFoundFault",
         "RepositoryPolicyNotFoundException",
         "LifecyclePolicyNotFoundException",
+        "RepositoryNotFoundException",
+        "ClusterNotFoundException",
         "NotFoundException",
         "NoSuchBucket",
         "DBInstanceNotFound",

--- a/integrations/aws-v3/aws/webhook/cloudtrail_parser.py
+++ b/integrations/aws-v3/aws/webhook/cloudtrail_parser.py
@@ -57,10 +57,7 @@ def _resolve_event_mapping(detail: CloudTrailDetail) -> EventNameMapping | None:
         return None
 
     event_source = detail.get("eventSource")
-    mapping = EVENT_NAME_MAPPINGS.get(cloudtrail_mapping_key(event_name, event_source))
-    if mapping is None:
-        mapping = EVENT_NAME_MAPPINGS.get(event_name)
-    return mapping
+    return EVENT_NAME_MAPPINGS.get(cloudtrail_mapping_key(event_name, event_source))
 
 
 def is_supported_cloudtrail_event(payload: EventBridgeCloudTrailPayload) -> bool:

--- a/integrations/aws-v3/aws/webhook/cloudtrail_parser.py
+++ b/integrations/aws-v3/aws/webhook/cloudtrail_parser.py
@@ -52,12 +52,9 @@ def get_event_name(payload: EventBridgeCloudTrailPayload) -> str | None:
 
 
 def _resolve_event_mapping(detail: CloudTrailDetail) -> EventNameMapping | None:
-    event_name = detail.get("eventName")
-    if not event_name:
-        return None
-
-    event_source = detail.get("eventSource")
-    return EVENT_NAME_MAPPINGS.get(cloudtrail_mapping_key(event_name, event_source))
+    return EVENT_NAME_MAPPINGS.get(
+        cloudtrail_mapping_key(detail.get("eventName"), detail.get("eventSource"))
+    )
 
 
 def is_supported_cloudtrail_event(payload: EventBridgeCloudTrailPayload) -> bool:
@@ -83,12 +80,12 @@ def parse_cloudtrail_event(
     if detail.get("errorCode"):
         return None
 
-    mapping = _resolve_event_mapping(detail)
-    if mapping is None:
-        return None
-
     event_name = detail.get("eventName")
     if not event_name:
+        return None
+
+    mapping = _resolve_event_mapping(detail)
+    if mapping is None:
         return None
 
     identifier = mapping.extract_identifier(detail)

--- a/integrations/aws-v3/aws/webhook/cloudtrail_parser.py
+++ b/integrations/aws-v3/aws/webhook/cloudtrail_parser.py
@@ -52,8 +52,11 @@ def get_event_name(payload: EventBridgeCloudTrailPayload) -> str | None:
 
 
 def _resolve_event_mapping(detail: CloudTrailDetail) -> EventNameMapping | None:
+    event_name = detail.get("eventName")
+    if not event_name:
+        return None
     return EVENT_NAME_MAPPINGS.get(
-        cloudtrail_mapping_key(detail.get("eventName"), detail.get("eventSource"))
+        cloudtrail_mapping_key(event_name, detail.get("eventSource"))
     )
 
 
@@ -80,10 +83,6 @@ def parse_cloudtrail_event(
     if detail.get("errorCode"):
         return None
 
-    event_name = detail.get("eventName")
-    if not event_name:
-        return None
-
     mapping = _resolve_event_mapping(detail)
     if mapping is None:
         return None
@@ -101,5 +100,5 @@ def parse_cloudtrail_event(
         account_id=str(account_id),
         region=str(region),
         action=mapping.action,
-        event_name=event_name,
+        event_name=detail["eventName"],
     )

--- a/integrations/aws-v3/aws/webhook/cloudtrail_parser.py
+++ b/integrations/aws-v3/aws/webhook/cloudtrail_parser.py
@@ -10,11 +10,13 @@ from loguru import logger
 
 from aws.core.helpers.metadata.cloudtrail_event_mappings import (
     EVENT_NAME_MAPPINGS,
+    cloudtrail_mapping_key,
 )
 from aws.core.helpers.metadata.types import (
     CloudTrailDetail,
     CloudTrailEventAction,
     EventBridgeCloudTrailPayload,
+    EventNameMapping,
 )
 
 __all__ = [
@@ -49,6 +51,18 @@ def get_event_name(payload: EventBridgeCloudTrailPayload) -> str | None:
     return _get_detail(payload).get("eventName")
 
 
+def _resolve_event_mapping(detail: CloudTrailDetail) -> EventNameMapping | None:
+    event_name = detail.get("eventName")
+    if not event_name:
+        return None
+
+    event_source = detail.get("eventSource")
+    mapping = EVENT_NAME_MAPPINGS.get(cloudtrail_mapping_key(event_name, event_source))
+    if mapping is None:
+        mapping = EVENT_NAME_MAPPINGS.get(event_name)
+    return mapping
+
+
 def is_supported_cloudtrail_event(payload: EventBridgeCloudTrailPayload) -> bool:
     detail = _get_detail(payload)
     if detail.get("errorCode"):
@@ -57,7 +71,7 @@ def is_supported_cloudtrail_event(payload: EventBridgeCloudTrailPayload) -> bool
             f"skipping live event (eventName={detail.get('eventName')})"
         )
         return False
-    return detail.get("eventName") in EVENT_NAME_MAPPINGS
+    return _resolve_event_mapping(detail) is not None
 
 
 def parse_cloudtrail_event(
@@ -72,12 +86,12 @@ def parse_cloudtrail_event(
     if detail.get("errorCode"):
         return None
 
-    event_name = detail.get("eventName")
-    if not event_name:
+    mapping = _resolve_event_mapping(detail)
+    if mapping is None:
         return None
 
-    mapping = EVENT_NAME_MAPPINGS.get(event_name)
-    if mapping is None:
+    event_name = detail.get("eventName")
+    if not event_name:
         return None
 
     identifier = mapping.extract_identifier(detail)

--- a/integrations/aws-v3/tests/core/exporters/ecr/repository/test_exporter.py
+++ b/integrations/aws-v3/tests/core/exporters/ecr/repository/test_exporter.py
@@ -84,6 +84,10 @@ class TestEcrRepositoryExporter:
                 }
             ],
             ["GetRepositoryPolicyAction"],
+            extra_context={
+                "AccountId": "123456789012",
+                "Region": "us-west-2",
+            },
         )
 
     @pytest.mark.asyncio

--- a/integrations/aws-v3/tests/core/exporters/ecs/cluster/test_cluster_exporter.py
+++ b/integrations/aws-v3/tests/core/exporters/ecs/cluster/test_cluster_exporter.py
@@ -1,6 +1,7 @@
 from typing import AsyncGenerator, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
+from botocore.exceptions import ClientError
 
 from aws.core.exporters.ecs.cluster.exporter import EcsClusterExporter
 from aws.core.exporters.ecs.cluster.models import (
@@ -48,6 +49,9 @@ class TestEcsClusterExporter:
         mock_client = AsyncMock()
         mock_proxy.client = mock_client
         mock_proxy_class.return_value.__aenter__.return_value = mock_proxy
+        mock_client.describe_clusters.return_value = {
+            "clusters": [{"clusterName": "test-cluster"}]
+        }
 
         mock_inspector = AsyncMock()
         mock_inspector_class.return_value = mock_inspector
@@ -83,9 +87,19 @@ class TestEcsClusterExporter:
         # Verify
         assert result == expected_cluster.model_dump(exclude_none=True)
         mock_proxy_class.assert_called_once_with(exporter.session, "us-west-2", "ecs")
+        mock_client.describe_clusters.assert_awaited_once_with(
+            clusters=["test-cluster"]
+        )
         # ResourceInspector was called correctly
         mock_inspector_class.assert_called_once()
-        mock_inspector.inspect.assert_called_once_with(["test-cluster"], [])
+        mock_inspector.inspect.assert_called_once_with(
+            ["test-cluster"],
+            [],
+            extra_context={
+                "AccountId": "123456789012",
+                "Region": "us-west-2",
+            },
+        )
 
     @pytest.mark.asyncio
     @patch("aws.core.exporters.ecs.cluster.exporter.AioBaseClientProxy")
@@ -102,6 +116,9 @@ class TestEcsClusterExporter:
         mock_client = AsyncMock()
         mock_proxy.client = mock_client
         mock_proxy_class.return_value.__aenter__.return_value = mock_proxy
+        mock_client.describe_clusters.return_value = {
+            "clusters": [{"clusterName": "prod-cluster"}]
+        }
 
         mock_inspector = AsyncMock()
         mock_inspector_class.return_value = mock_inspector
@@ -137,7 +154,14 @@ class TestEcsClusterExporter:
         mock_proxy_class.assert_called_once_with(exporter.session, "eu-west-1", "ecs")
         # ResourceInspector was called correctly
         mock_inspector_class.assert_called_once()
-        mock_inspector.inspect.assert_called_once_with(["prod-cluster"], [])
+        mock_inspector.inspect.assert_called_once_with(
+            ["prod-cluster"],
+            [],
+            extra_context={
+                "AccountId": "123456789012",
+                "Region": "eu-west-1",
+            },
+        )
 
     @pytest.mark.asyncio
     @patch("aws.core.exporters.ecs.cluster.exporter.AioBaseClientProxy")
@@ -316,6 +340,35 @@ class TestEcsClusterExporter:
     @pytest.mark.asyncio
     @patch("aws.core.exporters.ecs.cluster.exporter.AioBaseClientProxy")
     @patch("aws.core.exporters.ecs.cluster.exporter.ResourceInspector")
+    async def test_get_resource_describe_clusters_not_found(
+        self,
+        mock_inspector_class: MagicMock,
+        mock_proxy_class: MagicMock,
+        exporter: EcsClusterExporter,
+    ) -> None:
+        """Missing clusters must raise before stub resources are built."""
+        mock_proxy = AsyncMock()
+        mock_client = AsyncMock()
+        mock_proxy.client = mock_client
+        mock_proxy_class.return_value.__aenter__.return_value = mock_proxy
+        mock_client.describe_clusters.return_value = {"clusters": []}
+
+        options = SingleClusterRequest(
+            region="us-west-2",
+            account_id="123456789012",
+            cluster_name="nonexistent-cluster",
+            include=[],
+        )
+
+        with pytest.raises(ClientError) as exc_info:
+            await exporter.get_resource(options)
+
+        assert exc_info.value.response["Error"]["Code"] == "ClusterNotFoundException"
+        mock_inspector_class.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("aws.core.exporters.ecs.cluster.exporter.AioBaseClientProxy")
+    @patch("aws.core.exporters.ecs.cluster.exporter.ResourceInspector")
     async def test_get_resource_inspector_exception(
         self,
         mock_inspector_class: MagicMock,
@@ -328,6 +381,9 @@ class TestEcsClusterExporter:
         mock_client = AsyncMock()
         mock_proxy.client = mock_client
         mock_proxy_class.return_value.__aenter__.return_value = mock_proxy
+        mock_client.describe_clusters.return_value = {
+            "clusters": [{"clusterName": "nonexistent-cluster"}]
+        }
 
         mock_inspector = AsyncMock()
         mock_inspector_class.return_value = mock_inspector
@@ -359,6 +415,11 @@ class TestEcsClusterExporter:
         mock_proxy = AsyncMock()
         mock_proxy_class.return_value.__aenter__.return_value = mock_proxy
         mock_proxy_class.return_value.__aexit__ = AsyncMock()
+        mock_client = AsyncMock()
+        mock_proxy.client = mock_client
+        mock_client.describe_clusters.return_value = {
+            "clusters": [{"clusterName": "test-cluster"}]
+        }
 
         # Setup inspector to return a normal result
         mock_inspector = AsyncMock()
@@ -387,7 +448,14 @@ class TestEcsClusterExporter:
         assert result["Type"] == "AWS::ECS::Cluster"
 
         # Verify the inspector was called correctly
-        mock_inspector.inspect.assert_called_once_with(["test-cluster"], [])
+        mock_inspector.inspect.assert_called_once_with(
+            ["test-cluster"],
+            [],
+            extra_context={
+                "AccountId": "123456789012",
+                "Region": "us-west-2",
+            },
+        )
 
         # Verify the context manager was used correctly (__aenter__ and __aexit__ were called)
         mock_proxy_class.assert_called_once_with(exporter.session, "us-west-2", "ecs")

--- a/integrations/aws-v3/tests/core/exporters/eks/cluster/test_eks_cluster_exporter.py
+++ b/integrations/aws-v3/tests/core/exporters/eks/cluster/test_eks_cluster_exporter.py
@@ -1,6 +1,7 @@
 import pytest
 from typing import AsyncGenerator, Any
 from unittest.mock import AsyncMock, MagicMock, patch
+from botocore.exceptions import ClientError
 from aws.core.exporters.eks.cluster.exporter import EksClusterExporter
 from aws.core.exporters.eks.cluster.models import (
     SingleEksClusterRequest,
@@ -45,6 +46,9 @@ class TestEksClusterExporter:
         mock_client = AsyncMock()
         mock_proxy.client = mock_client
         mock_proxy_class.return_value.__aenter__.return_value = mock_proxy
+        mock_client.describe_cluster.return_value = {
+            "cluster": {"name": "test-cluster"}
+        }
 
         mock_inspector = AsyncMock()
         mock_inspector_class.return_value = mock_inspector
@@ -79,7 +83,15 @@ class TestEksClusterExporter:
         # Verify
         assert result == expected_cluster.model_dump(exclude_none=True)
         mock_proxy_class.assert_called_once_with(exporter.session, "us-west-2", "eks")
-        mock_inspector.inspect.assert_called_once_with(["test-cluster"], [])
+        mock_client.describe_cluster.assert_awaited_once_with(name="test-cluster")
+        mock_inspector.inspect.assert_called_once_with(
+            ["test-cluster"],
+            [],
+            extra_context={
+                "AccountId": "123456789012",
+                "Region": "us-west-2",
+            },
+        )
 
     @pytest.mark.asyncio
     @patch("aws.core.exporters.eks.cluster.exporter.AioBaseClientProxy")
@@ -199,6 +211,38 @@ class TestEksClusterExporter:
     @pytest.mark.asyncio
     @patch("aws.core.exporters.eks.cluster.exporter.AioBaseClientProxy")
     @patch("aws.core.exporters.eks.cluster.exporter.ResourceInspector")
+    async def test_get_resource_describe_cluster_not_found(
+        self,
+        mock_inspector_class: MagicMock,
+        mock_proxy_class: MagicMock,
+        exporter: EksClusterExporter,
+    ) -> None:
+        """Missing clusters must raise from describe_cluster before stub resources are built."""
+        mock_proxy = AsyncMock()
+        mock_client = AsyncMock()
+        mock_proxy.client = mock_client
+        mock_proxy_class.return_value.__aenter__.return_value = mock_proxy
+        mock_client.describe_cluster.side_effect = ClientError(
+            {"Error": {"Code": "ResourceNotFoundException", "Message": "gone"}},
+            "DescribeCluster",
+        )
+
+        options = SingleEksClusterRequest(
+            region="us-west-2",
+            account_id="123456789012",
+            cluster_name="nonexistent-cluster",
+            include=[],
+        )
+
+        with pytest.raises(ClientError) as exc_info:
+            await exporter.get_resource(options)
+
+        assert exc_info.value.response["Error"]["Code"] == "ResourceNotFoundException"
+        mock_inspector_class.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("aws.core.exporters.eks.cluster.exporter.AioBaseClientProxy")
+    @patch("aws.core.exporters.eks.cluster.exporter.ResourceInspector")
     async def test_get_resource_inspector_exception(
         self,
         mock_inspector_class: MagicMock,
@@ -211,6 +255,9 @@ class TestEksClusterExporter:
         mock_client = AsyncMock()
         mock_proxy.client = mock_client
         mock_proxy_class.return_value.__aenter__.return_value = mock_proxy
+        mock_client.describe_cluster.return_value = {
+            "cluster": {"name": "nonexistent-cluster"}
+        }
 
         mock_inspector = AsyncMock()
         mock_inspector_class.return_value = mock_inspector

--- a/integrations/aws-v3/tests/core/helpers/test_exception_helpers.py
+++ b/integrations/aws-v3/tests/core/helpers/test_exception_helpers.py
@@ -24,6 +24,17 @@ def test_is_resource_not_found_exception_includes_rds_codes() -> None:
     assert is_resource_not_found_exception(_client_error("DBInstanceNotFound")) is True
 
 
+def test_is_resource_not_found_exception_includes_ecr_and_cluster_codes() -> None:
+    assert (
+        is_resource_not_found_exception(_client_error("RepositoryNotFoundException"))
+        is True
+    )
+    assert (
+        is_resource_not_found_exception(_client_error("ClusterNotFoundException"))
+        is True
+    )
+
+
 def test_is_access_denied_exception() -> None:
     assert is_access_denied_exception(_client_error("AccessDenied")) is True
     assert is_access_denied_exception(_client_error("NoSuchBucket")) is False

--- a/integrations/aws-v3/tests/webhook/test_cloudtrail_parser.py
+++ b/integrations/aws-v3/tests/webhook/test_cloudtrail_parser.py
@@ -410,3 +410,240 @@ def test_parse_returns_none_when_db_instance_identifier_missing() -> None:
         "CreateDBInstance", db_instance_identifier=None
     )
     assert parse_cloudtrail_event(payload) is None
+
+
+def _cluster_eventbridge_envelope(
+    event_name: str,
+    *,
+    event_source: str,
+    cluster_name: str | None = "my-cluster",
+    account: str | None = "111122223333",
+    region: str | None = "us-east-1",
+    identifier_key: str = "clusterName",
+) -> EventBridgeCloudTrailPayload:
+    detail: CloudTrailDetail = {
+        "eventName": event_name,
+        "eventSource": event_source,
+    }
+    if region is not None:
+        detail["awsRegion"] = region
+    if account is not None:
+        detail["recipientAccountId"] = account
+    if cluster_name is not None:
+        detail["requestParameters"] = {identifier_key: cluster_name}
+    else:
+        detail["requestParameters"] = {}
+
+    payload: EventBridgeCloudTrailPayload = {"detail": detail}
+    if account is not None:
+        payload["account"] = account
+    if region is not None:
+        payload["region"] = region
+    return cast(
+        EventBridgeCloudTrailPayload,
+        {
+            **payload,
+            "version": "0",
+            "detail-type": "AWS API Call via CloudTrail",
+            "source": event_source,
+        },
+    )
+
+
+def _ecr_eventbridge_envelope(
+    event_name: str,
+    repository_name: str | None = "my-repo",
+    account: str | None = "111122223333",
+    region: str | None = "us-east-1",
+) -> EventBridgeCloudTrailPayload:
+    return _cluster_eventbridge_envelope(
+        event_name,
+        event_source="ecr.amazonaws.com",
+        cluster_name=repository_name,
+        account=account,
+        region=region,
+        identifier_key="repositoryName",
+    )
+
+
+def test_is_supported_cloudtrail_event_true_for_ecr_repository_events() -> None:
+    for event_name in ("CreateRepository", "DeleteRepository"):
+        payload = _ecr_eventbridge_envelope(event_name)
+        assert is_supported_cloudtrail_event(payload) is True
+
+
+def test_parse_create_repository_event() -> None:
+    payload = _ecr_eventbridge_envelope("CreateRepository", repository_name="my-repo")
+
+    parsed = parse_cloudtrail_event(payload)
+
+    assert parsed is not None
+    assert parsed.kind == ObjectKind.ECR_REPOSITORY
+    assert parsed.action == CloudTrailEventAction.UPSERT
+    assert parsed.identifier == "my-repo"
+    assert parsed.event_name == "CreateRepository"
+
+
+def test_parse_delete_repository_event() -> None:
+    payload = _ecr_eventbridge_envelope("DeleteRepository")
+
+    parsed = parse_cloudtrail_event(payload)
+
+    assert parsed is not None
+    assert parsed.kind == ObjectKind.ECR_REPOSITORY
+    assert parsed.action == CloudTrailEventAction.DELETE
+
+
+def test_parse_returns_none_when_repository_name_missing() -> None:
+    payload = _ecr_eventbridge_envelope("CreateRepository", repository_name=None)
+    assert parse_cloudtrail_event(payload) is None
+
+
+def test_is_supported_cloudtrail_event_true_for_ecs_cluster_events() -> None:
+    for event_name in (
+        "CreateCluster",
+        "PutClusterCapacityProviders",
+        "DeleteCluster",
+    ):
+        payload = _cluster_eventbridge_envelope(
+            event_name, event_source="ecs.amazonaws.com"
+        )
+        assert is_supported_cloudtrail_event(payload) is True
+
+
+def test_parse_ecs_create_cluster_event() -> None:
+    payload = _cluster_eventbridge_envelope(
+        "CreateCluster", event_source="ecs.amazonaws.com", cluster_name="ecs-cluster"
+    )
+
+    parsed = parse_cloudtrail_event(payload)
+
+    assert parsed is not None
+    assert parsed.kind == ObjectKind.ECS_CLUSTER
+    assert parsed.action == CloudTrailEventAction.UPSERT
+    assert parsed.identifier == "ecs-cluster"
+
+
+def test_parse_ecs_delete_cluster_event() -> None:
+    payload = _cluster_eventbridge_envelope(
+        "DeleteCluster", event_source="ecs.amazonaws.com"
+    )
+
+    parsed = parse_cloudtrail_event(payload)
+
+    assert parsed is not None
+    assert parsed.kind == ObjectKind.ECS_CLUSTER
+    assert parsed.action == CloudTrailEventAction.DELETE
+
+
+def test_parse_ecs_put_cluster_capacity_providers_event_from_cluster_name() -> None:
+    payload = _cluster_eventbridge_envelope(
+        "PutClusterCapacityProviders",
+        event_source="ecs.amazonaws.com",
+        cluster_name="ecs-cluster",
+        identifier_key="cluster",
+    )
+
+    parsed = parse_cloudtrail_event(payload)
+
+    assert parsed is not None
+    assert parsed.kind == ObjectKind.ECS_CLUSTER
+    assert parsed.action == CloudTrailEventAction.UPSERT
+    assert parsed.identifier == "ecs-cluster"
+
+
+def test_parse_ecs_put_cluster_capacity_providers_event_from_cluster_arn() -> None:
+    payload = _cluster_eventbridge_envelope(
+        "PutClusterCapacityProviders",
+        event_source="ecs.amazonaws.com",
+        cluster_name="arn:aws:ecs:us-east-1:111122223333:cluster/ecs-cluster",
+        identifier_key="cluster",
+    )
+
+    parsed = parse_cloudtrail_event(payload)
+
+    assert parsed is not None
+    assert parsed.kind == ObjectKind.ECS_CLUSTER
+    assert parsed.identifier == "ecs-cluster"
+
+
+def test_is_supported_cloudtrail_event_true_for_eks_cluster_events() -> None:
+    for event_name in (
+        "CreateCluster",
+        "UpdateClusterConfig",
+        "UpdateClusterVersion",
+        "DeleteCluster",
+    ):
+        payload = _cluster_eventbridge_envelope(
+            event_name, event_source="eks.amazonaws.com"
+        )
+        assert is_supported_cloudtrail_event(payload) is True
+
+
+def test_parse_eks_create_cluster_event_from_cluster_name() -> None:
+    payload = _cluster_eventbridge_envelope(
+        "CreateCluster", event_source="eks.amazonaws.com", cluster_name="eks-cluster"
+    )
+
+    parsed = parse_cloudtrail_event(payload)
+
+    assert parsed is not None
+    assert parsed.kind == ObjectKind.EKS_CLUSTER
+    assert parsed.action == CloudTrailEventAction.UPSERT
+    assert parsed.identifier == "eks-cluster"
+
+
+def test_parse_eks_create_cluster_event_from_name() -> None:
+    payload = _cluster_eventbridge_envelope(
+        "CreateCluster",
+        event_source="eks.amazonaws.com",
+        cluster_name="eks-cluster",
+        identifier_key="name",
+    )
+
+    parsed = parse_cloudtrail_event(payload)
+
+    assert parsed is not None
+    assert parsed.kind == ObjectKind.EKS_CLUSTER
+    assert parsed.identifier == "eks-cluster"
+
+
+def test_parse_eks_delete_cluster_event() -> None:
+    payload = _cluster_eventbridge_envelope(
+        "DeleteCluster", event_source="eks.amazonaws.com"
+    )
+
+    parsed = parse_cloudtrail_event(payload)
+
+    assert parsed is not None
+    assert parsed.kind == ObjectKind.EKS_CLUSTER
+    assert parsed.action == CloudTrailEventAction.DELETE
+
+
+def test_create_cluster_without_event_source_is_not_supported() -> None:
+    payload = _cluster_eventbridge_envelope(
+        "CreateCluster",
+        event_source="ecs.amazonaws.com",
+        cluster_name="ecs-cluster",
+    )
+    del payload["detail"]["eventSource"]
+
+    assert is_supported_cloudtrail_event(payload) is False
+    assert parse_cloudtrail_event(payload) is None
+
+
+def test_ecs_and_eks_create_cluster_are_disambiguated_by_event_source() -> None:
+    ecs_payload = _cluster_eventbridge_envelope(
+        "CreateCluster", event_source="ecs.amazonaws.com", cluster_name="shared-name"
+    )
+    eks_payload = _cluster_eventbridge_envelope(
+        "CreateCluster", event_source="eks.amazonaws.com", cluster_name="shared-name"
+    )
+
+    ecs_parsed = parse_cloudtrail_event(ecs_payload)
+    eks_parsed = parse_cloudtrail_event(eks_payload)
+
+    assert ecs_parsed is not None
+    assert eks_parsed is not None
+    assert ecs_parsed.kind == ObjectKind.ECS_CLUSTER
+    assert eks_parsed.kind == ObjectKind.EKS_CLUSTER

--- a/integrations/aws-v3/tests/webhook/test_cloudtrail_parser.py
+++ b/integrations/aws-v3/tests/webhook/test_cloudtrail_parser.py
@@ -16,7 +16,10 @@ def _eventbridge_envelope(
     account: str | None = "111122223333",
     region: str | None = "us-east-1",
 ) -> EventBridgeCloudTrailPayload:
-    detail: CloudTrailDetail = {"eventName": event_name}
+    detail: CloudTrailDetail = {
+        "eventName": event_name,
+        "eventSource": "s3.amazonaws.com",
+    }
     if region is not None:
         detail["awsRegion"] = region
     if account is not None:
@@ -136,7 +139,10 @@ def _lambda_eventbridge_envelope(
     account: str | None = "111122223333",
     region: str | None = "us-east-1",
 ) -> EventBridgeCloudTrailPayload:
-    detail: CloudTrailDetail = {"eventName": event_name}
+    detail: CloudTrailDetail = {
+        "eventName": event_name,
+        "eventSource": "lambda.amazonaws.com",
+    }
     if region is not None:
         detail["awsRegion"] = region
     if account is not None:
@@ -260,7 +266,10 @@ def _dynamodb_eventbridge_envelope(
     account: str | None = "111122223333",
     region: str | None = "us-east-1",
 ) -> EventBridgeCloudTrailPayload:
-    detail: CloudTrailDetail = {"eventName": event_name}
+    detail: CloudTrailDetail = {
+        "eventName": event_name,
+        "eventSource": "dynamodb.amazonaws.com",
+    }
     if region is not None:
         detail["awsRegion"] = region
     if account is not None:
@@ -326,7 +335,10 @@ def _rds_db_instance_eventbridge_envelope(
     region: str | None = "us-east-1",
     identifier_key: str = "dbInstanceIdentifier",
 ) -> EventBridgeCloudTrailPayload:
-    detail: CloudTrailDetail = {"eventName": event_name}
+    detail: CloudTrailDetail = {
+        "eventName": event_name,
+        "eventSource": "rds.amazonaws.com",
+    }
     if region is not None:
         detail["awsRegion"] = region
     if account is not None:

--- a/integrations/aws-v3/tests/webhook/webhook_processors/test_cloudtrail_webhook_processor.py
+++ b/integrations/aws-v3/tests/webhook/webhook_processors/test_cloudtrail_webhook_processor.py
@@ -132,6 +132,90 @@ def _rds_delete_event(db_instance_identifier: str = "my-db-instance") -> dict[st
     }
 
 
+def _ecr_create_event(repository_name: str = "my-repo") -> dict[str, Any]:
+    return {
+        "account": "111122223333",
+        "region": "us-east-1",
+        "detail": {
+            "eventName": "CreateRepository",
+            "eventSource": "ecr.amazonaws.com",
+            "awsRegion": "us-east-1",
+            "recipientAccountId": "111122223333",
+            "requestParameters": {"repositoryName": repository_name},
+        },
+    }
+
+
+def _ecr_delete_event(repository_name: str = "my-repo") -> dict[str, Any]:
+    return {
+        "account": "111122223333",
+        "region": "us-east-1",
+        "detail": {
+            "eventName": "DeleteRepository",
+            "eventSource": "ecr.amazonaws.com",
+            "awsRegion": "us-east-1",
+            "recipientAccountId": "111122223333",
+            "requestParameters": {"repositoryName": repository_name},
+        },
+    }
+
+
+def _ecs_create_event(cluster_name: str = "my-ecs-cluster") -> dict[str, Any]:
+    return {
+        "account": "111122223333",
+        "region": "us-east-1",
+        "detail": {
+            "eventName": "CreateCluster",
+            "eventSource": "ecs.amazonaws.com",
+            "awsRegion": "us-east-1",
+            "recipientAccountId": "111122223333",
+            "requestParameters": {"clusterName": cluster_name},
+        },
+    }
+
+
+def _ecs_delete_event(cluster_name: str = "my-ecs-cluster") -> dict[str, Any]:
+    return {
+        "account": "111122223333",
+        "region": "us-east-1",
+        "detail": {
+            "eventName": "DeleteCluster",
+            "eventSource": "ecs.amazonaws.com",
+            "awsRegion": "us-east-1",
+            "recipientAccountId": "111122223333",
+            "requestParameters": {"clusterName": cluster_name},
+        },
+    }
+
+
+def _eks_create_event(cluster_name: str = "my-eks-cluster") -> dict[str, Any]:
+    return {
+        "account": "111122223333",
+        "region": "us-east-1",
+        "detail": {
+            "eventName": "CreateCluster",
+            "eventSource": "eks.amazonaws.com",
+            "awsRegion": "us-east-1",
+            "recipientAccountId": "111122223333",
+            "requestParameters": {"name": cluster_name},
+        },
+    }
+
+
+def _eks_delete_event(cluster_name: str = "my-eks-cluster") -> dict[str, Any]:
+    return {
+        "account": "111122223333",
+        "region": "us-east-1",
+        "detail": {
+            "eventName": "DeleteCluster",
+            "eventSource": "eks.amazonaws.com",
+            "awsRegion": "us-east-1",
+            "recipientAccountId": "111122223333",
+            "requestParameters": {"name": cluster_name},
+        },
+    }
+
+
 def _delete_event(bucket_name: str = "my-bucket") -> dict[str, Any]:
     return {
         "account": "111122223333",
@@ -556,6 +640,181 @@ async def test_handle_event_rds_db_instance_create_treats_not_found_as_deleted(
             },
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_get_matching_kinds_returns_ecr_repository(
+    processor: CloudTrailWebhookProcessor,
+) -> None:
+    event = WebhookEvent(trace_id="t", payload=_ecr_create_event(), headers={})
+    assert await processor.get_matching_kinds(event) == [ObjectKind.ECR_REPOSITORY]
+
+
+@pytest.mark.asyncio
+async def test_handle_event_ecr_repository_delete_returns_deleted_result(
+    processor: CloudTrailWebhookProcessor,
+) -> None:
+    result = await processor.handle_event(_ecr_delete_event("repo-to-delete"), None)
+
+    assert result.updated_raw_results == []
+    assert result.deleted_raw_results == [
+        {
+            "Type": ObjectKind.ECR_REPOSITORY,
+            "Properties": {
+                "RepositoryArn": (
+                    "arn:aws:ecr:us-east-1:111122223333:repository/repo-to-delete"
+                ),
+                "RepositoryName": "repo-to-delete",
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_handle_event_ecr_repository_create_fetches_and_returns_resource(
+    processor: CloudTrailWebhookProcessor,
+) -> None:
+    fake_resource = {
+        "Type": ObjectKind.ECR_REPOSITORY,
+        "Properties": {"RepositoryName": "my-repo"},
+    }
+
+    fixture = _live_event_metadata()
+    with (
+        patch(
+            f"{MODULE}.get_session_for_account", new=AsyncMock(return_value="session")
+        ),
+        patch(
+            f"{MODULE}.kind_to_export_metadata",
+            {ObjectKind.ECR_REPOSITORY: fixture.metadata},
+        ),
+    ):
+        mock_exporter = fixture.exporter_cls.return_value
+        mock_exporter.get_resource = AsyncMock(return_value=fake_resource)
+
+        result = await processor.handle_event(_ecr_create_event(), None)
+
+    fixture.exporter_cls.assert_called_once_with("session")
+    assert result.updated_raw_results == [fake_resource]
+    assert result.deleted_raw_results == []
+
+
+@pytest.mark.asyncio
+async def test_get_matching_kinds_returns_ecs_cluster(
+    processor: CloudTrailWebhookProcessor,
+) -> None:
+    event = WebhookEvent(trace_id="t", payload=_ecs_create_event(), headers={})
+    assert await processor.get_matching_kinds(event) == [ObjectKind.ECS_CLUSTER]
+
+
+@pytest.mark.asyncio
+async def test_handle_event_ecs_cluster_delete_returns_deleted_result(
+    processor: CloudTrailWebhookProcessor,
+) -> None:
+    result = await processor.handle_event(
+        _ecs_delete_event("ecs-cluster-to-delete"), None
+    )
+
+    assert result.updated_raw_results == []
+    assert result.deleted_raw_results == [
+        {
+            "Type": ObjectKind.ECS_CLUSTER,
+            "Properties": {
+                "ClusterArn": (
+                    "arn:aws:ecs:us-east-1:111122223333:cluster/ecs-cluster-to-delete"
+                ),
+                "ClusterName": "ecs-cluster-to-delete",
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_handle_event_ecs_cluster_create_fetches_and_returns_resource(
+    processor: CloudTrailWebhookProcessor,
+) -> None:
+    fake_resource = {
+        "Type": ObjectKind.ECS_CLUSTER,
+        "Properties": {"ClusterName": "my-ecs-cluster"},
+    }
+
+    fixture = _live_event_metadata()
+    with (
+        patch(
+            f"{MODULE}.get_session_for_account", new=AsyncMock(return_value="session")
+        ),
+        patch(
+            f"{MODULE}.kind_to_export_metadata",
+            {ObjectKind.ECS_CLUSTER: fixture.metadata},
+        ),
+    ):
+        mock_exporter = fixture.exporter_cls.return_value
+        mock_exporter.get_resource = AsyncMock(return_value=fake_resource)
+
+        result = await processor.handle_event(_ecs_create_event(), None)
+
+    fixture.exporter_cls.assert_called_once_with("session")
+    assert result.updated_raw_results == [fake_resource]
+    assert result.deleted_raw_results == []
+
+
+@pytest.mark.asyncio
+async def test_get_matching_kinds_returns_eks_cluster(
+    processor: CloudTrailWebhookProcessor,
+) -> None:
+    event = WebhookEvent(trace_id="t", payload=_eks_create_event(), headers={})
+    assert await processor.get_matching_kinds(event) == [ObjectKind.EKS_CLUSTER]
+
+
+@pytest.mark.asyncio
+async def test_handle_event_eks_cluster_delete_returns_deleted_result(
+    processor: CloudTrailWebhookProcessor,
+) -> None:
+    result = await processor.handle_event(
+        _eks_delete_event("eks-cluster-to-delete"), None
+    )
+
+    assert result.updated_raw_results == []
+    assert result.deleted_raw_results == [
+        {
+            "Type": ObjectKind.EKS_CLUSTER,
+            "Properties": {
+                "Arn": (
+                    "arn:aws:eks:us-east-1:111122223333:cluster/eks-cluster-to-delete"
+                ),
+                "Name": "eks-cluster-to-delete",
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_handle_event_eks_cluster_create_fetches_and_returns_resource(
+    processor: CloudTrailWebhookProcessor,
+) -> None:
+    fake_resource = {
+        "Type": ObjectKind.EKS_CLUSTER,
+        "Properties": {"Name": "my-eks-cluster"},
+    }
+
+    fixture = _live_event_metadata()
+    with (
+        patch(
+            f"{MODULE}.get_session_for_account", new=AsyncMock(return_value="session")
+        ),
+        patch(
+            f"{MODULE}.kind_to_export_metadata",
+            {ObjectKind.EKS_CLUSTER: fixture.metadata},
+        ),
+    ):
+        mock_exporter = fixture.exporter_cls.return_value
+        mock_exporter.get_resource = AsyncMock(return_value=fake_resource)
+
+        result = await processor.handle_event(_eks_create_event(), None)
+
+    fixture.exporter_cls.assert_called_once_with("session")
+    assert result.updated_raw_results == [fake_resource]
+    assert result.deleted_raw_results == []
 
 
 @pytest.mark.asyncio

--- a/integrations/aws-v3/tests/webhook/webhook_processors/test_cloudtrail_webhook_processor.py
+++ b/integrations/aws-v3/tests/webhook/webhook_processors/test_cloudtrail_webhook_processor.py
@@ -47,6 +47,7 @@ def _create_event(bucket_name: str = "my-bucket") -> dict[str, Any]:
         "region": "us-east-1",
         "detail": {
             "eventName": "CreateBucket",
+            "eventSource": "s3.amazonaws.com",
             "awsRegion": "us-east-1",
             "recipientAccountId": "111122223333",
             "requestParameters": {"bucketName": bucket_name},
@@ -60,6 +61,7 @@ def _lambda_create_event(function_name: str = "my-function") -> dict[str, Any]:
         "region": "us-east-1",
         "detail": {
             "eventName": "CreateFunction20150331",
+            "eventSource": "lambda.amazonaws.com",
             "awsRegion": "us-east-1",
             "recipientAccountId": "111122223333",
             "requestParameters": {"functionName": function_name},
@@ -73,6 +75,7 @@ def _lambda_delete_event(function_name: str = "my-function") -> dict[str, Any]:
         "region": "us-east-1",
         "detail": {
             "eventName": "DeleteFunction20150331",
+            "eventSource": "lambda.amazonaws.com",
             "awsRegion": "us-east-1",
             "recipientAccountId": "111122223333",
             "requestParameters": {"functionName": function_name},
@@ -86,6 +89,7 @@ def _dynamodb_create_event(table_name: str = "my-table") -> dict[str, Any]:
         "region": "us-east-1",
         "detail": {
             "eventName": "CreateTable",
+            "eventSource": "dynamodb.amazonaws.com",
             "awsRegion": "us-east-1",
             "recipientAccountId": "111122223333",
             "requestParameters": {"tableName": table_name},
@@ -99,6 +103,7 @@ def _dynamodb_delete_event(table_name: str = "my-table") -> dict[str, Any]:
         "region": "us-east-1",
         "detail": {
             "eventName": "DeleteTable",
+            "eventSource": "dynamodb.amazonaws.com",
             "awsRegion": "us-east-1",
             "recipientAccountId": "111122223333",
             "requestParameters": {"tableName": table_name},
@@ -112,6 +117,7 @@ def _rds_create_event(db_instance_identifier: str = "my-db-instance") -> dict[st
         "region": "us-east-1",
         "detail": {
             "eventName": "CreateDBInstance",
+            "eventSource": "rds.amazonaws.com",
             "awsRegion": "us-east-1",
             "recipientAccountId": "111122223333",
             "requestParameters": {"dbInstanceIdentifier": db_instance_identifier},
@@ -125,6 +131,7 @@ def _rds_delete_event(db_instance_identifier: str = "my-db-instance") -> dict[st
         "region": "us-east-1",
         "detail": {
             "eventName": "DeleteDBInstance",
+            "eventSource": "rds.amazonaws.com",
             "awsRegion": "us-east-1",
             "recipientAccountId": "111122223333",
             "requestParameters": {"dbInstanceIdentifier": db_instance_identifier},
@@ -222,6 +229,7 @@ def _delete_event(bucket_name: str = "my-bucket") -> dict[str, Any]:
         "region": "us-east-1",
         "detail": {
             "eventName": "DeleteBucket",
+            "eventSource": "s3.amazonaws.com",
             "awsRegion": "us-east-1",
             "recipientAccountId": "111122223333",
             "requestParameters": {"bucketName": bucket_name},


### PR DESCRIPTION
# Description

Adds CloudTrail live event support for three AWS resource kinds in the AWS-v3 integration, enabling real-time upsert/delete sync via EventBridge webhooks instead of waiting for the next full resync.
- **ECR Repository** - `CreateRepository`, `DeleteRepository`
- **ECS Cluster** - `CreateCluster`, `PutClusterCapacityProviders`, `DeleteCluster`
- **EKS Cluster** - `CreateCluster`, `UpdateClusterConfig`, `UpdateClusterVersion`, `DeleteCluster`
Also introduces **event-source-aware CloudTrail mapping** to disambiguate overlapping event names (e.g. ECS and EKS both emit `CreateCluster`/`DeleteCluster`). Mappings are now keyed by `eventSource:eventName`, with a fallback to `eventName` for existing kinds.

## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live webhook routing and entity sync for container-related resources; incorrect CloudTrail mapping could mis-route ECS vs EKS events or skip updates until resync.
> 
> **Overview**
> Adds **CloudTrail live-event** handling for **ECR repositories**, **ECS clusters**, and **EKS clusters** so create/update/delete changes can sync via EventBridge webhooks instead of waiting for a full resync. Each kind gets `LiveEventFactories` (request builders, delete identifiers, and CloudTrail action mappings) and is registered on the corresponding `ExporterMetadata` entries.
> 
> CloudTrail routing now supports **`eventSource`-scoped keys** (`eventSource:eventName`), with a fallback to bare `eventName` for existing kinds. That disambiguates shared names like **`CreateCluster`** / **`DeleteCluster`** between ECS and EKS; events without `eventSource` no longer match those source-specific mappings.
> 
> **`is_resource_not_found_exception`** now treats **`RepositoryNotFoundException`** and **`ClusterNotFoundException`** as recoverable for live upserts. Parser and webhook processor tests cover the new events, identifier extraction (including ECS cluster ARN/name variants), and end-to-end upsert/delete behavior. Release intent: minor bump in `.ocean-release/ecr-ecs-eks-live-events.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 511525bc415edf65defa679d5b310ae1e26e88b2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->