### PR TITLE
[Draft] Test connection alignment with monorepo

### DIFF
--- a/integrations/github/github/probe/permissions/app.py
+++ b/integrations/github/github/probe/permissions/app.py
@@ -36,7 +36,7 @@ class GitHubAppPermissionProbe(GitHubPermissionProbeFlow):
         tokens = [
             await authenticator.get_token() for authenticator in self.authenticators
         ]
-        pending = self.context.add_scopes(
+        pending = await self.context.add_scopes(
             *org_scopes(
                 [authenticator.organization for authenticator in self.authenticators]
             )
@@ -44,7 +44,7 @@ class GitHubAppPermissionProbe(GitHubPermissionProbeFlow):
         kind_count = len(self.context.available_kinds)
         for index, token in enumerate(tokens):
             checks = pending[index * kind_count : (index + 1) * kind_count]
-            self._resolve_checks(checks, token.permissions, app_permission_verdict)
+            await self._resolve_checks(checks, token.permissions, app_permission_verdict)
 
 
 def app_permission_verdict(

--- a/integrations/github/github/probe/permissions/base.py
+++ b/integrations/github/github/probe/permissions/base.py
@@ -24,7 +24,7 @@ class GitHubPermissionProbeFlow(ABC):
     async def run(self) -> None:
         """Probe permissions for one GitHub authentication flow."""
 
-    def _resolve_checks(
+    async def _resolve_checks(
         self,
         checks: Sequence[ProbeCheck],
         permissions: dict[str, str] | None,
@@ -32,7 +32,7 @@ class GitHubPermissionProbeFlow(ABC):
     ) -> None:
         for check in checks:
             check.status, check.message = verdict(check.kind, permissions)
-        self.context.update_progress()
+        await self.context.update_progress()
 
 
 def org_scopes(organizations: Sequence[str | None]) -> list[dict[str, str]]:

--- a/integrations/github/github/probe/permissions/pat.py
+++ b/integrations/github/github/probe/permissions/pat.py
@@ -61,14 +61,14 @@ class GitHubPatPermissionProbe(GitHubPermissionProbeFlow):
         authenticator = self.authenticators[0]
         organizations = await self._get_organizations(authenticator)
         granted_scopes = await self._get_scopes(authenticator)
-        checks = self.context.add_scopes(*org_scopes(organizations))
+        checks = await self.context.add_scopes(*org_scopes(organizations))
 
         permissions = (
             {scope: "granted" for scope in expand_pat_scopes(granted_scopes)}
             if granted_scopes is not None
             else None
         )
-        self._resolve_checks(checks, permissions, pat_permission_verdict)
+        await self._resolve_checks(checks, permissions, pat_permission_verdict)
 
     async def _get_scopes(
         self,

--- a/integrations/github/github/probe/permissions/runner.py
+++ b/integrations/github/github/probe/permissions/runner.py
@@ -28,13 +28,13 @@ class GitHubPermissionProbe:
             )
             await flow.run()
         except (httpx.HTTPStatusError, httpx.RequestError) as error:
-            self.context.fail(_lookup_failure_message(error))
+            await self.context.fail(_lookup_failure_message(error))
         except AuthenticationException as error:
             cause = error.__cause__
             if isinstance(cause, (httpx.HTTPStatusError, httpx.RequestError)):
-                self.context.fail(_lookup_failure_message(cause))
+                await self.context.fail(_lookup_failure_message(cause))
             else:
-                self.context.fail(str(error))
+                await self.context.fail(str(error))
 
 
 def _lookup_failure_message(

--- a/integrations/jira/jira/probe/permissions.py
+++ b/integrations/jira/jira/probe/permissions.py
@@ -41,20 +41,20 @@ class JiraPermissionProbe:
         try:
             permissions = await client.get_current_user_permissions(permission_keys)
         except (httpx.HTTPStatusError, httpx.RequestError) as error:
-            self.context.fail(_lookup_failure_message(error))
+            await self.context.fail(_lookup_failure_message(error))
             return
 
-        checks = self.context.add_scopes({})
-        self._resolve_checks(checks, permissions)
+        checks = await self.context.add_scopes({})
+        await self._resolve_checks(checks, permissions)
 
-    def _resolve_checks(
+    async def _resolve_checks(
         self,
         checks: Sequence[ProbeCheck],
         permissions: dict[str, bool],
     ) -> None:
         for check in checks:
             check.status, check.message = _permission_verdict(check.kind, permissions)
-        self.context.update_progress()
+        await self.context.update_progress()
 
 
 def _lookup_failure_message(

--- a/port_ocean/clients/port/client.py
+++ b/port_ocean/clients/port/client.py
@@ -95,6 +95,24 @@ class PortClient(
 
         return response.json()["organization"]["id"]
 
+    async def patch_probe_health_result(
+        self, org_id: str, probe_id: str, body: dict[str, Any]
+    ) -> None:
+        logger.debug(
+            "Patching probe health result",
+            org_id=org_id,
+            probe_id=probe_id,
+            status=body.get("status"),
+        )
+        response = await self.client.patch(
+            f"{self.api_url}/org/{org_id}/probe/{probe_id}",
+            headers=await self.auth.headers(),
+            json=body,
+        )
+        handle_port_status_code(response)
+        if response.is_success:
+            logger.info("Probe health result updated successfully", probe_id=probe_id)
+
     async def update_integration_state(
         self, state: dict[str, Any], should_raise: bool = True, should_log: bool = True
     ) -> dict[str, Any]:

--- a/port_ocean/core/integrations/base.py
+++ b/port_ocean/core/integrations/base.py
@@ -103,13 +103,13 @@ class BaseIntegration(SyncRawMixin, SyncMixin):
     ) -> ProbeContext:
         """Invoke the registered ``on_probe`` listener."""
         context = ProbeContext(probe_id)
-        context.initialize(config)
+        await context.initialize(config)
         listener = self.event_strategy.on_probe
         if listener is None:
             error = ModeNotSupportedException(
                 self.context.config.integration.type, "probe"
             )
-            context.fail(str(error))
+            await context.fail(str(error))
             raise error
 
         async with event_context(
@@ -119,11 +119,11 @@ class BaseIntegration(SyncRawMixin, SyncMixin):
             try:
                 returned = await listener(context)
             except Exception as error:
-                context.fail(str(error))
+                await context.fail(str(error))
                 raise
 
             final_context = returned or context
             if final_context.status is ProbeStatus.FAILED:
                 raise ProbeFailedError(final_context.message or "Probe failed")
-            final_context.finalize()
+            await final_context.finalize()
             return final_context

--- a/port_ocean/core/probe/context.py
+++ b/port_ocean/core/probe/context.py
@@ -9,6 +9,7 @@ from port_ocean.core.probe.models import ProbeCheck, ProbeStatus
 from port_ocean.core.probe.reporters import ProbeReporter, REPORTER_MODES
 from port_ocean.exceptions.probe import InvalidProbeKindsError, ProbeNotInitializedError
 from port_ocean.utils.misc import get_spec_kinds
+from port_ocean.core.probe.serialization import serialize_probe_value
 
 
 @dataclass
@@ -23,7 +24,7 @@ class ProbeContext:
     checks: list[ProbeCheck] = field(default_factory=list)
     reporter: ProbeReporter | None = None
 
-    def add_scopes(self, *scopes: dict[str, str | int]) -> list[ProbeCheck]:
+    async def add_scopes(self, *scopes: dict[str, str | int]) -> list[ProbeCheck]:
         logger.debug("Registering additional scopes", scopes=scopes)
         new_checks: list[ProbeCheck] = []
         for scope in scopes:
@@ -32,29 +33,34 @@ class ProbeContext:
                 new_checks.append(check)
                 self.checks.append(check)
 
-        self.update_progress()
+        await self.update_progress()
         return new_checks
 
     def build_request_body(self) -> dict[str, Any]:
-        return {
-            "probe_id": self.probe_id,
-            "status": self.status,
-            "mode": self.config.mode,
-            "started_at": self.started_at.isoformat(),
-            "ended_at": self.ended_at.isoformat() if self.ended_at else None,
-            "message": self.message,
-            "checks": [
-                {
-                    "status": check.status,
-                    "message": check.message,
-                    "kind": check.kind,
-                    "scopes": check.scopes,
-                }
-                for check in self.checks
-            ],
-        }
+        return serialize_probe_value(
+            {
+                "probeId": self.probe_id,
+                "status": self.status,
+                "probeMode": self.config.mode,
+                "startedAt": self.started_at.isoformat(),
+                "endedAt": self.ended_at.isoformat() if self.ended_at else None,
+                "message": self.message,
+                "checks": [
+                    {
+                        "status": check.status,
+                        "message": check.message,
+                        "kind": check.kind,
+                        "scopes": {
+                            scope_key: str(scope_value)
+                            for scope_key, scope_value in check.scopes.items()
+                        },
+                    }
+                    for check in self.checks
+                ],
+            }
+        )
 
-    def initialize(self, config: ProbeConfig | None = None) -> None:
+    async def initialize(self, config: ProbeConfig | None = None) -> None:
         self.config = config or ProbeConfig()
         if self.config.kinds is not None:
             configured_kinds_set = set(self.config.kinds)
@@ -71,21 +77,21 @@ class ProbeContext:
 
         self.reporter = REPORTER_MODES[self.config.reporting_mode](self.config)
         self.status = ProbeStatus.IN_PROGRESS
-        self.update_progress()
+        await self.update_progress()
 
-    def update_progress(self) -> None:
+    async def update_progress(self) -> None:
         if not self.reporter:
             raise ProbeNotInitializedError("Reporter is not initialized")
 
-        self.reporter.report(self.build_request_body())
+        await self.reporter.report(self.build_request_body())
 
-    def finalize(self) -> None:
+    async def finalize(self) -> None:
         self.ended_at = datetime.now(timezone.utc)
         self.status = ProbeStatus.COMPLETED
-        self.update_progress()
+        await self.update_progress()
 
-    def fail(self, message: str) -> None:
+    async def fail(self, message: str) -> None:
         self.ended_at = datetime.now(timezone.utc)
         self.status = ProbeStatus.FAILED
         self.message = message
-        self.update_progress()
+        await self.update_progress()

--- a/port_ocean/core/probe/reporters/base.py
+++ b/port_ocean/core/probe/reporters/base.py
@@ -12,5 +12,5 @@ class ProbeReporter(ABC):
         self.config = config
 
     @abstractmethod
-    def report(self, report: dict[str, Any]) -> None:
+    async def report(self, report: dict[str, Any]) -> None:
         """Publish one probe status report."""

--- a/port_ocean/core/probe/reporters/file.py
+++ b/port_ocean/core/probe/reporters/file.py
@@ -16,7 +16,7 @@ class FileProbeReporter(ProbeReporter):
         super().__init__(config)
         self.timestamp: str = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S_%fZ")
 
-    def report(self, report: dict[str, Any]) -> None:
+    async def report(self, report: dict[str, Any]) -> None:
         reports_directory = self.config.path / PROBE_REPORTS_DIRECTORY
         reports_directory.mkdir(parents=True, exist_ok=True)
         report_path = reports_directory / f"probe_report_{self.timestamp}.json"

--- a/port_ocean/core/probe/reporters/log.py
+++ b/port_ocean/core/probe/reporters/log.py
@@ -9,5 +9,5 @@ from port_ocean.core.probe.reporters.base import ProbeReporter
 class LogProbeReporter(ProbeReporter):
     mode: ClassVar[ProbeReportingMode] = ProbeReportingMode.LOG
 
-    def report(self, report: dict[str, Any]) -> None:
+    async def report(self, report: dict[str, Any]) -> None:
         logger.info("Probe status report", probe_report=report)

--- a/port_ocean/core/probe/reporters/port.py
+++ b/port_ocean/core/probe/reporters/port.py
@@ -1,17 +1,25 @@
 from typing import Any, ClassVar
 
-from loguru import logger
-
 from port_ocean.core.probe.models import ProbeReportingMode
 from port_ocean.core.probe.reporters.base import ProbeReporter
+from port_ocean.exceptions.probe import ProbeNotInitializedError
 
 
 class PortProbeReporter(ProbeReporter):
     mode: ClassVar[ProbeReportingMode] = ProbeReportingMode.PORT
 
-    def report(self, report: dict[str, Any]) -> None:
-        """Placeholder for sending a probe status report to Port."""
-        logger.debug(
-            "Port probe reporting is not implemented yet",
-            probe_report=report,
-        )
+    async def report(self, report: dict[str, Any]) -> None:
+        from port_ocean.context.ocean import ocean
+
+        body = report.copy()
+        probe_id = body.pop("probeId", None)
+        if not probe_id:
+            raise ProbeNotInitializedError(
+                "probe_id is required when using Port probe reporting mode"
+            )
+
+        org_id = getattr(self, "_org_id", None)
+        if org_id is None:
+            org_id = await ocean.port_client.get_org_id()
+            self._org_id = org_id
+        await ocean.port_client.patch_probe_health_result(org_id, probe_id, body)

--- a/port_ocean/core/probe/serialization.py
+++ b/port_ocean/core/probe/serialization.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+
+def serialize_probe_value(value: Any) -> Any:
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {key: serialize_probe_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [serialize_probe_value(item) for item in value]
+    return value

--- a/port_ocean/core/probe/serialization.py
+++ b/port_ocean/core/probe/serialization.py
@@ -9,7 +9,11 @@ def serialize_probe_value(value: Any) -> Any:
     if isinstance(value, datetime):
         return value.isoformat()
     if isinstance(value, dict):
-        return {key: serialize_probe_value(item) for key, item in value.items()}
+        return {
+            key: serialize_probe_value(item)
+            for key, item in value.items()
+            if item is not None
+        }
     if isinstance(value, list):
         return [serialize_probe_value(item) for item in value]
     return value

--- a/port_ocean/tests/core/probe/test_context.py
+++ b/port_ocean/tests/core/probe/test_context.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timezone
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -11,7 +11,6 @@ from port_ocean.core.probe.context import ProbeContext
 from port_ocean.core.probe.models import (
     ProbeCheck,
     ProbeCheckStatus,
-    ProbeMode,
     ProbeReportingMode,
     ProbeStatus,
 )
@@ -39,16 +38,17 @@ def test_starts_with_empty_state() -> None:
     assert context.checks == []
 
 
-@patch("port_ocean.core.probe.context.ProbeContext.update_progress")
-def test_add_scopes_creates_check_per_kind_and_scope(
-    mock_update_progress: MagicMock,
+@patch("port_ocean.core.probe.context.ProbeContext.update_progress", new_callable=AsyncMock)
+@pytest.mark.asyncio
+async def test_add_scopes_creates_check_per_kind_and_scope(
+    mock_update_progress: AsyncMock,
 ) -> None:
     # Arrange
     context = ProbeContext()
     context.available_kinds = ["repository", "pull-request"]
 
     # Act
-    new_checks = context.add_scopes({"org": "acme"}, {"org": "other"})
+    new_checks = await context.add_scopes({"org": "acme"}, {"org": "other"})
 
     # Assert
     assert len(new_checks) == 4
@@ -58,26 +58,28 @@ def test_add_scopes_creates_check_per_kind_and_scope(
         ("pull-request", "acme"),
         ("pull-request", "other"),
     }
-    mock_update_progress.assert_called_once()
+    mock_update_progress.assert_awaited_once()
 
 
-@patch("port_ocean.core.probe.context.ProbeContext.update_progress")
-def test_add_scopes_copies_scope_dict(mock_update_progress: MagicMock) -> None:
+@patch("port_ocean.core.probe.context.ProbeContext.update_progress", new_callable=AsyncMock)
+@pytest.mark.asyncio
+async def test_add_scopes_copies_scope_dict(mock_update_progress: AsyncMock) -> None:
     # Arrange
     context = ProbeContext()
     context.available_kinds = ["repository"]
     scope: dict[str, str | int] = {"org": "acme"}
 
     # Act
-    new_checks = context.add_scopes(scope)
+    new_checks = await context.add_scopes(scope)
     scope["org"] = "mutated"
 
     # Assert
     assert new_checks[0].scopes == {"org": "acme"}
 
 
-@patch("port_ocean.core.probe.context.ProbeContext.update_progress")
-def test_add_scopes_returns_only_new_checks(mock_update_progress: MagicMock) -> None:
+@patch("port_ocean.core.probe.context.ProbeContext.update_progress", new_callable=AsyncMock)
+@pytest.mark.asyncio
+async def test_add_scopes_returns_only_new_checks(mock_update_progress: AsyncMock) -> None:
     # Arrange
     context = ProbeContext()
     context.available_kinds = ["repository"]
@@ -85,7 +87,7 @@ def test_add_scopes_returns_only_new_checks(mock_update_progress: MagicMock) -> 
     context.checks.append(existing_check)
 
     # Act
-    new_checks = context.add_scopes({"org": "new"})
+    new_checks = await context.add_scopes({"org": "new"})
 
     # Assert
     assert len(new_checks) == 1
@@ -113,15 +115,15 @@ def test_build_request_body() -> None:
 
     # Assert
     assert body == {
-        "probe_id": "probe-1",
-        "status": ProbeStatus.COMPLETED,
-        "mode": ProbeMode.SHALLOW,
-        "started_at": context.started_at.isoformat(),
-        "ended_at": ended_at.isoformat(),
+        "probeId": "probe-1",
+        "status": "COMPLETED",
+        "probeMode": "shallow",
+        "startedAt": context.started_at.isoformat(),
+        "endedAt": ended_at.isoformat(),
         "message": "probe finished",
         "checks": [
             {
-                "status": ProbeCheckStatus.SUCCESS,
+                "status": "SUCCESS",
                 "message": "ok",
                 "kind": "repository",
                 "scopes": {"org": "acme"},
@@ -138,16 +140,17 @@ def test_build_request_body_when_probe_in_progress() -> None:
     body = context.build_request_body()
 
     # Assert
-    assert body["probe_id"] == "probe-1"
-    assert body["status"] == ProbeStatus.IN_PROGRESS
-    assert body["mode"] == ProbeMode.SHALLOW
-    assert body["ended_at"] is None
+    assert body["probeId"] == "probe-1"
+    assert body["status"] == "IN_PROGRESS"
+    assert body["probeMode"] == "shallow"
+    assert body["endedAt"] is None
     assert body["message"] is None
     assert body["checks"] == []
 
 
 @patch("port_ocean.core.probe.context.get_spec_kinds", return_value=["repository"])
-def test_initialize_sets_config_and_available_kinds(
+@pytest.mark.asyncio
+async def test_initialize_sets_config_and_available_kinds(
     mock_get_spec_kinds: MagicMock,
 ) -> None:
     # Arrange
@@ -156,22 +159,23 @@ def test_initialize_sets_config_and_available_kinds(
     config = ProbeConfig(path=Path("/integration"), kinds=["repository"])
 
     # Act
-    with patch.object(context, "update_progress") as mock_update_progress:
-        context.initialize(config)
+    with patch.object(context, "update_progress", new_callable=AsyncMock) as mock_update_progress:
+        await context.initialize(config)
 
     # Assert
     assert context.config is config
     assert context.available_kinds == ["repository"]
     assert context.status == ProbeStatus.IN_PROGRESS
     mock_get_spec_kinds.assert_called_once_with(Path("/integration"))
-    mock_update_progress.assert_called_once_with()
+    mock_update_progress.assert_awaited_once_with()
 
 
 @patch(
     "port_ocean.core.probe.context.get_spec_kinds",
     return_value=["repository", "pull-request"],
 )
-def test_initialize_deduplicates_injected_kinds(
+@pytest.mark.asyncio
+async def test_initialize_deduplicates_injected_kinds(
     mock_get_spec_kinds: MagicMock,
 ) -> None:
     # Arrange
@@ -182,8 +186,8 @@ def test_initialize_deduplicates_injected_kinds(
     )
 
     # Act
-    with patch.object(context, "update_progress"):
-        context.initialize(config)
+    with patch.object(context, "update_progress", new_callable=AsyncMock):
+        await context.initialize(config)
 
     # Assert
     assert context.available_kinds == ["pull-request", "repository"]
@@ -194,7 +198,8 @@ def test_initialize_deduplicates_injected_kinds(
     "port_ocean.core.probe.context.get_spec_kinds",
     return_value=["repository", "pull-request"],
 )
-def test_initialize_raises_for_invalid_kinds(
+@pytest.mark.asyncio
+async def test_initialize_raises_for_invalid_kinds(
     mock_get_spec_kinds: MagicMock,
 ) -> None:
     # Arrange
@@ -208,13 +213,14 @@ def test_initialize_raises_for_invalid_kinds(
     with pytest.raises(
         InvalidProbeKindsError, match="Invalid probe kinds: \\['fake-kind'\\]"
     ):
-        context.initialize(config)
+        await context.initialize(config)
 
     mock_get_spec_kinds.assert_called_once_with(Path("/integration"))
 
 
 @patch("port_ocean.core.probe.context.get_spec_kinds", return_value=[])
-def test_initialize_uses_default_config_when_none(
+@pytest.mark.asyncio
+async def test_initialize_uses_default_config_when_none(
     mock_get_spec_kinds: MagicMock,
 ) -> None:
     # Arrange
@@ -222,14 +228,14 @@ def test_initialize_uses_default_config_when_none(
     context.status = ProbeStatus.COMPLETED
 
     # Act
-    with patch.object(context, "update_progress") as mock_update_progress:
-        context.initialize()
+    with patch.object(context, "update_progress", new_callable=AsyncMock) as mock_update_progress:
+        await context.initialize()
 
     # Assert
     assert context.config == ProbeConfig()
     assert context.status == ProbeStatus.IN_PROGRESS
     mock_get_spec_kinds.assert_called_once_with(Path("."))
-    mock_update_progress.assert_called_once_with()
+    mock_update_progress.assert_awaited_once_with()
 
 
 @pytest.mark.parametrize(
@@ -240,7 +246,8 @@ def test_initialize_uses_default_config_when_none(
     ],
 )
 @patch("port_ocean.core.probe.context.get_spec_kinds", return_value=[])
-def test_initialize_creates_reporter_for_reporting_mode(
+@pytest.mark.asyncio
+async def test_initialize_creates_reporter_for_reporting_mode(
     mock_get_spec_kinds: MagicMock,
     reporting_mode: ProbeReportingMode,
     expected_reporter_type: type[LogProbeReporter] | type[FileProbeReporter],
@@ -250,8 +257,8 @@ def test_initialize_creates_reporter_for_reporting_mode(
     config = ProbeConfig(reporting_mode=reporting_mode)
 
     # Act
-    with patch.object(context, "update_progress"):
-        context.initialize(config)
+    with patch.object(context, "update_progress", new_callable=AsyncMock):
+        await context.initialize(config)
 
     # Assert
     assert isinstance(context.reporter, expected_reporter_type)
@@ -259,53 +266,57 @@ def test_initialize_creates_reporter_for_reporting_mode(
     mock_get_spec_kinds.assert_called_once_with(Path("."))
 
 
-def test_update_progress_raises_when_reporter_not_initialized() -> None:
+@pytest.mark.asyncio
+async def test_update_progress_raises_when_reporter_not_initialized() -> None:
     # Act / Assert
     with pytest.raises(ProbeNotInitializedError, match="Reporter is not initialized"):
-        ProbeContext().update_progress()
+        await ProbeContext().update_progress()
 
 
-def test_update_progress_reports_merged_payload() -> None:
+@pytest.mark.asyncio
+async def test_update_progress_reports_merged_payload() -> None:
     # Arrange
     context = ProbeContext(probe_id="probe-123")
-    context.reporter = MagicMock()
+    context.reporter = AsyncMock()
 
     # Act
-    context.update_progress()
+    await context.update_progress()
 
     # Assert
-    context.reporter.report.assert_called_once_with(context.build_request_body())
+    context.reporter.report.assert_awaited_once_with(context.build_request_body())
 
 
-def test_finalize() -> None:
+@pytest.mark.asyncio
+async def test_finalize() -> None:
     # Arrange
     context = ProbeContext(probe_id="probe-1")
     started_before = datetime.now(timezone.utc)
 
     # Act
-    with patch.object(context, "update_progress") as mock_update_progress:
-        context.finalize()
+    with patch.object(context, "update_progress", new_callable=AsyncMock) as mock_update_progress:
+        await context.finalize()
 
     # Assert
     assert context.ended_at is not None
     assert context.ended_at >= started_before
     assert context.status == ProbeStatus.COMPLETED
-    mock_update_progress.assert_called_once_with()
+    mock_update_progress.assert_awaited_once_with()
 
 
-def test_fail() -> None:
+@pytest.mark.asyncio
+async def test_fail() -> None:
     # Arrange
     context = ProbeContext(probe_id="probe-1")
     started_before = datetime.now(timezone.utc)
     failure_message = "connection timed out"
 
     # Act
-    with patch.object(context, "update_progress") as mock_update_progress:
-        context.fail(failure_message)
+    with patch.object(context, "update_progress", new_callable=AsyncMock) as mock_update_progress:
+        await context.fail(failure_message)
 
     # Assert
     assert context.ended_at is not None
     assert context.ended_at >= started_before
     assert context.status == ProbeStatus.FAILED
     assert context.message == failure_message
-    mock_update_progress.assert_called_once_with()
+    mock_update_progress.assert_awaited_once_with()

--- a/port_ocean/tests/core/probe/test_context.py
+++ b/port_ocean/tests/core/probe/test_context.py
@@ -143,8 +143,8 @@ def test_build_request_body_when_probe_in_progress() -> None:
     assert body["probeId"] == "probe-1"
     assert body["status"] == "IN_PROGRESS"
     assert body["probeMode"] == "shallow"
-    assert body["endedAt"] is None
-    assert body["message"] is None
+    assert "endedAt" not in body
+    assert "message" not in body
     assert body["checks"] == []
 
 

--- a/port_ocean/tests/core/probe/test_file_reporter.py
+++ b/port_ocean/tests/core/probe/test_file_reporter.py
@@ -5,6 +5,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from port_ocean.core.probe.config import ProbeConfig
 from port_ocean.core.probe.models import ProbeReportingMode
 from port_ocean.core.probe.reporters.file import (
@@ -13,7 +15,8 @@ from port_ocean.core.probe.reporters.file import (
 )
 
 
-def test_file_probe_reporter_writes_report_to_configured_path(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_file_probe_reporter_writes_report_to_configured_path(tmp_path: Path) -> None:
     # Arrange
     report = {
         "probe_id": "probe-1",
@@ -27,7 +30,7 @@ def test_file_probe_reporter_writes_report_to_configured_path(tmp_path: Path) ->
         wraps=datetime,
     ) as mock_datetime:
         mock_datetime.now.return_value = fixed_time
-        FileProbeReporter(
+        await FileProbeReporter(
             ProbeConfig(path=tmp_path, reporting_mode=ProbeReportingMode.FILE)
         ).report(report)
 
@@ -39,7 +42,8 @@ def test_file_probe_reporter_writes_report_to_configured_path(tmp_path: Path) ->
     assert json.loads(report_path.read_text(encoding="utf-8")) == report
 
 
-def test_file_probe_reporter_creates_reports_directory(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_file_probe_reporter_creates_reports_directory(tmp_path: Path) -> None:
     # Arrange
     reporter = FileProbeReporter(
         ProbeConfig(path=tmp_path, reporting_mode=ProbeReportingMode.FILE)
@@ -47,7 +51,7 @@ def test_file_probe_reporter_creates_reports_directory(tmp_path: Path) -> None:
     reports_directory = tmp_path / PROBE_REPORTS_DIRECTORY
 
     # Act
-    reporter.report({"stage": "some_value"})
+    await reporter.report({"stage": "some_value"})
 
     # Assert
     assert reports_directory.is_dir()

--- a/port_ocean/tests/core/probe/test_log_reporter.py
+++ b/port_ocean/tests/core/probe/test_log_reporter.py
@@ -2,12 +2,15 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from port_ocean.core.probe.config import ProbeConfig
 from port_ocean.core.probe.reporters.log import LogProbeReporter
 
 
 @patch("port_ocean.core.probe.reporters.log.logger")
-def test_log_probe_reporter_logs_report(mock_logger: MagicMock) -> None:
+@pytest.mark.asyncio
+async def test_log_probe_reporter_logs_report(mock_logger: MagicMock) -> None:
     # Arrange
     reporter = LogProbeReporter(ProbeConfig())
     report = {
@@ -16,7 +19,7 @@ def test_log_probe_reporter_logs_report(mock_logger: MagicMock) -> None:
     }
 
     # Act
-    reporter.report(report)
+    await reporter.report(report)
 
     # Assert
     mock_logger.info.assert_called_once_with("Probe status report", probe_report=report)

--- a/port_ocean/tests/core/probe/test_port_reporter.py
+++ b/port_ocean/tests/core/probe/test_port_reporter.py
@@ -40,8 +40,6 @@ async def test_port_probe_reporter_patches_health_result(mock_ocean: MagicMock) 
             "status": "IN_PROGRESS",
             "probeMode": "shallow",
             "startedAt": context.started_at.isoformat(),
-            "endedAt": None,
-            "message": None,
             "checks": [
                 {
                     "kind": "repository",

--- a/port_ocean/tests/core/probe/test_port_reporter.py
+++ b/port_ocean/tests/core/probe/test_port_reporter.py
@@ -1,0 +1,67 @@
+"""Unit tests for the Port probe reporter."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from port_ocean.core.probe.config import ProbeConfig
+from port_ocean.core.probe.context import ProbeContext
+from port_ocean.core.probe.models import ProbeCheck, ProbeCheckStatus
+from port_ocean.core.probe.reporters.port import PortProbeReporter
+from port_ocean.exceptions.probe import ProbeNotInitializedError
+
+
+@pytest.mark.asyncio
+@patch("port_ocean.context.ocean.ocean")
+async def test_port_probe_reporter_patches_health_result(mock_ocean: MagicMock) -> None:
+    # Arrange
+    mock_ocean.port_client.get_org_id = AsyncMock(return_value="org_123")
+    mock_ocean.port_client.patch_probe_health_result = AsyncMock()
+    reporter = PortProbeReporter(ProbeConfig())
+    context = ProbeContext(probe_id="0191a2b3-c4d5-7000-8000-000000000001")
+    context.checks = [
+        ProbeCheck(
+            kind="repository",
+            scopes={"accountId": 123},
+            status=ProbeCheckStatus.SUCCESS,
+            message="All good",
+        )
+    ]
+
+    # Act
+    await reporter.report(context.build_request_body())
+
+    # Assert
+    mock_ocean.port_client.get_org_id.assert_awaited_once()
+    mock_ocean.port_client.patch_probe_health_result.assert_awaited_once_with(
+        "org_123",
+        "0191a2b3-c4d5-7000-8000-000000000001",
+        {
+            "status": "IN_PROGRESS",
+            "probeMode": "shallow",
+            "startedAt": context.started_at.isoformat(),
+            "endedAt": None,
+            "message": None,
+            "checks": [
+                {
+                    "kind": "repository",
+                    "scopes": {"accountId": "123"},
+                    "status": "SUCCESS",
+                    "message": "All good",
+                }
+            ],
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_port_probe_reporter_requires_probe_id() -> None:
+    # Arrange
+    reporter = PortProbeReporter(ProbeConfig())
+
+    # Act / Assert
+    with pytest.raises(
+        ProbeNotInitializedError,
+        match="probe_id is required when using Port probe reporting mode",
+    ):
+        await reporter.report(ProbeContext().build_request_body())

--- a/port_ocean/tests/core/probe/test_serialization.py
+++ b/port_ocean/tests/core/probe/test_serialization.py
@@ -23,6 +23,19 @@ def test_serialize_probe_check_serializes_enums() -> None:
     }
 
 
+def test_serialize_probe_value_omits_none_fields() -> None:
+    assert serialize_probe_value(
+        {
+            "message": None,
+            "status": "IN_PROGRESS",
+            "checks": [{"kind": "repository", "message": None, "status": "SUCCESS"}],
+        }
+    ) == {
+        "status": "IN_PROGRESS",
+        "checks": [{"kind": "repository", "status": "SUCCESS"}],
+    }
+
+
 def test_serialize_probe_value_serializes_datetimes() -> None:
     # Arrange
     timestamp = datetime(2026, 8, 30, 12, 0, 0, tzinfo=timezone.utc)
@@ -39,6 +52,5 @@ def test_serialize_probe_value_serializes_datetimes() -> None:
     # Assert
     assert serialized == {
         "startedAt": "2026-08-30T12:00:00+00:00",
-        "endedAt": None,
         "checks": [],
     }

--- a/port_ocean/tests/core/probe/test_serialization.py
+++ b/port_ocean/tests/core/probe/test_serialization.py
@@ -1,0 +1,44 @@
+"""Unit tests for probe serialization."""
+
+from dataclasses import asdict
+from datetime import datetime, timezone
+
+from port_ocean.core.probe.models import ProbeCheck, ProbeCheckStatus
+from port_ocean.core.probe.serialization import serialize_probe_value
+
+
+def test_serialize_probe_check_serializes_enums() -> None:
+    check = ProbeCheck(
+        kind="repository",
+        scopes={"org": "acme", "repo_id": 42},
+        status=ProbeCheckStatus.SUCCESS,
+        message="ok",
+    )
+
+    assert serialize_probe_value(asdict(check)) == {
+        "kind": "repository",
+        "scopes": {"org": "acme", "repo_id": 42},
+        "status": "SUCCESS",
+        "message": "ok",
+    }
+
+
+def test_serialize_probe_value_serializes_datetimes() -> None:
+    # Arrange
+    timestamp = datetime(2026, 8, 30, 12, 0, 0, tzinfo=timezone.utc)
+
+    # Act
+    serialized = serialize_probe_value(
+        {
+            "startedAt": timestamp,
+            "endedAt": None,
+            "checks": [],
+        }
+    )
+
+    # Assert
+    assert serialized == {
+        "startedAt": "2026-08-30T12:00:00+00:00",
+        "endedAt": None,
+        "checks": [],
+    }


### PR DESCRIPTION
# Description

What -

Why -

How -

## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Probe payloads and reporting are now async with a new live Port API contract; custom `on_probe` code must await context methods, and incorrect payloads could fail health updates in production.
> 
> **Overview**
> Aligns integration **test connection** (probe) reporting with the Port monorepo API by making probe progress reporting **async** and pushing live updates when using Port reporting mode.
> 
> **Probe context and reporters** — `initialize`, `add_scopes`, `update_progress`, `finalize`, and `fail` on `ProbeContext` are now async, and all `ProbeReporter.report` implementations follow suit. Request bodies use **camelCase** fields (`probeId`, `probeMode`, `startedAt`, `endedAt`) with enums serialized to string values, `None` fields omitted, and check scope values coerced to strings via new `serialize_probe_value`.
> 
> **Port backend** — Adds `PortClient.patch_probe_health_result` (`PATCH /org/{org_id}/probe/{probe_id}`). `PortProbeReporter` replaces the previous no-op with that call (resolves org id once, requires `probe_id`).
> 
> **Integrations** — GitHub and Jira permission probes await the updated probe context APIs. `BaseIntegration.run_probe` awaits the async lifecycle methods.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29f59f56be77913ce6b1e601f69036a7940e94e1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->