### PR TITLE
[Integration][ADO] skip repos with no default branch in folder sync

### DIFF
--- a/integrations/azure-devops/.ocean-release/skip-empty-repo-folder-sync.yaml
+++ b/integrations/azure-devops/.ocean-release/skip-empty-repo-folder-sync.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: bugfix
+changelog: Skip Azure DevOps repos with no default branch during folder sync

--- a/integrations/azure-devops/azure_devops/client/azure_devops_client.py
+++ b/integrations/azure-devops/azure_devops/client/azure_devops_client.py
@@ -40,9 +40,13 @@ from azure_devops.incremental import (
     flatten_advanced_security_params,
     wiql_changed_after_clause,
 )
-from azure_devops.client.base_client import MAX_TIMEMOUT_RETRIES, HTTPBaseClient
+from azure_devops.client.base_client import (
+    CONTINUATION_TOKEN_HEADER,
+    MAX_TIMEMOUT_RETRIES,
+    PAGE_SIZE,
+    HTTPBaseClient,
+)
 from azure_devops.misc import FolderPattern, RepositoryBranchMapping
-from azure_devops.client.base_client import CONTINUATION_TOKEN_HEADER, PAGE_SIZE
 
 from azure_devops.client.file_processing import (
     PathDescriptor,
@@ -2337,6 +2341,23 @@ class AzureDevopsClient(HTTPBaseClient):
             async for batch in stream_async_iterators_tasks(*tasks):
                 yield batch
 
+    def _resolve_repository_branch(
+        self,
+        repository: dict[str, Any],
+        branch_override: str | None = None,
+    ) -> str | None:
+        if branch_override:
+            return branch_override
+
+        default_branch = repository.get("defaultBranch")
+        if not default_branch:
+            logger.warning(
+                f"Repository {repository['name']} has no default branch. Skipping."
+            )
+            return None
+
+        return default_branch.replace("refs/heads/", "")
+
     async def _get_repository_files(
         self,
         repository: dict[str, Any],
@@ -2346,14 +2367,9 @@ class AzureDevopsClient(HTTPBaseClient):
             f"Checking repository {repository['name']} for files matching {paths}"
         )
 
-        branch = repository.get("defaultBranch")
+        branch = self._resolve_repository_branch(repository)
         if not branch:
-            logger.warning(
-                f"Repository {repository['name']} has no default branch. Skipping."
-            )
             return
-
-        branch = branch.replace("refs/heads/", "")
 
         files = []
         literal_paths, glob_patterns = separate_glob_and_literal_paths(paths)
@@ -2768,20 +2784,24 @@ class AzureDevopsClient(HTTPBaseClient):
         folder_pattern: FolderPattern,
         repo_mapping: RepositoryBranchMapping | None,
     ) -> AsyncGenerator[list[dict[str, Any]], None]:
-        branch = repo_mapping.branch if repo_mapping else None
-        if not branch and "defaultBranch" in repo:
-            branch = repo["defaultBranch"].replace("refs/heads/", "")
+        branch = self._resolve_repository_branch(
+            repo, repo_mapping.branch if repo_mapping else None
+        )
+        if not branch:
+            return
 
         async for found_folders in self.get_repository_folders(
             repo["id"], [folder_pattern.path]
         ):
-            processed_folders = []
-            for folder in found_folders:
-                folder_dict = dict(folder)
-                folder_dict["__repository"] = repo
-                folder_dict["__branch"] = branch
-                folder_dict["__pattern"] = folder_pattern.path
-                processed_folders.append(folder_dict)
+            processed_folders = [
+                {
+                    **folder,
+                    "__repository": repo,
+                    "__branch": branch,
+                    "__pattern": folder_pattern.path,
+                }
+                for folder in found_folders
+            ]
             if processed_folders:
                 yield processed_folders
 

--- a/integrations/azure-devops/azure_devops/client/azure_devops_client.py
+++ b/integrations/azure-devops/azure_devops/client/azure_devops_client.py
@@ -2351,9 +2351,6 @@ class AzureDevopsClient(HTTPBaseClient):
 
         default_branch = repository.get("defaultBranch")
         if not default_branch:
-            logger.warning(
-                f"Repository {repository['name']} has no default branch. Skipping."
-            )
             return None
 
         return default_branch.replace("refs/heads/", "")
@@ -2369,6 +2366,9 @@ class AzureDevopsClient(HTTPBaseClient):
 
         branch = self._resolve_repository_branch(repository)
         if not branch:
+            logger.warning(
+                f"Repository {repository['name']} has no default branch. Skipping."
+            )
             return
 
         files = []
@@ -2788,6 +2788,9 @@ class AzureDevopsClient(HTTPBaseClient):
             repo, repo_mapping.branch if repo_mapping else None
         )
         if not branch:
