### PR TITLE
[Integration][GitHub] Handle GraphQLForbiddenFieldError in SAML identity query

### DIFF
--- a/integrations/github/.ocean-release/fix-saml-forbidden-field-error.yml
+++ b/integrations/github/.ocean-release/fix-saml-forbidden-field-error.yml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: bugfix
+changelog: Fixed user sync abort when SAML identity query returns FORBIDDEN by handling GraphQLForbiddenFieldError gracefully, restoring pre-6.9.6 behavior of continuing with empty SAML map

--- a/integrations/github/github/helpers/utils.py
+++ b/integrations/github/github/helpers/utils.py
@@ -16,6 +16,7 @@ from typing import (
 
 from loguru import logger
 
+from github.helpers.exceptions import GraphQLForbiddenFieldError
 from port_ocean.utils import cache
 from port_ocean.utils.cache import cache_coroutine_result
 
@@ -327,6 +328,11 @@ async def get_saml_identities(
         )
     except TypeError:
         logger.info(f"SAML not enabled for organization '{organization}'")
+    except GraphQLForbiddenFieldError:
+        logger.warning(
+            f"SAML identity query returned FORBIDDEN for organization '{organization}', "
+            "skipping SAML enrichment"
+        )
 
     return saml_users
 


### PR DESCRIPTION
# Description

What - _handle_graphql_errors to raise                                                                                                                                                        GraphQLForbiddenFieldError for field-level FORBIDDEN errors, enabling                                                                                                                                              
  callers to retry without forbidden fields. The PR exporter was updated                                                                                                                                             
  with a regenerate_query callback, but get_saml_identities was not —                                                                                                                                                
  it only caught TypeError.      

Why -

How -
Fix: catch GraphQLForbiddenFieldError separately with a warning log,                                                                                                                                               
  returning an empty SAML map.

## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [X] Bug fix (non-breaking change which fixes an issue)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [X] Integration able to create all default resources from scratch
- [X] Resync finishes successfully
- [X] Resync able to create entities
- [X] Resync able to update entities
- [X] Resync able to detect and delete entities
- [X] Scheduled resync able to abort existing resync and start a new one
- [X] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized error-handling in SAML enrichment; no auth or data-model changes—only avoids failing sync when SAML fields are forbidden.
> 
> **Overview**
> Fixes **user sync aborting** when the SAML external-identities GraphQL query hits field-level **FORBIDDEN** responses (e.g. insufficient permissions on `samlIdentity`), which could surface after broader GraphQL error handling changes in 6.9.6.
> 
> `get_saml_identities` now **catches `GraphQLForbiddenFieldError`**, logs a warning, and **returns an empty SAML map** instead of failing—matching the pre-6.9.6 behavior where sync continues without SAML email enrichment. **`TypeError`** handling for orgs without SAML remains unchanged.
> 
> Patch release intent documents the bugfix for integrations consumers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf9eff4f321ad1b0518e616deaebee10ea90dda5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->