### PR TITLE
[Core] Task tkf6n9/b8 discover kinds from integration py rather than spec

### DIFF
--- a/.ocean-release/core/discover_probe_kinds_from_integration.yaml
+++ b/.ocean-release/core/discover_probe_kinds_from_integration.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: feature
+changelog: Probe discovers supported resource kinds from the integration PortAppConfig and adds per-kind probe_permissions with KindPermissionVerdict for permission checks

--- a/.ocean-release/core/discover_probe_kinds_from_integration.yaml
+++ b/.ocean-release/core/discover_probe_kinds_from_integration.yaml
@@ -1,3 +1,3 @@
 bump: patch
 changelog-type: feature
-changelog: Probe discovers supported resource kinds from the integration PortAppConfig and adds per-kind probe_permissions with KindPermissionVerdict for permission checks
+changelog: Probe discovers supported resource kinds from the integration PortAppConfig

--- a/port_ocean/clients/port/client.py
+++ b/port_ocean/clients/port/client.py
@@ -105,7 +105,7 @@ class PortClient(
             status=body.get("status"),
         )
         response = await self.client.patch(
-            f"{self.api_url}/org/{org_id}/probe/{probe_id}",
+            f"{self.api_url}/org/{org_id}/integration/probe/{probe_id}",
             headers=await self.auth.headers(),
             json=body,
         )

--- a/port_ocean/core/handlers/port_app_config/models.py
+++ b/port_ocean/core/handlers/port_app_config/models.py
@@ -7,6 +7,7 @@ from pydantic.v1 import BaseModel, Field
 from port_ocean.clients.port.types import RequestOptions
 
 CUSTOM_KIND = "__custom__"
+ProbePermissions = tuple[str, ...] | dict[str, tuple[str, ...]]
 
 
 class Rule(BaseModel):
@@ -104,6 +105,8 @@ class Selector(BaseModel):
 
 
 class ResourceConfig(BaseModel):
