### PR TITLE
[Integration][GitHub] Add Multi-Document YAML Parsing to GitHub File Exporter

### DIFF
--- a/integrations/github/.ocean-release/multi-document-yaml-parsing.yaml
+++ b/integrations/github/.ocean-release/multi-document-yaml-parsing.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: bugfix
+changelog: Fixed multi-document YAML parsing in the GitHub file exporter

--- a/integrations/github/github/core/exporters/file_exporter/file_processor.py
+++ b/integrations/github/github/core/exporters/file_exporter/file_processor.py
@@ -162,7 +162,7 @@ class FileProcessor:
     async def _process_list_content(
         self,
         organization: str,
-        data: List[Dict[str, Any]],
+        data: List[Any],
         parent_directory: str,
         file_path: str,
         file_name: str,
@@ -170,9 +170,12 @@ class FileProcessor:
         file_info: Dict[str, Any],
         repo_info: Dict[str, Any],
     ) -> FileObject:
-        """Process each dict item in the list concurrently, resolving file references."""
+        """Process list content, resolving file references in dict items only."""
 
-        async def process_item(item: Dict[str, Any]) -> Dict[str, Any]:
+        async def process_item(item: Any) -> Any:
+            if not isinstance(item, dict):
+                return item
+
             keys = list(item.keys())
             values = await asyncio.gather(
                 *[

--- a/integrations/github/github/core/exporters/file_exporter/utils.py
+++ b/integrations/github/github/core/exporters/file_exporter/utils.py
@@ -99,7 +99,10 @@ def parse_content(content: str, file_path: str) -> Any:
             return json.loads(content)
         elif file_path.endswith(YAML_FILE_SUFFIX):
             yaml = YAML(typ="safe")
-            return yaml.load(content)
+            documents = [doc for doc in yaml.load_all(content) if doc is not None]
+            if not documents:
+                return content
+            return documents if len(documents) > 1 else documents[0]
     except Exception as e:
         logger.error(f"Error parsing file: {e}")
 

--- a/integrations/github/tests/github/core/exporters/test_file_exporter.py
+++ b/integrations/github/tests/github/core/exporters/test_file_exporter.py
@@ -1345,3 +1345,38 @@ class TestFileProcessorMultiDocumentYaml:
             {"name": "service-a", "version": "1.0.0"},
             {"name": "service-b", "version": "2.0.0"},
         ]
+
+    async def test_process_file_passes_through_non_mapping_documents(self) -> None:
+        exporter = RestFileExporter(MagicMock(spec=GithubRestClient))
+        mixed_doc_yaml = "name: service-a\n---\njust a string\n---\n42\n"
+
+        result = await exporter.file_processor.process_file(
+            organization="test-org",
+            repository={"name": "test-repo", "owner": {"login": "test-org"}},
+            file_path="services.yaml",
+            skip_parsing=False,
+            branch="main",
+            content=mixed_doc_yaml,
+            metadata={},
+        )
+
+        assert result["content"] == [
+            {"name": "service-a"},
+            "just a string",
+            42,
+        ]
+
+    async def test_process_file_passes_through_top_level_yaml_list(self) -> None:
+        exporter = RestFileExporter(MagicMock(spec=GithubRestClient))
+
+        result = await exporter.file_processor.process_file(
+            organization="test-org",
+            repository={"name": "test-repo", "owner": {"login": "test-org"}},
+            file_path="items.yaml",
+            skip_parsing=False,
+            branch="main",
+            content="- item1\n- item2\n",
+            metadata={},
+        )
+
+        assert result["content"] == ["item1", "item2"]

--- a/integrations/github/tests/github/core/exporters/test_file_exporter.py
+++ b/integrations/github/tests/github/core/exporters/test_file_exporter.py
@@ -1183,6 +1183,20 @@ class TestFileExporterUtils:
         content = parse_content("invalid: yaml: content:", "config.yaml")
         assert content == "invalid: yaml: content:"
 
+    def test_parse_content_multi_document_yaml(self) -> None:
+        content = parse_content(
+            "name: service-a\nversion: 1.0.0\n---\nname: service-b\nversion: 2.0.0\n",
+            "services.yaml",
+        )
+        assert content == [
+            {"name": "service-a", "version": "1.0.0"},
+            {"name": "service-b", "version": "2.0.0"},
+        ]
+
+    def test_parse_content_single_document_yaml_with_leading_marker(self) -> None:
+        content = parse_content("---\nname: test\nvalue: 123\n", "config.yaml")
+        assert content == {"name": "test", "value": 123}
+
     def test_match_file_path_against_glob_pattern_exact(self) -> None:
         assert match_file_path_against_glob_pattern("test.txt", "test.txt") is True
 

--- a/integrations/github/tests/github/core/exporters/test_file_exporter.py
+++ b/integrations/github/tests/github/core/exporters/test_file_exporter.py
@@ -1345,4 +1345,3 @@ class TestFileProcessorMultiDocumentYaml:
             {"name": "service-a", "version": "1.0.0"},
             {"name": "service-b", "version": "2.0.0"},
         ]
