### PR TITLE
[Integration][AWS-V3] Add CloudTrail live events for SES Email Identity and Configuration Set

### DIFF
--- a/integrations/aws-v3/.ocean-release/ses-live-events.yaml
+++ b/integrations/aws-v3/.ocean-release/ses-live-events.yaml
@@ -1,0 +1,3 @@
+bump: minor
+changelog-type: feature
+changelog: Add CloudTrail live events support for SES email identities and configuration sets.

--- a/integrations/aws-v3/aws/core/exporters/exporter_metadata.py
+++ b/integrations/aws-v3/aws/core/exporters/exporter_metadata.py
@@ -82,6 +82,12 @@ from aws.core.exporters.ses import (
     SesConfigurationSetExporter,
     SesEmailIdentityExporter,
 )
+from aws.core.exporters.ses.configuration_set.live_events import (
+    SES_CONFIGURATION_SET_LIVE_EVENTS,
+)
+from aws.core.exporters.ses.email_identity.live_events import (
+    SES_EMAIL_IDENTITY_LIVE_EVENTS,
+)
 from aws.core.exporters.sns import SNSTopicExporter, PaginatedTopicRequest
 from aws.core.exporters.sns.topic.live_events import SNS_TOPIC_LIVE_EVENTS
 from aws.core.exporters.sqs import SqsQueueExporter
