### PR TITLE
[Core] Task tkkyc9/b10 add skip retry configuration to ocean

### DIFF
--- a/.ocean-release/core/skip-retry-configuration.yaml
+++ b/.ocean-release/core/skip-retry-configuration.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: feature
+changelog: Allow individual HTTP requests to opt out of retries via the skip_retry request extension

--- a/port_ocean/helpers/retry.py
+++ b/port_ocean/helpers/retry.py
@@ -25,6 +25,11 @@ from port_ocean.context.ocean import ocean
 MAX_BACKOFF_WAIT_IN_SECONDS = 60
 _ON_RETRY_CALLBACK: Callable[[httpx.Request], httpx.Request] | None = None
 _RETRY_CONFIG_CALLBACK: Callable[[], "RetryConfig"] | None = None
+SKIP_RETRY_EXTENSION_KEY = "skip_retry"
+"""
+Request extension that overrides the retry decision for a single request.
+Set it to True to opt out of retries entirely.
+"""
 
 
 def register_on_retry_callback(
@@ -409,6 +414,10 @@ class RetryTransport(httpx.AsyncBaseTransport, httpx.BaseTransport):
         transport.close()
 
     def _is_retryable_method(self, request: httpx.Request) -> bool:
+        skip_retry = request.extensions.get(SKIP_RETRY_EXTENSION_KEY)
+        if skip_retry:
+            return False
+
         return (
             request.method in self._retry_config.retryable_methods
             or request.extensions.get("retryable", False)

--- a/port_ocean/tests/helpers/test_retry.py
+++ b/port_ocean/tests/helpers/test_retry.py
@@ -8,6 +8,7 @@ import httpx
 from port_ocean.helpers.retry import (
     RetryConfig,
     RetryTransport,
+    SKIP_RETRY_EXTENSION_KEY,
     register_retry_config_callback,
     register_on_retry_callback,
 )
@@ -255,6 +256,28 @@ class TestRetryTransport:
 
         # Test with retryable extension
         mock_request.extensions = {"retryable": True}
+        assert transport._is_retryable_method(mock_request) is True
+
+    def test_is_retryable_method_with_skip_retry_true(self) -> None:
+        """Test that skip_retry=True opts out of retries for retryable methods."""
+        mock_transport = Mock()
+        transport = RetryTransport(wrapped_transport=mock_transport)
+
+        mock_request = Mock()
+        mock_request.method = "GET"
+        mock_request.extensions = {SKIP_RETRY_EXTENSION_KEY: True}
+
+        assert transport._is_retryable_method(mock_request) is False
+
+    def test_is_retryable_method_with_skip_retry_false(self) -> None:
+        """Test that skip_retry=False does not opt out of retries."""
+        mock_transport = Mock()
+        transport = RetryTransport(wrapped_transport=mock_transport)
+
+        mock_request = Mock()
+        mock_request.method = "GET"
+        mock_request.extensions = {SKIP_RETRY_EXTENSION_KEY: False}
+
         assert transport._is_retryable_method(mock_request) is True
 
     def test_should_retry(self) -> None:


### PR DESCRIPTION
# Description

What - Added httpx extension to support skipping retries entirely

Why - Probe mode. They're supposed to be super fast and return a success/fail value to the requester asap. The retries with waits in between kinda mess with that, so this allows us to skip that entirely.

How -

## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, opt-in change to retry gating with tests; default retry behavior is unchanged unless callers set the extension.
> 
> **Overview**
> Adds a per-request **httpx** extension so callers can bypass Ocean’s retry transport when they need a fast single attempt (e.g. probe mode).
> 
> `RetryTransport._is_retryable_method` now checks `request.extensions["skip_retry"]` first; when it is truthy, the request is treated as non-retryable even for normally retryable methods or `retryable: True`. The public constant is `SKIP_RETRY_EXTENSION_KEY` (`"skip_retry"`). Unit tests cover `skip_retry=True` and `False`.
> 
> Core release intent is recorded in `.ocean-release/core/skip-retry-configuration.yaml` (patch bump, feature changelog).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59e8529e75b6a30be7a0af48aeb7f5ae9b4201a7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->