-

--- a/integrations/github/tests/github/core/exporters/test_file_exporter.py
+++ b/integrations/github/tests/github/core/exporters/test_file_exporter.py
@@ -1320,3 +1320,29 @@ class TestFileExporterUtils:
         assert 'repository(owner: "test-org", name: "repo1")' in query["query"]
         # Should not contain any file objects
         assert "file_0: object" not in query["query"]
+
+
+@pytest.mark.asyncio
+class TestFileProcessorMultiDocumentYaml:
+    async def test_process_file_returns_list_for_multi_document_yaml(self) -> None:
+        """Resync and webhook file processing both route through FileProcessor."""
+        exporter = RestFileExporter(MagicMock(spec=GithubRestClient))
+        multi_doc_yaml = (
+            "name: service-a\nversion: 1.0.0\n---\nname: service-b\nversion: 2.0.0\n"
+        )
+
+        result = await exporter.file_processor.process_file(
+            organization="test-org",
+            repository={"name": "test-repo", "owner": {"login": "test-org"}},
+            file_path="services.yaml",
+            skip_parsing=False,
+            branch="main",
+            content=multi_doc_yaml,
+            metadata={},
+        )
+
+        assert result["content"] == [
+            {"name": "service-a", "version": "1.0.0"},
+            {"name": "service-b", "version": "2.0.0"},
+        ]
+


### PR DESCRIPTION
# Description

What -
GitHub Ocean file exporter now parses multi-document YAML files (documents separated by ---) instead of failing with a single-document parse error.

Why - 
Customers reported that multi-doc YAML files were not parsed and .content was unavailable ([#3894](https://github.com/port-labs/ocean/issues/3894)). Port docs already describe this behavior, but the integration only used single-document YAML loading.

How -
Updated parse_content() in the file exporter to use yaml.load_all(). Single-document files still return an object; multi-document files return an array. Added unit tests for both cases.


## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [x] Integration able to create all default resources from scratch
- [x] Resync finishes successfully
- [x] Resync able to create entities
- [x] Resync able to update entities
- [x] Resync able to detect and delete entities
- [x] Scheduled resync able to abort existing resync and start a new one
- [x] Tested with at least 2 integrations from scratch
- [x] Tested with Kafka and Polling event listeners
- [x] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [x] Integration able to create all default resources from scratch
- [x] Completed a full resync from a freshly installed integration and it completed successfully
- [x] Resync able to create entities
- [x]  Resync able to update entities
- [x] Resync able to detect and delete entities
- [x] Resync finishes successfully
- [x] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [x] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [x] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [x] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized parsing change with backward-compatible single-document behavior; downstream mappings may need to handle list-shaped `content` for multi-doc YAML only.
> 
> **Overview**
> Fixes GitHub file exporter YAML handling so files with multiple `---`-separated documents no longer fail or lose parsed `.content`.
> 
> **`parse_content`** now uses `yaml.load_all()` instead of a single `load()`. **Multi-document** `.yaml`/`.yml` files return a **list** of documents; **single-document** files (including those with a leading `---`) still return one object. Empty or all-null streams fall back to the raw string, matching existing error behavior.
> 
> Coverage adds unit tests for multi-doc and leading-marker single-doc parsing, plus an async **`FileProcessor`** test so resync/webhook paths expose the list on `content`. Patch release intent is recorded in `.ocean-release/multi-document-yaml-parsing.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cafca4c9734cb9b829186489cd14b90c814d4dc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->