+            logger.warning(
+                f"Repository {repo['name']} has no default branch. Skipping."
+            )
             return
 
         async for found_folders in self.get_repository_folders(

--- a/integrations/azure-devops/tests/azure_devops/client/test_folder_sync_empty_repo.py
+++ b/integrations/azure-devops/tests/azure_devops/client/test_folder_sync_empty_repo.py
@@ -1,0 +1,54 @@
+"""
+Repos with no commits/branches have no default branch in the ADO API
+(`defaultBranch` is null). Folder sync must skip those repos and continue.
+"""
+
+from typing import Any, AsyncGenerator
+
+import pytest
+
+from azure_devops.client.auth import PatAuthProvider
+from azure_devops.client.azure_devops_client import AzureDevopsClient
+from azure_devops.misc import FolderPattern, RepositoryBranchMapping
+
+
+@pytest.mark.asyncio
+async def test_process_folder_patterns_skips_repo_without_default_branch() -> None:
+    client = AzureDevopsClient("https://dev.azure.com/test", PatAuthProvider("token"))
+    patterns = [
+        FolderPattern(
+            path="src",
+            repos=[
+                RepositoryBranchMapping(name="empty-repo"),
+                RepositoryBranchMapping(name="good-repo"),
+            ],
+        )
+    ]
+
+    async def mock_get_repositories_for_project(
+        project_name: str,
+    ) -> AsyncGenerator[list[dict[str, Any]], None]:
+        yield [
+            {"name": "empty-repo", "id": "empty-id", "defaultBranch": None},
+            {
+                "name": "good-repo",
+                "id": "good-id",
+                "defaultBranch": "refs/heads/main",
+            },
+        ]
+
+    async def mock_get_repository_folders(
+        repo_id: str, paths: list[str], **kwargs: Any
+    ) -> AsyncGenerator[list[dict[str, Any]], None]:
+        if repo_id == "good-id":
+            yield [{"path": "src", "gitObjectType": "tree"}]
+
+    client._get_repositories_for_project = mock_get_repositories_for_project  # type: ignore[method-assign]
+    client.get_repository_folders = mock_get_repository_folders  # type: ignore[method-assign]
+
+    results = []
+    async for folders in client.process_folder_patterns(patterns, project_name="proj"):
+        results.extend(folders)
+
+    assert len(results) == 1
+    assert results[0]["__repository"]["name"] == "good-repo"

--- a/integrations/azure-devops/tests/azure_devops/client/test_folder_sync_empty_repo.py
+++ b/integrations/azure-devops/tests/azure_devops/client/test_folder_sync_empty_repo.py
@@ -4,6 +4,7 @@ Repos with no commits/branches have no default branch in the ADO API
 """
 
 from typing import Any, AsyncGenerator
+from unittest.mock import patch
 
 import pytest
 
@@ -43,12 +44,23 @@ async def test_process_folder_patterns_skips_repo_without_default_branch() -> No
         if repo_id == "good-id":
             yield [{"path": "src", "gitObjectType": "tree"}]
 
-    client._get_repositories_for_project = mock_get_repositories_for_project  # type: ignore[method-assign]
-    client.get_repository_folders = mock_get_repository_folders  # type: ignore[method-assign]
-
-    results = []
-    async for folders in client.process_folder_patterns(patterns, project_name="proj"):
-        results.extend(folders)
+    with (
+        patch.object(
+            client,
+            "_get_repositories_for_project",
+            side_effect=mock_get_repositories_for_project,
+        ),
+        patch.object(
+            client,
+            "get_repository_folders",
+            side_effect=mock_get_repository_folders,
+        ),
+    ):
+        results = []
+        async for folders in client.process_folder_patterns(
+            patterns, project_name="proj"
+        ):
+            results.extend(folders)
 
     assert len(results) == 1
     assert results[0]["__repository"]["name"] == "good-repo"


### PR DESCRIPTION
# Description
Jira [bug](https://getport.atlassian.net/browse/PORT-18438)
Skip ADO repos where `defaultBranch` is `null` during folder sync, matching file sync behavior. Adds a shared `_resolve_repository_branch` helper and a regression test

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted bugfix in repository branch resolution for file/folder sync; behavior change is to skip empty repos instead of erroring, with test coverage.
> 
> **Overview**
> **Folder sync** no longer fails when a matched Azure DevOps repo has no commits and ADO returns `defaultBranch: null`. Those repos are **skipped with a warning**, and sync continues for other repositories—aligned with existing **file sync** behavior.
> 
> Introduces shared **`_resolve_repository_branch`** (optional mapping override, null-safe default branch, `refs/heads/` normalization) and wires it into **`_get_repository_files`** and **`_process_pattern`**, with an early return when no branch can be resolved. Adds a regression test and a patch **changelog** entry for the integration release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03cac1055d3e2c126cfb26f1ee55b8dabbada9a5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->