### PR TITLE
[Integration][ADO] fix folder sync pagination when scopePath lacks a leading slash

### DIFF
--- a/integrations/azure-devops/.ocean-release/fix-folder-scope-path-pagination.yaml
+++ b/integrations/azure-devops/.ocean-release/fix-folder-scope-path-pagination.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: bugfix
+changelog: Normalize Git Items API scopePath for folder sync so pagination continuation tokens remain valid when listing more than 50 folders under a path.

--- a/integrations/azure-devops/azure_devops/client/azure_devops_client.py
+++ b/integrations/azure-devops/azure_devops/client/azure_devops_client.py
@@ -184,11 +184,7 @@ def _parse_change_timestamp(timestamp: str) -> datetime:
 
 
 def _normalize_git_scope_path(path: str) -> str:
-    """Normalize a Git item path for the Azure DevOps Items API ``scopePath`` parameter.
-
-    ADO expects a leading slash (e.g. ``/App/root``). Continuation tokens are bound to
-    the normalized scope path, so pagination must use the same format on every request.
-    """
+    """Format ``scopePath`` for the Git Items API (leading ``/``, no trailing ``/``)."""
     normalized = path.strip().strip("/")
     return "/" if not normalized else f"/{normalized}"
 

--- a/integrations/azure-devops/azure_devops/client/azure_devops_client.py
+++ b/integrations/azure-devops/azure_devops/client/azure_devops_client.py
@@ -183,6 +183,16 @@ def _parse_change_timestamp(timestamp: str) -> datetime:
         return datetime.max.replace(tzinfo=timezone.utc)
 
 