@@ -195,7 +201,9 @@ kind_to_export_metadata: dict[ObjectKind, ExporterMetadata] = {
         CodePipelineActionExecutionExporter, PaginatedCodePipelineActionExecutionRequest
     ),
     ObjectKind.SES_EMAIL_IDENTITY: ExporterMetadata(
-        SesEmailIdentityExporter, PaginatedEmailIdentityRequest
+        SesEmailIdentityExporter,
+        PaginatedEmailIdentityRequest,
+        live_events=SES_EMAIL_IDENTITY_LIVE_EVENTS,
     ),
     ObjectKind.DYNAMODB_TABLE: ExporterMetadata(
         DynamoDBTableExporter,
@@ -203,7 +211,9 @@ kind_to_export_metadata: dict[ObjectKind, ExporterMetadata] = {
         live_events=DYNAMODB_TABLE_LIVE_EVENTS,
     ),
     ObjectKind.SES_CONFIGURATION_SET: ExporterMetadata(
-        SesConfigurationSetExporter, PaginatedConfigurationSetRequest
+        SesConfigurationSetExporter,
+        PaginatedConfigurationSetRequest,
+        live_events=SES_CONFIGURATION_SET_LIVE_EVENTS,
     ),
     ObjectKind.SNS_TOPIC: ExporterMetadata(
         SNSTopicExporter,

--- a/integrations/aws-v3/aws/core/exporters/ses/configuration_set/exporter.py
+++ b/integrations/aws-v3/aws/core/exporters/ses/configuration_set/exporter.py
@@ -28,6 +28,15 @@ class SesConfigurationSetExporter(IResourceExporter[list[ConfigurationSetRecord]
         async with AioBaseClientProxy(
             self.session, options.region, self._service_name
         ) as proxy:
+            # Live-event single-configuration-set fetch only has a name from CloudTrail.
+            # GetConfigurationSetAction swallows recoverable not-found errors,
+            # so the inspector would return an empty stub for a deleted set.
+            # Confirm it exists so a missing set raises and the live-event handler
+            # can treat the update as a delete instead.
+            await proxy.client.get_configuration_set(  # type: ignore[attr-defined]
+                ConfigurationSetName=options.configuration_set_name
+            )
+
             inspector = ResourceInspector(
                 proxy.client, self._actions_map(), lambda: self._model_cls()
             )

--- a/integrations/aws-v3/aws/core/exporters/ses/configuration_set/live_events.py
+++ b/integrations/aws-v3/aws/core/exporters/ses/configuration_set/live_events.py
@@ -1,0 +1,60 @@
+from aws.core.exporters.ses.configuration_set.models import SingleConfigurationSetRequest
+from aws.core.helpers.metadata.types import (
+    CloudTrailDetail,
+    CloudTrailEventAction,
+    CloudTrailEventMapping,
+    LiveEventContext,
+    LiveEventFactories,
+)
+
+CLOUDTRAIL_EVENT_SOURCE = "ses.amazonaws.com"
+
+
+def _extract_configuration_set_name(detail: CloudTrailDetail) -> str | None:
+    request_parameters = detail.get("requestParameters", {})
+    name = request_parameters.get("configurationSetName")
+    return name if isinstance(name, str) else None
+
+
+def _request_factory(
+    context: LiveEventContext, include_actions: list[str]
+) -> SingleConfigurationSetRequest:
+    return SingleConfigurationSetRequest(
+        configuration_set_name=context.identifier,
+        region=context.region,
+        account_id=context.account_id,
+        include=include_actions,
+    )
+
+
+def _deletion_identifier_properties(context: LiveEventContext) -> dict[str, str]:
+    return {
+        "ConfigurationSetName": context.identifier,
+    }
+
+
+_CONFIGURATION_SET_UPSERT_MAPPING = CloudTrailEventMapping(
+    CloudTrailEventAction.UPSERT,
+    _extract_configuration_set_name,
+    event_source=CLOUDTRAIL_EVENT_SOURCE,
+)
+
+SES_CONFIGURATION_SET_LIVE_EVENTS = LiveEventFactories(
+    request_factory=_request_factory,
+    deletion_identifier_properties_factory=_deletion_identifier_properties,
+    cloudtrail_mappings={
+        "CreateConfigurationSet": _CONFIGURATION_SET_UPSERT_MAPPING,
+        "PutConfigurationSetDeliveryOptions": _CONFIGURATION_SET_UPSERT_MAPPING,
+        "PutConfigurationSetReputationOptions": _CONFIGURATION_SET_UPSERT_MAPPING,
+        "PutConfigurationSetSendingOptions": _CONFIGURATION_SET_UPSERT_MAPPING,
+        "PutConfigurationSetTrackingOptions": _CONFIGURATION_SET_UPSERT_MAPPING,
+        "PutConfigurationSetSuppressionOptions": _CONFIGURATION_SET_UPSERT_MAPPING,
+        "PutConfigurationSetVdmOptions": _CONFIGURATION_SET_UPSERT_MAPPING,
+        "PutConfigurationSetArchivingOptions": _CONFIGURATION_SET_UPSERT_MAPPING,
+        "DeleteConfigurationSet": CloudTrailEventMapping(
+            CloudTrailEventAction.DELETE,
+            _extract_configuration_set_name,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
+        ),
+    },
+)

--- a/integrations/aws-v3/aws/core/exporters/ses/configuration_set/live_events.py
+++ b/integrations/aws-v3/aws/core/exporters/ses/configuration_set/live_events.py
@@ -1,4 +1,6 @@
-from aws.core.exporters.ses.configuration_set.models import SingleConfigurationSetRequest
+from aws.core.exporters.ses.configuration_set.models import (
+    SingleConfigurationSetRequest,
+)
 from aws.core.helpers.metadata.types import (
     CloudTrailDetail,
     CloudTrailEventAction,

--- a/integrations/aws-v3/aws/core/exporters/ses/configuration_set/live_events.py
+++ b/integrations/aws-v3/aws/core/exporters/ses/configuration_set/live_events.py
@@ -14,6 +14,9 @@ CLOUDTRAIL_EVENT_SOURCE = "ses.amazonaws.com"
 
 def _extract_configuration_set_name(detail: CloudTrailDetail) -> str | None:
     request_parameters = detail.get("requestParameters", {})
+    if not isinstance(request_parameters, dict):
+        return None
+
     name = request_parameters.get("configurationSetName")
     return name if isinstance(name, str) else None
 

--- a/integrations/aws-v3/aws/core/exporters/ses/email_identity/exporter.py
+++ b/integrations/aws-v3/aws/core/exporters/ses/email_identity/exporter.py
@@ -26,6 +26,15 @@ class SesEmailIdentityExporter(IResourceExporter[list[EmailIdentityRecord]]):
         async with AioBaseClientProxy(
             self.session, options.region, self._service_name
         ) as proxy:
+            # Live-event single-identity fetch only has an identity name from CloudTrail.
+            # GetEmailIdentityAction swallows recoverable not-found errors,
+            # so the inspector would return an empty stub for a deleted identity.
+            # Confirm it exists so a missing identity raises and the live-event handler
+            # can treat the update as a delete instead.
+            await proxy.client.get_email_identity(  # type: ignore[attr-defined]
+                EmailIdentity=options.identity_name
+            )
+
             inspector = ResourceInspector(
                 proxy.client, self._actions_map(), lambda: self._model_cls()
             )

--- a/integrations/aws-v3/aws/core/exporters/ses/email_identity/live_events.py
+++ b/integrations/aws-v3/aws/core/exporters/ses/email_identity/live_events.py
@@ -1,0 +1,56 @@
+from aws.core.exporters.ses.email_identity.models import SingleEmailIdentityRequest
+from aws.core.helpers.metadata.types import (
+    CloudTrailDetail,
+    CloudTrailEventAction,
+    CloudTrailEventMapping,
+    LiveEventContext,
+    LiveEventFactories,
+)
+
+CLOUDTRAIL_EVENT_SOURCE = "ses.amazonaws.com"
+
+
+def _extract_email_identity(detail: CloudTrailDetail) -> str | None:
+    request_parameters = detail.get("requestParameters", {})
+    identity = request_parameters.get("emailIdentity")
+    return identity if isinstance(identity, str) else None
+
+
+def _request_factory(
+    context: LiveEventContext, include_actions: list[str]
+) -> SingleEmailIdentityRequest:
+    return SingleEmailIdentityRequest(
+        identity_name=context.identifier,
+        region=context.region,
+        account_id=context.account_id,
+        include=include_actions,
+    )
+
+
+def _deletion_identifier_properties(context: LiveEventContext) -> dict[str, str]:
+    return {
+        "IdentityName": context.identifier,
+    }
+
+
+_EMAIL_IDENTITY_UPSERT_MAPPING = CloudTrailEventMapping(
+    CloudTrailEventAction.UPSERT,
+    _extract_email_identity,
+    event_source=CLOUDTRAIL_EVENT_SOURCE,
+)
+
+SES_EMAIL_IDENTITY_LIVE_EVENTS = LiveEventFactories(
+    request_factory=_request_factory,
+    deletion_identifier_properties_factory=_deletion_identifier_properties,
+    cloudtrail_mappings={
+        "CreateEmailIdentity": _EMAIL_IDENTITY_UPSERT_MAPPING,
+        "PutEmailIdentityDkimSigningAttributes": _EMAIL_IDENTITY_UPSERT_MAPPING,
+        "PutEmailIdentityMailFromAttributes": _EMAIL_IDENTITY_UPSERT_MAPPING,
+        "PutEmailIdentityFeedbackAttributes": _EMAIL_IDENTITY_UPSERT_MAPPING,
+        "DeleteEmailIdentity": CloudTrailEventMapping(
+            CloudTrailEventAction.DELETE,
+            _extract_email_identity,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
+        ),
+    },
+)

--- a/integrations/aws-v3/aws/core/exporters/ses/email_identity/live_events.py
+++ b/integrations/aws-v3/aws/core/exporters/ses/email_identity/live_events.py
@@ -12,6 +12,9 @@ CLOUDTRAIL_EVENT_SOURCE = "ses.amazonaws.com"
 
 def _extract_email_identity(detail: CloudTrailDetail) -> str | None:
     request_parameters = detail.get("requestParameters", {})
+    if not isinstance(request_parameters, dict):
+        return None
+
     identity = request_parameters.get("emailIdentity")
     return identity if isinstance(identity, str) else None
 

--- a/integrations/aws-v3/tests/core/exporters/ses/configuration_set/test_exporter.py
+++ b/integrations/aws-v3/tests/core/exporters/ses/configuration_set/test_exporter.py
@@ -1,5 +1,6 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
+from botocore.exceptions import ClientError
 
 from aws.core.exporters.ses.configuration_set.exporter import (
     SesConfigurationSetExporter,
@@ -47,6 +48,9 @@ class TestSesConfigurationSetExporter:
         mock_client = AsyncMock()
         mock_proxy.client = mock_client
         mock_proxy_class.return_value.__aenter__.return_value = mock_proxy
+        mock_client.get_configuration_set.return_value = {
+            "ConfigurationSetName": "my-config-set",
+        }
 
         # Inspector
         mock_inspector = AsyncMock()
@@ -74,11 +78,44 @@ class TestSesConfigurationSetExporter:
         assert isinstance(result, dict)
         assert result["ConfigurationSetName"] == "my-config-set"
 
-        mock_client.get_configuration_set.assert_not_called()
+        mock_client.get_configuration_set.assert_awaited_once_with(
+            ConfigurationSetName="my-config-set"
+        )
         mock_inspector.inspect.assert_called_once()
         assert mock_inspector.inspect.call_args.args[0] == [
             {"ConfigurationSetName": "my-config-set"}
         ]
+
+    @pytest.mark.asyncio
+    @patch("aws.core.exporters.ses.configuration_set.exporter.AioBaseClientProxy")
+    @patch("aws.core.exporters.ses.configuration_set.exporter.ResourceInspector")
+    async def test_get_resource_configuration_set_not_found(
+        self,
+        mock_inspector_class: MagicMock,
+        mock_proxy_class: MagicMock,
+        exporter: SesConfigurationSetExporter,
+    ) -> None:
+        mock_proxy = AsyncMock()
+        mock_client = AsyncMock()
+        mock_proxy.client = mock_client
+        mock_proxy_class.return_value.__aenter__.return_value = mock_proxy
+        mock_client.get_configuration_set.side_effect = ClientError(
+            {"Error": {"Code": "NotFoundException", "Message": "gone"}},
+            "GetConfigurationSet",
+        )
+
+        request = SingleConfigurationSetRequest(
+            configuration_set_name="my-config-set",
+            region="us-east-1",
+            include=[],
+            account_id="123456789012",
+        )
+
+        with pytest.raises(ClientError) as exc_info:
+            await exporter.get_resource(request)
+
+        assert exc_info.value.response["Error"]["Code"] == "NotFoundException"
+        mock_inspector_class.assert_not_called()
 
     @pytest.mark.asyncio
     @patch("aws.core.exporters.ses.configuration_set.exporter.AioBaseClientProxy")
@@ -94,6 +131,9 @@ class TestSesConfigurationSetExporter:
         mock_client = AsyncMock()
         mock_proxy.client = mock_client
         mock_proxy_class.return_value.__aenter__.return_value = mock_proxy
+        mock_client.get_configuration_set.return_value = {
+            "ConfigurationSetName": "nonexistent-set",
+        }
 
         # Inspector returns empty
         mock_inspector = AsyncMock()

--- a/integrations/aws-v3/tests/core/exporters/ses/email_identity/test_exporter.py
+++ b/integrations/aws-v3/tests/core/exporters/ses/email_identity/test_exporter.py
@@ -1,5 +1,6 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
+from botocore.exceptions import ClientError
 
 from aws.core.exporters.ses.email_identity.exporter import SesEmailIdentityExporter
 from aws.core.exporters.ses.email_identity.models import (
@@ -45,9 +46,11 @@ class TestSesEmailIdentityExporter:
         mock_client = AsyncMock()
         mock_proxy.client = mock_client
         mock_proxy_class.return_value.__aenter__.return_value = mock_proxy
+        mock_client.get_email_identity.return_value = {
+            "IdentityName": "example.com",
+            "IdentityType": "DOMAIN",
+        }
 
-        # Inspector - GetEmailIdentityAction (a default action) is the sole fetcher;
-        # the exporter itself must not call get_email_identity directly
         mock_inspector = AsyncMock()
         mock_inspector_class.return_value = mock_inspector
 
@@ -74,11 +77,44 @@ class TestSesEmailIdentityExporter:
         assert result["IdentityName"] == "example.com"
         assert result["IdentityType"] == "DOMAIN"
 
-        mock_client.get_email_identity.assert_not_called()
+        mock_client.get_email_identity.assert_awaited_once_with(
+            EmailIdentity="example.com"
+        )
         mock_inspector.inspect.assert_called_once()
         assert mock_inspector.inspect.call_args.args[0] == [
             {"IdentityName": "example.com"}
         ]
+
+    @pytest.mark.asyncio
+    @patch("aws.core.exporters.ses.email_identity.exporter.AioBaseClientProxy")
+    @patch("aws.core.exporters.ses.email_identity.exporter.ResourceInspector")
+    async def test_get_resource_identity_not_found(
+        self,
+        mock_inspector_class: MagicMock,
+        mock_proxy_class: MagicMock,
+        exporter: SesEmailIdentityExporter,
+    ) -> None:
+        mock_proxy = AsyncMock()
+        mock_client = AsyncMock()
+        mock_proxy.client = mock_client
+        mock_proxy_class.return_value.__aenter__.return_value = mock_proxy
+        mock_client.get_email_identity.side_effect = ClientError(
+            {"Error": {"Code": "NotFoundException", "Message": "gone"}},
+            "GetEmailIdentity",
+        )
+
+        request = SingleEmailIdentityRequest(
+            identity_name="example.com",
+            region="us-east-1",
+            include=[],
+            account_id="123456789012",
+        )
+
+        with pytest.raises(ClientError) as exc_info:
+            await exporter.get_resource(request)
+
+        assert exc_info.value.response["Error"]["Code"] == "NotFoundException"
+        mock_inspector_class.assert_not_called()
 
     @pytest.mark.asyncio
     @patch("aws.core.exporters.ses.email_identity.exporter.AioBaseClientProxy")
@@ -252,6 +288,9 @@ class TestSesEmailIdentityExporter:
         mock_client = AsyncMock()
         mock_proxy.client = mock_client
         mock_proxy_class.return_value.__aenter__.return_value = mock_proxy
+        mock_client.get_email_identity.return_value = {
+            "IdentityName": "example.com",
+        }
 
         # Inspector raises exception
         mock_inspector = AsyncMock()

--- a/integrations/aws-v3/tests/webhook/test_cloudtrail_parser.py
+++ b/integrations/aws-v3/tests/webhook/test_cloudtrail_parser.py
@@ -1134,8 +1134,9 @@ def _ses_email_identity_eventbridge_envelope(
 def test_is_supported_cloudtrail_event_true_for_ses_email_identity_events() -> None:
     for event_name in (
         "CreateEmailIdentity",
-        "UpdateEmailIdentity",
         "PutEmailIdentityDkimSigningAttributes",
+        "PutEmailIdentityMailFromAttributes",
+        "PutEmailIdentityFeedbackAttributes",
         "DeleteEmailIdentity",
     ):
         payload = _ses_email_identity_eventbridge_envelope(event_name)
@@ -1176,9 +1177,7 @@ def _ses_configuration_set_eventbridge_envelope(
         detail["recipientAccountId"] = account
 
     if configuration_set_name is not None:
-        detail["requestParameters"] = {
-            "configurationSetName": configuration_set_name
-        }
+        detail["requestParameters"] = {"configurationSetName": configuration_set_name}
     else:
         detail["requestParameters"] = {}
 

--- a/integrations/aws-v3/tests/webhook/test_cloudtrail_parser.py
+++ b/integrations/aws-v3/tests/webhook/test_cloudtrail_parser.py
@@ -1092,3 +1092,138 @@ def test_parse_elasticache_cluster_events() -> None:
     assert delete_parsed is not None
     assert delete_parsed.kind == ObjectKind.ELASTICACHE_CLUSTER
     assert delete_parsed.action == CloudTrailEventAction.DELETE
+
+
+def _ses_email_identity_eventbridge_envelope(
+    event_name: str,
+    *,
+    email_identity: str | None = "example.com",
+    account: str | None = "111122223333",
+    region: str | None = "us-east-1",
+) -> EventBridgeCloudTrailPayload:
+    detail: CloudTrailDetail = {
+        "eventName": event_name,
+        "eventSource": "ses.amazonaws.com",
+    }
+    if region is not None:
+        detail["awsRegion"] = region
+    if account is not None:
+        detail["recipientAccountId"] = account
+
+    if email_identity is not None:
+        detail["requestParameters"] = {"emailIdentity": email_identity}
+    else:
+        detail["requestParameters"] = {}
+
+    payload: EventBridgeCloudTrailPayload = {"detail": detail}
+    if account is not None:
+        payload["account"] = account
+    if region is not None:
+        payload["region"] = region
+    return cast(
+        EventBridgeCloudTrailPayload,
+        {
+            **payload,
+            "version": "0",
+            "detail-type": "AWS API Call via CloudTrail",
+            "source": "aws.ses",
+        },
+    )
+
+
+def test_is_supported_cloudtrail_event_true_for_ses_email_identity_events() -> None:
+    for event_name in (
+        "CreateEmailIdentity",
+        "UpdateEmailIdentity",
+        "PutEmailIdentityDkimSigningAttributes",
+        "DeleteEmailIdentity",
+    ):
+        payload = _ses_email_identity_eventbridge_envelope(event_name)
+        assert is_supported_cloudtrail_event(payload) is True
+
+
+def test_parse_ses_email_identity_events() -> None:
+    create_payload = _ses_email_identity_eventbridge_envelope("CreateEmailIdentity")
+    delete_payload = _ses_email_identity_eventbridge_envelope("DeleteEmailIdentity")
+
+    create_parsed = parse_cloudtrail_event(create_payload)
+    delete_parsed = parse_cloudtrail_event(delete_payload)
+
+    assert create_parsed is not None
+    assert create_parsed.kind == ObjectKind.SES_EMAIL_IDENTITY
+    assert create_parsed.action == CloudTrailEventAction.UPSERT
+    assert create_parsed.identifier == "example.com"
+
+    assert delete_parsed is not None
+    assert delete_parsed.kind == ObjectKind.SES_EMAIL_IDENTITY
+    assert delete_parsed.action == CloudTrailEventAction.DELETE
+
+
+def _ses_configuration_set_eventbridge_envelope(
+    event_name: str,
+    *,
+    configuration_set_name: str | None = "my-config-set",
+    account: str | None = "111122223333",
+    region: str | None = "us-east-1",
+) -> EventBridgeCloudTrailPayload:
+    detail: CloudTrailDetail = {
+        "eventName": event_name,
+        "eventSource": "ses.amazonaws.com",
+    }
+    if region is not None:
+        detail["awsRegion"] = region
+    if account is not None:
+        detail["recipientAccountId"] = account
+
+    if configuration_set_name is not None:
+        detail["requestParameters"] = {
+            "configurationSetName": configuration_set_name
+        }
+    else:
+        detail["requestParameters"] = {}
+
+    payload: EventBridgeCloudTrailPayload = {"detail": detail}
+    if account is not None:
+        payload["account"] = account
+    if region is not None:
+        payload["region"] = region
+    return cast(
+        EventBridgeCloudTrailPayload,
+        {
+            **payload,
+            "version": "0",
+            "detail-type": "AWS API Call via CloudTrail",
+            "source": "aws.ses",
+        },
+    )
+
+
+def test_is_supported_cloudtrail_event_true_for_ses_configuration_set_events() -> None:
+    for event_name in (
+        "CreateConfigurationSet",
+        "PutConfigurationSetTrackingOptions",
+        "DeleteConfigurationSet",
+    ):
+        payload = _ses_configuration_set_eventbridge_envelope(event_name)
+        assert is_supported_cloudtrail_event(payload) is True
+
+
+def test_parse_ses_configuration_set_events() -> None:
+    create_payload = _ses_configuration_set_eventbridge_envelope(
+        "CreateConfigurationSet"
+    )
+    delete_payload = _ses_configuration_set_eventbridge_envelope(
+        "DeleteConfigurationSet"
+    )
+
+    create_parsed = parse_cloudtrail_event(create_payload)
+    delete_parsed = parse_cloudtrail_event(delete_payload)
+
+    assert create_parsed is not None
+    assert create_parsed.kind == ObjectKind.SES_CONFIGURATION_SET
+    assert create_parsed.action == CloudTrailEventAction.UPSERT
+    assert create_parsed.identifier == "my-config-set"
+
+    assert delete_parsed is not None
+    assert delete_parsed.kind == ObjectKind.SES_CONFIGURATION_SET
+    assert delete_parsed.action == CloudTrailEventAction.DELETE


### PR DESCRIPTION
# Description

- Add CloudTrail live events support for `AWS::SES::EmailIdentity` and `AWS::SES::ConfigurationSet` in aws-v3
- Wire SES kinds into `exporter_metadata` and the unified `CloudTrailWebhookProcessor` pipeline
- Harden SES exporters so missing resources raise on live-event fetch instead of returning empty stubs


## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live-event ingestion and single-resource SES fetch semantics (extra API call plus surfacing NotFound), which affects how deletes are detected versus prior stub responses.
> 
> **Overview**
> Adds **CloudTrail-driven live events** for `SES_EMAIL_IDENTITY` and `SES_CONFIGURATION_SET`, registering new `live_events` modules and wiring them through `exporter_metadata` so EventBridge/CloudTrail payloads can upsert or delete Port entities when SES APIs change identities or configuration sets.
> 
> Each kind maps `ses.amazonaws.com` events (create/put-style updates and deletes) to identifiers from `requestParameters` (`emailIdentity`, `configurationSetName`), with factories for single-resource fetch and deletion properties.
> 
> **Exporter behavior change:** `get_resource` now calls `get_email_identity` / `get_configuration_set` before the resource inspector so a missing resource raises instead of returning an empty stub—letting the live-event path treat a failed refresh after delete as removal. Tests cover not-found propagation and CloudTrail parsing for both SES kinds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ee80742f08a064a27fc1b8d6e7b001d3ac9297e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->