### PR TITLE
[Core] Task tk17r6/b6 incremental result reporting from entrypoint

### DIFF
--- a/.ocean-release/core/probe-port-reporting.yaml
+++ b/.ocean-release/core/probe-port-reporting.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: feature
+changelog: Add async Port probe reporter that sends incremental probe health results to Port during probe runs

--- a/port_ocean/clients/port/client.py
+++ b/port_ocean/clients/port/client.py
@@ -95,6 +95,24 @@ class PortClient(
 
         return response.json()["organization"]["id"]
 
+    async def patch_probe_health_result(
+        self, org_id: str, probe_id: str, body: dict[str, Any]
+    ) -> None:
+        logger.debug(
+            "Patching probe health result",
+            org_id=org_id,
+            probe_id=probe_id,
+            status=body.get("status"),
+        )
+        response = await self.client.patch(
+            f"{self.api_url}/org/{org_id}/probe/{probe_id}",
+            headers=await self.auth.headers(),
+            json=body,
+        )
+        handle_port_status_code(response)
+        if response.is_success:
+            logger.info("Probe health result updated successfully", probe_id=probe_id)
+
     async def update_integration_state(
         self, state: dict[str, Any], should_raise: bool = True, should_log: bool = True
     ) -> dict[str, Any]:

--- a/port_ocean/clients/port/client.py
+++ b/port_ocean/clients/port/client.py
@@ -109,9 +109,11 @@ class PortClient(
             headers=await self.auth.headers(),
             json=body,
         )
-        handle_port_status_code(response)
+
         if response.is_success:
             logger.info("Probe health result updated successfully", probe_id=probe_id)
+        else:
+            logger.warning("Probe health result update failed", probe_id=probe_id)
 
     async def update_integration_state(
         self, state: dict[str, Any], should_raise: bool = True, should_log: bool = True

--- a/port_ocean/core/integrations/base.py
+++ b/port_ocean/core/integrations/base.py
@@ -112,22 +112,22 @@ class BaseIntegration(SyncRawMixin, SyncMixin):
             error = ModeNotSupportedException(
                 self.context.config.integration.type, "probe"
             )
-            context.fail(str(error))
+            await context.fail(str(error))
             raise error
 
         async with event_context(
             EventType.ON_PROBE,
             trigger_type="machine",
         ):
-            context.initialize(config)
+            await context.initialize(config)
             try:
                 returned = await listener(context)
             except Exception as error:
-                context.fail(str(error))
+                await context.fail(str(error))
                 raise
 
             final_context = returned or context
             if final_context.status is ProbeStatus.FAILED:
                 raise ProbeFailedError(final_context.message or "Probe failed")
-            final_context.finalize()
+            await final_context.finalize()
             return final_context

--- a/port_ocean/core/probe/context.py
+++ b/port_ocean/core/probe/context.py
@@ -40,7 +40,7 @@ class ProbeContext:
         data = {
             "probeId": self.probe_id,
             "status": self.status,
-            "mode": self.config.mode,
+            "probeMode": self.config.mode,
             "startedAt": self.started_at.isoformat(),
             "checks": [
                 {

--- a/port_ocean/core/probe/context.py
+++ b/port_ocean/core/probe/context.py
@@ -42,15 +42,7 @@ class ProbeContext:
             "status": self.status,
             "probeMode": self.config.mode,
             "startedAt": self.started_at.isoformat(),
-            "checks": [
-                {
-                    "status": check.status,
-                    "message": check.message,
-                    "kind": check.kind,
-                    "scopes": check.scopes,
-                }
-                for check in self.checks
-            ],
+            "checks": [check.serialize() for check in self.checks],
         }
 
         if self.ended_at:

--- a/port_ocean/core/probe/context.py
+++ b/port_ocean/core/probe/context.py
@@ -24,7 +24,7 @@ class ProbeContext:
     checks: list[ProbeCheck] = field(default_factory=list)
     reporter: ProbeReporter | None = None
 
-    def add_scopes(self, *scopes: dict[str, str | int]) -> list[ProbeCheck]:
+    async def add_scopes(self, *scopes: dict[str, str | int]) -> list[ProbeCheck]:
         logger.debug("Registering additional scopes", scopes=scopes)
         new_checks: list[ProbeCheck] = []
         for scope in scopes:
@@ -33,7 +33,7 @@ class ProbeContext:
                 new_checks.append(check)
                 self.checks.append(check)
 
-        self.update_progress()
+        await self.update_progress()
         return new_checks
 
     def build_request_body(self) -> dict[str, Any]:
@@ -55,7 +55,7 @@ class ProbeContext:
             ],
         }
 
-    def initialize(self, config: ProbeConfig | None = None) -> None:
+    async def initialize(self, config: ProbeConfig | None = None) -> None:
         self.config = config or ProbeConfig()
         if self.config.kinds is not None:
             configured_kinds_set = set(self.config.kinds)
@@ -72,21 +72,21 @@ class ProbeContext:
 
         self.reporter = REPORTER_MODES[self.config.reporting_mode](self.config)
         self.status = ProbeStatus.IN_PROGRESS
-        self.update_progress()
+        await self.update_progress()
 
-    def update_progress(self) -> None:
+    async def update_progress(self) -> None:
         if not self.reporter:
             raise ProbeNotInitializedError("Reporter is not initialized")
 
-        self.reporter.report(self.build_request_body())
+        await self.reporter.report(self.build_request_body())
 
-    def finalize(self) -> None:
+    async def finalize(self) -> None:
         self.ended_at = datetime.now(timezone.utc)
         self.status = ProbeStatus.COMPLETED
-        self.update_progress()
+        await self.update_progress()
 
-    def fail(self, message: str) -> None:
+    async def fail(self, message: str) -> None:
         self.ended_at = datetime.now(timezone.utc)
         self.status = ProbeStatus.FAILED
         self.message = message
-        self.update_progress()
+        await self.update_progress()

--- a/port_ocean/core/probe/context.py
+++ b/port_ocean/core/probe/context.py
@@ -37,13 +37,11 @@ class ProbeContext:
         return new_checks
 
     def build_request_body(self) -> dict[str, Any]:
-        return {
-            "probe_id": self.probe_id,
+        data = {
+            "probeId": self.probe_id,
             "status": self.status,
             "mode": self.config.mode,
-            "started_at": self.started_at.isoformat(),
-            "ended_at": self.ended_at.isoformat() if self.ended_at else None,
-            "message": self.message,
+            "startedAt": self.started_at.isoformat(),
             "checks": [
                 {
                     "status": check.status,
@@ -54,6 +52,13 @@ class ProbeContext:
                 for check in self.checks
             ],
         }
+
+        if self.ended_at:
+            data["endedAt"] = self.ended_at.isoformat()
+        if self.message:
+            data["message"] = self.message
+
+        return data
 
     async def initialize(self, config: ProbeConfig | None = None) -> None:
         self.config = config or ProbeConfig()

--- a/port_ocean/core/probe/models.py
+++ b/port_ocean/core/probe/models.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from enum import StrEnum
+from typing import Any
 
 
 class ProbeMode(StrEnum):
@@ -34,8 +35,8 @@ class ProbeCheck:
     status: ProbeCheckStatus = ProbeCheckStatus.PENDING
     message: str | None = None
 
-    def serialize(self) -> dict[str, str | dict]:
-        data = {
+    def serialize(self) -> dict[str, Any]:
+        data: dict[str, Any] = {
             "kind": self.kind,
             "scopes": self.scopes,
             "status": self.status,

--- a/port_ocean/core/probe/models.py
+++ b/port_ocean/core/probe/models.py
@@ -33,3 +33,15 @@ class ProbeCheck:
     scopes: dict[str, str | int] = field(default_factory=dict)
     status: ProbeCheckStatus = ProbeCheckStatus.PENDING
     message: str | None = None
+
+    def serialize(self) -> dict[str, str | dict]:
+        data = {
+            "kind": self.kind,
+            "scopes": self.scopes,
+            "status": self.status,
+        }
+
+        if self.message:
+            data["message"] = self.message
+
+        return data

--- a/port_ocean/core/probe/reporters/base.py
+++ b/port_ocean/core/probe/reporters/base.py
@@ -12,5 +12,5 @@ class ProbeReporter(ABC):
         self.config = config
 
     @abstractmethod
-    def report(self, report: dict[str, Any]) -> None:
+    async def report(self, report: dict[str, Any]) -> None:
         """Publish one probe status report."""

--- a/port_ocean/core/probe/reporters/file.py
+++ b/port_ocean/core/probe/reporters/file.py
@@ -16,7 +16,7 @@ class FileProbeReporter(ProbeReporter):
         super().__init__(config)
         self.timestamp: str = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S_%fZ")
 
-    def report(self, report: dict[str, Any]) -> None:
+    async def report(self, report: dict[str, Any]) -> None:
         reports_directory = self.config.path / PROBE_REPORTS_DIRECTORY
         reports_directory.mkdir(parents=True, exist_ok=True)
         report_path = reports_directory / f"probe_report_{self.timestamp}.json"

--- a/port_ocean/core/probe/reporters/log.py
+++ b/port_ocean/core/probe/reporters/log.py
@@ -9,5 +9,5 @@ from port_ocean.core.probe.reporters.base import ProbeReporter
 class LogProbeReporter(ProbeReporter):
     mode: ClassVar[ProbeReportingMode] = ProbeReportingMode.LOG
 
-    def report(self, report: dict[str, Any]) -> None:
+    async def report(self, report: dict[str, Any]) -> None:
         logger.info("Probe status report", probe_report=report)

--- a/port_ocean/core/probe/reporters/port.py
+++ b/port_ocean/core/probe/reporters/port.py
@@ -1,17 +1,25 @@
 from typing import Any, ClassVar
 
-from loguru import logger
-
 from port_ocean.core.probe.models import ProbeReportingMode
 from port_ocean.core.probe.reporters.base import ProbeReporter
+from port_ocean.exceptions.probe import ProbeNotInitializedError
 
 
 class PortProbeReporter(ProbeReporter):
     mode: ClassVar[ProbeReportingMode] = ProbeReportingMode.PORT
+    _org_id: str | None = None
 
     async def report(self, report: dict[str, Any]) -> None:
-        """Placeholder for sending a probe status report to Port."""
-        logger.debug(
-            "Port probe reporting is not implemented yet",
-            probe_report=report,
-        )
+        from port_ocean.context.ocean import ocean
+
+        body = report.copy()
+        probe_id = body.pop("probe_id", None)
+        if not probe_id:
+            raise ProbeNotInitializedError(
+                "probe_id is required when using Port probe reporting mode"
+            )
+
+        if self._org_id is None:
+            self._org_id = await ocean.port_client.get_org_id()
+
+        await ocean.port_client.patch_probe_health_result(self._org_id, probe_id, body)

--- a/port_ocean/core/probe/reporters/port.py
+++ b/port_ocean/core/probe/reporters/port.py
@@ -13,7 +13,7 @@ class PortProbeReporter(ProbeReporter):
         from port_ocean.context.ocean import ocean
 
         body = report.copy()
-        probe_id = body.pop("probe_id", None)
+        probe_id = body.pop("probeId", None)
         if not probe_id:
             raise ProbeNotInitializedError(
                 "probe_id is required when using Port probe reporting mode"

--- a/port_ocean/core/probe/reporters/port.py
+++ b/port_ocean/core/probe/reporters/port.py
@@ -9,7 +9,7 @@ from port_ocean.core.probe.reporters.base import ProbeReporter
 class PortProbeReporter(ProbeReporter):
     mode: ClassVar[ProbeReportingMode] = ProbeReportingMode.PORT
 
-    def report(self, report: dict[str, Any]) -> None:
+    async def report(self, report: dict[str, Any]) -> None:
         """Placeholder for sending a probe status report to Port."""
         logger.debug(
             "Port probe reporting is not implemented yet",

--- a/port_ocean/tests/clients/port/test_port_client.py
+++ b/port_ocean/tests/clients/port/test_port_client.py
@@ -1,0 +1,78 @@
+"""Unit tests for PortClient."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from port_ocean.clients.port.client import PortClient
+
+TEST_BASE_URL = "https://api.example.com"
+TEST_API_URL = f"{TEST_BASE_URL}/v1"
+
+
+@pytest.fixture
+def port_client() -> PortClient:
+    auth = MagicMock()
+    auth.headers = AsyncMock(return_value={"Authorization": "Bearer test-token"})
+
+    http_client = MagicMock()
+    http_client.get = AsyncMock()
+    http_client.patch = AsyncMock()
+
+    client = PortClient(
+        base_url=TEST_BASE_URL,
+        client_id="client-id",
+        client_secret="client-secret",
+        integration_identifier="my-integration",
+        integration_type="github",
+        integration_version="1.0.0",
+    )
+    client.auth = auth
+    client.client = http_client
+    return client
+
+
+@pytest.mark.asyncio
+async def test_get_org_id_returns_organization_id(port_client: PortClient) -> None:
+    # Arrange
+    response = MagicMock()
+    response.is_error = False
+    response.json.return_value = {"organization": {"id": "org-123"}}
+    port_client.client.get.return_value = response
+
+    # Act
+    with patch("port_ocean.clients.port.client.handle_port_status_code"):
+        org_id = await port_client.get_org_id()
+
+    # Assert
+    assert org_id == "org-123"
+    port_client.client.get.assert_called_once_with(
+        f"{TEST_API_URL}/organization",
+        headers={"Authorization": "Bearer test-token"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_patch_probe_health_result_sends_patch_request(
+    port_client: PortClient,
+) -> None:
+    # Arrange
+    response = MagicMock()
+    response.is_success = True
+    port_client.client.patch.return_value = response
+    body: dict[str, Any] = {
+        "status": "IN_PROGRESS",
+        "checks": [],
+    }
+
+    # Act
+    with patch("port_ocean.clients.port.client.handle_port_status_code"):
+        await port_client.patch_probe_health_result("org-123", "probe-1", body)
+
+    # Assert
+    port_client.client.patch.assert_called_once_with(
+        f"{TEST_API_URL}/org/org-123/probe/probe-1",
+        headers={"Authorization": "Bearer test-token"},
+        json=body,
+    )

--- a/port_ocean/tests/clients/port/test_port_client.py
+++ b/port_ocean/tests/clients/port/test_port_client.py
@@ -39,7 +39,8 @@ async def test_get_org_id_returns_organization_id(port_client: PortClient) -> No
     response = MagicMock()
     response.is_error = False
     response.json.return_value = {"organization": {"id": "org-123"}}
-    port_client.client.get.return_value = response
+    get_mock = AsyncMock(return_value=response)
+    port_client.client.get = get_mock  # type: ignore[method-assign]
 
     # Act
     with patch("port_ocean.clients.port.client.handle_port_status_code"):
@@ -47,7 +48,7 @@ async def test_get_org_id_returns_organization_id(port_client: PortClient) -> No
 
     # Assert
     assert org_id == "org-123"
-    port_client.client.get.assert_called_once_with(
+    get_mock.assert_called_once_with(
         f"{TEST_API_URL}/organization",
         headers={"Authorization": "Bearer test-token"},
     )
@@ -60,7 +61,8 @@ async def test_patch_probe_health_result_sends_patch_request(
     # Arrange
     response = MagicMock()
     response.is_success = True
-    port_client.client.patch.return_value = response
+    patch_mock = AsyncMock(return_value=response)
+    port_client.client.patch = patch_mock  # type: ignore[method-assign]
     body: dict[str, Any] = {
         "status": "IN_PROGRESS",
         "checks": [],
@@ -71,7 +73,7 @@ async def test_patch_probe_health_result_sends_patch_request(
         await port_client.patch_probe_health_result("org-123", "probe-1", body)
 
     # Assert
-    port_client.client.patch.assert_called_once_with(
+    patch_mock.assert_called_once_with(
         f"{TEST_API_URL}/org/org-123/probe/probe-1",
         headers={"Authorization": "Bearer test-token"},
         json=body,

--- a/port_ocean/tests/core/integrations/test_run_probe.py
+++ b/port_ocean/tests/core/integrations/test_run_probe.py
@@ -96,7 +96,7 @@ async def test_run_probe_raises_when_context_is_failed(
 
     async def on_probe(context: ProbeContext) -> ProbeContext:
         captured_context.append(context)
-        context.fail(message)
+        await context.fail(message)
         return context
 
     integration.event_strategy.on_probe = on_probe

--- a/port_ocean/tests/core/probe/test_context.py
+++ b/port_ocean/tests/core/probe/test_context.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timezone
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -40,7 +40,8 @@ def test_starts_with_empty_state() -> None:
 
 
 @patch("port_ocean.core.probe.context.ProbeContext.update_progress")
-def test_add_scopes_creates_check_per_kind_and_scope(
+@pytest.mark.asyncio
+async def test_add_scopes_creates_check_per_kind_and_scope(
     mock_update_progress: MagicMock,
 ) -> None:
     # Arrange
@@ -48,7 +49,7 @@ def test_add_scopes_creates_check_per_kind_and_scope(
     context.available_kinds = ["repository", "pull-request"]
 
     # Act
-    new_checks = context.add_scopes({"org": "acme"}, {"org": "other"})
+    new_checks = await context.add_scopes({"org": "acme"}, {"org": "other"})
 
     # Assert
     assert len(new_checks) == 4
@@ -62,14 +63,15 @@ def test_add_scopes_creates_check_per_kind_and_scope(
 
 
 @patch("port_ocean.core.probe.context.ProbeContext.update_progress")
-def test_add_scopes_copies_scope_dict(mock_update_progress: MagicMock) -> None:
+@pytest.mark.asyncio
+async def test_add_scopes_copies_scope_dict(mock_update_progress: MagicMock) -> None:
     # Arrange
     context = ProbeContext()
     context.available_kinds = ["repository"]
     scope: dict[str, str | int] = {"org": "acme"}
 
     # Act
-    new_checks = context.add_scopes(scope)
+    new_checks = await context.add_scopes(scope)
     scope["org"] = "mutated"
 
     # Assert
@@ -77,7 +79,10 @@ def test_add_scopes_copies_scope_dict(mock_update_progress: MagicMock) -> None:
 
 
 @patch("port_ocean.core.probe.context.ProbeContext.update_progress")
-def test_add_scopes_returns_only_new_checks(mock_update_progress: MagicMock) -> None:
+@pytest.mark.asyncio
+async def test_add_scopes_returns_only_new_checks(
+    mock_update_progress: MagicMock,
+) -> None:
     # Arrange
     context = ProbeContext()
     context.available_kinds = ["repository"]
@@ -85,7 +90,7 @@ def test_add_scopes_returns_only_new_checks(mock_update_progress: MagicMock) -> 
     context.checks.append(existing_check)
 
     # Act
-    new_checks = context.add_scopes({"org": "new"})
+    new_checks = await context.add_scopes({"org": "new"})
 
     # Assert
     assert len(new_checks) == 1
@@ -147,7 +152,8 @@ def test_build_request_body_when_probe_in_progress() -> None:
 
 
 @patch("port_ocean.core.probe.context.get_spec_kinds", return_value=["repository"])
-def test_initialize_sets_config_and_available_kinds(
+@pytest.mark.asyncio
+async def test_initialize_sets_config_and_available_kinds(
     mock_get_spec_kinds: MagicMock,
 ) -> None:
     # Arrange
@@ -157,7 +163,7 @@ def test_initialize_sets_config_and_available_kinds(
 
     # Act
     with patch.object(context, "update_progress") as mock_update_progress:
-        context.initialize(config)
+        await context.initialize(config)
 
     # Assert
     assert context.config is config
@@ -171,7 +177,8 @@ def test_initialize_sets_config_and_available_kinds(
     "port_ocean.core.probe.context.get_spec_kinds",
     return_value=["repository", "pull-request"],
 )
-def test_initialize_deduplicates_injected_kinds(
+@pytest.mark.asyncio
+async def test_initialize_deduplicates_injected_kinds(
     mock_get_spec_kinds: MagicMock,
 ) -> None:
     # Arrange
@@ -183,7 +190,7 @@ def test_initialize_deduplicates_injected_kinds(
 
     # Act
     with patch.object(context, "update_progress"):
-        context.initialize(config)
+        await context.initialize(config)
 
     # Assert
     assert context.available_kinds == ["pull-request", "repository"]
@@ -194,7 +201,8 @@ def test_initialize_deduplicates_injected_kinds(
     "port_ocean.core.probe.context.get_spec_kinds",
     return_value=["repository", "pull-request"],
 )
-def test_initialize_raises_for_invalid_kinds(
+@pytest.mark.asyncio
+async def test_initialize_raises_for_invalid_kinds(
     mock_get_spec_kinds: MagicMock,
 ) -> None:
     # Arrange
@@ -208,13 +216,14 @@ def test_initialize_raises_for_invalid_kinds(
     with pytest.raises(
         InvalidProbeKindsError, match="Invalid probe kinds: \\['fake-kind'\\]"
     ):
-        context.initialize(config)
+        await context.initialize(config)
 
     mock_get_spec_kinds.assert_called_once_with(Path("/integration"))
 
 
 @patch("port_ocean.core.probe.context.get_spec_kinds", return_value=[])
-def test_initialize_uses_default_config_when_none(
+@pytest.mark.asyncio
+async def test_initialize_uses_default_config_when_none(
     mock_get_spec_kinds: MagicMock,
 ) -> None:
     # Arrange
@@ -223,7 +232,7 @@ def test_initialize_uses_default_config_when_none(
 
     # Act
     with patch.object(context, "update_progress") as mock_update_progress:
-        context.initialize()
+        await context.initialize()
 
     # Assert
     assert context.config == ProbeConfig()
@@ -240,7 +249,8 @@ def test_initialize_uses_default_config_when_none(
     ],
 )
 @patch("port_ocean.core.probe.context.get_spec_kinds", return_value=[])
-def test_initialize_creates_reporter_for_reporting_mode(
+@pytest.mark.asyncio
+async def test_initialize_creates_reporter_for_reporting_mode(
     mock_get_spec_kinds: MagicMock,
     reporting_mode: ProbeReportingMode,
     expected_reporter_type: type[LogProbeReporter] | type[FileProbeReporter],
@@ -251,7 +261,7 @@ def test_initialize_creates_reporter_for_reporting_mode(
 
     # Act
     with patch.object(context, "update_progress"):
-        context.initialize(config)
+        await context.initialize(config)
 
     # Assert
     assert isinstance(context.reporter, expected_reporter_type)
@@ -259,32 +269,36 @@ def test_initialize_creates_reporter_for_reporting_mode(
     mock_get_spec_kinds.assert_called_once_with(Path("."))
 
 
-def test_update_progress_raises_when_reporter_not_initialized() -> None:
+@pytest.mark.asyncio
+async def test_update_progress_raises_when_reporter_not_initialized() -> None:
     # Act / Assert
     with pytest.raises(ProbeNotInitializedError, match="Reporter is not initialized"):
-        ProbeContext().update_progress()
+        await ProbeContext().update_progress()
 
 
-def test_update_progress_reports_merged_payload() -> None:
+@pytest.mark.asyncio
+async def test_update_progress_reports_merged_payload() -> None:
     # Arrange
     context = ProbeContext(probe_id="probe-123")
     context.reporter = MagicMock()
+    context.reporter.report = AsyncMock()
 
     # Act
-    context.update_progress()
+    await context.update_progress()
 
     # Assert
     context.reporter.report.assert_called_once_with(context.build_request_body())
 
 
-def test_finalize() -> None:
+@pytest.mark.asyncio
+async def test_finalize() -> None:
     # Arrange
     context = ProbeContext(probe_id="probe-1")
     started_before = datetime.now(timezone.utc)
 
     # Act
     with patch.object(context, "update_progress") as mock_update_progress:
-        context.finalize()
+        await context.finalize()
 
     # Assert
     assert context.ended_at is not None
@@ -293,7 +307,8 @@ def test_finalize() -> None:
     mock_update_progress.assert_called_once_with()
 
 
-def test_fail() -> None:
+@pytest.mark.asyncio
+async def test_fail() -> None:
     # Arrange
     context = ProbeContext(probe_id="probe-1")
     started_before = datetime.now(timezone.utc)
@@ -301,7 +316,7 @@ def test_fail() -> None:
 
     # Act
     with patch.object(context, "update_progress") as mock_update_progress:
-        context.fail(failure_message)
+        await context.fail(failure_message)
 
     # Assert
     assert context.ended_at is not None

--- a/port_ocean/tests/core/probe/test_context.py
+++ b/port_ocean/tests/core/probe/test_context.py
@@ -118,11 +118,11 @@ def test_build_request_body() -> None:
 
     # Assert
     assert body == {
-        "probe_id": "probe-1",
+        "probeId": "probe-1",
         "status": ProbeStatus.COMPLETED,
         "mode": ProbeMode.SHALLOW,
-        "started_at": context.started_at.isoformat(),
-        "ended_at": ended_at.isoformat(),
+        "startedAt": context.started_at.isoformat(),
+        "endedAt": ended_at.isoformat(),
         "message": "probe finished",
         "checks": [
             {
@@ -143,11 +143,11 @@ def test_build_request_body_when_probe_in_progress() -> None:
     body = context.build_request_body()
 
     # Assert
-    assert body["probe_id"] == "probe-1"
+    assert body["probeId"] == "probe-1"
     assert body["status"] == ProbeStatus.IN_PROGRESS
     assert body["mode"] == ProbeMode.SHALLOW
-    assert body["ended_at"] is None
-    assert body["message"] is None
+    assert "endedAt" not in body
+    assert "message" not in body
     assert body["checks"] == []
 
 

--- a/port_ocean/tests/core/probe/test_context.py
+++ b/port_ocean/tests/core/probe/test_context.py
@@ -120,16 +120,16 @@ def test_build_request_body() -> None:
     assert body == {
         "probeId": "probe-1",
         "status": ProbeStatus.COMPLETED,
-        "mode": ProbeMode.SHALLOW,
+        "probeMode": ProbeMode.SHALLOW,
         "startedAt": context.started_at.isoformat(),
         "endedAt": ended_at.isoformat(),
         "message": "probe finished",
         "checks": [
             {
-                "status": ProbeCheckStatus.SUCCESS,
-                "message": "ok",
                 "kind": "repository",
                 "scopes": {"org": "acme"},
+                "status": ProbeCheckStatus.SUCCESS,
+                "message": "ok",
             }
         ],
     }
@@ -145,7 +145,7 @@ def test_build_request_body_when_probe_in_progress() -> None:
     # Assert
     assert body["probeId"] == "probe-1"
     assert body["status"] == ProbeStatus.IN_PROGRESS
-    assert body["mode"] == ProbeMode.SHALLOW
+    assert body["probeMode"] == ProbeMode.SHALLOW
     assert "endedAt" not in body
     assert "message" not in body
     assert body["checks"] == []

--- a/port_ocean/tests/core/probe/test_file_reporter.py
+++ b/port_ocean/tests/core/probe/test_file_reporter.py
@@ -5,6 +5,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from port_ocean.core.probe.config import ProbeConfig
 from port_ocean.core.probe.models import ProbeReportingMode
 from port_ocean.core.probe.reporters.file import (
@@ -13,7 +15,10 @@ from port_ocean.core.probe.reporters.file import (
 )
 
 
-def test_file_probe_reporter_writes_report_to_configured_path(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_file_probe_reporter_writes_report_to_configured_path(
+    tmp_path: Path,
+) -> None:
     # Arrange
     report = {
         "probe_id": "probe-1",
@@ -27,7 +32,7 @@ def test_file_probe_reporter_writes_report_to_configured_path(tmp_path: Path) ->
         wraps=datetime,
     ) as mock_datetime:
         mock_datetime.now.return_value = fixed_time
-        FileProbeReporter(
+        await FileProbeReporter(
             ProbeConfig(path=tmp_path, reporting_mode=ProbeReportingMode.FILE)
         ).report(report)
 
@@ -39,7 +44,8 @@ def test_file_probe_reporter_writes_report_to_configured_path(tmp_path: Path) ->
     assert json.loads(report_path.read_text(encoding="utf-8")) == report
 
 
-def test_file_probe_reporter_creates_reports_directory(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_file_probe_reporter_creates_reports_directory(tmp_path: Path) -> None:
     # Arrange
     reporter = FileProbeReporter(
         ProbeConfig(path=tmp_path, reporting_mode=ProbeReportingMode.FILE)
@@ -47,7 +53,7 @@ def test_file_probe_reporter_creates_reports_directory(tmp_path: Path) -> None:
     reports_directory = tmp_path / PROBE_REPORTS_DIRECTORY
 
     # Act
-    reporter.report({"stage": "some_value"})
+    await reporter.report({"stage": "some_value"})
 
     # Assert
     assert reports_directory.is_dir()

--- a/port_ocean/tests/core/probe/test_log_reporter.py
+++ b/port_ocean/tests/core/probe/test_log_reporter.py
@@ -2,12 +2,15 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from port_ocean.core.probe.config import ProbeConfig
 from port_ocean.core.probe.reporters.log import LogProbeReporter
 
 
 @patch("port_ocean.core.probe.reporters.log.logger")
-def test_log_probe_reporter_logs_report(mock_logger: MagicMock) -> None:
+@pytest.mark.asyncio
+async def test_log_probe_reporter_logs_report(mock_logger: MagicMock) -> None:
     # Arrange
     reporter = LogProbeReporter(ProbeConfig())
     report = {
@@ -16,7 +19,7 @@ def test_log_probe_reporter_logs_report(mock_logger: MagicMock) -> None:
     }
 
     # Act
-    reporter.report(report)
+    await reporter.report(report)
 
     # Assert
     mock_logger.info.assert_called_once_with("Probe status report", probe_report=report)

--- a/port_ocean/tests/core/probe/test_port_reporter.py
+++ b/port_ocean/tests/core/probe/test_port_reporter.py
@@ -1,0 +1,76 @@
+"""Unit tests for the Port probe reporter."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from port_ocean.core.probe.config import ProbeConfig
+from port_ocean.core.probe.reporters.port import PortProbeReporter
+from port_ocean.exceptions.probe import ProbeNotInitializedError
+
+
+@patch("port_ocean.context.ocean.ocean")
+@pytest.mark.asyncio
+async def test_port_probe_reporter_patches_health_result(mock_ocean: MagicMock) -> None:
+    # Arrange
+    mock_ocean.port_client.get_org_id = AsyncMock(return_value="org-123")
+    mock_ocean.port_client.patch_probe_health_result = AsyncMock()
+    reporter = PortProbeReporter(ProbeConfig())
+    report = {
+        "probe_id": "probe-1",
+        "status": "IN_PROGRESS",
+        "checks": [],
+    }
+
+    # Act
+    await reporter.report(report)
+
+    # Assert
+    mock_ocean.port_client.get_org_id.assert_called_once()
+    mock_ocean.port_client.patch_probe_health_result.assert_called_once_with(
+        "org-123",
+        "probe-1",
+        {"status": "IN_PROGRESS", "checks": []},
+    )
+
+
+@patch("port_ocean.context.ocean.ocean")
+@pytest.mark.asyncio
+async def test_port_probe_reporter_reuses_cached_org_id(
+    mock_ocean: MagicMock,
+) -> None:
+    # Arrange
+    mock_ocean.port_client.get_org_id = AsyncMock(return_value="org-123")
+    mock_ocean.port_client.patch_probe_health_result = AsyncMock()
+    reporter = PortProbeReporter(ProbeConfig())
+
+    # Act
+    await reporter.report({"probe_id": "probe-1", "status": "IN_PROGRESS"})
+    await reporter.report({"probe_id": "probe-1", "status": "COMPLETED"})
+
+    # Assert
+    mock_ocean.port_client.get_org_id.assert_called_once()
+    assert mock_ocean.port_client.patch_probe_health_result.call_count == 2
+    mock_ocean.port_client.patch_probe_health_result.assert_any_call(
+        "org-123",
+        "probe-1",
+        {"status": "IN_PROGRESS"},
+    )
+    mock_ocean.port_client.patch_probe_health_result.assert_any_call(
+        "org-123",
+        "probe-1",
+        {"status": "COMPLETED"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_port_probe_reporter_raises_when_probe_id_missing() -> None:
+    # Arrange
+    reporter = PortProbeReporter(ProbeConfig())
+
+    # Act + Assert
+    with pytest.raises(
+        ProbeNotInitializedError,
+        match="probe_id is required when using Port probe reporting mode",
+    ):
+        await reporter.report({"status": "IN_PROGRESS"})

--- a/port_ocean/tests/core/probe/test_port_reporter.py
+++ b/port_ocean/tests/core/probe/test_port_reporter.py
@@ -17,7 +17,7 @@ async def test_port_probe_reporter_patches_health_result(mock_ocean: MagicMock) 
     mock_ocean.port_client.patch_probe_health_result = AsyncMock()
     reporter = PortProbeReporter(ProbeConfig())
     report = {
-        "probe_id": "probe-1",
+        "probeId": "probe-1",
         "status": "IN_PROGRESS",
         "checks": [],
     }
@@ -45,8 +45,8 @@ async def test_port_probe_reporter_reuses_cached_org_id(
     reporter = PortProbeReporter(ProbeConfig())
 
     # Act
-    await reporter.report({"probe_id": "probe-1", "status": "IN_PROGRESS"})
-    await reporter.report({"probe_id": "probe-1", "status": "COMPLETED"})
+    await reporter.report({"probeId": "probe-1", "status": "IN_PROGRESS"})
+    await reporter.report({"probeId": "probe-1", "status": "COMPLETED"})
 
     # Assert
     mock_ocean.port_client.get_org_id.assert_called_once()


### PR DESCRIPTION
# Description

What - Implement sending probe update requests to Port

Why -

How -

## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Custom `on_probe` handlers must await probe context methods (breaking API change), and probe updates now depend on Port API availability and correct `probe_id` when using PORT reporting mode.
> 
> **Overview**
> **Probe progress can now be pushed to Port** instead of only logging or writing local files. `PortProbeReporter` is implemented (replacing the debug placeholder): it resolves the org id once, requires `probe_id`, and PATCHes probe status via new `PortClient.patch_probe_health_result` (`/org/{org_id}/probe/{probe_id}`).
> 
> The probe pipeline is **async end-to-end** so those HTTP calls do not block the event loop: `ProbeReporter.report`, `ProbeContext` methods (`initialize`, `update_progress`, `finalize`, `fail`, `add_scopes`), and `BaseIntegration.run_probe` all `await` reporting. File and log reporters keep the same behavior but expose async `report` for a single interface.
> 
> **Tests** are updated to use `@pytest.mark.asyncio` and `AsyncMock` where reporters are mocked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a76688f0cf0b6bf4e15b99580599417ef91b0154. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->