+    probe_permissions: ClassVar[ProbePermissions | None] = None
+
     kind: str = Field(
         title="Kind",
         description="key is a specifier for the object you wish to map from the tool's API.",

--- a/port_ocean/core/handlers/port_app_config/validators.py
+++ b/port_ocean/core/handlers/port_app_config/validators.py
@@ -10,6 +10,7 @@ from pydantic.v1 import BaseModel
 from port_ocean.core.handlers.port_app_config.models import (
     CUSTOM_KIND,
     PortAppConfig,
+    ProbePermissions,
     ResourceConfig,
     Selector,
 )
@@ -28,6 +29,71 @@ def validate_and_get_config_schema(
         "kinds": kinds,
         "advancedConfig": _get_advanced_config(config_class),
     }
+
+
+def get_port_app_config_kinds(config_class: Type[PortAppConfig]) -> list[str]:
+    """Return literal resource kind values declared on a PortAppConfig class."""
+    kinds = _build_kinds_mapping(
+        _get_resource_config_models(config_class),
+        config_class.allow_custom_kinds,
+    )
+    return sorted(kind for kind in kinds if kind != CUSTOM_KIND)
+
+
+def get_kind_probe_permissions(
+    config_class: Type[PortAppConfig],
+    *,
+    permission_key: str | None = None,
+) -> dict[str, tuple[str, ...]]:
+    """Return probe permission requirements keyed by resource kind.
+
+    Resource configs may declare ``probe_permissions`` as either a single tuple
+    (one permission namespace) or a dict keyed by auth mode / namespace.
+    When a dict is used, *permission_key* selects the active namespace.
+    """
+    kind_permissions: dict[str, tuple[str, ...]] = {}
+    for model in _get_resource_config_models(config_class):
+        if not (isinstance(model, type) and issubclass(model, ResourceConfig)):
+            continue
+
+        kind_field = model.__fields__.get("kind")
+        if kind_field is None:
+            continue
+
+        kind_value = _resolve_kind_value(
+            kind_field, model.__name__, config_class.allow_custom_kinds
+        )
+        if kind_value is None or kind_value == CUSTOM_KIND:
+            continue
+
+        permissions = _resolve_probe_permissions_for_model(model, permission_key)
+        if permissions:
+            kind_permissions[kind_value] = permissions
+
+    return kind_permissions
+
+
+def _resolve_probe_permissions_for_model(
+    model: type,
+    permission_key: str | None,
+) -> tuple[str, ...] | None:
+    permissions: ProbePermissions | None = getattr(model, "probe_permissions", None)
+    if permissions is None:
+        return None
+    if isinstance(permissions, tuple):
+        return permissions
+    if isinstance(permissions, dict):
+        if permission_key is None:
+            raise ValueError(
+                f"{model.__name__}.probe_permissions is a dict; "
+                "permission_key is required"
+            )
+        resolved = permissions.get(permission_key)
+        return resolved if resolved else None
+    raise TypeError(
+        f"{model.__name__}.probe_permissions must be a tuple or dict, "
+        f"got {type(permissions).__name__}"
+    )
 
 
 def _is_model(annotation: Any, model: type) -> bool:

--- a/port_ocean/core/handlers/port_app_config/validators.py
+++ b/port_ocean/core/handlers/port_app_config/validators.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import json
 import types
+from collections.abc import Iterable, Iterator
 from typing import Any, Literal, Type, Union, get_args, get_origin
 
 from pydantic.v1 import BaseModel
@@ -33,11 +34,14 @@ def validate_and_get_config_schema(
 
 def get_port_app_config_kinds(config_class: Type[PortAppConfig]) -> list[str]:
     """Return literal resource kind values declared on a PortAppConfig class."""
-    kinds = _build_kinds_mapping(
-        _get_resource_config_models(config_class),
-        config_class.allow_custom_kinds,
+    return sorted(
+        kind
+        for _, kind in _iter_resource_kinds(
+            _get_resource_config_models(config_class),
+            config_class.allow_custom_kinds,
+        )
+        if kind != CUSTOM_KIND
     )
-    return sorted(kind for kind in kinds if kind != CUSTOM_KIND)
 
 
 def get_kind_probe_permissions(
@@ -52,18 +56,11 @@ def get_kind_probe_permissions(
     When a dict is used, *permission_key* selects the active namespace.
     """
     kind_permissions: dict[str, tuple[str, ...]] = {}
-    for model in _get_resource_config_models(config_class):
-        if not (isinstance(model, type) and issubclass(model, ResourceConfig)):
-            continue
-
-        kind_field = model.__fields__.get("kind")
-        if kind_field is None:
-            continue
-
-        kind_value = _resolve_kind_value(
-            kind_field, model.__name__, config_class.allow_custom_kinds
-        )
-        if kind_value is None or kind_value == CUSTOM_KIND:
+    for model, kind_value in _iter_resource_kinds(
+        _get_resource_config_models(config_class),
+        config_class.allow_custom_kinds,
+    ):
+        if kind_value == CUSTOM_KIND:
             continue
 
         permissions = _resolve_probe_permissions_for_model(model, permission_key)
@@ -220,6 +217,26 @@ def _get_resource_config_models(config_class: Type[PortAppConfig]) -> list[type]
     return _unwrap_union(list_args[0])
 
 
+def _iter_resource_kinds(
+    models: Iterable[type],
+    allow_custom_kinds: bool,
+) -> Iterator[tuple[type[ResourceConfig], str]]:
+    """Yield each ``ResourceConfig`` model with its resolved kind value."""
+    for model in models:
+        if not (isinstance(model, type) and issubclass(model, ResourceConfig)):
+            continue
+
+        kind_field = model.__fields__.get("kind")
+        if kind_field is None:
+            raise ValueError(f"{model.__name__} is missing the required 'kind' field")
+
+        kind_value = _resolve_kind_value(kind_field, model.__name__, allow_custom_kinds)
+        if kind_value is None:
+            raise ValueError(f"{model.__name__}: could not resolve kind value")
+
+        yield model, kind_value
+
+
 def _unwrap_union(annotation: Any) -> list[type]:
     """Unwrap a ``Union`` (or Python 3.10+ ``X | Y``) into member types."""
     origin = get_origin(annotation)
@@ -255,22 +272,13 @@ def _build_kinds_mapping(
     """Walk *models*, validate each ``kind``, and build the kinds mapping."""
     kinds: dict[str, dict[str, Any]] = {}
 
-    for model in models:
-        if not (isinstance(model, type) and issubclass(model, ResourceConfig)):
-            continue
-
-        kind_field = model.__fields__.get("kind")
-        if kind_field is None:
-            raise ValueError(f"{model.__name__} is missing the required 'kind' field")
-
-        kind_value = _resolve_kind_value(kind_field, model.__name__, allow_custom_kinds)
-        if kind_value is None:
-            raise ValueError(f"{model.__name__}: could not resolve kind value")
+    for model, kind_value in _iter_resource_kinds(models, allow_custom_kinds):
         if kind_value != CUSTOM_KIND and kind_value in kinds:
             raise ValueError(
                 f"Duplicate kind '{kind_value}' found in resource config models"
             )
 
+        kind_field = model.__fields__["kind"]
         kind_entry = _field_info_to_dict(kind_field.field_info)
 
         selector_field = model.__fields__.get("selector")

--- a/port_ocean/core/integrations/base.py
+++ b/port_ocean/core/integrations/base.py
@@ -119,7 +119,10 @@ class BaseIntegration(SyncRawMixin, SyncMixin):
             EventType.ON_PROBE,
             trigger_type="machine",
         ):
-            context.initialize(config)
+            context.initialize(
+                config,
+                port_app_config_class=self.AppConfigHandlerClass.CONFIG_CLASS,
+            )
             try:
                 returned = await listener(context)
             except Exception as error:

--- a/port_ocean/core/integrations/base.py
+++ b/port_ocean/core/integrations/base.py
@@ -120,8 +120,8 @@ class BaseIntegration(SyncRawMixin, SyncMixin):
             trigger_type="machine",
         ):
             await context.initialize(
+                self.AppConfigHandlerClass.CONFIG_CLASS,
                 config,
-                port_app_config_class=self.AppConfigHandlerClass.CONFIG_CLASS,
             )
             try:
                 returned = await listener(context)

--- a/port_ocean/core/probe/__init__.py
+++ b/port_ocean/core/probe/__init__.py
@@ -8,3 +8,7 @@ from port_ocean.core.probe.models import (
     ProbeCheckStatus,
     ProbeReportingMode,
 )
+from port_ocean.core.probe.permissions import (
+    KindPermissionVerdict,
+    PermissionCombination,
+)

--- a/port_ocean/core/probe/context.py
+++ b/port_ocean/core/probe/context.py
@@ -1,14 +1,20 @@
+import typing
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
 
 from loguru import logger
 
+from port_ocean.core.handlers.port_app_config.validators import (
+    get_port_app_config_kinds,
+)
 from port_ocean.core.probe.config import ProbeConfig
 from port_ocean.core.probe.models import ProbeCheck, ProbeStatus
 from port_ocean.core.probe.reporters import ProbeReporter, REPORTER_MODES
 from port_ocean.exceptions.probe import InvalidProbeKindsError, ProbeNotInitializedError
-from port_ocean.utils.misc import get_spec_kinds
+
+if typing.TYPE_CHECKING:
+    from port_ocean.core.handlers.port_app_config.models import PortAppConfig
 
 
 @dataclass
@@ -55,11 +61,15 @@ class ProbeContext:
             ],
         }
 
-    def initialize(self, config: ProbeConfig | None = None) -> None:
+    def initialize(
+        self,
+        port_app_config_class: type[PortAppConfig],
+        config: ProbeConfig | None = None,
+    ) -> None:
         self.config = config or ProbeConfig()
         if self.config.kinds is not None:
             configured_kinds_set = set(self.config.kinds)
-            supported_kinds = get_spec_kinds(self.config.path)
+            supported_kinds = get_port_app_config_kinds(port_app_config_class)
             supported_kinds_set = set(supported_kinds)
             if not configured_kinds_set.issubset(supported_kinds_set):
                 raise InvalidProbeKindsError(
@@ -68,7 +78,9 @@ class ProbeContext:
 
             self.available_kinds = sorted(list(configured_kinds_set))
         else:
-            self.available_kinds = sorted(get_spec_kinds(self.config.path))
+            self.available_kinds = sorted(
+                get_port_app_config_kinds(port_app_config_class)
+            )
 
         self.reporter = REPORTER_MODES[self.config.reporting_mode](self.config)
         self.status = ProbeStatus.IN_PROGRESS

--- a/port_ocean/core/probe/context.py
+++ b/port_ocean/core/probe/context.py
@@ -75,7 +75,7 @@ class ProbeContext:
                     list(configured_kinds_set - supported_kinds_set), supported_kinds
                 )
 
-            self.available_kinds = sorted(list(configured_kinds_set))
+            self.available_kinds = sorted(configured_kinds_set)
         else:
             self.available_kinds = get_port_app_config_kinds(port_app_config_class)
 

--- a/port_ocean/core/probe/context.py
+++ b/port_ocean/core/probe/context.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import typing
 from dataclasses import dataclass, field
 from datetime import datetime, timezone

--- a/port_ocean/core/probe/context.py
+++ b/port_ocean/core/probe/context.py
@@ -77,9 +77,7 @@ class ProbeContext:
 
             self.available_kinds = sorted(list(configured_kinds_set))
         else:
-            self.available_kinds = sorted(
-                get_port_app_config_kinds(port_app_config_class)
-            )
+            self.available_kinds = get_port_app_config_kinds(port_app_config_class)
 
         self.reporter = REPORTER_MODES[self.config.reporting_mode](self.config)
         self.status = ProbeStatus.IN_PROGRESS

--- a/port_ocean/core/probe/permissions.py
+++ b/port_ocean/core/probe/permissions.py
@@ -1,0 +1,85 @@
+from abc import ABC, abstractmethod
+from collections.abc import Mapping
+from enum import StrEnum
+
+from port_ocean.core.probe.models import ProbeCheckStatus
+
+
+class PermissionCombination(StrEnum):
+    AND = "and"
+    OR = "or"
+
+
+class KindPermissionVerdict(ABC):
+    _kind_permissions: Mapping[str, tuple[str, ...]] | None = None
+
+    @abstractmethod
+    def load_kind_permissions(self) -> Mapping[str, tuple[str, ...]]:
+        """Maps probe kinds to the permissions required to sync them."""
+
+    @property
+    def kind_permissions(self) -> Mapping[str, tuple[str, ...]]:
+        if self._kind_permissions is None:
+            self._kind_permissions = self.load_kind_permissions()
+        return self._kind_permissions
+
+    @property
+    @abstractmethod
+    def combination(self) -> PermissionCombination:
+        """Whether all mapped permissions must be granted (AND) or any one (OR)."""
+
+    @abstractmethod
+    def unmapped_message(self, kind: str) -> str:
+        """Message when no permission mapping exists for a kind."""
+
+    @abstractmethod
+    def granted_message(self, granted: tuple[str, ...]) -> str:
+        """Message when the required permissions are satisfied."""
+
+    @abstractmethod
+    def denied_message(self, denied: tuple[str, ...]) -> str:
+        """Message when the required permissions are not satisfied."""
+
+    def missing_message(self, missing: tuple[str, ...]) -> str | None:
+        """Message when the provider omitted one or more required permissions."""
+        return None
+
+    def is_granted(self, permission: str, permissions: Mapping[str, object]) -> bool:
+        return permission in permissions and bool(permissions[permission])
+
+    def verdict(
+        self,
+        kind: str,
+        permissions: Mapping[str, object],
+    ) -> tuple[ProbeCheckStatus, str]:
+        required = self.kind_permissions.get(kind)
+        if required is None:
+            return ProbeCheckStatus.UNKNOWN, self.unmapped_message(kind)
+
+        if self.combination is PermissionCombination.AND:
+            missing = [
+                permission for permission in required if permission not in permissions
+            ]
+            missing_message = self.missing_message(tuple(missing)) if missing else None
+            if missing_message is not None:
+                return ProbeCheckStatus.UNKNOWN, missing_message
+
+            denied = tuple(
+                permission
+                for permission in required
+                if not self.is_granted(permission, permissions)
+            )
+            if denied:
+                return ProbeCheckStatus.FAILURE, self.denied_message(denied)
+
+            return ProbeCheckStatus.SUCCESS, self.granted_message(required)
+
+        granted = tuple(
+            permission
+            for permission in required
+            if self.is_granted(permission, permissions)
+        )
+        if granted:
+            return ProbeCheckStatus.SUCCESS, self.granted_message(granted)
+
+        return ProbeCheckStatus.FAILURE, self.denied_message(required)

--- a/port_ocean/core/probe/permissions.py
+++ b/port_ocean/core/probe/permissions.py
@@ -28,17 +28,14 @@ class KindPermissionVerdict(ABC):
     def combination(self) -> PermissionCombination:
         """Whether all mapped permissions must be granted (AND) or any one (OR)."""
 
-    @abstractmethod
     def unmapped_message(self, kind: str) -> str:
-        """Message when no permission mapping exists for a kind."""
+        return f"No permission mapping is defined for {kind}"
 
-    @abstractmethod
     def granted_message(self, granted: tuple[str, ...]) -> str:
-        """Message when the required permissions are satisfied."""
+        return "Permission(s) granted: " + ", ".join(granted)
 
-    @abstractmethod
     def denied_message(self, denied: tuple[str, ...]) -> str:
-        """Message when the required permissions are not satisfied."""
+        return "Missing permission(s): " + ", ".join(denied)
 
     def missing_message(self, missing: tuple[str, ...]) -> str | None:
         """Message when the provider omitted one or more required permissions."""

--- a/port_ocean/tests/clients/port/test_port_client.py
+++ b/port_ocean/tests/clients/port/test_port_client.py
@@ -74,7 +74,7 @@ async def test_patch_probe_health_result_sends_patch_request(
 
     # Assert
     patch_mock.assert_called_once_with(
-        f"{TEST_API_URL}/org/org-123/probe/probe-1",
+        f"{TEST_API_URL}/org/org-123/integration/probe/probe-1",
         headers={"Authorization": "Bearer test-token"},
         json=body,
     )

--- a/port_ocean/tests/core/handlers/port_app_config/test_get_port_app_config_kinds.py
+++ b/port_ocean/tests/core/handlers/port_app_config/test_get_port_app_config_kinds.py
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar, Literal
+from typing import ClassVar, Literal
 
 from pydantic.v1 import Field
 
@@ -11,14 +11,7 @@ from port_ocean.core.handlers.port_app_config.validators import (
     get_kind_probe_permissions,
     get_port_app_config_kinds,
 )
-
-
-def _resources() -> Any:
-    return Field(
-        default_factory=list,
-        title="Resources",
-        description="The list of resource configurations for the integration.",
-    )
+from port_ocean.tests.core.handlers.port_app_config.test_helpers import resources_field
 
 
 def test_get_port_app_config_kinds_returns_sorted_literal_kinds() -> None:
@@ -32,7 +25,7 @@ def test_get_port_app_config_kinds_returns_sorted_literal_kinds() -> None:
         )
 
     class Config(PortAppConfig):
-        resources: list[RepositoryConfig | PullRequestConfig] = _resources()  # type: ignore[assignment]
+        resources: list[RepositoryConfig | PullRequestConfig] = resources_field()  # type: ignore[assignment]
 
     assert get_port_app_config_kinds(Config) == ["pull-request", "repository"]
 
@@ -46,7 +39,7 @@ def test_get_port_app_config_kinds_skips_custom_kind_slot() -> None:
 
     class Config(PortAppConfig):
         allow_custom_kinds: ClassVar[bool] = True
-        resources: list[IncidentConfig | CustomResourceConfig] = _resources()  # type: ignore[assignment]
+        resources: list[IncidentConfig | CustomResourceConfig] = resources_field()  # type: ignore[assignment]
 
     assert get_port_app_config_kinds(Config) == ["incident"]
     assert CUSTOM_KIND not in get_port_app_config_kinds(Config)
@@ -64,7 +57,7 @@ def test_get_kind_probe_permissions_returns_tuple_permissions() -> None:
         kind: Literal["user"] = Field(title="User", description="User.")
 
     class Config(PortAppConfig):
-        resources: list[ProjectConfig | UserConfig] = _resources()  # type: ignore[assignment]
+        resources: list[ProjectConfig | UserConfig] = resources_field()  # type: ignore[assignment]
 
     assert get_kind_probe_permissions(Config) == {
         "project": ("BROWSE_PROJECTS",),
@@ -82,7 +75,7 @@ def test_get_kind_probe_permissions_returns_dict_permissions_by_key() -> None:
         kind: Literal["repository"] = Field(title="Repository", description="Repo.")
 
     class Config(PortAppConfig):
-        resources: list[RepositoryConfig] = _resources()  # type: ignore[assignment]
+        resources: list[RepositoryConfig] = resources_field()  # type: ignore[assignment]
 
     assert get_kind_probe_permissions(Config, permission_key="pat") == {
         "repository": ("repo",),
@@ -102,6 +95,6 @@ def test_get_kind_probe_permissions_skips_kinds_without_metadata() -> None:
         kind: Literal["team"] = Field(title="Team", description="Team.")
 
     class Config(PortAppConfig):
-        resources: list[RepositoryConfig | UnmappedConfig] = _resources()  # type: ignore[assignment]
+        resources: list[RepositoryConfig | UnmappedConfig] = resources_field()  # type: ignore[assignment]
 
     assert get_kind_probe_permissions(Config) == {"repository": ("repo",)}

--- a/port_ocean/tests/core/handlers/port_app_config/test_get_port_app_config_kinds.py
+++ b/port_ocean/tests/core/handlers/port_app_config/test_get_port_app_config_kinds.py
@@ -1,0 +1,107 @@
+from typing import Any, ClassVar, Literal
+
+from pydantic.v1 import Field
+
+from port_ocean.core.handlers.port_app_config.models import (
+    CUSTOM_KIND,
+    PortAppConfig,
+    ResourceConfig,
+)
+from port_ocean.core.handlers.port_app_config.validators import (
+    get_kind_probe_permissions,
+    get_port_app_config_kinds,
+)
+
+
+def _resources() -> Any:
+    return Field(
+        default_factory=list,
+        title="Resources",
+        description="The list of resource configurations for the integration.",
+    )
+
+
+def test_get_port_app_config_kinds_returns_sorted_literal_kinds() -> None:
+    class RepositoryConfig(ResourceConfig):
+        kind: Literal["repository"] = Field(title="Repository", description="Repo.")
+
+    class PullRequestConfig(ResourceConfig):
+        kind: Literal["pull-request"] = Field(
+            title="Pull Request",
+            description="PR.",
+        )
+
+    class Config(PortAppConfig):
+        resources: list[RepositoryConfig | PullRequestConfig] = _resources()  # type: ignore[assignment]
+
+    assert get_port_app_config_kinds(Config) == ["pull-request", "repository"]
+
+
+def test_get_port_app_config_kinds_skips_custom_kind_slot() -> None:
+    class IncidentConfig(ResourceConfig):
+        kind: Literal["incident"] = Field(title="Incident", description="Incident.")
+
+    class CustomResourceConfig(ResourceConfig):
+        kind: str = Field(title="Custom", description="Custom kind.")
+
+    class Config(PortAppConfig):
+        allow_custom_kinds = True
+        resources: list[IncidentConfig | CustomResourceConfig] = _resources()  # type: ignore[assignment]
+
+    assert get_port_app_config_kinds(Config) == ["incident"]
+    assert CUSTOM_KIND not in get_port_app_config_kinds(Config)
+
+
+def test_get_kind_probe_permissions_returns_tuple_permissions() -> None:
+    class ProjectConfig(ResourceConfig):
+        probe_permissions: ClassVar[tuple[str, ...]] = ("BROWSE_PROJECTS",)
+
+        kind: Literal["project"] = Field(title="Project", description="Project.")
+
+    class UserConfig(ResourceConfig):
+        probe_permissions: ClassVar[tuple[str, ...]] = ("USER_PICKER",)
+
+        kind: Literal["user"] = Field(title="User", description="User.")
+
+    class Config(PortAppConfig):
+        resources: list[ProjectConfig | UserConfig] = _resources()  # type: ignore[assignment]
+
+    assert get_kind_probe_permissions(Config) == {
+        "project": ("BROWSE_PROJECTS",),
+        "user": ("USER_PICKER",),
+    }
+
+
+def test_get_kind_probe_permissions_returns_dict_permissions_by_key() -> None:
+    class RepositoryConfig(ResourceConfig):
+        probe_permissions: ClassVar[dict[str, tuple[str, ...]]] = {
+            "pat": ("repo",),
+            "app": ("metadata",),
+        }
+
+        kind: Literal["repository"] = Field(title="Repository", description="Repo.")
+
+    class Config(PortAppConfig):
+        resources: list[RepositoryConfig] = _resources()  # type: ignore[assignment]
+
+    assert get_kind_probe_permissions(Config, permission_key="pat") == {
+        "repository": ("repo",),
+    }
+    assert get_kind_probe_permissions(Config, permission_key="app") == {
+        "repository": ("metadata",),
+    }
+
+
+def test_get_kind_probe_permissions_skips_kinds_without_metadata() -> None:
+    class RepositoryConfig(ResourceConfig):
+        probe_permissions: ClassVar[tuple[str, ...]] = ("repo",)
+
+        kind: Literal["repository"] = Field(title="Repository", description="Repo.")
+
+    class UnmappedConfig(ResourceConfig):
+        kind: Literal["team"] = Field(title="Team", description="Team.")
+
+    class Config(PortAppConfig):
+        resources: list[RepositoryConfig | UnmappedConfig] = _resources()  # type: ignore[assignment]
+
+    assert get_kind_probe_permissions(Config) == {"repository": ("repo",)}

--- a/port_ocean/tests/core/handlers/port_app_config/test_get_port_app_config_kinds.py
+++ b/port_ocean/tests/core/handlers/port_app_config/test_get_port_app_config_kinds.py
@@ -45,7 +45,7 @@ def test_get_port_app_config_kinds_skips_custom_kind_slot() -> None:
         kind: str = Field(title="Custom", description="Custom kind.")
 
     class Config(PortAppConfig):
-        allow_custom_kinds = True
+        allow_custom_kinds: ClassVar[bool] = True
         resources: list[IncidentConfig | CustomResourceConfig] = _resources()  # type: ignore[assignment]
 
     assert get_port_app_config_kinds(Config) == ["incident"]

--- a/port_ocean/tests/core/handlers/port_app_config/test_helpers.py
+++ b/port_ocean/tests/core/handlers/port_app_config/test_helpers.py
@@ -1,0 +1,11 @@
+from typing import Any
+
+from pydantic.v1 import Field
+
+
+def resources_field() -> Any:
+    return Field(
+        default_factory=list,
+        title="Resources",
+        description="The list of resource configurations for the integration.",
+    )

--- a/port_ocean/tests/core/integrations/test_run_probe.py
+++ b/port_ocean/tests/core/integrations/test_run_probe.py
@@ -1,6 +1,5 @@
 """Unit tests for BaseIntegration.run_probe."""
 
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -18,10 +17,8 @@ def integration() -> BaseIntegration:
     return BaseIntegration(context)
 
 
-@patch("port_ocean.core.probe.context.get_spec_kinds", return_value=["repository"])
 @pytest.mark.asyncio
 async def test_run_probe_raises_when_listener_is_not_registered(
-    mock_get_spec_kinds: MagicMock,
     integration: BaseIntegration,
 ) -> None:
     # Arrange
@@ -32,15 +29,16 @@ async def test_run_probe_raises_when_listener_is_not_registered(
         ModeNotSupportedException,
         match="github does not support probe mode",
     ):
-        await integration.run_probe("probe-123", ProbeConfig(path=Path("/integration")))
-
-    mock_get_spec_kinds.assert_not_called()
+        await integration.run_probe("probe-123", ProbeConfig())
 
 
-@patch("port_ocean.core.probe.context.get_spec_kinds", return_value=["repository"])
+@patch(
+    "port_ocean.core.probe.context.get_port_app_config_kinds",
+    return_value=["repository"],
+)
 @pytest.mark.asyncio
 async def test_run_probe_finalizes_listener_context(
-    mock_get_spec_kinds: MagicMock,
+    mock_get_port_app_config_kinds: MagicMock,
     integration: BaseIntegration,
 ) -> None:
     # Arrange
@@ -48,7 +46,7 @@ async def test_run_probe_finalizes_listener_context(
         return context
 
     integration.event_strategy.on_probe = on_probe
-    config = ProbeConfig(path=Path("/integration"), kinds=["repository"])
+    config = ProbeConfig(kinds=["repository"])
 
     # Act
     result = await integration.run_probe("probe-123", config)
@@ -57,13 +55,18 @@ async def test_run_probe_finalizes_listener_context(
     assert result.probe_id == "probe-123"
     assert result.status == ProbeStatus.COMPLETED
     assert result.ended_at is not None
-    mock_get_spec_kinds.assert_called_once_with(Path("/integration"))
+    mock_get_port_app_config_kinds.assert_called_once_with(
+        integration.AppConfigHandlerClass.CONFIG_CLASS
+    )
 
 
-@patch("port_ocean.core.probe.context.get_spec_kinds", return_value=["repository"])
+@patch(
+    "port_ocean.core.probe.context.get_port_app_config_kinds",
+    return_value=["repository"],
+)
 @pytest.mark.asyncio
 async def test_run_probe_marks_context_failed_when_listener_raises(
-    mock_get_spec_kinds: MagicMock,
+    mock_get_port_app_config_kinds: MagicMock,
     integration: BaseIntegration,
 ) -> None:
     # Arrange
@@ -74,7 +77,7 @@ async def test_run_probe_marks_context_failed_when_listener_raises(
         raise RuntimeError("probe failed")
 
     integration.event_strategy.on_probe = on_probe
-    config = ProbeConfig(path=Path("/integration"), kinds=["repository"])
+    config = ProbeConfig(kinds=["repository"])
 
     # Act / Assert
     with pytest.raises(RuntimeError, match="probe failed"):
@@ -84,10 +87,13 @@ async def test_run_probe_marks_context_failed_when_listener_raises(
     assert captured_context[0].ended_at is not None
 
 
-@patch("port_ocean.core.probe.context.get_spec_kinds", return_value=["repository"])
+@patch(
+    "port_ocean.core.probe.context.get_port_app_config_kinds",
+    return_value=["repository"],
+)
 @pytest.mark.asyncio
 async def test_run_probe_raises_when_context_is_failed(
-    mock_get_spec_kinds: MagicMock,
+    mock_get_port_app_config_kinds: MagicMock,
     integration: BaseIntegration,
 ) -> None:
     # Arrange
@@ -100,7 +106,7 @@ async def test_run_probe_raises_when_context_is_failed(
         return context
 
     integration.event_strategy.on_probe = on_probe
-    config = ProbeConfig(path=Path("/integration"), kinds=["repository"])
+    config = ProbeConfig(kinds=["repository"])
 
     # Act / Assert
     with pytest.raises(ProbeFailedError, match=message):

--- a/port_ocean/tests/core/probe/test_context.py
+++ b/port_ocean/tests/core/probe/test_context.py
@@ -1,11 +1,16 @@
 """Unit tests for probe context."""
 
 from datetime import datetime, timezone
-from pathlib import Path
+from typing import Any, Literal
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from pydantic.v1 import Field
 
+from port_ocean.core.handlers.port_app_config.models import (
+    PortAppConfig,
+    ResourceConfig,
+)
 from port_ocean.core.probe.config import ProbeConfig
 from port_ocean.core.probe.context import ProbeContext
 from port_ocean.core.probe.models import (
@@ -18,6 +23,26 @@ from port_ocean.core.probe.models import (
 from port_ocean.core.probe.reporters.file import FileProbeReporter
 from port_ocean.core.probe.reporters.log import LogProbeReporter
 from port_ocean.exceptions.probe import InvalidProbeKindsError, ProbeNotInitializedError
+
+
+def _resources() -> Any:
+    return Field(
+        default_factory=list,
+        title="Resources",
+        description="The list of resource configurations for the integration.",
+    )
+
+
+class _RepositoryConfig(ResourceConfig):
+    kind: Literal["repository"] = Field(title="Repository", description="Repo.")
+
+
+class _PullRequestConfig(ResourceConfig):
+    kind: Literal["pull-request"] = Field(title="Pull Request", description="PR.")
+
+
+class _TestPortAppConfig(PortAppConfig):
+    resources: list[_RepositoryConfig | _PullRequestConfig] = _resources()  # type: ignore[assignment]
 
 
 def test_starts_with_empty_state() -> None:
@@ -151,64 +176,45 @@ def test_build_request_body_when_probe_in_progress() -> None:
     assert body["checks"] == []
 
 
-@patch("port_ocean.core.probe.context.get_spec_kinds", return_value=["repository"])
 @pytest.mark.asyncio
-async def test_initialize_sets_config_and_available_kinds(
-    mock_get_spec_kinds: MagicMock,
-) -> None:
+async def test_initialize_sets_config_and_available_kinds() -> None:
     # Arrange
     context = ProbeContext(probe_id="probe-1")
     context.status = ProbeStatus.COMPLETED
-    config = ProbeConfig(path=Path("/integration"), kinds=["repository"])
+    config = ProbeConfig(kinds=["repository"])
 
     # Act
     with patch.object(context, "update_progress") as mock_update_progress:
-        await context.initialize(config)
+        await context.initialize(_TestPortAppConfig, config)
 
     # Assert
     assert context.config is config
     assert context.available_kinds == ["repository"]
     assert context.status == ProbeStatus.IN_PROGRESS
-    mock_get_spec_kinds.assert_called_once_with(Path("/integration"))
     mock_update_progress.assert_called_once_with()
 
 
-@patch(
-    "port_ocean.core.probe.context.get_spec_kinds",
-    return_value=["repository", "pull-request"],
-)
 @pytest.mark.asyncio
-async def test_initialize_deduplicates_injected_kinds(
-    mock_get_spec_kinds: MagicMock,
-) -> None:
+async def test_initialize_deduplicates_injected_kinds() -> None:
     # Arrange
     context = ProbeContext(probe_id="probe-1")
     config = ProbeConfig(
-        path=Path("/integration"),
         kinds=["repository", "repository", "pull-request", "repository"],
     )
 
     # Act
     with patch.object(context, "update_progress"):
-        await context.initialize(config)
+        await context.initialize(_TestPortAppConfig, config)
 
     # Assert
     assert context.available_kinds == ["pull-request", "repository"]
-    mock_get_spec_kinds.assert_called_once_with(Path("/integration"))
 
 
-@patch(
-    "port_ocean.core.probe.context.get_spec_kinds",
-    return_value=["repository", "pull-request"],
-)
 @pytest.mark.asyncio
-async def test_initialize_raises_for_invalid_kinds(
-    mock_get_spec_kinds: MagicMock,
-) -> None:
+async def test_initialize_raises_for_invalid_kinds() -> None:
     # Arrange
     context = ProbeContext(probe_id="probe-1")
     config = ProbeConfig(
-        path=Path("/integration"),
         kinds=["repository", "fake-kind"],
     )
 
@@ -216,28 +222,23 @@ async def test_initialize_raises_for_invalid_kinds(
     with pytest.raises(
         InvalidProbeKindsError, match="Invalid probe kinds: \\['fake-kind'\\]"
     ):
-        await context.initialize(config)
-
-    mock_get_spec_kinds.assert_called_once_with(Path("/integration"))
+        await context.initialize(_TestPortAppConfig, config)
 
 
-@patch("port_ocean.core.probe.context.get_spec_kinds", return_value=[])
 @pytest.mark.asyncio
-async def test_initialize_uses_default_config_when_none(
-    mock_get_spec_kinds: MagicMock,
-) -> None:
+async def test_initialize_uses_default_config_when_none() -> None:
     # Arrange
     context = ProbeContext(probe_id="probe-1")
     context.status = ProbeStatus.COMPLETED
 
     # Act
     with patch.object(context, "update_progress") as mock_update_progress:
-        await context.initialize()
+        await context.initialize(_TestPortAppConfig)
 
     # Assert
     assert context.config == ProbeConfig()
+    assert context.available_kinds == ["pull-request", "repository"]
     assert context.status == ProbeStatus.IN_PROGRESS
-    mock_get_spec_kinds.assert_called_once_with(Path("."))
     mock_update_progress.assert_called_once_with()
 
 
@@ -248,10 +249,8 @@ async def test_initialize_uses_default_config_when_none(
         (ProbeReportingMode.FILE, FileProbeReporter),
     ],
 )
-@patch("port_ocean.core.probe.context.get_spec_kinds", return_value=[])
 @pytest.mark.asyncio
 async def test_initialize_creates_reporter_for_reporting_mode(
-    mock_get_spec_kinds: MagicMock,
     reporting_mode: ProbeReportingMode,
     expected_reporter_type: type[LogProbeReporter] | type[FileProbeReporter],
 ) -> None:
@@ -261,12 +260,11 @@ async def test_initialize_creates_reporter_for_reporting_mode(
 
     # Act
     with patch.object(context, "update_progress"):
-        await context.initialize(config)
+        await context.initialize(_TestPortAppConfig, config)
 
     # Assert
     assert isinstance(context.reporter, expected_reporter_type)
     assert context.reporter.config is config
-    mock_get_spec_kinds.assert_called_once_with(Path("."))
 
 
 @pytest.mark.asyncio

--- a/port_ocean/tests/core/probe/test_context.py
+++ b/port_ocean/tests/core/probe/test_context.py
@@ -1,7 +1,7 @@
 """Unit tests for probe context."""
 
 from datetime import datetime, timezone
-from typing import Any, Literal
+from typing import Literal
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -23,14 +23,7 @@ from port_ocean.core.probe.models import (
 from port_ocean.core.probe.reporters.file import FileProbeReporter
 from port_ocean.core.probe.reporters.log import LogProbeReporter
 from port_ocean.exceptions.probe import InvalidProbeKindsError, ProbeNotInitializedError
-
-
-def _resources() -> Any:
-    return Field(
-        default_factory=list,
-        title="Resources",
-        description="The list of resource configurations for the integration.",
-    )
+from port_ocean.tests.core.handlers.port_app_config.test_helpers import resources_field
 
 
 class _RepositoryConfig(ResourceConfig):
@@ -42,7 +35,7 @@ class _PullRequestConfig(ResourceConfig):
 
 
 class _TestPortAppConfig(PortAppConfig):
-    resources: list[_RepositoryConfig | _PullRequestConfig] = _resources()  # type: ignore[assignment]
+    resources: list[_RepositoryConfig | _PullRequestConfig] = resources_field()  # type: ignore[assignment]
 
 
 def test_starts_with_empty_state() -> None:

--- a/port_ocean/tests/core/probe/test_permissions.py
+++ b/port_ocean/tests/core/probe/test_permissions.py
@@ -1,3 +1,5 @@
+from collections.abc import Mapping
+
 import pytest
 
 from port_ocean.core.probe.models import ProbeCheckStatus
@@ -56,7 +58,7 @@ class PresenceOrKindPermissionVerdict(OrKindPermissionVerdict):
     def load_kind_permissions(self) -> dict[str, tuple[str, ...]]:
         return {"project": ("repo",)}
 
-    def is_granted(self, permission: str, permissions: dict[str, object]) -> bool:
+    def is_granted(self, permission: str, permissions: Mapping[str, object]) -> bool:
         return permission in permissions
 
 

--- a/port_ocean/tests/core/probe/test_permissions.py
+++ b/port_ocean/tests/core/probe/test_permissions.py
@@ -1,0 +1,121 @@
+import pytest
+
+from port_ocean.core.probe.models import ProbeCheckStatus
+from port_ocean.core.probe.permissions import (
+    KindPermissionVerdict,
+    PermissionCombination,
+)
+
+KIND_PERMISSIONS = {
+    "project": ("BROWSE_PROJECTS",),
+    "user": ("USER_PICKER",),
+    "package": ("organization_packages", "packages"),
+}
+
+
+class AndKindPermissionVerdict(KindPermissionVerdict):
+    def load_kind_permissions(self) -> dict[str, tuple[str, ...]]:
+        return KIND_PERMISSIONS
+
+    @property
+    def combination(self) -> PermissionCombination:
+        return PermissionCombination.AND
+
+    def unmapped_message(self, kind: str) -> str:
+        return "unmapped"
+
+    def missing_message(self, missing: tuple[str, ...]) -> str:
+        return f"missing {', '.join(missing)}"
+
+    def granted_message(self, granted: tuple[str, ...]) -> str:
+        return f"grants {', '.join(granted)}"
+
+    def denied_message(self, denied: tuple[str, ...]) -> str:
+        return f"requires {', '.join(denied)}"
+
+
+class OrKindPermissionVerdict(KindPermissionVerdict):
+    def load_kind_permissions(self) -> dict[str, tuple[str, ...]]:
+        return KIND_PERMISSIONS
+
+    @property
+    def combination(self) -> PermissionCombination:
+        return PermissionCombination.OR
+
+    def unmapped_message(self, kind: str) -> str:
+        return "unmapped"
+
+    def granted_message(self, granted: tuple[str, ...]) -> str:
+        return f"grants {', '.join(granted)}"
+
+    def denied_message(self, denied: tuple[str, ...]) -> str:
+        return f"requires {' or '.join(denied)}"
+
+
+class PresenceOrKindPermissionVerdict(OrKindPermissionVerdict):
+    def load_kind_permissions(self) -> dict[str, tuple[str, ...]]:
+        return {"project": ("repo",)}
+
+    def is_granted(self, permission: str, permissions: dict[str, object]) -> bool:
+        return permission in permissions
+
+
+@pytest.mark.parametrize(
+    "permissions, expected_status, expected_message",
+    [
+        (
+            {"BROWSE_PROJECTS": True},
+            ProbeCheckStatus.SUCCESS,
+            "grants BROWSE_PROJECTS",
+        ),
+        (
+            {},
+            ProbeCheckStatus.UNKNOWN,
+            "missing BROWSE_PROJECTS",
+        ),
+        (
+            {"BROWSE_PROJECTS": False},
+            ProbeCheckStatus.FAILURE,
+            "requires BROWSE_PROJECTS",
+        ),
+    ],
+)
+def test_and_combination_requires_all_permissions(
+    permissions: dict[str, bool],
+    expected_status: ProbeCheckStatus,
+    expected_message: str,
+) -> None:
+    status, message = AndKindPermissionVerdict().verdict("project", permissions)
+
+    assert status is expected_status
+    assert expected_message in message
+
+
+def test_or_combination_accepts_any_required_permission() -> None:
+    status, message = OrKindPermissionVerdict().verdict(
+        "package",
+        {"packages": True},
+    )
+
+    assert status is ProbeCheckStatus.SUCCESS
+    assert message == "grants packages"
+
+
+def test_or_combination_fails_when_no_required_permission_is_granted() -> None:
+    status, message = OrKindPermissionVerdict().verdict(
+        "package",
+        {"metadata": True},
+    )
+
+    assert status is ProbeCheckStatus.FAILURE
+    assert message == "requires organization_packages or packages"
+
+
+def test_custom_is_granted_supports_presence_checks() -> None:
+    status, message = PresenceOrKindPermissionVerdict().verdict(
+        "project",
+        {"repo": True},
+    )
+
+    assert status is ProbeCheckStatus.SUCCESS
+    assert message == "grants repo"


### PR DESCRIPTION
# Description

What -

Why -

How -

## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Probe initialization now depends on the integration config class instead of the spec file, which can change which kinds are considered valid at runtime; callers of `ProbeContext.initialize` must pass the config class.
> 
> **Overview**
> **Probe** now discovers supported resource kinds from the integration’s `PortAppConfig` / `ResourceConfig` Python types (`get_port_app_config_kinds`) instead of reading kinds from the integration spec path. `ProbeContext.initialize` takes a `port_app_config_class`, and `run_probe` passes `AppConfigHandlerClass.CONFIG_CLASS`.
> 
> Integrations can declare optional **`probe_permissions`** on each `ResourceConfig` (a tuple or a dict keyed by auth mode). **`get_kind_probe_permissions`** resolves those into a kind → permissions map for probes.
> 
> A new **`KindPermissionVerdict`** helper standardizes permission probe checks with **AND** or **OR** semantics, including handling for unmapped kinds, missing permission data, and grant/deny messaging. Unit tests cover the validators and verdict logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7bbb51ac77f06871b828e1daeaf1b1e442a839d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->