### PR TITLE
[Core] Task tkryuq/b11 populate empty scope probe kinds

### DIFF
--- a/.ocean-release/core/setup-unscoped-probe-checks.yaml
+++ b/.ocean-release/core/setup-unscoped-probe-checks.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: feature
+changelog: Add ProbeContext.setup_unscoped_checks to register one unscoped check per available kind

--- a/port_ocean/core/probe/context.py
+++ b/port_ocean/core/probe/context.py
@@ -44,6 +44,17 @@ class ProbeContext:
         await self.update_progress()
         return new_checks
 
+    async def setup_unscoped_checks(self) -> list[ProbeCheck]:
+        logger.debug("Registering unscoped checks")
+        new_checks: list[ProbeCheck] = []
+        for kind in self.available_kinds:
+            check = ProbeCheck(kind=kind)
+            new_checks.append(check)
+            self.checks.append(check)
+
+        await self.update_progress()
+        return new_checks
+
     def build_request_body(self) -> dict[str, Any]:
         data = {
             "probeId": self.probe_id,

--- a/port_ocean/tests/core/probe/test_context.py
+++ b/port_ocean/tests/core/probe/test_context.py
@@ -115,6 +115,67 @@ async def test_add_scopes_returns_only_new_checks(
     assert existing_check not in new_checks
 
 
+@patch("port_ocean.core.probe.context.ProbeContext.update_progress")
+@pytest.mark.asyncio
+async def test_setup_unscoped_checks_creates_check_per_kind(
+    mock_update_progress: MagicMock,
+) -> None:
+    # Arrange
+    context = ProbeContext()
+    context.available_kinds = ["repository", "pull-request"]
+
+    # Act
+    new_checks = await context.setup_unscoped_checks()
+
+    # Assert
+    assert len(new_checks) == 2
+    assert {check.kind for check in new_checks} == {"repository", "pull-request"}
+    assert all(check.scopes == {} for check in new_checks)
+    assert context.checks == new_checks
+    mock_update_progress.assert_called_once()
+
+
+@patch("port_ocean.core.probe.context.ProbeContext.update_progress")
+@pytest.mark.asyncio
+async def test_setup_unscoped_checks_returns_only_new_checks(
+    mock_update_progress: MagicMock,
+) -> None:
+    # Arrange
+    context = ProbeContext()
+    context.available_kinds = ["repository"]
+    existing_check = ProbeCheck(kind="existing", scopes={"org": "old"})
+    context.checks.append(existing_check)
+
+    # Act
+    new_checks = await context.setup_unscoped_checks()
+
+    # Assert
+    assert len(new_checks) == 1
+    assert new_checks[0].kind == "repository"
+    assert new_checks[0].scopes == {}
+    assert existing_check not in new_checks
+    assert len(context.checks) == 2
+    mock_update_progress.assert_called_once()
+
+
+@patch("port_ocean.core.probe.context.ProbeContext.update_progress")
+@pytest.mark.asyncio
+async def test_setup_unscoped_checks_with_no_available_kinds(
+    mock_update_progress: MagicMock,
+) -> None:
+    # Arrange
+    context = ProbeContext()
+    context.available_kinds = []
+
+    # Act
+    new_checks = await context.setup_unscoped_checks()
+
+    # Assert
+    assert new_checks == []
+    assert context.checks == []
+    mock_update_progress.assert_called_once()
+
+
 def test_build_request_body() -> None:
     # Arrange
     context = ProbeContext(probe_id="probe-1")


### PR DESCRIPTION
# Description

Added util function to add checks for integrations that don't need scopes instead of forcing an `add_scopes({})` call which isn't very indicative

## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API and tests on probe context with no changes to existing `add_scopes` behavior or reported payloads beyond the new registration path.
> 
> **Overview**
> Adds **`ProbeContext.setup_unscoped_checks()`** so integrations that do not use probe scopes can register one check per `available_kinds` with empty scopes, instead of calling **`add_scopes({})`**.
> 
> The method mirrors **`add_scopes`**: it appends new **`ProbeCheck`** instances, triggers **`update_progress()`**, and returns only the checks it just created. Unit tests cover multi-kind registration, coexistence with existing checks, and the empty-kinds case. A core **patch** release note documents the feature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e32c2c5f17d21eedb4ff4a4c7aa52195b578e4bf. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->