### PR TITLE
[Integration][aws-v3] Add CloudTrail live events for RDS DB cluster, SNS, SQS, EC2 instance/volume, and ElastiCache

### DIFF
--- a/integrations/aws-v3/.ocean-release/phase-1-live-events.yaml
+++ b/integrations/aws-v3/.ocean-release/phase-1-live-events.yaml
@@ -1,0 +1,3 @@
+bump: minor
+changelog-type: feature
+changelog: Add CloudTrail live events support for RDS DB clusters, SNS topics, SQS queues, EC2 instances, EC2 volumes, and ElastiCache clusters.

--- a/integrations/aws-v3/aws/core/exporters/ec2/instance/exporter.py
+++ b/integrations/aws-v3/aws/core/exporters/ec2/instance/exporter.py
@@ -1,5 +1,7 @@
 from typing import Any, AsyncGenerator, Type, List, Dict
 
+from botocore.exceptions import ClientError
+
 from loguru import logger
 
 from aws.core.client.proxy import AioBaseClientProxy
@@ -12,7 +14,6 @@ from aws.core.exporters.ec2.instance.models import (
 from aws.core.helpers.types import SupportedServices
 from aws.core.interfaces.exporter import IResourceExporter
 from aws.core.modeling.resource_inspector import ResourceInspector
-from loguru import logger
 
 
 class EC2InstanceExporter(IResourceExporter[list[dict[str, Any]]]):
@@ -26,6 +27,28 @@ class EC2InstanceExporter(IResourceExporter[list[dict[str, Any]]]):
         async with AioBaseClientProxy(
             self.session, options.region, self._service_name
         ) as proxy:
+            # Live-event single-instance fetch only has an instance ID from CloudTrail.
+            # Confirm it exists so a missing instance raises and the live-event
+            # handler can treat the update as a delete instead.
+            response = await proxy.client.describe_instances(  # type: ignore[attr-defined]
+                InstanceIds=[options.instance_id]
+            )
+            reservations = response.get("Reservations", [])
+            instances = [
+                instance
+                for reservation in reservations
+                for instance in reservation.get("Instances", [])
+            ]
+            if not instances:
+                raise ClientError(
+                    {
+                        "Error": {
+                            "Code": "InvalidInstanceID.NotFound",
+                            "Message": (f"Instance not found: {options.instance_id}"),
+                        }
+                    },
+                    "DescribeInstances",
+                )
 
             inspector = ResourceInspector(
                 proxy.client,

--- a/integrations/aws-v3/aws/core/exporters/ec2/instance/exporter.py
+++ b/integrations/aws-v3/aws/core/exporters/ec2/instance/exporter.py
@@ -1,7 +1,6 @@
 from typing import Any, AsyncGenerator, Type, List, Dict
 
-from botocore.exceptions import ClientError
-
+from aws.core.helpers.utils import extract_ec2_instances, require_aws_resource
 from loguru import logger
 
 from aws.core.client.proxy import AioBaseClientProxy
@@ -33,22 +32,12 @@ class EC2InstanceExporter(IResourceExporter[list[dict[str, Any]]]):
             response = await proxy.client.describe_instances(  # type: ignore[attr-defined]
                 InstanceIds=[options.instance_id]
             )
-            reservations = response.get("Reservations", [])
-            instances = [
-                instance
-                for reservation in reservations
-                for instance in reservation.get("Instances", [])
-            ]
-            if not instances:
-                raise ClientError(
-                    {
-                        "Error": {
-                            "Code": "InvalidInstanceID.NotFound",
-                            "Message": (f"Instance not found: {options.instance_id}"),
-                        }
-                    },
-                    "DescribeInstances",
-                )
+            instances = require_aws_resource(
+                extract_ec2_instances(response),
+                error_code="InvalidInstanceID.NotFound",
+                message=f"Instance not found: {options.instance_id}",
+                operation_name="DescribeInstances",
+            )
 
             inspector = ResourceInspector(
                 proxy.client,

--- a/integrations/aws-v3/aws/core/exporters/ec2/instance/exporter.py
+++ b/integrations/aws-v3/aws/core/exporters/ec2/instance/exporter.py
@@ -55,11 +55,16 @@ class EC2InstanceExporter(IResourceExporter[list[dict[str, Any]]]):
                 self._actions_map(),
                 lambda: self._model_cls(),
             )
-            response = await inspector.inspect(
-                [{"InstanceId": options.instance_id}], options.include
+            result = await inspector.inspect(
+                instances,
+                options.include,
+                extra_context={
+                    "AccountId": options.account_id,
+                    "Region": options.region,
+                },
             )
 
-            return response[0] if response else {}
+            return result[0] if result else {}
 
     async def get_paginated_resources(
         self, options: PaginatedEC2InstanceRequest

--- a/integrations/aws-v3/aws/core/exporters/ec2/instance/exporter.py
+++ b/integrations/aws-v3/aws/core/exporters/ec2/instance/exporter.py
@@ -1,10 +1,11 @@
 from typing import Any, AsyncGenerator, Type, List, Dict
 
-from aws.core.helpers.utils import extract_ec2_instances, require_aws_resource
+from aws.core.helpers.utils import require_aws_resource
 from loguru import logger
 
 from aws.core.client.proxy import AioBaseClientProxy
 from aws.core.exporters.ec2.instance.actions import EC2InstanceActionsMap
+from aws.core.exporters.ec2.instance.utils import extract_ec2_instances
 from aws.core.exporters.ec2.instance.models import EC2Instance
 from aws.core.exporters.ec2.instance.models import (
     SingleEC2InstanceRequest,
@@ -26,9 +27,6 @@ class EC2InstanceExporter(IResourceExporter[list[dict[str, Any]]]):
         async with AioBaseClientProxy(
             self.session, options.region, self._service_name
         ) as proxy:
-            # Live-event single-instance fetch only has an instance ID from CloudTrail.
-            # Confirm it exists so a missing instance raises and the live-event
-            # handler can treat the update as a delete instead.
             response = await proxy.client.describe_instances(  # type: ignore[attr-defined]
                 InstanceIds=[options.instance_id]
             )

--- a/integrations/aws-v3/aws/core/exporters/ec2/instance/live_events.py
+++ b/integrations/aws-v3/aws/core/exporters/ec2/instance/live_events.py
@@ -1,0 +1,88 @@
+from typing import Any
+
+from aws.core.exporters.ec2.instance.models import SingleEC2InstanceRequest
+from aws.core.helpers.metadata.types import (
+    CloudTrailDetail,
+    CloudTrailEventAction,
+    CloudTrailEventMapping,
+    LiveEventContext,
+    LiveEventFactories,
+)
+from aws.utils import RegionHelper
+
+CLOUDTRAIL_EVENT_SOURCE = "ec2.amazonaws.com"
+
+
+def _instance_arn(context: LiveEventContext) -> str:
+    partition = RegionHelper.get_partition()
+    return (
+        f"arn:{partition}:ec2:{context.region}:{context.account_id}:instance/"
+        f"{context.identifier}"
+    )
+
+
+def _extract_instance_id_from_instances_set(instances_set: Any) -> str | None:
+    if not isinstance(instances_set, dict):
+        return None
+    items = instances_set.get("items", [])
+    if not isinstance(items, list) or not items:
+        return None
+    first_item = items[0]
+    if not isinstance(first_item, dict):
+        return None
+    instance_id = first_item.get("instanceId")
+    return instance_id if isinstance(instance_id, str) else None
+
+
+def _extract_instance_id_from_request_parameters(
+    detail: CloudTrailDetail,
+) -> str | None:
+    request_parameters = detail.get("requestParameters", {})
+    return _extract_instance_id_from_instances_set(
+        request_parameters.get("instancesSet")
+    )
+
+
+def _extract_run_instances_instance_id(detail: CloudTrailDetail) -> str | None:
+    response_elements = detail.get("responseElements")
+    if not isinstance(response_elements, dict):
+        return None
+    return _extract_instance_id_from_instances_set(
+        response_elements.get("instancesSet")
+    )
+
+
+def _request_factory(
+    context: LiveEventContext, include_actions: list[str]
+) -> SingleEC2InstanceRequest:
+    return SingleEC2InstanceRequest(
+        instance_id=context.identifier,
+        region=context.region,
+        account_id=context.account_id,
+        include=include_actions,
+    )
+
+
+def _deletion_identifier_properties(context: LiveEventContext) -> dict[str, str]:
+    return {
+        "InstanceArn": _instance_arn(context),
+        "InstanceId": context.identifier,
+    }
+
+
+EC2_INSTANCE_LIVE_EVENTS = LiveEventFactories(
+    request_factory=_request_factory,
+    deletion_identifier_properties_factory=_deletion_identifier_properties,
+    cloudtrail_mappings={
+        "RunInstances": CloudTrailEventMapping(
+            CloudTrailEventAction.UPSERT,
+            _extract_run_instances_instance_id,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
+        ),
+        "TerminateInstances": CloudTrailEventMapping(
+            CloudTrailEventAction.DELETE,
+            _extract_instance_id_from_request_parameters,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
+        ),
+    },
+)

--- a/integrations/aws-v3/aws/core/exporters/ec2/instance/utils.py
+++ b/integrations/aws-v3/aws/core/exporters/ec2/instance/utils.py
@@ -1,0 +1,9 @@
+from typing import Any
+
+
+def extract_ec2_instances(response: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        instance
+        for reservation in response.get("Reservations", [])
+        for instance in reservation.get("Instances", [])
+    ]

--- a/integrations/aws-v3/aws/core/exporters/ec2/volume/exporter.py
+++ b/integrations/aws-v3/aws/core/exporters/ec2/volume/exporter.py
@@ -1,5 +1,7 @@
 from typing import Any, AsyncGenerator, Type
 
+from botocore.exceptions import ClientError
+
 from aws.core.client.proxy import AioBaseClientProxy
 from aws.core.exporters.ec2.volume.actions import EbsVolumeActionsMap
 from aws.core.exporters.ec2.volume.models import (
@@ -32,7 +34,15 @@ class EbsVolumeExporter(IResourceExporter[list[dict[str, Any]]]):
             )
             volumes = response.get("Volumes", [])
             if not volumes:
-                return {}
+                raise ClientError(
+                    {
+                        "Error": {
+                            "Code": "InvalidVolume.NotFound",
+                            "Message": f"Volume not found: {options.volume_id}",
+                        }
+                    },
+                    "DescribeVolumes",
+                )
             result = await inspector.inspect(
                 volumes,
                 options.include,

--- a/integrations/aws-v3/aws/core/exporters/ec2/volume/exporter.py
+++ b/integrations/aws-v3/aws/core/exporters/ec2/volume/exporter.py
@@ -1,8 +1,7 @@
 from typing import Any, AsyncGenerator, Type
 
-from botocore.exceptions import ClientError
-
 from aws.core.client.proxy import AioBaseClientProxy
+from aws.core.helpers.utils import require_aws_resource
 from aws.core.exporters.ec2.volume.actions import EbsVolumeActionsMap
 from aws.core.exporters.ec2.volume.models import (
     EbsVolume,
@@ -32,17 +31,12 @@ class EbsVolumeExporter(IResourceExporter[list[dict[str, Any]]]):
             response = await proxy.client.describe_volumes(  # type: ignore[attr-defined]
                 VolumeIds=[options.volume_id]
             )
-            volumes = response.get("Volumes", [])
-            if not volumes:
-                raise ClientError(
-                    {
-                        "Error": {
-                            "Code": "InvalidVolume.NotFound",
-                            "Message": f"Volume not found: {options.volume_id}",
-                        }
-                    },
-                    "DescribeVolumes",
-                )
+            volumes = require_aws_resource(
+                response.get("Volumes", []),
+                error_code="InvalidVolume.NotFound",
+                message=f"Volume not found: {options.volume_id}",
+                operation_name="DescribeVolumes",
+            )
             result = await inspector.inspect(
                 volumes,
                 options.include,

--- a/integrations/aws-v3/aws/core/exporters/ec2/volume/live_events.py
+++ b/integrations/aws-v3/aws/core/exporters/ec2/volume/live_events.py
@@ -10,7 +10,7 @@ from aws.core.helpers.metadata.types import (
 CLOUDTRAIL_EVENT_SOURCE = "ec2.amazonaws.com"
 
 
-def _extract_volume_id_from_request(detail: CloudTrailDetail) -> str | None:
+def _extract_volume_id_from_delete_request(detail: CloudTrailDetail) -> str | None:
     """DeleteVolume: requestParameters.volumeId."""
     request_parameters = detail.get("requestParameters", {})
     if not isinstance(request_parameters, dict):
@@ -34,7 +34,7 @@ def _extract_volume_id_from_modify_request(detail: CloudTrailDetail) -> str | No
     return volume_id if isinstance(volume_id, str) else None
 
 
-def _extract_volume_id_from_response(detail: CloudTrailDetail) -> str | None:
+def _extract_volume_id_from_create_response(detail: CloudTrailDetail) -> str | None:
     """CreateVolume: responseElements.volumeId."""
     response_elements = detail.get("responseElements")
     if not isinstance(response_elements, dict):
@@ -67,7 +67,7 @@ EC2_VOLUME_LIVE_EVENTS = LiveEventFactories(
     cloudtrail_mappings={
         "CreateVolume": CloudTrailEventMapping(
             CloudTrailEventAction.UPSERT,
-            _extract_volume_id_from_response,
+            _extract_volume_id_from_create_response,
             event_source=CLOUDTRAIL_EVENT_SOURCE,
         ),
         "ModifyVolume": CloudTrailEventMapping(
@@ -77,7 +77,7 @@ EC2_VOLUME_LIVE_EVENTS = LiveEventFactories(
         ),
         "DeleteVolume": CloudTrailEventMapping(
             CloudTrailEventAction.DELETE,
-            _extract_volume_id_from_request,
+            _extract_volume_id_from_delete_request,
             event_source=CLOUDTRAIL_EVENT_SOURCE,
         ),
     },

--- a/integrations/aws-v3/aws/core/exporters/ec2/volume/live_events.py
+++ b/integrations/aws-v3/aws/core/exporters/ec2/volume/live_events.py
@@ -1,0 +1,65 @@
+from aws.core.exporters.ec2.volume.models import SingleEbsVolumeRequest
+from aws.core.helpers.metadata.types import (
+    CloudTrailDetail,
+    CloudTrailEventAction,
+    CloudTrailEventMapping,
+    LiveEventContext,
+    LiveEventFactories,
+)
+
+CLOUDTRAIL_EVENT_SOURCE = "ec2.amazonaws.com"
+
+
+def _extract_volume_id(detail: CloudTrailDetail) -> str | None:
+    request_parameters = detail.get("requestParameters", {})
+    volume_id = request_parameters.get("volumeId")
+    if isinstance(volume_id, str):
+        return volume_id
+
+    response_elements = detail.get("responseElements")
+    if isinstance(response_elements, dict):
+        response_volume_id = response_elements.get("volumeId")
+        if isinstance(response_volume_id, str):
+            return response_volume_id
+
+    return None
+
+
+def _request_factory(
+    context: LiveEventContext, include_actions: list[str]
+) -> SingleEbsVolumeRequest:
+    return SingleEbsVolumeRequest(
+        volume_id=context.identifier,
+        region=context.region,
+        account_id=context.account_id,
+        include=include_actions,
+    )
+
+
+def _deletion_identifier_properties(context: LiveEventContext) -> dict[str, str]:
+    return {
+        "VolumeId": context.identifier,
+    }
+
+
+EC2_VOLUME_LIVE_EVENTS = LiveEventFactories(
+    request_factory=_request_factory,
+    deletion_identifier_properties_factory=_deletion_identifier_properties,
+    cloudtrail_mappings={
+        "CreateVolume": CloudTrailEventMapping(
+            CloudTrailEventAction.UPSERT,
+            _extract_volume_id,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
+        ),
+        "ModifyVolume": CloudTrailEventMapping(
+            CloudTrailEventAction.UPSERT,
+            _extract_volume_id,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
+        ),
+        "DeleteVolume": CloudTrailEventMapping(
+            CloudTrailEventAction.DELETE,
+            _extract_volume_id,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
+        ),
+    },
+)

--- a/integrations/aws-v3/aws/core/exporters/ec2/volume/live_events.py
+++ b/integrations/aws-v3/aws/core/exporters/ec2/volume/live_events.py
@@ -10,34 +10,38 @@ from aws.core.helpers.metadata.types import (
 CLOUDTRAIL_EVENT_SOURCE = "ec2.amazonaws.com"
 
 
-def _extract_volume_id(detail: CloudTrailDetail) -> str | None:
+def _extract_volume_id_from_request(detail: CloudTrailDetail) -> str | None:
+    """DeleteVolume: requestParameters.volumeId."""
     request_parameters = detail.get("requestParameters", {})
-    if isinstance(request_parameters, dict):
-        volume_id = request_parameters.get("volumeId")
-        if isinstance(volume_id, str):
-            return volume_id
+    if not isinstance(request_parameters, dict):
+        return None
 
-        modify_volume_request = request_parameters.get("ModifyVolumeRequest")
-        if isinstance(modify_volume_request, dict):
-            modify_volume_id = modify_volume_request.get("VolumeId")
-            if isinstance(modify_volume_id, str):
-                return modify_volume_id
+    volume_id = request_parameters.get("volumeId")
+    return volume_id if isinstance(volume_id, str) else None
 
+
+def _extract_volume_id_from_modify_request(detail: CloudTrailDetail) -> str | None:
+    """ModifyVolume: requestParameters.ModifyVolumeRequest.VolumeId."""
+    request_parameters = detail.get("requestParameters", {})
+    if not isinstance(request_parameters, dict):
+        return None
+
+    modify_volume_request = request_parameters.get("ModifyVolumeRequest")
+    if not isinstance(modify_volume_request, dict):
+        return None
+
+    volume_id = modify_volume_request.get("VolumeId")
+    return volume_id if isinstance(volume_id, str) else None
+
+
+def _extract_volume_id_from_response(detail: CloudTrailDetail) -> str | None:
+    """CreateVolume: responseElements.volumeId."""
     response_elements = detail.get("responseElements")
-    if isinstance(response_elements, dict):
-        response_volume_id = response_elements.get("volumeId")
-        if isinstance(response_volume_id, str):
-            return response_volume_id
+    if not isinstance(response_elements, dict):
+        return None
 
-        modify_volume_response = response_elements.get("ModifyVolumeResponse")
-        if isinstance(modify_volume_response, dict):
-            volume_modification = modify_volume_response.get("volumeModification")
-            if isinstance(volume_modification, dict):
-                modification_volume_id = volume_modification.get("volumeId")
-                if isinstance(modification_volume_id, str):
-                    return modification_volume_id
-
-    return None
+    volume_id = response_elements.get("volumeId")
+    return volume_id if isinstance(volume_id, str) else None
 
 
 def _request_factory(
@@ -63,17 +67,17 @@ EC2_VOLUME_LIVE_EVENTS = LiveEventFactories(
     cloudtrail_mappings={
         "CreateVolume": CloudTrailEventMapping(
             CloudTrailEventAction.UPSERT,
-            _extract_volume_id,
+            _extract_volume_id_from_response,
             event_source=CLOUDTRAIL_EVENT_SOURCE,
         ),
         "ModifyVolume": CloudTrailEventMapping(
             CloudTrailEventAction.UPSERT,
-            _extract_volume_id,
+            _extract_volume_id_from_modify_request,
             event_source=CLOUDTRAIL_EVENT_SOURCE,
         ),
         "DeleteVolume": CloudTrailEventMapping(
             CloudTrailEventAction.DELETE,
-            _extract_volume_id,
+            _extract_volume_id_from_request,
             event_source=CLOUDTRAIL_EVENT_SOURCE,
         ),
     },

--- a/integrations/aws-v3/aws/core/exporters/ec2/volume/live_events.py
+++ b/integrations/aws-v3/aws/core/exporters/ec2/volume/live_events.py
@@ -12,15 +12,30 @@ CLOUDTRAIL_EVENT_SOURCE = "ec2.amazonaws.com"
 
 def _extract_volume_id(detail: CloudTrailDetail) -> str | None:
     request_parameters = detail.get("requestParameters", {})
-    volume_id = request_parameters.get("volumeId")
-    if isinstance(volume_id, str):
-        return volume_id
+    if isinstance(request_parameters, dict):
+        volume_id = request_parameters.get("volumeId")
+        if isinstance(volume_id, str):
+            return volume_id
+
+        modify_volume_request = request_parameters.get("ModifyVolumeRequest")
+        if isinstance(modify_volume_request, dict):
+            modify_volume_id = modify_volume_request.get("VolumeId")
+            if isinstance(modify_volume_id, str):
+                return modify_volume_id
 
     response_elements = detail.get("responseElements")
     if isinstance(response_elements, dict):
         response_volume_id = response_elements.get("volumeId")
         if isinstance(response_volume_id, str):
             return response_volume_id
+
+        modify_volume_response = response_elements.get("ModifyVolumeResponse")
+        if isinstance(modify_volume_response, dict):
+            volume_modification = modify_volume_response.get("volumeModification")
+            if isinstance(volume_modification, dict):
+                modification_volume_id = volume_modification.get("volumeId")
+                if isinstance(modification_volume_id, str):
+                    return modification_volume_id
 
     return None
 

--- a/integrations/aws-v3/aws/core/exporters/ecs/cluster/exporter.py
+++ b/integrations/aws-v3/aws/core/exporters/ecs/cluster/exporter.py
@@ -24,11 +24,6 @@ class EcsClusterExporter(IResourceExporter[list[str]]):
         async with AioBaseClientProxy(
             self.session, options.region, self._service_name
         ) as proxy:
-            # Live-event single-cluster fetch only has a cluster name from CloudTrail.
-            # describe_clusters returns an empty list when the cluster is gone instead
-            # of raising, and the inspector would still build a stub from that name.
-            # Confirm it exists so a missing cluster raises and the live-event handler
-            # can treat the update as a delete instead.
             response = await proxy.client.describe_clusters(  # type: ignore[attr-defined]
                 clusters=[options.cluster_name]
             )

--- a/integrations/aws-v3/aws/core/exporters/ecs/cluster/exporter.py
+++ b/integrations/aws-v3/aws/core/exporters/ecs/cluster/exporter.py
@@ -1,8 +1,7 @@
 from typing import Any, AsyncGenerator, Type
 
-from botocore.exceptions import ClientError
-
 from aws.core.client.proxy import AioBaseClientProxy
+from aws.core.helpers.utils import require_aws_resource
 from aws.core.exporters.ecs.cluster.actions import EcsClusterActionsMap
 from aws.core.exporters.ecs.cluster.models import Cluster
 from aws.core.exporters.ecs.cluster.models import (
@@ -33,16 +32,12 @@ class EcsClusterExporter(IResourceExporter[list[str]]):
             response = await proxy.client.describe_clusters(  # type: ignore[attr-defined]
                 clusters=[options.cluster_name]
             )
-            if not response.get("clusters"):
-                raise ClientError(
-                    {
-                        "Error": {
-                            "Code": "ClusterNotFoundException",
-                            "Message": f"Cluster not found: {options.cluster_name}",
-                        }
-                    },
-                    "DescribeClusters",
-                )
+            require_aws_resource(
+                response.get("clusters"),
+                error_code="ClusterNotFoundException",
+                message=f"Cluster not found: {options.cluster_name}",
+                operation_name="DescribeClusters",
+            )
 
             inspector = ResourceInspector(
                 proxy.client, self._actions_map(), lambda: self._model_cls()

--- a/integrations/aws-v3/aws/core/exporters/elasticache/cluster/exporter.py
+++ b/integrations/aws-v3/aws/core/exporters/elasticache/cluster/exporter.py
@@ -1,8 +1,7 @@
 from typing import Any, AsyncGenerator, Type
 
-from botocore.exceptions import ClientError
-
 from aws.core.client.proxy import AioBaseClientProxy
+from aws.core.helpers.utils import require_aws_resource
 from aws.core.exporters.elasticache.cluster.actions import ElastiCacheClusterActionsMap
 from aws.core.exporters.elasticache.cluster.models import CacheCluster
 from aws.core.exporters.elasticache.cluster.models import (
@@ -30,19 +29,12 @@ class ElastiCacheClusterExporter(IResourceExporter[list[dict[str, Any]]]):
                 ShowCacheNodeInfo=True,
             )
 
-            cache_clusters = response.get("CacheClusters", [])
-            if not cache_clusters:
-                raise ClientError(
-                    {
-                        "Error": {
-                            "Code": "CacheClusterNotFoundFault",
-                            "Message": (
-                                f"Cache cluster not found: {options.cache_cluster_id}"
-                            ),
-                        }
-                    },
-                    "DescribeCacheClusters",
-                )
+            cache_clusters = require_aws_resource(
+                response.get("CacheClusters", []),
+                error_code="CacheClusterNotFoundFault",
+                message=f"Cache cluster not found: {options.cache_cluster_id}",
+                operation_name="DescribeCacheClusters",
+            )
 
             inspector = ResourceInspector(
                 proxy.client, self._actions_map(), lambda: self._model_cls()

--- a/integrations/aws-v3/aws/core/exporters/elasticache/cluster/exporter.py
+++ b/integrations/aws-v3/aws/core/exporters/elasticache/cluster/exporter.py
@@ -1,5 +1,7 @@
 from typing import Any, AsyncGenerator, Type
 
+from botocore.exceptions import ClientError
+
 from aws.core.client.proxy import AioBaseClientProxy
 from aws.core.exporters.elasticache.cluster.actions import ElastiCacheClusterActionsMap
 from aws.core.exporters.elasticache.cluster.models import CacheCluster
@@ -23,16 +25,28 @@ class ElastiCacheClusterExporter(IResourceExporter[list[dict[str, Any]]]):
         async with AioBaseClientProxy(
             self.session, options.region, self._service_name
         ) as proxy:
-            inspector = ResourceInspector(
-                proxy.client, self._actions_map(), lambda: self._model_cls()
-            )
-
             response = await proxy.client.describe_cache_clusters(  # type: ignore[attr-defined]
                 CacheClusterId=options.cache_cluster_id,
                 ShowCacheNodeInfo=True,
             )
 
-            cache_clusters = response["CacheClusters"]
+            cache_clusters = response.get("CacheClusters", [])
+            if not cache_clusters:
+                raise ClientError(
+                    {
+                        "Error": {
+                            "Code": "CacheClusterNotFoundFault",
+                            "Message": (
+                                f"Cache cluster not found: {options.cache_cluster_id}"
+                            ),
+                        }
+                    },
+                    "DescribeCacheClusters",
+                )
+
+            inspector = ResourceInspector(
+                proxy.client, self._actions_map(), lambda: self._model_cls()
+            )
             action_result = await inspector.inspect(
                 cache_clusters,
                 options.include,

--- a/integrations/aws-v3/aws/core/exporters/elasticache/cluster/live_events.py
+++ b/integrations/aws-v3/aws/core/exporters/elasticache/cluster/live_events.py
@@ -1,0 +1,56 @@
+from aws.core.exporters.elasticache.cluster.models import SingleCacheClusterRequest
+from aws.core.helpers.metadata.types import (
+    CloudTrailDetail,
+    CloudTrailEventAction,
+    CloudTrailEventMapping,
+    LiveEventContext,
+    LiveEventFactories,
+)
+
+CLOUDTRAIL_EVENT_SOURCE = "elasticache.amazonaws.com"
+
+
+def _extract_cache_cluster_id(detail: CloudTrailDetail) -> str | None:
+    request_parameters = detail.get("requestParameters", {})
+    cache_cluster_id = request_parameters.get("cacheClusterId")
+    return cache_cluster_id if isinstance(cache_cluster_id, str) else None
+
+
+def _request_factory(
+    context: LiveEventContext, include_actions: list[str]
+) -> SingleCacheClusterRequest:
+    return SingleCacheClusterRequest(
+        cache_cluster_id=context.identifier,
+        region=context.region,
+        account_id=context.account_id,
+        include=include_actions,
+    )
+
+
+def _deletion_identifier_properties(context: LiveEventContext) -> dict[str, str]:
+    return {
+        "CacheClusterId": context.identifier,
+    }
+
+
+ELASTICACHE_CLUSTER_LIVE_EVENTS = LiveEventFactories(
+    request_factory=_request_factory,
+    deletion_identifier_properties_factory=_deletion_identifier_properties,
+    cloudtrail_mappings={
+        "CreateCacheCluster": CloudTrailEventMapping(
+            CloudTrailEventAction.UPSERT,
+            _extract_cache_cluster_id,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
+        ),
+        "ModifyCacheCluster": CloudTrailEventMapping(
+            CloudTrailEventAction.UPSERT,
+            _extract_cache_cluster_id,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
+        ),
+        "DeleteCacheCluster": CloudTrailEventMapping(
+            CloudTrailEventAction.DELETE,
+            _extract_cache_cluster_id,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
+        ),
+    },
+)

--- a/integrations/aws-v3/aws/core/exporters/elasticache/cluster/live_events.py
+++ b/integrations/aws-v3/aws/core/exporters/elasticache/cluster/live_events.py
@@ -6,8 +6,17 @@ from aws.core.helpers.metadata.types import (
     LiveEventContext,
     LiveEventFactories,
 )
+from aws.utils import RegionHelper
 
 CLOUDTRAIL_EVENT_SOURCE = "elasticache.amazonaws.com"
+
+
+def _cache_cluster_arn(context: LiveEventContext) -> str:
+    partition = RegionHelper.get_partition()
+    return (
+        f"arn:{partition}:elasticache:{context.region}:{context.account_id}:cluster:"
+        f"{context.identifier}"
+    )
 
 
 def _extract_cache_cluster_id(detail: CloudTrailDetail) -> str | None:
@@ -29,6 +38,7 @@ def _request_factory(
 
 def _deletion_identifier_properties(context: LiveEventContext) -> dict[str, str]:
     return {
+        "ARN": _cache_cluster_arn(context),
         "CacheClusterId": context.identifier,
     }
 

--- a/integrations/aws-v3/aws/core/exporters/exporter_metadata.py
+++ b/integrations/aws-v3/aws/core/exporters/exporter_metadata.py
@@ -38,7 +38,9 @@ from aws.core.exporters.ec2.instance import (
     EC2InstanceExporter,
     PaginatedEC2InstanceRequest,
 )
+from aws.core.exporters.ec2.instance.live_events import EC2_INSTANCE_LIVE_EVENTS
 from aws.core.exporters.ec2.volume import EbsVolumeExporter
+from aws.core.exporters.ec2.volume.live_events import EC2_VOLUME_LIVE_EVENTS
 from aws.core.exporters.ec2.volume.models import PaginatedEbsVolumeRequest
 from aws.core.exporters.ecr import EcrRepositoryExporter
 from aws.core.exporters.ecr.repository.live_events import ECR_REPOSITORY_LIVE_EVENTS
@@ -54,6 +56,9 @@ from aws.core.exporters.eks.cluster.exporter import EksClusterExporter
 from aws.core.exporters.eks.cluster.live_events import EKS_CLUSTER_LIVE_EVENTS
 from aws.core.exporters.eks.cluster.models import PaginatedEksClusterRequest
 from aws.core.exporters.elasticache import ElastiCacheClusterExporter
+from aws.core.exporters.elasticache.cluster.live_events import (
+    ELASTICACHE_CLUSTER_LIVE_EVENTS,
+)
 from aws.core.exporters.elasticache.cluster.models import PaginatedCacheClusterRequest
 from aws.core.exporters.memorydb.user.exporter import MemoryDbUserExporter
 from aws.core.exporters.memorydb.user.models import PaginatedMemoryDbUserRequest
@@ -64,6 +69,7 @@ from aws.core.exporters.msk.serverless_cluster.models import (
     PaginatedMskServerlessClusterRequest,
 )
 from aws.core.exporters.rds.db_cluster.exporter import RdsDbClusterExporter
+from aws.core.exporters.rds.db_cluster.live_events import RDS_DB_CLUSTER_LIVE_EVENTS
 from aws.core.exporters.rds.db_cluster.models import PaginatedDbClusterRequest
 from aws.core.exporters.rds.db_instance.exporter import RdsDbInstanceExporter
 from aws.core.exporters.rds.db_instance.live_events import RDS_DB_INSTANCE_LIVE_EVENTS
@@ -77,7 +83,9 @@ from aws.core.exporters.ses import (
     SesEmailIdentityExporter,
 )
 from aws.core.exporters.sns import SNSTopicExporter, PaginatedTopicRequest
+from aws.core.exporters.sns.topic.live_events import SNS_TOPIC_LIVE_EVENTS
 from aws.core.exporters.sqs import SqsQueueExporter
+from aws.core.exporters.sqs.queue.live_events import SQS_QUEUE_LIVE_EVENTS
 from aws.core.exporters.sqs.queue.models import PaginatedQueueRequest
 from aws.core.helpers.types import ObjectKind
 
@@ -89,7 +97,9 @@ kind_to_export_metadata: dict[ObjectKind, ExporterMetadata] = {
         live_events=S3_BUCKET_LIVE_EVENTS,
     ),
     ObjectKind.EC2_INSTANCE: ExporterMetadata(
-        EC2InstanceExporter, PaginatedEC2InstanceRequest
+        EC2InstanceExporter,
+        PaginatedEC2InstanceRequest,
+        live_events=EC2_INSTANCE_LIVE_EVENTS,
     ),
     ObjectKind.ECS_CLUSTER: ExporterMetadata(
         EcsClusterExporter,
@@ -107,7 +117,9 @@ kind_to_export_metadata: dict[ObjectKind, ExporterMetadata] = {
         live_events=RDS_DB_INSTANCE_LIVE_EVENTS,
     ),
     ObjectKind.RDS_DB_CLUSTER: ExporterMetadata(
-        RdsDbClusterExporter, PaginatedDbClusterRequest
+        RdsDbClusterExporter,
+        PaginatedDbClusterRequest,
+        live_events=RDS_DB_CLUSTER_LIVE_EVENTS,
     ),
     ObjectKind.LAMBDA_FUNCTION: ExporterMetadata(
         LambdaFunctionExporter,
@@ -120,7 +132,11 @@ kind_to_export_metadata: dict[ObjectKind, ExporterMetadata] = {
     ObjectKind.ECS_TASK_DEFINITION: ExporterMetadata(
         EcsTaskDefinitionExporter, PaginatedTaskDefinitionRequest
     ),
-    ObjectKind.SQS_QUEUE: ExporterMetadata(SqsQueueExporter, PaginatedQueueRequest),
+    ObjectKind.SQS_QUEUE: ExporterMetadata(
+        SqsQueueExporter,
+        PaginatedQueueRequest,
+        live_events=SQS_QUEUE_LIVE_EVENTS,
+    ),
     ObjectKind.ECR_REPOSITORY: ExporterMetadata(
         EcrRepositoryExporter,
         PaginatedRepositoryRequest,
@@ -136,10 +152,14 @@ kind_to_export_metadata: dict[ObjectKind, ExporterMetadata] = {
         MskClusterExporter, PaginatedMskClusterRequest
     ),
     ObjectKind.ELASTICACHE_CLUSTER: ExporterMetadata(
-        ElastiCacheClusterExporter, PaginatedCacheClusterRequest
+        ElastiCacheClusterExporter,
+        PaginatedCacheClusterRequest,
+        live_events=ELASTICACHE_CLUSTER_LIVE_EVENTS,
     ),
     ObjectKind.EC2_VOLUME: ExporterMetadata(
-        EbsVolumeExporter, PaginatedEbsVolumeRequest
+        EbsVolumeExporter,
+        PaginatedEbsVolumeRequest,
+        live_events=EC2_VOLUME_LIVE_EVENTS,
     ),
     ObjectKind.CODEBUILD_PROJECT: ExporterMetadata(
         CodeBuildProjectExporter, PaginatedCodeBuildProjectRequest
@@ -185,5 +205,9 @@ kind_to_export_metadata: dict[ObjectKind, ExporterMetadata] = {
     ObjectKind.SES_CONFIGURATION_SET: ExporterMetadata(
         SesConfigurationSetExporter, PaginatedConfigurationSetRequest
     ),
-    ObjectKind.SNS_TOPIC: ExporterMetadata(SNSTopicExporter, PaginatedTopicRequest),
+    ObjectKind.SNS_TOPIC: ExporterMetadata(
+        SNSTopicExporter,
+        PaginatedTopicRequest,
+        live_events=SNS_TOPIC_LIVE_EVENTS,
+    ),
 }

--- a/integrations/aws-v3/aws/core/exporters/rds/db_cluster/exporter.py
+++ b/integrations/aws-v3/aws/core/exporters/rds/db_cluster/exporter.py
@@ -1,8 +1,7 @@
 from typing import Any, AsyncGenerator, Type
 
-from botocore.exceptions import ClientError
-
 from aws.core.client.proxy import AioBaseClientProxy
+from aws.core.helpers.utils import require_aws_resource
 from aws.core.exporters.rds.db_cluster.actions import RdsDbClusterActionsMap
 from aws.core.exporters.rds.db_cluster.models import (
     DbCluster,
@@ -29,19 +28,12 @@ class RdsDbClusterExporter(IResourceExporter[list[dict[str, Any]]]):
                 DBClusterIdentifier=options.db_cluster_identifier
             )
 
-            db_clusters = response.get("DBClusters", [])
-            if not db_clusters:
-                raise ClientError(
-                    {
-                        "Error": {
-                            "Code": "DBClusterNotFoundFault",
-                            "Message": (
-                                f"DB cluster not found: {options.db_cluster_identifier}"
-                            ),
-                        }
-                    },
-                    "DescribeDBClusters",
-                )
+            db_clusters = require_aws_resource(
+                response.get("DBClusters", []),
+                error_code="DBClusterNotFoundFault",
+                message=f"DB cluster not found: {options.db_cluster_identifier}",
+                operation_name="DescribeDBClusters",
+            )
 
             inspector = ResourceInspector(
                 proxy.client, self._actions_map(), lambda: self._model_cls()

--- a/integrations/aws-v3/aws/core/exporters/rds/db_cluster/exporter.py
+++ b/integrations/aws-v3/aws/core/exporters/rds/db_cluster/exporter.py
@@ -1,5 +1,7 @@
 from typing import Any, AsyncGenerator, Type
 
+from botocore.exceptions import ClientError
+
 from aws.core.client.proxy import AioBaseClientProxy
 from aws.core.exporters.rds.db_cluster.actions import RdsDbClusterActionsMap
 from aws.core.exporters.rds.db_cluster.models import (
@@ -23,17 +25,30 @@ class RdsDbClusterExporter(IResourceExporter[list[dict[str, Any]]]):
         async with AioBaseClientProxy(
             self.session, options.region, self._service_name
         ) as proxy:
-            inspector = ResourceInspector(
-                proxy.client, self._actions_map(), lambda: self._model_cls()
-            )
-
             response = await proxy.client.describe_db_clusters(  # type: ignore[attr-defined]
                 DBClusterIdentifier=options.db_cluster_identifier
             )
 
-            db_cluster = response["DBClusters"]
+            db_clusters = response.get("DBClusters", [])
+            if not db_clusters:
+                raise ClientError(
+                    {
+                        "Error": {
+                            "Code": "DBClusterNotFoundFault",
+                            "Message": (
+                                f"DB cluster not found: {options.db_cluster_identifier}"
+                            ),
+                        }
+                    },
+                    "DescribeDBClusters",
+                )
+
+            inspector = ResourceInspector(
+                proxy.client, self._actions_map(), lambda: self._model_cls()
+            )
+
             action_result = await inspector.inspect(
-                db_cluster,
+                db_clusters,
                 options.include,
                 extra_context={
                     "AccountId": options.account_id,

--- a/integrations/aws-v3/aws/core/exporters/rds/db_cluster/live_events.py
+++ b/integrations/aws-v3/aws/core/exporters/rds/db_cluster/live_events.py
@@ -1,0 +1,69 @@
+from aws.core.exporters.rds.db_cluster.models import SingleDbClusterRequest
+from aws.core.helpers.metadata.types import (
+    CloudTrailDetail,
+    CloudTrailEventAction,
+    CloudTrailEventMapping,
+    LiveEventContext,
+    LiveEventFactories,
+)
+from aws.utils import RegionHelper
+
+CLOUDTRAIL_EVENT_SOURCE = "rds.amazonaws.com"
+
+
+def _db_cluster_arn(context: LiveEventContext) -> str:
+    partition = RegionHelper.get_partition()
+    return (
+        f"arn:{partition}:rds:{context.region}:{context.account_id}:cluster:"
+        f"{context.identifier}"
+    )
+
+
+def _extract_db_cluster_identifier(detail: CloudTrailDetail) -> str | None:
+    request_parameters = detail.get("requestParameters", {})
+    identifier = request_parameters.get("dbClusterIdentifier")
+    if isinstance(identifier, str):
+        return identifier
+    identifier = request_parameters.get("dBClusterIdentifier")
+    return identifier if isinstance(identifier, str) else None
+
+
+def _request_factory(
+    context: LiveEventContext, include_actions: list[str]
+) -> SingleDbClusterRequest:
+    return SingleDbClusterRequest(
+        db_cluster_identifier=context.identifier,
+        region=context.region,
+        account_id=context.account_id,
+        include=include_actions,
+    )
+
+
+def _deletion_identifier_properties(context: LiveEventContext) -> dict[str, str]:
+    return {
+        "DBClusterArn": _db_cluster_arn(context),
+        "DBClusterIdentifier": context.identifier,
+    }
+
+
+RDS_DB_CLUSTER_LIVE_EVENTS = LiveEventFactories(
+    request_factory=_request_factory,
+    deletion_identifier_properties_factory=_deletion_identifier_properties,
+    cloudtrail_mappings={
+        "CreateDBCluster": CloudTrailEventMapping(
+            CloudTrailEventAction.UPSERT,
+            _extract_db_cluster_identifier,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
+        ),
+        "ModifyDBCluster": CloudTrailEventMapping(
+            CloudTrailEventAction.UPSERT,
+            _extract_db_cluster_identifier,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
+        ),
+        "DeleteDBCluster": CloudTrailEventMapping(
+            CloudTrailEventAction.DELETE,
+            _extract_db_cluster_identifier,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
+        ),
+    },
+)

--- a/integrations/aws-v3/aws/core/exporters/sns/topic/exporter.py
+++ b/integrations/aws-v3/aws/core/exporters/sns/topic/exporter.py
@@ -26,6 +26,15 @@ class SNSTopicExporter(IResourceExporter[SNSTopicActionInput]):
         async with AioBaseClientProxy(
             self.session, options.region, self._service_name
         ) as proxy:
+            # Live-event single-topic fetch only has a topic ARN from CloudTrail.
+            # GetTopicAttributesAction swallows ResourceNotFound as recoverable,
+            # so the inspector would build a stub from ListTopicsAction for a deleted topic.
+            # Confirm it exists so a missing topic raises and the live-event handler
+            # can treat the update as a delete instead.
+            await proxy.client.get_topic_attributes(  # type: ignore[attr-defined]
+                TopicArn=options.topic_arn
+            )
+
             inspector = ResourceInspector(
                 proxy.client, self._actions_map(), lambda: self._model_cls()
             )

--- a/integrations/aws-v3/aws/core/exporters/sns/topic/live_events.py
+++ b/integrations/aws-v3/aws/core/exporters/sns/topic/live_events.py
@@ -1,0 +1,83 @@
+from aws.core.exporters.sns.topic.models import SingleTopicRequest
+from aws.core.helpers.metadata.types import (
+    CloudTrailDetail,
+    CloudTrailEventAction,
+    CloudTrailEventMapping,
+    LiveEventContext,
+    LiveEventFactories,
+)
+from aws.utils import RegionHelper
+
+CLOUDTRAIL_EVENT_SOURCE = "sns.amazonaws.com"
+
+
+def _topic_arn(context: LiveEventContext) -> str:
+    partition = RegionHelper.get_partition()
+    return (
+        f"arn:{partition}:sns:{context.region}:{context.account_id}:"
+        f"{context.identifier}"
+    )
+
+
+def _topic_name_from_arn(topic_arn: str) -> str | None:
+    topic_name = topic_arn.rsplit(":", maxsplit=1)[-1]
+    return topic_name if topic_name else None
+
+
+def _extract_topic_name(detail: CloudTrailDetail) -> str | None:
+    request_parameters = detail.get("requestParameters", {})
+    topic_name = request_parameters.get("name")
+    if isinstance(topic_name, str):
+        return topic_name
+
+    topic_arn = request_parameters.get("topicArn")
+    if isinstance(topic_arn, str):
+        return _topic_name_from_arn(topic_arn)
+
+    response_elements = detail.get("responseElements")
+    if isinstance(response_elements, dict):
+        response_topic_arn = response_elements.get("topicArn")
+        if isinstance(response_topic_arn, str):
+            return _topic_name_from_arn(response_topic_arn)
+
+    return None
+
+
+def _request_factory(
+    context: LiveEventContext, include_actions: list[str]
+) -> SingleTopicRequest:
+    return SingleTopicRequest(
+        topic_arn=_topic_arn(context),
+        region=context.region,
+        account_id=context.account_id,
+        include=include_actions,
+    )
+
+
+def _deletion_identifier_properties(context: LiveEventContext) -> dict[str, str]:
+    return {
+        "TopicArn": _topic_arn(context),
+    }
+
+
+SNS_TOPIC_LIVE_EVENTS = LiveEventFactories(
+    request_factory=_request_factory,
+    deletion_identifier_properties_factory=_deletion_identifier_properties,
+    cloudtrail_mappings={
+        "CreateTopic": CloudTrailEventMapping(
+            CloudTrailEventAction.UPSERT,
+            _extract_topic_name,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
+        ),
+        "SetTopicAttributes": CloudTrailEventMapping(
+            CloudTrailEventAction.UPSERT,
+            _extract_topic_name,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
+        ),
+        "DeleteTopic": CloudTrailEventMapping(
+            CloudTrailEventAction.DELETE,
+            _extract_topic_name,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
+        ),
+    },
+)

--- a/integrations/aws-v3/aws/core/exporters/sqs/queue/exporter.py
+++ b/integrations/aws-v3/aws/core/exporters/sqs/queue/exporter.py
@@ -21,6 +21,16 @@ class SqsQueueExporter(IResourceExporter[list[str]]):
         async with AioBaseClientProxy(
             self.session, options.region, self._service_name
         ) as proxy:
+            # Live-event single-queue fetch only has a queue URL from CloudTrail.
+            # GetQueueAttributesAction swallows recoverable not-found errors,
+            # so the inspector would build a stub from ListQueuesAction for a deleted queue.
+            # Confirm it exists so a missing queue raises and the live-event handler
+            # can treat the update as a delete instead.
+            await proxy.client.get_queue_attributes(  # type: ignore[attr-defined]
+                QueueUrl=options.queue_url,
+                AttributeNames=["All"],
+            )
+
             inspector = ResourceInspector(
                 proxy.client, self._actions_map(), lambda: self._model_cls()
             )

--- a/integrations/aws-v3/aws/core/exporters/sqs/queue/exporter.py
+++ b/integrations/aws-v3/aws/core/exporters/sqs/queue/exporter.py
@@ -21,11 +21,7 @@ class SqsQueueExporter(IResourceExporter[list[str]]):
         async with AioBaseClientProxy(
             self.session, options.region, self._service_name
         ) as proxy:
-            # Live-event single-queue fetch only has a queue URL from CloudTrail.
-            # GetQueueAttributesAction swallows recoverable not-found errors,
-            # so the inspector would build a stub from ListQueuesAction for a deleted queue.
-            # Confirm it exists so a missing queue raises and the live-event handler
-            # can treat the update as a delete instead.
+            # Confirm the queue exists so live events can treat a missing queue as deleted.
             await proxy.client.get_queue_attributes(  # type: ignore[attr-defined]
                 QueueUrl=options.queue_url,
                 AttributeNames=["All"],

--- a/integrations/aws-v3/aws/core/exporters/sqs/queue/exporter.py
+++ b/integrations/aws-v3/aws/core/exporters/sqs/queue/exporter.py
@@ -21,10 +21,13 @@ class SqsQueueExporter(IResourceExporter[list[str]]):
         async with AioBaseClientProxy(
             self.session, options.region, self._service_name
         ) as proxy:
-            # Confirm the queue exists so live events can treat a missing queue as deleted.
+            # Live-event single-queue fetch only has a queue URL from CloudTrail.
+            # GetQueueAttributesAction swallows recoverable not-found errors,
+            # so the inspector would build a stub from ListQueuesAction for a deleted queue.
+            # Confirm it exists so a missing queue raises and the live-event handler
+            # can treat the update as a delete instead.
             await proxy.client.get_queue_attributes(  # type: ignore[attr-defined]
                 QueueUrl=options.queue_url,
-                AttributeNames=["All"],
             )
 
             inspector = ResourceInspector(

--- a/integrations/aws-v3/aws/core/exporters/sqs/queue/live_events.py
+++ b/integrations/aws-v3/aws/core/exporters/sqs/queue/live_events.py
@@ -1,0 +1,89 @@
+from aws.core.exporters.sqs.queue.models import SingleQueueRequest
+from aws.core.helpers.metadata.types import (
+    CloudTrailDetail,
+    CloudTrailEventAction,
+    CloudTrailEventMapping,
+    LiveEventContext,
+    LiveEventFactories,
+)
+from aws.utils import RegionHelper
+
+CLOUDTRAIL_EVENT_SOURCE = "sqs.amazonaws.com"
+
+
+def _queue_url(context: LiveEventContext) -> str:
+    partition = RegionHelper.get_partition()
+    domain_suffix = "amazonaws.com.cn" if partition == "aws-cn" else "amazonaws.com"
+    return (
+        f"https://sqs.{context.region}.{domain_suffix}/"
+        f"{context.account_id}/{context.identifier}"
+    )
+
+
+def _queue_name_from_url(queue_url: str) -> str | None:
+    queue_name = queue_url.rstrip("/").rsplit("/", maxsplit=1)[-1]
+    return queue_name if queue_name else None
+
+
+def _extract_queue_name(detail: CloudTrailDetail) -> str | None:
+    request_parameters = detail.get("requestParameters", {})
+    queue_name = request_parameters.get("queueName")
+    if isinstance(queue_name, str):
+        return queue_name
+
+    queue_url = request_parameters.get("queueUrl")
+    if isinstance(queue_url, str):
+        return _queue_name_from_url(queue_url)
+
+    response_elements = detail.get("responseElements")
+    if isinstance(response_elements, dict):
+        response_queue_url = response_elements.get("queueUrl")
+        if isinstance(response_queue_url, str):
+            return _queue_name_from_url(response_queue_url)
+
+    return None
+
+
+def _request_factory(
+    context: LiveEventContext, include_actions: list[str]
+) -> SingleQueueRequest:
+    return SingleQueueRequest(
+        queue_url=_queue_url(context),
+        region=context.region,
+        account_id=context.account_id,
+        include=include_actions,
+    )
+
+
+def _deletion_identifier_properties(context: LiveEventContext) -> dict[str, str]:
+    return {
+        "QueueArn": (
+            f"arn:{RegionHelper.get_partition()}:sqs:{context.region}:"
+            f"{context.account_id}:{context.identifier}"
+        ),
+        "QueueName": context.identifier,
+        "QueueUrl": _queue_url(context),
+    }
+
+
+SQS_QUEUE_LIVE_EVENTS = LiveEventFactories(
+    request_factory=_request_factory,
+    deletion_identifier_properties_factory=_deletion_identifier_properties,
+    cloudtrail_mappings={
+        "CreateQueue": CloudTrailEventMapping(
+            CloudTrailEventAction.UPSERT,
+            _extract_queue_name,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
+        ),
+        "SetQueueAttributes": CloudTrailEventMapping(
+            CloudTrailEventAction.UPSERT,
+            _extract_queue_name,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
+        ),
+        "DeleteQueue": CloudTrailEventMapping(
+            CloudTrailEventAction.DELETE,
+            _extract_queue_name,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
+        ),
+    },
+)

--- a/integrations/aws-v3/aws/core/helpers/metadata/types.py
+++ b/integrations/aws-v3/aws/core/helpers/metadata/types.py
@@ -17,6 +17,7 @@ class CloudTrailDetail(TypedDict, total=False):
     awsRegion: str
     recipientAccountId: str
     requestParameters: dict[str, Any]
+    responseElements: dict[str, Any]
 
 
 class EventBridgeCloudTrailPayload(TypedDict, total=False):

--- a/integrations/aws-v3/aws/core/helpers/utils.py
+++ b/integrations/aws-v3/aws/core/helpers/utils.py
@@ -27,6 +27,7 @@ def require_aws_resource(
         operation_name,
     )
 
+
 def is_access_denied_exception(e: Exception) -> bool:
     access_denied_error_codes = [
         "AccessDenied",

--- a/integrations/aws-v3/aws/core/helpers/utils.py
+++ b/integrations/aws-v3/aws/core/helpers/utils.py
@@ -30,6 +30,10 @@ def is_resource_not_found_exception(e: Exception) -> bool:
         "NotFoundException",
         "NoSuchBucket",
         "DBInstanceNotFound",
+        "DBClusterNotFoundFault",
+        "CacheClusterNotFoundFault",
+        "InvalidInstanceID.NotFound",
+        "InvalidVolume.NotFound",
         "404",
     ]
     response = getattr(e, "response", None)

--- a/integrations/aws-v3/aws/core/helpers/utils.py
+++ b/integrations/aws-v3/aws/core/helpers/utils.py
@@ -1,8 +1,39 @@
-from typing import Any, Callable, Awaitable, cast
+from typing import Any, Callable, Awaitable, TypeVar, cast
 from aiobotocore.session import AioSession
 from aws.auth.region_resolver import RegionResolver
 from loguru import logger
 import asyncio
+from botocore.exceptions import ClientError
+
+T = TypeVar("T")
+
+
+def require_aws_resource(
+    items: list[T] | None,
+    *,
+    error_code: str,
+    message: str,
+    operation_name: str,
+) -> list[T]:
+    """Raise a not-found ClientError when a describe call returns no resources.
+
+    Live-event handlers rely on this to distinguish a deleted resource from a
+    successful empty inspect result when the AWS API returns an empty list.
+    """
+    if items:
+        return items
+    raise ClientError(
+        {"Error": {"Code": error_code, "Message": message}},
+        operation_name,
+    )
+
+
+def extract_ec2_instances(response: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        instance
+        for reservation in response.get("Reservations", [])
+        for instance in reservation.get("Instances", [])
+    ]
 
 
 def is_access_denied_exception(e: Exception) -> bool:

--- a/integrations/aws-v3/aws/core/helpers/utils.py
+++ b/integrations/aws-v3/aws/core/helpers/utils.py
@@ -34,6 +34,7 @@ def is_resource_not_found_exception(e: Exception) -> bool:
         "CacheClusterNotFoundFault",
         "InvalidInstanceID.NotFound",
         "InvalidVolume.NotFound",
+        "AWS.SimpleQueueService.NonExistentQueue",
         "404",
     ]
     response = getattr(e, "response", None)

--- a/integrations/aws-v3/aws/core/helpers/utils.py
+++ b/integrations/aws-v3/aws/core/helpers/utils.py
@@ -27,15 +27,6 @@ def require_aws_resource(
         operation_name,
     )
 
-
-def extract_ec2_instances(response: dict[str, Any]) -> list[dict[str, Any]]:
-    return [
-        instance
-        for reservation in response.get("Reservations", [])
-        for instance in reservation.get("Instances", [])
-    ]
-
-
 def is_access_denied_exception(e: Exception) -> bool:
     access_denied_error_codes = [
         "AccessDenied",

--- a/integrations/aws-v3/tests/core/exporters/ec2/instance/test_exporter.py
+++ b/integrations/aws-v3/tests/core/exporters/ec2/instance/test_exporter.py
@@ -43,6 +43,18 @@ class TestEC2InstanceExporter:
         mock_client = AsyncMock()
         mock_proxy.client = mock_client
         mock_proxy_class.return_value.__aenter__.return_value = mock_proxy
+        mock_client.describe_instances.return_value = {
+            "Reservations": [
+                {
+                    "Instances": [
+                        {
+                            "InstanceId": "i-1234567890abcdef0",
+                            "InstanceType": "t3.micro",
+                        }
+                    ]
+                }
+            ]
+        }
 
         # Inspector
         mock_inspector = AsyncMock()
@@ -66,6 +78,9 @@ class TestEC2InstanceExporter:
 
         assert result == instance.dict(exclude_none=True)
         mock_proxy_class.assert_called_once_with(exporter.session, "us-west-2", "ec2")
+        mock_client.describe_instances.assert_called_once_with(
+            InstanceIds=["i-1234567890abcdef0"]
+        )
         mock_inspector_class.assert_called_once()
         mock_inspector.inspect.assert_called_once_with(
             [{"InstanceId": "i-1234567890abcdef0"}], ["GetInstanceStatusAction"]
@@ -81,7 +96,12 @@ class TestEC2InstanceExporter:
         exporter: EC2InstanceExporter,
     ) -> None:
         mock_proxy = AsyncMock()
+        mock_client = AsyncMock()
+        mock_proxy.client = mock_client
         mock_proxy_class.return_value.__aenter__.return_value = mock_proxy
+        mock_client.describe_instances.return_value = {
+            "Reservations": [{"Instances": [{"InstanceId": "i-notexists"}]}]
+        }
 
         mock_inspector = AsyncMock()
         mock_inspector_class.return_value = mock_inspector
@@ -251,8 +271,13 @@ class TestEC2InstanceExporter:
         exporter: EC2InstanceExporter,
     ) -> None:
         mock_proxy = AsyncMock()
+        mock_client = AsyncMock()
+        mock_proxy.client = mock_client
         mock_proxy_class.return_value.__aenter__.return_value = mock_proxy
         mock_proxy_class.return_value.__aexit__ = AsyncMock()
+        mock_client.describe_instances.return_value = {
+            "Reservations": [{"Instances": [{"InstanceId": "i-55"}]}]
+        }
 
         mock_inspector = AsyncMock()
         instance = EC2Instance(Properties=EC2InstanceProperties(InstanceId="i-55"))

--- a/integrations/aws-v3/tests/core/exporters/ec2/instance/test_exporter.py
+++ b/integrations/aws-v3/tests/core/exporters/ec2/instance/test_exporter.py
@@ -1,6 +1,7 @@
 from typing import AsyncGenerator, List, Dict, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
+from botocore.exceptions import ClientError
 
 from aws.core.exporters.ec2.instance.exporter import EC2InstanceExporter
 from aws.core.exporters.ec2.instance.models import (
@@ -43,17 +44,12 @@ class TestEC2InstanceExporter:
         mock_client = AsyncMock()
         mock_proxy.client = mock_client
         mock_proxy_class.return_value.__aenter__.return_value = mock_proxy
+        instance_data = {
+            "InstanceId": "i-1234567890abcdef0",
+            "InstanceType": "t3.micro",
+        }
         mock_client.describe_instances.return_value = {
-            "Reservations": [
-                {
-                    "Instances": [
-                        {
-                            "InstanceId": "i-1234567890abcdef0",
-                            "InstanceType": "t3.micro",
-                        }
-                    ]
-                }
-            ]
+            "Reservations": [{"Instances": [instance_data]}]
         }
 
         # Inspector
@@ -65,7 +61,7 @@ class TestEC2InstanceExporter:
                 InstanceId="i-1234567890abcdef0", InstanceType="t3.micro"
             )
         )
-        mock_inspector.inspect.return_value = [instance.dict(exclude_none=True)]
+        mock_inspector.inspect.return_value = [instance.model_dump(exclude_none=True)]
 
         options = SingleEC2InstanceRequest(
             region="us-west-2",
@@ -76,15 +72,50 @@ class TestEC2InstanceExporter:
 
         result = await exporter.get_resource(options)
 
-        assert result == instance.dict(exclude_none=True)
+        assert result == instance.model_dump(exclude_none=True)
         mock_proxy_class.assert_called_once_with(exporter.session, "us-west-2", "ec2")
         mock_client.describe_instances.assert_called_once_with(
             InstanceIds=["i-1234567890abcdef0"]
         )
         mock_inspector_class.assert_called_once()
         mock_inspector.inspect.assert_called_once_with(
-            [{"InstanceId": "i-1234567890abcdef0"}], ["GetInstanceStatusAction"]
+            [instance_data],
+            ["GetInstanceStatusAction"],
+            extra_context={
+                "AccountId": "123456789012",
+                "Region": "us-west-2",
+            },
         )
+
+    @pytest.mark.asyncio
+    @patch("aws.core.exporters.ec2.instance.exporter.AioBaseClientProxy")
+    @patch("aws.core.exporters.ec2.instance.exporter.ResourceInspector")
+    async def test_get_resource_raises_when_instance_not_found(
+        self,
+        mock_inspector_class: MagicMock,
+        mock_proxy_class: MagicMock,
+        exporter: EC2InstanceExporter,
+    ) -> None:
+        """Missing instances must raise so live events can treat fetch-after-delete as deleted."""
+        mock_proxy = AsyncMock()
+        mock_client = AsyncMock()
+        mock_proxy.client = mock_client
+        mock_proxy_class.return_value.__aenter__.return_value = mock_proxy
+
+        mock_client.describe_instances.return_value = {"Reservations": []}
+
+        options = SingleEC2InstanceRequest(
+            region="us-east-1",
+            account_id="123456789012",
+            instance_id="i-nonexistent",
+            include=[],
+        )
+
+        with pytest.raises(ClientError) as exc_info:
+            await exporter.get_resource(options)
+
+        assert exc_info.value.response["Error"]["Code"] == "InvalidInstanceID.NotFound"
+        mock_inspector_class.assert_not_called()
 
     @pytest.mark.asyncio
     @patch("aws.core.exporters.ec2.instance.exporter.AioBaseClientProxy")
@@ -167,8 +198,8 @@ class TestEC2InstanceExporter:
         inst3 = EC2Instance(Properties=EC2InstanceProperties(InstanceId="i-3"))
 
         mock_inspector.inspect.side_effect = [
-            [inst1.dict(exclude_none=True), inst2.dict(exclude_none=True)],
-            [inst3.dict(exclude_none=True)],
+            [inst1.model_dump(exclude_none=True), inst2.model_dump(exclude_none=True)],
+            [inst3.model_dump(exclude_none=True)],
         ]
 
         options = PaginatedEC2InstanceRequest(
@@ -182,9 +213,9 @@ class TestEC2InstanceExporter:
             collected.extend(page)
 
         assert len(collected) == 3
-        assert collected[0] == inst1.dict(exclude_none=True)
-        assert collected[1] == inst2.dict(exclude_none=True)
-        assert collected[2] == inst3.dict(exclude_none=True)
+        assert collected[0] == inst1.model_dump(exclude_none=True)
+        assert collected[1] == inst2.model_dump(exclude_none=True)
+        assert collected[2] == inst3.model_dump(exclude_none=True)
 
         mock_proxy_class.assert_called_once_with(exporter.session, "us-east-1", "ec2")
         mock_proxy.get_paginator.assert_called_once_with(
@@ -275,13 +306,14 @@ class TestEC2InstanceExporter:
         mock_proxy.client = mock_client
         mock_proxy_class.return_value.__aenter__.return_value = mock_proxy
         mock_proxy_class.return_value.__aexit__ = AsyncMock()
+        instance_data = {"InstanceId": "i-55"}
         mock_client.describe_instances.return_value = {
-            "Reservations": [{"Instances": [{"InstanceId": "i-55"}]}]
+            "Reservations": [{"Instances": [instance_data]}]
         }
 
         mock_inspector = AsyncMock()
         instance = EC2Instance(Properties=EC2InstanceProperties(InstanceId="i-55"))
-        mock_inspector.inspect.return_value = [instance.dict(exclude_none=True)]
+        mock_inspector.inspect.return_value = [instance.model_dump(exclude_none=True)]
         mock_inspector_class.return_value = mock_inspector
 
         options = SingleEC2InstanceRequest(
@@ -295,7 +327,14 @@ class TestEC2InstanceExporter:
         assert result["Properties"]["InstanceId"] == "i-55"
         assert result["Type"] == "AWS::EC2::Instance"
 
-        mock_inspector.inspect.assert_called_once_with([{"InstanceId": "i-55"}], [])
+        mock_inspector.inspect.assert_called_once_with(
+            [instance_data],
+            [],
+            extra_context={
+                "AccountId": "123456789012",
+                "Region": "us-west-2",
+            },
+        )
         mock_proxy_class.assert_called_once_with(exporter.session, "us-west-2", "ec2")
         mock_proxy_class.return_value.__aenter__.assert_called_once()
         mock_proxy_class.return_value.__aexit__.assert_called_once()

--- a/integrations/aws-v3/tests/core/exporters/ec2/instance/test_instance_utils.py
+++ b/integrations/aws-v3/tests/core/exporters/ec2/instance/test_instance_utils.py
@@ -1,0 +1,20 @@
+from aws.core.exporters.ec2.instance.utils import extract_ec2_instances
+
+
+class TestExtractEc2Instances:
+    def test_flattens_reservations(self) -> None:
+        response = {
+            "Reservations": [
+                {"Instances": [{"InstanceId": "i-1"}, {"InstanceId": "i-2"}]},
+                {"Instances": [{"InstanceId": "i-3"}]},
+            ]
+        }
+
+        assert extract_ec2_instances(response) == [
+            {"InstanceId": "i-1"},
+            {"InstanceId": "i-2"},
+            {"InstanceId": "i-3"},
+        ]
+
+    def test_returns_empty_list_when_missing(self) -> None:
+        assert extract_ec2_instances({}) == []

--- a/integrations/aws-v3/tests/core/exporters/ec2/volume/test_exporter.py
+++ b/integrations/aws-v3/tests/core/exporters/ec2/volume/test_exporter.py
@@ -1,5 +1,6 @@
 from typing import AsyncGenerator, List, Dict, Any
 from unittest.mock import AsyncMock, MagicMock, patch
+from botocore.exceptions import ClientError
 import pytest
 
 from aws.core.exporters.ec2.volume.exporter import EbsVolumeExporter
@@ -97,8 +98,10 @@ class TestEbsVolumeExporter:
             volume_id="vol-nonexistent",
         )
 
-        result = await exporter.get_resource(options)
-        assert result == {}
+        with pytest.raises(ClientError) as exc_info:
+            await exporter.get_resource(options)
+
+        assert exc_info.value.response["Error"]["Code"] == "InvalidVolume.NotFound"
 
     @pytest.mark.asyncio
     @patch("aws.core.exporters.ec2.volume.exporter.AioBaseClientProxy")

--- a/integrations/aws-v3/tests/core/exporters/elasticache/cluster/test_exporter.py
+++ b/integrations/aws-v3/tests/core/exporters/elasticache/cluster/test_exporter.py
@@ -1,6 +1,7 @@
 from typing import AsyncGenerator, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
+from botocore.exceptions import ClientError
 
 from aws.core.exporters.elasticache.cluster.exporter import ElastiCacheClusterExporter
 from aws.core.exporters.elasticache.cluster.models import (
@@ -89,6 +90,36 @@ class TestElastiCacheClusterExporter:
         call_kwargs = mock_inspector.inspect.call_args[1]
         assert call_kwargs["extra_context"]["AccountId"] == "123456789012"
         assert call_kwargs["extra_context"]["Region"] == "us-west-2"
+
+    @pytest.mark.asyncio
+    @patch("aws.core.exporters.elasticache.cluster.exporter.AioBaseClientProxy")
+    @patch("aws.core.exporters.elasticache.cluster.exporter.ResourceInspector")
+    async def test_get_resource_raises_when_cluster_not_found(
+        self,
+        mock_inspector_class: MagicMock,
+        mock_proxy_class: MagicMock,
+        exporter: ElastiCacheClusterExporter,
+    ) -> None:
+        """Missing clusters must raise so live events can treat fetch-after-delete as deleted."""
+        mock_proxy = AsyncMock()
+        mock_client = AsyncMock()
+        mock_proxy.client = mock_client
+        mock_proxy_class.return_value.__aenter__.return_value = mock_proxy
+
+        mock_client.describe_cache_clusters.return_value = {"CacheClusters": []}
+
+        options = SingleCacheClusterRequest(
+            region="us-west-2",
+            account_id="123456789012",
+            cache_cluster_id="cluster-missing",
+            include=[],
+        )
+
+        with pytest.raises(ClientError) as exc_info:
+            await exporter.get_resource(options)
+
+        assert exc_info.value.response["Error"]["Code"] == "CacheClusterNotFoundFault"
+        mock_inspector_class.assert_not_called()
 
     @pytest.mark.asyncio
     @patch("aws.core.exporters.elasticache.cluster.exporter.AioBaseClientProxy")

--- a/integrations/aws-v3/tests/core/exporters/rds/db_cluster/test_exporter.py
+++ b/integrations/aws-v3/tests/core/exporters/rds/db_cluster/test_exporter.py
@@ -1,5 +1,6 @@
 from typing import AsyncGenerator, Any
 from unittest.mock import AsyncMock, MagicMock, patch
+from botocore.exceptions import ClientError
 import pytest
 
 from aws.core.exporters.rds.db_cluster.exporter import RdsDbClusterExporter
@@ -88,23 +89,19 @@ class TestRdsDbClusterExporter:
     @pytest.mark.asyncio
     @patch("aws.core.exporters.rds.db_cluster.exporter.AioBaseClientProxy")
     @patch("aws.core.exporters.rds.db_cluster.exporter.ResourceInspector")
-    async def test_get_resource_returns_empty_when_inspector_returns_nothing(
+    async def test_get_resource_raises_when_cluster_not_found(
         self,
         mock_inspector_class: MagicMock,
         mock_proxy_class: MagicMock,
         exporter: RdsDbClusterExporter,
     ) -> None:
-        """Test that an empty dict is returned when the inspector yields no results."""
+        """Test that a missing DB cluster raises so live events can treat it as deleted."""
         mock_proxy = AsyncMock()
         mock_client = AsyncMock()
         mock_proxy.client = mock_client
         mock_proxy_class.return_value.__aenter__.return_value = mock_proxy
 
         mock_client.describe_db_clusters.return_value = {"DBClusters": []}
-
-        mock_inspector = AsyncMock()
-        mock_inspector_class.return_value = mock_inspector
-        mock_inspector.inspect.return_value = []
 
         options = SingleDbClusterRequest(
             region="us-east-1",
@@ -113,9 +110,11 @@ class TestRdsDbClusterExporter:
             include=[],
         )
 
-        result = await exporter.get_resource(options)
+        with pytest.raises(ClientError) as exc_info:
+            await exporter.get_resource(options)
 
-        assert result == {}
+        assert exc_info.value.response["Error"]["Code"] == "DBClusterNotFoundFault"
+        mock_inspector_class.assert_not_called()
 
     @pytest.mark.asyncio
     @patch("aws.core.exporters.rds.db_cluster.exporter.AioBaseClientProxy")

--- a/integrations/aws-v3/tests/core/exporters/sns/topic/test_topic_exporter.py
+++ b/integrations/aws-v3/tests/core/exporters/sns/topic/test_topic_exporter.py
@@ -1,6 +1,7 @@
 from typing import AsyncGenerator, List, Dict, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
+from botocore.exceptions import ClientError
 
 from aws.core.exporters.sns.topic.exporter import SNSTopicExporter
 from aws.core.exporters.sns.topic.models import (
@@ -40,6 +41,12 @@ class TestSNSTopicExporter:
         mock_client = AsyncMock()
         mock_proxy.client = mock_client
         mock_proxy_class.return_value.__aenter__.return_value = mock_proxy
+        mock_client.get_topic_attributes.return_value = {
+            "Attributes": {
+                "TopicArn": "arn:aws:sns:us-east-1:123456789012:my-topic",
+                "Owner": "123456789012",
+            }
+        }
 
         mock_inspector = AsyncMock()
         mock_inspector_class.return_value = mock_inspector
@@ -62,6 +69,40 @@ class TestSNSTopicExporter:
 
         assert isinstance(result, dict)
         assert result["TopicArn"] == "arn:aws:sns:us-east-1:123456789012:my-topic"
+        mock_client.get_topic_attributes.assert_awaited_once_with(
+            TopicArn="arn:aws:sns:us-east-1:123456789012:my-topic"
+        )
+
+    @pytest.mark.asyncio
+    @patch("aws.core.exporters.sns.topic.exporter.AioBaseClientProxy")
+    @patch("aws.core.exporters.sns.topic.exporter.ResourceInspector")
+    async def test_get_resource_topic_not_found(
+        self,
+        mock_inspector_class: MagicMock,
+        mock_proxy_class: MagicMock,
+        exporter: SNSTopicExporter,
+    ) -> None:
+        mock_proxy = AsyncMock()
+        mock_client = AsyncMock()
+        mock_proxy.client = mock_client
+        mock_proxy_class.return_value.__aenter__.return_value = mock_proxy
+        mock_client.get_topic_attributes.side_effect = ClientError(
+            {"Error": {"Code": "ResourceNotFound", "Message": "gone"}},
+            "GetTopicAttributes",
+        )
+
+        request = SingleTopicRequest(
+            topic_arn="arn:aws:sns:us-east-1:123456789012:nonexistent",
+            region="us-east-1",
+            include=[],
+            account_id="123456789012",
+        )
+
+        with pytest.raises(ClientError) as exc_info:
+            await exporter.get_resource(request)
+
+        assert exc_info.value.response["Error"]["Code"] == "ResourceNotFound"
+        mock_inspector_class.assert_not_called()
 
     @pytest.mark.asyncio
     @patch("aws.core.exporters.sns.topic.exporter.AioBaseClientProxy")
@@ -73,8 +114,14 @@ class TestSNSTopicExporter:
         exporter: SNSTopicExporter,
     ) -> None:
         mock_proxy = AsyncMock()
-        mock_proxy.client = AsyncMock()
+        mock_client = AsyncMock()
+        mock_proxy.client = mock_client
         mock_proxy_class.return_value.__aenter__.return_value = mock_proxy
+        mock_client.get_topic_attributes.return_value = {
+            "Attributes": {
+                "TopicArn": "arn:aws:sns:us-east-1:123456789012:nonexistent",
+            }
+        }
 
         mock_inspector = AsyncMock()
         mock_inspector_class.return_value = mock_inspector
@@ -196,6 +243,11 @@ class TestSNSTopicExporter:
         mock_proxy = AsyncMock()
         mock_proxy.client = AsyncMock()
         mock_proxy_class.return_value.__aenter__.return_value = mock_proxy
+        mock_proxy.client.get_topic_attributes.return_value = {
+            "Attributes": {
+                "TopicArn": "arn:aws:sns:us-east-1:123456789012:my-topic",
+            }
+        }
 
         mock_inspector = AsyncMock()
         mock_inspector_class.return_value = mock_inspector

--- a/integrations/aws-v3/tests/core/exporters/sqs/queue/test_queue_exporter.py
+++ b/integrations/aws-v3/tests/core/exporters/sqs/queue/test_queue_exporter.py
@@ -86,7 +86,6 @@ class TestSqsQueueExporter:
         )
         mock_client.get_queue_attributes.assert_awaited_once_with(
             QueueUrl="https://sqs.us-east-1.amazonaws.com/123456789012/test-queue",
-            AttributeNames=["All"],
         )
 
     @pytest.mark.asyncio

--- a/integrations/aws-v3/tests/core/exporters/sqs/queue/test_queue_exporter.py
+++ b/integrations/aws-v3/tests/core/exporters/sqs/queue/test_queue_exporter.py
@@ -1,6 +1,7 @@
 from typing import AsyncGenerator, List, Dict, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
+from botocore.exceptions import ClientError
 
 from aws.core.exporters.sqs.queue.exporter import SqsQueueExporter
 from aws.core.exporters.sqs.queue.models import (
@@ -41,6 +42,11 @@ class TestSqsQueueExporter:
         mock_client = AsyncMock()
         mock_proxy.client = mock_client
         mock_proxy_class.return_value.__aenter__.return_value = mock_proxy
+        mock_client.get_queue_attributes.return_value = {
+            "Attributes": {
+                "QueueArn": "arn:aws:sqs:us-east-1:123456789012:test-queue",
+            }
+        }
 
         # Inspector
         mock_inspector = AsyncMock()
@@ -78,6 +84,49 @@ class TestSqsQueueExporter:
             result["Attributes"]["QueueArn"]
             == "arn:aws:sqs:us-east-1:123456789012:test-queue"
         )
+        mock_client.get_queue_attributes.assert_awaited_once_with(
+            QueueUrl="https://sqs.us-east-1.amazonaws.com/123456789012/test-queue",
+            AttributeNames=["All"],
+        )
+
+    @pytest.mark.asyncio
+    @patch("aws.core.exporters.sqs.queue.exporter.AioBaseClientProxy")
+    @patch("aws.core.exporters.sqs.queue.exporter.ResourceInspector")
+    async def test_get_resource_queue_not_found(
+        self,
+        mock_inspector_class: MagicMock,
+        mock_proxy_class: MagicMock,
+        exporter: SqsQueueExporter,
+    ) -> None:
+        mock_proxy = AsyncMock()
+        mock_client = AsyncMock()
+        mock_proxy.client = mock_client
+        mock_proxy_class.return_value.__aenter__.return_value = mock_proxy
+        mock_client.get_queue_attributes.side_effect = ClientError(
+            {
+                "Error": {
+                    "Code": "AWS.SimpleQueueService.NonExistentQueue",
+                    "Message": "gone",
+                }
+            },
+            "GetQueueAttributes",
+        )
+
+        request = SingleQueueRequest(
+            queue_url="https://sqs.us-east-1.amazonaws.com/123456789012/nonexistent",
+            region="us-east-1",
+            include=[],
+            account_id="123456789012",
+        )
+
+        with pytest.raises(ClientError) as exc_info:
+            await exporter.get_resource(request)
+
+        assert (
+            exc_info.value.response["Error"]["Code"]
+            == "AWS.SimpleQueueService.NonExistentQueue"
+        )
+        mock_inspector_class.assert_not_called()
 
     @pytest.mark.asyncio
     @patch("aws.core.exporters.sqs.queue.exporter.AioBaseClientProxy")
@@ -218,6 +267,11 @@ class TestSqsQueueExporter:
         mock_client = AsyncMock()
         mock_proxy.client = mock_client
         mock_proxy_class.return_value.__aenter__.return_value = mock_proxy
+        mock_client.get_queue_attributes.return_value = {
+            "Attributes": {
+                "QueueArn": "arn:aws:sqs:us-east-1:123456789012:test-queue",
+            }
+        }
 
         # Inspector raises exception
         mock_inspector = AsyncMock()

--- a/integrations/aws-v3/tests/core/helpers/test_exception_helpers.py
+++ b/integrations/aws-v3/tests/core/helpers/test_exception_helpers.py
@@ -22,6 +22,23 @@ def test_is_resource_not_found_exception_includes_s3_codes() -> None:
 
 def test_is_resource_not_found_exception_includes_rds_codes() -> None:
     assert is_resource_not_found_exception(_client_error("DBInstanceNotFound")) is True
+    assert (
+        is_resource_not_found_exception(_client_error("DBClusterNotFoundFault")) is True
+    )
+
+
+def test_is_resource_not_found_exception_includes_ec2_and_elasticache_codes() -> None:
+    assert (
+        is_resource_not_found_exception(_client_error("InvalidInstanceID.NotFound"))
+        is True
+    )
+    assert (
+        is_resource_not_found_exception(_client_error("InvalidVolume.NotFound")) is True
+    )
+    assert (
+        is_resource_not_found_exception(_client_error("CacheClusterNotFoundFault"))
+        is True
+    )
 
 
 def test_is_resource_not_found_exception_includes_ecr_and_cluster_codes() -> None:

--- a/integrations/aws-v3/tests/core/helpers/test_exception_helpers.py
+++ b/integrations/aws-v3/tests/core/helpers/test_exception_helpers.py
@@ -52,6 +52,15 @@ def test_is_resource_not_found_exception_includes_ecr_and_cluster_codes() -> Non
     )
 
 
+def test_is_resource_not_found_exception_includes_sqs_codes() -> None:
+    assert (
+        is_resource_not_found_exception(
+            _client_error("AWS.SimpleQueueService.NonExistentQueue")
+        )
+        is True
+    )
+
+
 def test_is_access_denied_exception() -> None:
     assert is_access_denied_exception(_client_error("AccessDenied")) is True
     assert is_access_denied_exception(_client_error("NoSuchBucket")) is False

--- a/integrations/aws-v3/tests/core/helpers/test_utils.py
+++ b/integrations/aws-v3/tests/core/helpers/test_utils.py
@@ -3,7 +3,11 @@ from typing import Any
 import pytest
 from botocore.exceptions import ClientError
 
-from aws.core.helpers.utils import execute_concurrent_aws_operations
+from aws.core.helpers.utils import (
+    execute_concurrent_aws_operations,
+    extract_ec2_instances,
+    require_aws_resource,
+)
 
 
 class TestExecuteConcurrentAwsOperations:
@@ -109,3 +113,56 @@ class TestExecuteConcurrentAwsOperations:
         )
 
         assert result == []
+
+
+class TestRequireAwsResource:
+    def test_returns_items_when_present(self) -> None:
+        items = [{"id": "vol-1"}]
+        assert require_aws_resource(
+            items,
+            error_code="InvalidVolume.NotFound",
+            message="Volume not found: vol-1",
+            operation_name="DescribeVolumes",
+        ) == items
+
+    def test_raises_client_error_when_empty(self) -> None:
+        with pytest.raises(ClientError) as exc_info:
+            require_aws_resource(
+                [],
+                error_code="InvalidVolume.NotFound",
+                message="Volume not found: vol-1",
+                operation_name="DescribeVolumes",
+            )
+
+        assert exc_info.value.response["Error"]["Code"] == "InvalidVolume.NotFound"
+        assert exc_info.value.operation_name == "DescribeVolumes"
+
+    def test_raises_client_error_when_none(self) -> None:
+        with pytest.raises(ClientError) as exc_info:
+            require_aws_resource(
+                None,
+                error_code="ClusterNotFoundException",
+                message="Cluster not found: my-cluster",
+                operation_name="DescribeClusters",
+            )
+
+        assert exc_info.value.response["Error"]["Code"] == "ClusterNotFoundException"
+
+
+class TestExtractEc2Instances:
+    def test_flattens_reservations(self) -> None:
+        response = {
+            "Reservations": [
+                {"Instances": [{"InstanceId": "i-1"}, {"InstanceId": "i-2"}]},
+                {"Instances": [{"InstanceId": "i-3"}]},
+            ]
+        }
+
+        assert extract_ec2_instances(response) == [
+            {"InstanceId": "i-1"},
+            {"InstanceId": "i-2"},
+            {"InstanceId": "i-3"},
+        ]
+
+    def test_returns_empty_list_when_missing(self) -> None:
+        assert extract_ec2_instances({}) == []

--- a/integrations/aws-v3/tests/core/helpers/test_utils.py
+++ b/integrations/aws-v3/tests/core/helpers/test_utils.py
@@ -5,7 +5,6 @@ from botocore.exceptions import ClientError
 
 from aws.core.helpers.utils import (
     execute_concurrent_aws_operations,
-    extract_ec2_instances,
     require_aws_resource,
 )
 
@@ -150,22 +149,3 @@ class TestRequireAwsResource:
             )
 
         assert exc_info.value.response["Error"]["Code"] == "ClusterNotFoundException"
-
-
-class TestExtractEc2Instances:
-    def test_flattens_reservations(self) -> None:
-        response = {
-            "Reservations": [
-                {"Instances": [{"InstanceId": "i-1"}, {"InstanceId": "i-2"}]},
-                {"Instances": [{"InstanceId": "i-3"}]},
-            ]
-        }
-
-        assert extract_ec2_instances(response) == [
-            {"InstanceId": "i-1"},
-            {"InstanceId": "i-2"},
-            {"InstanceId": "i-3"},
-        ]
-
-    def test_returns_empty_list_when_missing(self) -> None:
-        assert extract_ec2_instances({}) == []

--- a/integrations/aws-v3/tests/core/helpers/test_utils.py
+++ b/integrations/aws-v3/tests/core/helpers/test_utils.py
@@ -118,12 +118,15 @@ class TestExecuteConcurrentAwsOperations:
 class TestRequireAwsResource:
     def test_returns_items_when_present(self) -> None:
         items = [{"id": "vol-1"}]
-        assert require_aws_resource(
-            items,
-            error_code="InvalidVolume.NotFound",
-            message="Volume not found: vol-1",
-            operation_name="DescribeVolumes",
-        ) == items
+        assert (
+            require_aws_resource(
+                items,
+                error_code="InvalidVolume.NotFound",
+                message="Volume not found: vol-1",
+                operation_name="DescribeVolumes",
+            )
+            == items
+        )
 
     def test_raises_client_error_when_empty(self) -> None:
         with pytest.raises(ClientError) as exc_info:

--- a/integrations/aws-v3/tests/webhook/test_cloudtrail_parser.py
+++ b/integrations/aws-v3/tests/webhook/test_cloudtrail_parser.py
@@ -977,6 +977,10 @@ def _ec2_volume_eventbridge_envelope(
 
     if event_name == "CreateVolume" and volume_id is not None:
         detail["responseElements"] = {"volumeId": volume_id}
+    elif event_name == "ModifyVolume" and volume_id is not None:
+        detail["requestParameters"] = {
+            "ModifyVolumeRequest": {"VolumeId": volume_id, "Size": "2"}
+        }
     elif volume_id is not None:
         detail["requestParameters"] = {"volumeId": volume_id}
     else:
@@ -1006,15 +1010,22 @@ def test_is_supported_cloudtrail_event_true_for_ec2_volume_events() -> None:
 
 def test_parse_ec2_volume_events() -> None:
     create_payload = _ec2_volume_eventbridge_envelope("CreateVolume")
+    modify_payload = _ec2_volume_eventbridge_envelope("ModifyVolume")
     delete_payload = _ec2_volume_eventbridge_envelope("DeleteVolume")
 
     create_parsed = parse_cloudtrail_event(create_payload)
+    modify_parsed = parse_cloudtrail_event(modify_payload)
     delete_parsed = parse_cloudtrail_event(delete_payload)
 
     assert create_parsed is not None
     assert create_parsed.kind == ObjectKind.EC2_VOLUME
     assert create_parsed.action == CloudTrailEventAction.UPSERT
     assert create_parsed.identifier == "vol-1234567890abcdef0"
+
+    assert modify_parsed is not None
+    assert modify_parsed.kind == ObjectKind.EC2_VOLUME
+    assert modify_parsed.action == CloudTrailEventAction.UPSERT
+    assert modify_parsed.identifier == "vol-1234567890abcdef0"
 
     assert delete_parsed is not None
     assert delete_parsed.kind == ObjectKind.EC2_VOLUME

--- a/integrations/aws-v3/tests/webhook/test_cloudtrail_parser.py
+++ b/integrations/aws-v3/tests/webhook/test_cloudtrail_parser.py
@@ -659,3 +659,425 @@ def test_ecs_and_eks_create_cluster_are_disambiguated_by_event_source() -> None:
     assert eks_parsed is not None
     assert ecs_parsed.kind == ObjectKind.ECS_CLUSTER
     assert eks_parsed.kind == ObjectKind.EKS_CLUSTER
+
+
+def _rds_db_cluster_eventbridge_envelope(
+    event_name: str,
+    db_cluster_identifier: str | None = "my-db-cluster",
+    account: str | None = "111122223333",
+    region: str | None = "us-east-1",
+    identifier_key: str = "dbClusterIdentifier",
+) -> EventBridgeCloudTrailPayload:
+    detail: CloudTrailDetail = {
+        "eventName": event_name,
+        "eventSource": "rds.amazonaws.com",
+    }
+    if region is not None:
+        detail["awsRegion"] = region
+    if account is not None:
+        detail["recipientAccountId"] = account
+    if db_cluster_identifier is not None:
+        detail["requestParameters"] = {identifier_key: db_cluster_identifier}
+    else:
+        detail["requestParameters"] = {}
+
+    payload: EventBridgeCloudTrailPayload = {"detail": detail}
+    if account is not None:
+        payload["account"] = account
+    if region is not None:
+        payload["region"] = region
+    return cast(
+        EventBridgeCloudTrailPayload,
+        {
+            **payload,
+            "version": "0",
+            "detail-type": "AWS API Call via CloudTrail",
+            "source": "aws.rds",
+        },
+    )
+
+
+def test_is_supported_cloudtrail_event_true_for_rds_db_cluster_events() -> None:
+    for event_name in ("CreateDBCluster", "ModifyDBCluster", "DeleteDBCluster"):
+        payload = _rds_db_cluster_eventbridge_envelope(event_name)
+        assert is_supported_cloudtrail_event(payload) is True
+
+
+def test_parse_rds_db_cluster_events() -> None:
+    create_payload = _rds_db_cluster_eventbridge_envelope("CreateDBCluster")
+    delete_payload = _rds_db_cluster_eventbridge_envelope("DeleteDBCluster")
+
+    create_parsed = parse_cloudtrail_event(create_payload)
+    delete_parsed = parse_cloudtrail_event(delete_payload)
+
+    assert create_parsed is not None
+    assert create_parsed.kind == ObjectKind.RDS_DB_CLUSTER
+    assert create_parsed.action == CloudTrailEventAction.UPSERT
+    assert create_parsed.identifier == "my-db-cluster"
+
+    assert delete_parsed is not None
+    assert delete_parsed.kind == ObjectKind.RDS_DB_CLUSTER
+    assert delete_parsed.action == CloudTrailEventAction.DELETE
+
+
+def test_parse_db_cluster_identifier_from_d_b_cluster_identifier_key() -> None:
+    payload = _rds_db_cluster_eventbridge_envelope(
+        "DeleteDBCluster",
+        db_cluster_identifier="legacy-cluster",
+        identifier_key="dBClusterIdentifier",
+    )
+
+    parsed = parse_cloudtrail_event(payload)
+
+    assert parsed is not None
+    assert parsed.identifier == "legacy-cluster"
+
+
+def _sns_topic_eventbridge_envelope(
+    event_name: str,
+    *,
+    topic_name: str | None = "my-topic",
+    topic_arn: str | None = None,
+    account: str | None = "111122223333",
+    region: str | None = "us-east-1",
+) -> EventBridgeCloudTrailPayload:
+    detail: CloudTrailDetail = {
+        "eventName": event_name,
+        "eventSource": "sns.amazonaws.com",
+    }
+    if region is not None:
+        detail["awsRegion"] = region
+    if account is not None:
+        detail["recipientAccountId"] = account
+
+    request_parameters: dict[str, str] = {}
+    if topic_name is not None:
+        request_parameters["name"] = topic_name
+    if topic_arn is not None:
+        request_parameters["topicArn"] = topic_arn
+    detail["requestParameters"] = request_parameters
+
+    if event_name == "CreateTopic" and topic_name is not None and account and region:
+        detail["responseElements"] = {
+            "topicArn": f"arn:aws:sns:{region}:{account}:{topic_name}"
+        }
+
+    payload: EventBridgeCloudTrailPayload = {"detail": detail}
+    if account is not None:
+        payload["account"] = account
+    if region is not None:
+        payload["region"] = region
+    return cast(
+        EventBridgeCloudTrailPayload,
+        {
+            **payload,
+            "version": "0",
+            "detail-type": "AWS API Call via CloudTrail",
+            "source": "aws.sns",
+        },
+    )
+
+
+def test_is_supported_cloudtrail_event_true_for_sns_topic_events() -> None:
+    for event_name in ("CreateTopic", "SetTopicAttributes", "DeleteTopic"):
+        payload = _sns_topic_eventbridge_envelope(
+            event_name,
+            topic_name=None if event_name != "CreateTopic" else "my-topic",
+            topic_arn=(
+                "arn:aws:sns:us-east-1:111122223333:my-topic"
+                if event_name != "CreateTopic"
+                else None
+            ),
+        )
+        assert is_supported_cloudtrail_event(payload) is True
+
+
+def test_parse_sns_topic_events() -> None:
+    create_payload = _sns_topic_eventbridge_envelope("CreateTopic")
+    delete_payload = _sns_topic_eventbridge_envelope(
+        "DeleteTopic",
+        topic_name=None,
+        topic_arn="arn:aws:sns:us-east-1:111122223333:my-topic",
+    )
+
+    create_parsed = parse_cloudtrail_event(create_payload)
+    delete_parsed = parse_cloudtrail_event(delete_payload)
+
+    assert create_parsed is not None
+    assert create_parsed.kind == ObjectKind.SNS_TOPIC
+    assert create_parsed.action == CloudTrailEventAction.UPSERT
+    assert create_parsed.identifier == "my-topic"
+
+    assert delete_parsed is not None
+    assert delete_parsed.kind == ObjectKind.SNS_TOPIC
+    assert delete_parsed.action == CloudTrailEventAction.DELETE
+
+
+def _sqs_queue_eventbridge_envelope(
+    event_name: str,
+    *,
+    queue_name: str | None = "my-queue",
+    queue_url: str | None = None,
+    account: str | None = "111122223333",
+    region: str | None = "us-east-1",
+) -> EventBridgeCloudTrailPayload:
+    detail: CloudTrailDetail = {
+        "eventName": event_name,
+        "eventSource": "sqs.amazonaws.com",
+    }
+    if region is not None:
+        detail["awsRegion"] = region
+    if account is not None:
+        detail["recipientAccountId"] = account
+
+    request_parameters: dict[str, str] = {}
+    if queue_name is not None:
+        request_parameters["queueName"] = queue_name
+    if queue_url is not None:
+        request_parameters["queueUrl"] = queue_url
+    detail["requestParameters"] = request_parameters
+
+    if event_name == "CreateQueue" and queue_name is not None and account and region:
+        detail["responseElements"] = {
+            "queueUrl": f"https://sqs.{region}.amazonaws.com/{account}/{queue_name}"
+        }
+
+    payload: EventBridgeCloudTrailPayload = {"detail": detail}
+    if account is not None:
+        payload["account"] = account
+    if region is not None:
+        payload["region"] = region
+    return cast(
+        EventBridgeCloudTrailPayload,
+        {
+            **payload,
+            "version": "0",
+            "detail-type": "AWS API Call via CloudTrail",
+            "source": "aws.sqs",
+        },
+    )
+
+
+def test_is_supported_cloudtrail_event_true_for_sqs_queue_events() -> None:
+    for event_name in ("CreateQueue", "SetQueueAttributes", "DeleteQueue"):
+        payload = _sqs_queue_eventbridge_envelope(
+            event_name,
+            queue_name=None if event_name != "CreateQueue" else "my-queue",
+            queue_url=(
+                "https://sqs.us-east-1.amazonaws.com/111122223333/my-queue"
+                if event_name != "CreateQueue"
+                else None
+            ),
+        )
+        assert is_supported_cloudtrail_event(payload) is True
+
+
+def test_parse_sqs_queue_events() -> None:
+    create_payload = _sqs_queue_eventbridge_envelope("CreateQueue")
+    delete_payload = _sqs_queue_eventbridge_envelope(
+        "DeleteQueue",
+        queue_name=None,
+        queue_url="https://sqs.us-east-1.amazonaws.com/111122223333/my-queue",
+    )
+
+    create_parsed = parse_cloudtrail_event(create_payload)
+    delete_parsed = parse_cloudtrail_event(delete_payload)
+
+    assert create_parsed is not None
+    assert create_parsed.kind == ObjectKind.SQS_QUEUE
+    assert create_parsed.action == CloudTrailEventAction.UPSERT
+    assert create_parsed.identifier == "my-queue"
+
+    assert delete_parsed is not None
+    assert delete_parsed.kind == ObjectKind.SQS_QUEUE
+    assert delete_parsed.action == CloudTrailEventAction.DELETE
+
+
+def _ec2_instance_eventbridge_envelope(
+    event_name: str,
+    *,
+    instance_id: str | None = "i-1234567890abcdef0",
+    account: str | None = "111122223333",
+    region: str | None = "us-east-1",
+) -> EventBridgeCloudTrailPayload:
+    detail: CloudTrailDetail = {
+        "eventName": event_name,
+        "eventSource": "ec2.amazonaws.com",
+    }
+    if region is not None:
+        detail["awsRegion"] = region
+    if account is not None:
+        detail["recipientAccountId"] = account
+
+    if event_name == "RunInstances" and instance_id is not None:
+        detail["responseElements"] = {
+            "instancesSet": {"items": [{"instanceId": instance_id}]}
+        }
+    elif instance_id is not None:
+        detail["requestParameters"] = {
+            "instancesSet": {"items": [{"instanceId": instance_id}]}
+        }
+    else:
+        detail["requestParameters"] = {}
+
+    payload: EventBridgeCloudTrailPayload = {"detail": detail}
+    if account is not None:
+        payload["account"] = account
+    if region is not None:
+        payload["region"] = region
+    return cast(
+        EventBridgeCloudTrailPayload,
+        {
+            **payload,
+            "version": "0",
+            "detail-type": "AWS API Call via CloudTrail",
+            "source": "aws.ec2",
+        },
+    )
+
+
+def test_is_supported_cloudtrail_event_true_for_ec2_instance_events() -> None:
+    for event_name in ("RunInstances", "TerminateInstances"):
+        payload = _ec2_instance_eventbridge_envelope(event_name)
+        assert is_supported_cloudtrail_event(payload) is True
+
+
+def test_parse_ec2_instance_events() -> None:
+    create_payload = _ec2_instance_eventbridge_envelope("RunInstances")
+    delete_payload = _ec2_instance_eventbridge_envelope("TerminateInstances")
+
+    create_parsed = parse_cloudtrail_event(create_payload)
+    delete_parsed = parse_cloudtrail_event(delete_payload)
+
+    assert create_parsed is not None
+    assert create_parsed.kind == ObjectKind.EC2_INSTANCE
+    assert create_parsed.action == CloudTrailEventAction.UPSERT
+    assert create_parsed.identifier == "i-1234567890abcdef0"
+
+    assert delete_parsed is not None
+    assert delete_parsed.kind == ObjectKind.EC2_INSTANCE
+    assert delete_parsed.action == CloudTrailEventAction.DELETE
+
+
+def _ec2_volume_eventbridge_envelope(
+    event_name: str,
+    *,
+    volume_id: str | None = "vol-1234567890abcdef0",
+    account: str | None = "111122223333",
+    region: str | None = "us-east-1",
+) -> EventBridgeCloudTrailPayload:
+    detail: CloudTrailDetail = {
+        "eventName": event_name,
+        "eventSource": "ec2.amazonaws.com",
+    }
+    if region is not None:
+        detail["awsRegion"] = region
+    if account is not None:
+        detail["recipientAccountId"] = account
+
+    if event_name == "CreateVolume" and volume_id is not None:
+        detail["responseElements"] = {"volumeId": volume_id}
+    elif volume_id is not None:
+        detail["requestParameters"] = {"volumeId": volume_id}
+    else:
+        detail["requestParameters"] = {}
+
+    payload: EventBridgeCloudTrailPayload = {"detail": detail}
+    if account is not None:
+        payload["account"] = account
+    if region is not None:
+        payload["region"] = region
+    return cast(
+        EventBridgeCloudTrailPayload,
+        {
+            **payload,
+            "version": "0",
+            "detail-type": "AWS API Call via CloudTrail",
+            "source": "aws.ec2",
+        },
+    )
+
+
+def test_is_supported_cloudtrail_event_true_for_ec2_volume_events() -> None:
+    for event_name in ("CreateVolume", "ModifyVolume", "DeleteVolume"):
+        payload = _ec2_volume_eventbridge_envelope(event_name)
+        assert is_supported_cloudtrail_event(payload) is True
+
+
+def test_parse_ec2_volume_events() -> None:
+    create_payload = _ec2_volume_eventbridge_envelope("CreateVolume")
+    delete_payload = _ec2_volume_eventbridge_envelope("DeleteVolume")
+
+    create_parsed = parse_cloudtrail_event(create_payload)
+    delete_parsed = parse_cloudtrail_event(delete_payload)
+
+    assert create_parsed is not None
+    assert create_parsed.kind == ObjectKind.EC2_VOLUME
+    assert create_parsed.action == CloudTrailEventAction.UPSERT
+    assert create_parsed.identifier == "vol-1234567890abcdef0"
+
+    assert delete_parsed is not None
+    assert delete_parsed.kind == ObjectKind.EC2_VOLUME
+    assert delete_parsed.action == CloudTrailEventAction.DELETE
+
+
+def _elasticache_cluster_eventbridge_envelope(
+    event_name: str,
+    cache_cluster_id: str | None = "my-cache-cluster",
+    account: str | None = "111122223333",
+    region: str | None = "us-east-1",
+) -> EventBridgeCloudTrailPayload:
+    detail: CloudTrailDetail = {
+        "eventName": event_name,
+        "eventSource": "elasticache.amazonaws.com",
+    }
+    if region is not None:
+        detail["awsRegion"] = region
+    if account is not None:
+        detail["recipientAccountId"] = account
+    if cache_cluster_id is not None:
+        detail["requestParameters"] = {"cacheClusterId": cache_cluster_id}
+    else:
+        detail["requestParameters"] = {}
+
+    payload: EventBridgeCloudTrailPayload = {"detail": detail}
+    if account is not None:
+        payload["account"] = account
+    if region is not None:
+        payload["region"] = region
+    return cast(
+        EventBridgeCloudTrailPayload,
+        {
+            **payload,
+            "version": "0",
+            "detail-type": "AWS API Call via CloudTrail",
+            "source": "aws.elasticache",
+        },
+    )
+
+
+def test_is_supported_cloudtrail_event_true_for_elasticache_cluster_events() -> None:
+    for event_name in (
+        "CreateCacheCluster",
+        "ModifyCacheCluster",
+        "DeleteCacheCluster",
+    ):
+        payload = _elasticache_cluster_eventbridge_envelope(event_name)
+        assert is_supported_cloudtrail_event(payload) is True
+
+
+def test_parse_elasticache_cluster_events() -> None:
+    create_payload = _elasticache_cluster_eventbridge_envelope("CreateCacheCluster")
+    delete_payload = _elasticache_cluster_eventbridge_envelope("DeleteCacheCluster")
+
+    create_parsed = parse_cloudtrail_event(create_payload)
+    delete_parsed = parse_cloudtrail_event(delete_payload)
+
+    assert create_parsed is not None
+    assert create_parsed.kind == ObjectKind.ELASTICACHE_CLUSTER
+    assert create_parsed.action == CloudTrailEventAction.UPSERT
+    assert create_parsed.identifier == "my-cache-cluster"
+
+    assert delete_parsed is not None
+    assert delete_parsed.kind == ObjectKind.ELASTICACHE_CLUSTER
+    assert delete_parsed.action == CloudTrailEventAction.DELETE


### PR DESCRIPTION
# Description


Extends aws-v3 CloudTrail live events to six additional resource kinds. Events are handled by the existing unified `CloudTrailWebhookProcessor` - each kind adds a `live_events.py` module and is wired through `exporter_metadata.py`.
**Kinds added:**
- `AWS::RDS::DBCluster` — Create / Modify / Delete
- `AWS::SNS::Topic` — Create / SetTopicAttributes / Delete
- `AWS::SQS::Queue` — Create / SetQueueAttributes / Delete
- `AWS::EC2::Instance` — RunInstances / TerminateInstances
- `AWS::EC2::Volume` — Create / Modify / Delete
- `AWS::ElastiCache::Cluster` — Create / Modify / Delete
## Implementation notes
- **SNS / SQS**: CloudTrail exposes names or URLs; `request_factory` builds topic ARN / queue URL from identifier + account + region (SQS supports `aws-cn` via `amazonaws.com.cn`).
- **EC2 instance**: `RunInstances` reads instance ID from `responseElements.instancesSet` (first instance only).
- **EC2 volume**: `CreateVolume` can read `volumeId` from `responseElements`.
- **Existence checks**: `get_resource()` hardened for RDS cluster, EC2 instance/volume, and ElastiCache so missing resources raise and live events can be treated as deletes.
- **Not-found errors**: Added `DBClusterNotFoundFault`, `CacheClusterNotFoundFault`, `InvalidInstanceID.NotFound`, `InvalidVolume.NotFound` to `is_resource_not_found_exception`.

## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live-event sync and single-resource fetch behavior (not-found now errors), which can affect entity upsert/delete timing across several core AWS resource kinds.
> 
> **Overview**
> Adds **CloudTrail-driven live events** for RDS DB clusters, SNS topics, SQS queues, EC2 instances/volumes, and ElastiCache clusters, wired through new `live_events` modules and `ExporterMetadata` registration (minor release intent in `.ocean-release/phase-1-live-events.yaml`).
> 
> Each kind maps create/modify/delete (or equivalent) API calls to **UPSERT/DELETE**, with identifier extraction from `requestParameters` and, where needed, **`responseElements`** (now on `CloudTrailDetail`). SNS/SQS/RDS cluster handlers also build ARNs/URLs for fetch and delete payloads.
> 
> **Single-resource exporters** (EC2 instance/volume, RDS DB cluster, ElastiCache cluster) now **raise `ClientError` with not-found codes** when describe calls return nothing, instead of `{}`, so upsert-after-delete can be treated as deletion. Matching codes were added to **`is_resource_not_found_exception`**.
> 
> Coverage includes exporter unit tests, exception helper tests, and **CloudTrail parser** tests for all new event shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0ca0388386cfe16fd068343661b0e79a73926a5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->