+def _normalize_git_scope_path(path: str) -> str:
+    """Normalize a Git item path for the Azure DevOps Items API ``scopePath`` parameter.
+
+    ADO expects a leading slash (e.g. ``/App/root``). Continuation tokens are bound to
+    the normalized scope path, so pagination must use the same format on every request.
+    """
+    normalized = path.strip().strip("/")
+    return "/" if not normalized else f"/{normalized}"
+
+
 def _normalize_area_path(path: str) -> str:
     """Convert a classification-node path to work-item ``System.AreaPath`` format.
 
@@ -2692,7 +2702,7 @@ class AzureDevopsClient(HTTPBaseClient):
         items_batch_url = f"{self._organization_base_url}/_apis/git/repositories/{repository_id}/items"
 
         params = {
-            "scopePath": path,
+            "scopePath": _normalize_git_scope_path(path),
             "recursionLevel": recursion_level,
             "$top": PAGE_SIZE,
             "api-version": "7.1",
@@ -2725,16 +2735,16 @@ class AzureDevopsClient(HTTPBaseClient):
         parts = pattern.split("/")
         base_parts = []
         for part in parts:
-            if "*" not in part:
-                base_parts.append(part)
-            else:
+            if "*" in part:
                 break
+            if part:
+                base_parts.append(part)
         base_path = "/".join(base_parts)
 
         return functools.partial(
             self.get_repository_tree,
             repository_id,
-            path=base_path or "/",
+            path=_normalize_git_scope_path(base_path),
             recursion_level="oneLevel",  # Always use oneLevel recursion
         )
 

--- a/integrations/azure-devops/tests/azure_devops/client/test_azure_devops_client.py
+++ b/integrations/azure-devops/tests/azure_devops/client/test_azure_devops_client.py
@@ -17,6 +17,7 @@ from azure_devops.client.azure_devops_client import (
     AzureDevopsClient,
     _flatten_area_path_tree,
     _normalize_area_path,
+    _normalize_git_scope_path,
 )
 from azure_devops.client.file_processing import PathDescriptor
 from azure_devops.webhooks.webhook_event import WebhookSubscription
@@ -3225,6 +3226,129 @@ async def test_get_repository_tree_with_deep_path() -> None:
         paths = {folder["path"] for folder in folders}
         assert paths == {"/src/main", "/src/main/api", "/src/test"}
         assert all(folder["gitObjectType"] == "tree" for folder in folders)
+
+
+@pytest.mark.parametrize(
+    ("raw_path", "expected"),
+    [
+        ("/", "/"),
+        ("", "/"),
+        ("App/root/env/region", "/App/root/env/region"),
+        ("/App/root/env/region", "/App/root/env/region"),
+        ("/App/root/env/region/", "/App/root/env/region"),
+        ("test/", "/test"),
+        ("/src/**/*.py", "/src/**/*.py"),
+    ],
+)
+def test_normalize_git_scope_path(raw_path: str, expected: str) -> None:
+    assert _normalize_git_scope_path(raw_path) == expected
+
+
+@pytest.mark.asyncio
+async def test_get_repository_tree_normalizes_scope_path() -> None:
+    """Folder patterns without a leading slash must still use ADO scopePath format."""
+    client = AzureDevopsClient(MOCK_ORG_URL, MOCK_AUTH_PROVIDER, MOCK_AUTH_USERNAME)
+    captured_params: list[dict[str, Any]] = []
+
+    async def mock_get_paginated_by_top_and_continuation_token(
+        url: str, additional_params: Optional[Dict[str, Any]] = None, **kwargs: Any
+    ) -> AsyncGenerator[List[Dict[str, Any]], None]:
+        if additional_params is not None:
+            captured_params.append(dict(additional_params))
+        yield []
+
+    with patch.object(
+        client,
+        "_get_paginated_by_top_and_continuation_token",
+        side_effect=mock_get_paginated_by_top_and_continuation_token,
+    ):
+        async for _ in client.get_repository_tree(
+            MOCK_REPOSITORY_ID,
+            path="App/root/env/region",
+            recursion_level="oneLevel",
+        ):
+            pass
+
+    assert captured_params[0]["scopePath"] == "/App/root/env/region"
+
+
+@pytest.mark.asyncio
+async def test_get_repository_tree_keeps_scope_path_on_pagination() -> None:
+    """Continuation requests must repeat the same normalized scopePath as page one."""
+    client = AzureDevopsClient(MOCK_ORG_URL, MOCK_AUTH_PROVIDER, MOCK_AUTH_USERNAME)
+    captured_params: list[dict[str, Any]] = []
+
+    mock_response1 = AsyncMock(spec=Response)
+    mock_response1.status_code = 200
+    mock_response1.headers = {"x-ms-continuationtoken": "token-page-2"}
+    mock_response1.json.return_value = {
+        "value": [
+            {
+                "objectId": "abc123",
+                "gitObjectType": "tree",
+                "path": "/App/root/env/region/folder-a",
+            }
+        ]
+    }
+
+    mock_response2 = AsyncMock(spec=Response)
+    mock_response2.status_code = 200
+    mock_response2.headers = {}
+    mock_response2.json.return_value = {
+        "value": [
+            {
+                "objectId": "def456",
+                "gitObjectType": "tree",
+                "path": "/App/root/env/region/folder-b",
+            }
+        ]
+    }
+
+    async def capture_send_request(method: str, url: str, **kwargs: Any) -> Response:
+        captured_params.append(dict(kwargs.get("params") or {}))
+        if len(captured_params) == 1:
+            return mock_response1
+        return mock_response2
+
+    with patch.object(client, "send_request", side_effect=capture_send_request):
+        folders = []
+        async for folder_batch in client.get_repository_tree(
+            MOCK_REPOSITORY_ID,
+            path="App/root/env/region",
+            recursion_level="oneLevel",
+        ):
+            folders.extend(folder_batch)
+
+    assert len(folders) == 2
+    assert len(captured_params) == 2
+    assert captured_params[0]["scopePath"] == "/App/root/env/region"
+    assert captured_params[1]["scopePath"] == "/App/root/env/region"
+    assert captured_params[1]["continuationToken"] == "token-page-2"
+
+
+@pytest.mark.asyncio
+async def test_build_tree_fetcher_normalizes_pattern_base_path() -> None:
+    client = AzureDevopsClient(MOCK_ORG_URL, MOCK_AUTH_PROVIDER, MOCK_AUTH_USERNAME)
+    captured_paths: list[str] = []
+
+    async def mock_get_repository_tree(
+        repository_id: str,
+        recursion_level: str,
+        path: str = "/",
+    ) -> AsyncGenerator[list[dict[str, Any]], None]:
+        captured_paths.append(path)
+        yield []
+
+    with patch.object(
+        client, "get_repository_tree", side_effect=mock_get_repository_tree
+    ):
+        fetcher = client._build_tree_fetcher(
+            MOCK_REPOSITORY_ID, "/App/root/env/region/*"
+        )
+        async for _ in fetcher():
+            pass
+
+    assert captured_paths == ["/App/root/env/region"]
 
 
 @pytest.mark.asyncio

--- a/integrations/azure-devops/tests/azure_devops/client/test_azure_devops_client.py
+++ b/integrations/azure-devops/tests/azure_devops/client/test_azure_devops_client.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch, AsyncMock
 
 import asyncio
 import json
+from functools import partial
 import pytest
 from _pytest.monkeypatch import MonkeyPatch
 from httpx import Request, Response, HTTPStatusError
@@ -3248,6 +3249,7 @@ def test_build_tree_fetcher_normalizes_wildcard_base_path() -> None:
     client = AzureDevopsClient(MOCK_ORG_URL, MOCK_AUTH_PROVIDER, MOCK_AUTH_USERNAME)
     fetcher = client._build_tree_fetcher(MOCK_REPOSITORY_ID, "App/root/env/region/*")
 
+    assert isinstance(fetcher, partial)
     assert fetcher.args == (MOCK_REPOSITORY_ID,)
     assert fetcher.keywords == {
         "path": "/App/root/env/region",

--- a/integrations/azure-devops/tests/azure_devops/client/test_azure_devops_client.py
+++ b/integrations/azure-devops/tests/azure_devops/client/test_azure_devops_client.py
@@ -19,6 +19,7 @@ from azure_devops.client.azure_devops_client import (
     _normalize_area_path,
     _normalize_git_scope_path,
 )
+from azure_devops.client.base_client import CONTINUATION_TOKEN_HEADER
 from azure_devops.client.file_processing import PathDescriptor
 from azure_devops.webhooks.webhook_event import WebhookSubscription
 from azure_devops.misc import FolderPattern, RepositoryBranchMapping
@@ -3234,7 +3235,6 @@ async def test_get_repository_tree_with_deep_path() -> None:
         ("/", "/"),
         ("", "/"),
         ("App/root/env/region", "/App/root/env/region"),
-        ("/App/root/env/region", "/App/root/env/region"),
         ("/App/root/env/region/", "/App/root/env/region"),
         ("test/", "/test"),
         ("/src/**/*.py", "/src/**/*.py"),
@@ -3244,44 +3244,26 @@ def test_normalize_git_scope_path(raw_path: str, expected: str) -> None:
     assert _normalize_git_scope_path(raw_path) == expected
 
 
-@pytest.mark.asyncio
-async def test_get_repository_tree_normalizes_scope_path() -> None:
-    """Folder patterns without a leading slash must still use ADO scopePath format."""
+def test_build_tree_fetcher_normalizes_wildcard_base_path() -> None:
     client = AzureDevopsClient(MOCK_ORG_URL, MOCK_AUTH_PROVIDER, MOCK_AUTH_USERNAME)
-    captured_params: list[dict[str, Any]] = []
+    fetcher = client._build_tree_fetcher(MOCK_REPOSITORY_ID, "App/root/env/region/*")
 
-    async def mock_get_paginated_by_top_and_continuation_token(
-        url: str, additional_params: Optional[Dict[str, Any]] = None, **kwargs: Any
-    ) -> AsyncGenerator[List[Dict[str, Any]], None]:
-        if additional_params is not None:
-            captured_params.append(dict(additional_params))
-        yield []
-
-    with patch.object(
-        client,
-        "_get_paginated_by_top_and_continuation_token",
-        side_effect=mock_get_paginated_by_top_and_continuation_token,
-    ):
-        async for _ in client.get_repository_tree(
-            MOCK_REPOSITORY_ID,
-            path="App/root/env/region",
-            recursion_level="oneLevel",
-        ):
-            pass
-
-    assert captured_params[0]["scopePath"] == "/App/root/env/region"
+    assert fetcher.args == (MOCK_REPOSITORY_ID,)
+    assert fetcher.keywords == {
+        "path": "/App/root/env/region",
+        "recursion_level": "oneLevel",
+    }
 
 
 @pytest.mark.asyncio
-async def test_get_repository_tree_keeps_scope_path_on_pagination() -> None:
-    """Continuation requests must repeat the same normalized scopePath as page one."""
+async def test_get_repository_tree_normalizes_scope_path_across_pages() -> None:
     client = AzureDevopsClient(MOCK_ORG_URL, MOCK_AUTH_PROVIDER, MOCK_AUTH_USERNAME)
     captured_params: list[dict[str, Any]] = []
 
-    mock_response1 = AsyncMock(spec=Response)
-    mock_response1.status_code = 200
-    mock_response1.headers = {"x-ms-continuationtoken": "token-page-2"}
-    mock_response1.json.return_value = {
+    page_one = AsyncMock(spec=Response)
+    page_one.status_code = 200
+    page_one.headers = {CONTINUATION_TOKEN_HEADER: "token-page-2"}
+    page_one.json.return_value = {
         "value": [
             {
                 "objectId": "abc123",
@@ -3291,10 +3273,10 @@ async def test_get_repository_tree_keeps_scope_path_on_pagination() -> None:
         ]
     }
 
-    mock_response2 = AsyncMock(spec=Response)
-    mock_response2.status_code = 200
-    mock_response2.headers = {}
-    mock_response2.json.return_value = {
+    page_two = AsyncMock(spec=Response)
+    page_two.status_code = 200
+    page_two.headers = {}
+    page_two.json.return_value = {
         "value": [
             {
                 "objectId": "def456",
@@ -3306,49 +3288,21 @@ async def test_get_repository_tree_keeps_scope_path_on_pagination() -> None:
 
     async def capture_send_request(method: str, url: str, **kwargs: Any) -> Response:
         captured_params.append(dict(kwargs.get("params") or {}))
-        if len(captured_params) == 1:
-            return mock_response1
-        return mock_response2
+        return page_one if len(captured_params) == 1 else page_two
 
     with patch.object(client, "send_request", side_effect=capture_send_request):
         folders = []
-        async for folder_batch in client.get_repository_tree(
+        async for batch in client.get_repository_tree(
             MOCK_REPOSITORY_ID,
             path="App/root/env/region",
             recursion_level="oneLevel",
         ):
-            folders.extend(folder_batch)
+            folders.extend(batch)
 
     assert len(folders) == 2
     assert len(captured_params) == 2
-    assert captured_params[0]["scopePath"] == "/App/root/env/region"
-    assert captured_params[1]["scopePath"] == "/App/root/env/region"
+    assert all(p["scopePath"] == "/App/root/env/region" for p in captured_params)
     assert captured_params[1]["continuationToken"] == "token-page-2"
-
-
-@pytest.mark.asyncio
-async def test_build_tree_fetcher_normalizes_pattern_base_path() -> None:
-    client = AzureDevopsClient(MOCK_ORG_URL, MOCK_AUTH_PROVIDER, MOCK_AUTH_USERNAME)
-    captured_paths: list[str] = []
-
-    async def mock_get_repository_tree(
-        repository_id: str,
-        recursion_level: str,
-        path: str = "/",
-    ) -> AsyncGenerator[list[dict[str, Any]], None]:
-        captured_paths.append(path)
-        yield []
-
-    with patch.object(
-        client, "get_repository_tree", side_effect=mock_get_repository_tree
-    ):
-        fetcher = client._build_tree_fetcher(
-            MOCK_REPOSITORY_ID, "/App/root/env/region/*"
-        )
-        async for _ in fetcher():
-            pass
-
-    assert captured_paths == ["/App/root/env/region"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Description
Jira [bug](https://getport.atlassian.net/browse/PORT-18445)

### What
- Normalize Git Items API `scopePath` before folder tree requests (`/App/root/env/region` instead of `App/root/env/region`)
- Apply the same normalized path on every pagination request so ADO continuation tokens stay valid
- Skip empty path segments when resolving wildcard folder patterns (e.g. trailing slashes)

### Why
Folder sync fails with 400 Bad Request / `VS403659`: The continuation token is not valid when a repo has more than 50 folders under a path. The first page succeeds, but page 2 sends `scopePath=App/root/env/region` while the token is bound to `/App/root/env/region`, aborting the resync.

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped bugfix to folder listing API parameters and pattern parsing; no auth or data-model changes, with new tests covering pagination behavior.
> 
> **Overview**
> Fixes folder sync failing on the second page when a path has more than 50 child folders (ADO error `VS403659` / invalid continuation token).
> 
> Adds **`_normalize_git_scope_path`** so Git Items API `scopePath` always uses Azure DevOps’s leading-slash form (e.g. `/App/root/env/region`). **`get_repository_tree`** and **`_build_tree_fetcher`** now pass normalized paths on every request, including continuation pages, so tokens stay bound to the same scope. Wildcard pattern base-path resolution also skips empty segments (e.g. trailing slashes).
> 
> Includes unit tests for normalization, pagination param consistency, and tree-fetcher behavior, plus a patch changelog entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b0c8fc95ccba462b7d5d1b9e09301f668ffb6fd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->