### PR TITLE
[Integration][GitHub] Report status labels through the workflow dispatch lifecycle

### DIFF
--- a/integrations/github/.ocean-release/dispatch-workflow-status-labels.yaml
+++ b/integrations/github/.ocean-release/dispatch-workflow-status-labels.yaml
@@ -1,0 +1,3 @@
+bump: minor
+changelog-type: improvement
+changelog: Added run logs and status labels to the dispatch_workflow action, so Port shows when a workflow is being dispatched, running, or finished with its GitHub conclusion

--- a/integrations/github/.ocean-release/dispatch-workflow-status-labels.yaml
+++ b/integrations/github/.ocean-release/dispatch-workflow-status-labels.yaml
@@ -1,3 +1,3 @@
 bump: minor
 changelog-type: improvement
-changelog: Added run logs and status labels to the dispatch_workflow action, so Port shows when a workflow is being dispatched, running, or finished with its GitHub conclusion
+changelog: Added run logs and status labels to the dispatch_workflow action, so Port shows when a workflow is being dispatched, running, or finished with its GitHub conclusion. Dispatch failures now report GitHub's error message even when the response body is not JSON

--- a/integrations/github/github/actions/dispatch_workflow_executor.py
+++ b/integrations/github/github/actions/dispatch_workflow_executor.py
@@ -39,6 +39,10 @@ from port_ocean.exceptions.execution_manager import ActionExecutionError
 MAX_WORKFLOW_POLL_ATTEMPTS = 30
 WORKFLOW_POLL_DELAY_SECONDS = 2
 
+DISPATCHING_STATUS_LABEL = "Dispatching workflow"
+DISPATCH_FAILED_STATUS_LABEL = "Dispatch failed"
+WORKFLOW_RUNNING_STATUS_LABEL = "Workflow running"
+
 
 class DispatchWorkflowExecutor(AbstractGithubExecutor):
     """
@@ -285,6 +289,14 @@ class DispatchWorkflowExecutor(AbstractGithubExecutor):
         ref = inputs.pop("ref", None)
         if not ref:
             ref = await self._get_default_ref(rest_client, organization, repo)
+
+        await ocean.port_client.post_run_log(
+            run,
+            f"Dispatching workflow '{workflow}' in {organization}/{repo} on ref '{ref}'",
+            status_label=DISPATCHING_STATUS_LABEL,
+            should_raise=False,
+        )
+
         try:
             if self._use_legacy_dispatch_workflow_tracking():
                 iso_date = datetime.now(timezone.utc).isoformat()
@@ -324,9 +336,21 @@ class DispatchWorkflowExecutor(AbstractGithubExecutor):
                 workflow_run["html_url"],
                 external_id,
                 extra_output={"workflowRunId": workflow_run_id},
+                status_label=WORKFLOW_RUNNING_STATUS_LABEL,
+            )
+            await ocean.port_client.post_run_log(
+                run,
+                f"Workflow run started: {workflow_run['html_url']}",
+                should_raise=False,
             )
         except Exception as e:
             error_message = str(e)
             if isinstance(e, httpx.HTTPStatusError):
                 error_message = json.loads(e.response.text).get("message", str(e))
-            raise ActionExecutionError(f"Error dispatching workflow: {error_message}")
+            specific_label = (
+                e.status_label if isinstance(e, ActionExecutionError) else None
+            )
+            raise ActionExecutionError(
+                f"Error dispatching workflow: {error_message}",
+                status_label=specific_label or DISPATCH_FAILED_STATUS_LABEL,
+            )

--- a/integrations/github/github/actions/dispatch_workflow_executor.py
+++ b/integrations/github/github/actions/dispatch_workflow_executor.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import httpx
 from loguru import logger
-from github.actions.utils import build_external_id
+from github.actions.utils import build_external_id, extract_error_message
 from github.clients.auth import get_auth_provider
 from github.core.exporters.repository_exporter import (
     RestRepositoryExporter,
@@ -346,7 +346,7 @@ class DispatchWorkflowExecutor(AbstractGithubExecutor):
         except Exception as e:
             error_message = str(e)
             if isinstance(e, httpx.HTTPStatusError):
-                error_message = json.loads(e.response.text).get("message", str(e))
+                error_message = extract_error_message(e.response)
             specific_label = (
                 e.status_label if isinstance(e, ActionExecutionError) else None
             )

--- a/integrations/github/github/actions/utils.py
+++ b/integrations/github/github/actions/utils.py
@@ -1,5 +1,28 @@
+import json
 from typing import Any
+
+import httpx
 
 
 def build_external_id(workflow_run: dict[str, Any]) -> str:
     return f'gh_{workflow_run["repository"]["owner"]["id"]}_{workflow_run["repository"]["id"]}_{workflow_run["id"]}'
+
+
+def extract_error_message(response: httpx.Response) -> str:
+    """Pull the most useful message out of a GitHub error response.
+
+    GitHub usually answers with ``{"message": ...}``, but proxies and gateways
+    can return HTML or plain text, so neither valid JSON nor a dict is
+    guaranteed.
+    """
+    try:
+        body = response.json()
+    except ValueError:
+        body = None
+
+    if isinstance(body, dict):
+        message = body.get("message")
+        if message:
+            return message if isinstance(message, str) else json.dumps(message)
+
+    return response.text.strip() or f"HTTP {response.status_code}"

--- a/integrations/github/github/helpers/exceptions.py
+++ b/integrations/github/github/helpers/exceptions.py
@@ -1,5 +1,6 @@
 from typing import List, TYPE_CHECKING
 from port_ocean.exceptions.core import OceanAbortException
+from port_ocean.exceptions.execution_manager import ActionExecutionError
 
 if TYPE_CHECKING:
     from github.clients.rate_limiter.utils import RateLimitInfo
@@ -46,16 +47,22 @@ class OrganizationConflictError(Exception):
     """Raised when both github_organization and github_multi_organizations are provided."""
 
 
-class RepositoryDefaultBranchNotFoundException(Exception):
+class RepositoryDefaultBranchNotFoundException(ActionExecutionError):
     """Exception for default branch not found."""
 
+    DEFAULT_STATUS_LABEL = "Branch missing"
 
-class InvalidActionParametersException(Exception):
+
+class InvalidActionParametersException(ActionExecutionError):
     """Exception for invalid action parameters."""
 
+    DEFAULT_STATUS_LABEL = "Invalid inputs"
 
-class NoWorkflowRunsFoundException(Exception):
+
+class NoWorkflowRunsFoundException(ActionExecutionError):
     """Exception for workflow runs not found after dispatch."""
+
+    DEFAULT_STATUS_LABEL = "Tracking failed"
 
 
 class RateLimitException(Exception):

--- a/integrations/github/github/webhook/webhook_processors/workflow_run/dispatch_workflow_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/workflow_run/dispatch_workflow_webhook_processor.py
@@ -15,6 +15,19 @@ from port_ocean.core.handlers.webhook.abstract_webhook_processor import (
 )
 from loguru import logger
 
+# Status labels for the GitHub `workflow_run.conclusion` values, shown on the
+# Port run. Anything unmapped falls back to echoing the raw conclusion.
+CONCLUSION_STATUS_LABELS = {
+    "success": "Workflow succeeded",
+    "failure": "Workflow failed",
+    "cancelled": "Workflow cancelled",
+    "timed_out": "Workflow timeout",
+    "skipped": "Workflow skipped",
+    "neutral": "Workflow neutral",
+    "action_required": "Action required",
+    "stale": "Workflow stale",
+}
+
 
 class DispatchWorkflowWebhookProcessor(BaseWorkflowRunWebhookProcessor):
     """
@@ -92,7 +105,12 @@ class DispatchWorkflowWebhookProcessor(BaseWorkflowRunWebhookProcessor):
                 conclusion=conclusion,
             )
             await ocean.port_client.report_run_completed(
-                run, success, f"Workflow completed: {conclusion}"
+                run,
+                success,
+                f"Workflow completed: {conclusion}",
+                status_label=CONCLUSION_STATUS_LABELS.get(
+                    conclusion, f"Workflow completed: {conclusion}"
+                ),
             )
 
         return WebhookEventRawResults(updated_raw_results=[], deleted_raw_results=[])

--- a/integrations/github/github/webhook/webhook_processors/workflow_run/dispatch_workflow_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/workflow_run/dispatch_workflow_webhook_processor.py
@@ -16,7 +16,8 @@ from port_ocean.core.handlers.webhook.abstract_webhook_processor import (
 from loguru import logger
 
 # Status labels for the GitHub `workflow_run.conclusion` values, shown on the
-# Port run. Anything unmapped falls back to echoing the raw conclusion.
+# Port run. Anything unmapped echoes the raw conclusion. Keep every label to
+# two words at most so it stays readable in Port's UI.
 CONCLUSION_STATUS_LABELS = {
     "success": "Workflow succeeded",
     "failure": "Workflow failed",
@@ -109,7 +110,7 @@ class DispatchWorkflowWebhookProcessor(BaseWorkflowRunWebhookProcessor):
                 success,
                 f"Workflow completed: {conclusion}",
                 status_label=CONCLUSION_STATUS_LABELS.get(
-                    conclusion, f"Workflow completed: {conclusion}"
+                    conclusion, f"Workflow {conclusion}"
                 ),
             )
 

--- a/integrations/github/tests/github/actions/test_dispatch_workflow_executor.py
+++ b/integrations/github/tests/github/actions/test_dispatch_workflow_executor.py
@@ -7,7 +7,10 @@ import httpx
 import pytest
 from port_ocean.context.ocean import ocean
 
-from github.actions.dispatch_workflow_executor import DispatchWorkflowExecutor
+from github.actions.dispatch_workflow_executor import (
+    DispatchWorkflowExecutor,
+    WORKFLOW_RUNNING_STATUS_LABEL,
+)
 from github.clients.http.rest_client import GithubRestClient
 from github.helpers.exceptions import (
     InvalidActionParametersException,
@@ -49,6 +52,7 @@ WORKFLOW_RUN = {
 def patched_ocean() -> Generator[MagicMock, None, None]:
     mock_client = MagicMock()
     mock_client.update_run_started = AsyncMock()
+    mock_client.post_run_log = AsyncMock()
     with patch("github.actions.dispatch_workflow_executor.ocean") as mock_ocean:
         mock_ocean.port_client = mock_client
         mock_ocean.integration_config = {
@@ -155,6 +159,7 @@ class TestDispatchWorkflowExecutor:
             WORKFLOW_RUN["html_url"],
             "gh_1_99_12345",
             extra_output={"workflowRunId": 12345},
+            status_label=WORKFLOW_RUNNING_STATUS_LABEL,
         )
 
     @pytest.mark.asyncio
@@ -384,6 +389,7 @@ class TestLegacyDispatchWorkflowExecutor:
             WORKFLOW_RUN["html_url"],
             "gh_1_99_12345",
             extra_output={"workflowRunId": 12345},
+            status_label=WORKFLOW_RUNNING_STATUS_LABEL,
         )
 
     @pytest.mark.asyncio

--- a/integrations/github/tests/github/actions/test_dispatch_workflow_executor.py
+++ b/integrations/github/tests/github/actions/test_dispatch_workflow_executor.py
@@ -9,6 +9,8 @@ from port_ocean.context.ocean import ocean
 
 from github.actions.dispatch_workflow_executor import (
     DispatchWorkflowExecutor,
+    DISPATCH_FAILED_STATUS_LABEL,
+    DISPATCHING_STATUS_LABEL,
     WORKFLOW_RUNNING_STATUS_LABEL,
 )
 from github.clients.http.rest_client import GithubRestClient
@@ -161,6 +163,19 @@ class TestDispatchWorkflowExecutor:
             extra_output={"workflowRunId": 12345},
             status_label=WORKFLOW_RUNNING_STATUS_LABEL,
         )
+        assert mock_port_client.post_run_log.await_args_list == [
+            call(
+                run,
+                "Dispatching workflow 'deploy.yml' in port-labs/ocean on ref 'main'",
+                status_label=DISPATCHING_STATUS_LABEL,
+                should_raise=False,
+            ),
+            call(
+                run,
+                f"Workflow run started: {WORKFLOW_RUN['html_url']}",
+                should_raise=False,
+            ),
+        ]
 
     @pytest.mark.asyncio
     async def test_uses_ref_from_workflow_inputs(
@@ -267,6 +282,40 @@ class TestDispatchWorkflowExecutor:
                 match="Error dispatching workflow: Workflow not found",
             ):
                 await executor.execute(run)
+
+    @pytest.mark.asyncio
+    async def test_github_non_json_http_error_raises(
+        self,
+        executor: DispatchWorkflowExecutor,
+        mock_rest_client: MagicMock,
+        mock_port_client: MagicMock,
+    ) -> None:
+        """A gateway can answer with HTML instead of GitHub's JSON error body."""
+        run = make_run(
+            {
+                "org": "port-labs",
+                "repo": "ocean",
+                "workflow": "deploy.yml",
+            }
+        )
+
+        request = httpx.Request(
+            "POST",
+            "https://api.github.com/repos/port-labs/ocean/actions/workflows/deploy.yml/dispatches",
+        )
+        response = httpx.Response(502, text="<html>Bad gateway</html>", request=request)
+        mock_rest_client.make_request.side_effect = httpx.HTTPStatusError(
+            "502", request=request, response=response
+        )
+
+        with patch.object(executor, "_get_default_ref", AsyncMock(return_value="main")):
+            with pytest.raises(
+                ActionExecutionError,
+                match="Error dispatching workflow: <html>Bad gateway</html>",
+            ) as exc_info:
+                await executor.execute(run)
+
+        assert exc_info.value.status_label == DISPATCH_FAILED_STATUS_LABEL
 
     @pytest.mark.asyncio
     async def test_default_branch_not_found_raises(

--- a/integrations/github/tests/github/actions/test_utils.py
+++ b/integrations/github/tests/github/actions/test_utils.py
@@ -1,0 +1,40 @@
+import httpx
+
+from github.actions.utils import build_external_id, extract_error_message
+
+
+class TestBuildExternalId:
+    def test_combines_owner_repo_and_run_ids(self) -> None:
+        workflow_run = {
+            "id": 12345,
+            "repository": {"id": 99, "owner": {"id": 1}},
+        }
+
+        assert build_external_id(workflow_run) == "gh_1_99_12345"
+
+
+class TestExtractErrorMessage:
+    def test_uses_github_message_field(self) -> None:
+        response = httpx.Response(422, json={"message": "Workflow not found"})
+
+        assert extract_error_message(response) == "Workflow not found"
+
+    def test_falls_back_to_raw_text_for_non_json_body(self) -> None:
+        response = httpx.Response(502, text="<html>Bad gateway</html>")
+
+        assert extract_error_message(response) == "<html>Bad gateway</html>"
+
+    def test_falls_back_to_raw_text_for_non_object_json(self) -> None:
+        response = httpx.Response(500, json=["boom"])
+
+        assert extract_error_message(response) == '["boom"]'
+
+    def test_serializes_non_string_message(self) -> None:
+        response = httpx.Response(422, json={"message": {"detail": "nested"}})
+
+        assert extract_error_message(response) == '{"detail": "nested"}'
+
+    def test_falls_back_to_status_code_for_empty_body(self) -> None:
+        response = httpx.Response(503, text="   ")
+
+        assert extract_error_message(response) == "HTTP 503"

--- a/integrations/github/tests/github/webhook/webhook_processors/test_dispatch_workflow_webhook_processor.py
+++ b/integrations/github/tests/github/webhook/webhook_processors/test_dispatch_workflow_webhook_processor.py
@@ -1,0 +1,178 @@
+from typing import Any, Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from github.helpers.utils import ObjectKind
+from github.webhook.webhook_processors.workflow_run.dispatch_workflow_webhook_processor import (
+    CONCLUSION_STATUS_LABELS,
+    DispatchWorkflowWebhookProcessor,
+)
+from port_ocean.core.handlers.port_app_config.models import (
+    EntityMapping,
+    MappingsConfig,
+    PortResourceConfig,
+    ResourceConfig,
+)
+from port_ocean.core.handlers.webhook.webhook_event import WebhookEvent
+from port_ocean.core.models import (
+    ActionRun,
+    IntegrationActionInvocationPayload,
+    RunStatus,
+)
+from integration import GithubWorkflowRunConfig, GithubWorkflowRunSelector
+
+WORKFLOW_RUN = {
+    "id": 12345,
+    "conclusion": "success",
+    "html_url": "https://github.com/port-labs/ocean/actions/runs/12345",
+    "repository": {
+        "id": 99,
+        "owner": {"id": 1},
+    },
+}
+
+
+def make_run(execution_properties: dict[str, Any]) -> ActionRun:
+    return ActionRun(
+        id="run-123",
+        status=RunStatus.IN_PROGRESS,
+        action=ActionRun.Action(identifier="dispatch_workflow"),
+        payload=IntegrationActionInvocationPayload(
+            type="INTEGRATION_ACTION",
+            installationId="inst-1",
+            integrationActionType="dispatch_workflow",
+            integrationActionExecutionProperties=execution_properties,
+        ),
+    )
+
+
+def make_payload(conclusion: str) -> dict[str, Any]:
+    return {"workflow_run": {**WORKFLOW_RUN, "conclusion": conclusion}}
+
+
+@pytest.fixture
+def resource_config() -> ResourceConfig:
+    return GithubWorkflowRunConfig(
+        kind=ObjectKind.WORKFLOW_RUN,
+        selector=GithubWorkflowRunSelector(query="true"),
+        port=PortResourceConfig(
+            entity=MappingsConfig(
+                mappings=EntityMapping(
+                    identifier=".full_name",
+                    title=".name",
+                    blueprint='"githubRepository"',
+                    properties={},
+                )
+            )
+        ),
+    )
+
+
+@pytest.fixture
+def mock_port_client() -> Generator[MagicMock, None, None]:
+    client = MagicMock()
+    client.find_run_by_external_id = AsyncMock(
+        return_value=make_run({"reportWorkflowStatus": True})
+    )
+    client.is_run_in_progress = MagicMock(return_value=True)
+    client.report_run_completed = AsyncMock()
+    with patch(
+        "github.webhook.webhook_processors.workflow_run."
+        "dispatch_workflow_webhook_processor.ocean"
+    ) as mock_ocean:
+        mock_ocean.port_client = client
+        yield client
+
+
+@pytest.fixture
+def processor(
+    mock_webhook_event: WebhookEvent,
+) -> DispatchWorkflowWebhookProcessor:
+    return DispatchWorkflowWebhookProcessor(event=mock_webhook_event)
+
+
+def test_status_labels_are_two_words_max() -> None:
+    for label in CONCLUSION_STATUS_LABELS.values():
+        assert len(label.split()) <= 2, label
+
+
+@pytest.mark.asyncio
+class TestDispatchWorkflowWebhookProcessor:
+    @pytest.mark.parametrize(
+        "conclusion,expected_label,expected_success",
+        [
+            ("success", "Workflow succeeded", True),
+            ("failure", "Workflow failed", False),
+            ("cancelled", "Workflow cancelled", False),
+            ("timed_out", "Workflow timeout", False),
+            ("skipped", "Workflow skipped", True),
+            ("neutral", "Workflow neutral", True),
+            ("action_required", "Action required", False),
+            ("stale", "Workflow stale", False),
+        ],
+    )
+    async def test_reports_status_label_per_conclusion(
+        self,
+        processor: DispatchWorkflowWebhookProcessor,
+        resource_config: ResourceConfig,
+        mock_port_client: MagicMock,
+        conclusion: str,
+        expected_label: str,
+        expected_success: bool,
+    ) -> None:
+        await processor.handle_event(make_payload(conclusion), resource_config)
+
+        mock_port_client.report_run_completed.assert_awaited_once()
+        args, kwargs = mock_port_client.report_run_completed.await_args
+        assert args[1] is expected_success
+        assert kwargs["status_label"] == expected_label
+
+    async def test_unmapped_conclusion_falls_back_to_raw_conclusion(
+        self,
+        processor: DispatchWorkflowWebhookProcessor,
+        resource_config: ResourceConfig,
+        mock_port_client: MagicMock,
+    ) -> None:
+        """A conclusion GitHub adds later should still yield a short label."""
+        await processor.handle_event(make_payload("brand_new"), resource_config)
+
+        label = mock_port_client.report_run_completed.await_args.kwargs["status_label"]
+        assert label == "Workflow brand_new"
+
+    @pytest.mark.parametrize(
+        "in_progress,execution_properties",
+        [
+            (False, {"reportWorkflowStatus": True}),
+            (True, {"reportWorkflowStatus": False}),
+            (True, {}),
+        ],
+    )
+    async def test_does_not_report_untracked_runs(
+        self,
+        processor: DispatchWorkflowWebhookProcessor,
+        resource_config: ResourceConfig,
+        mock_port_client: MagicMock,
+        in_progress: bool,
+        execution_properties: dict[str, Any],
+    ) -> None:
+        mock_port_client.is_run_in_progress.return_value = in_progress
+        mock_port_client.find_run_by_external_id.return_value = make_run(
+            execution_properties
+        )
+
+        await processor.handle_event(make_payload("success"), resource_config)
+
+        mock_port_client.report_run_completed.assert_not_awaited()
+
+    async def test_does_not_report_when_run_not_found(
+        self,
+        processor: DispatchWorkflowWebhookProcessor,
+        resource_config: ResourceConfig,
+        mock_port_client: MagicMock,
+    ) -> None:
+        mock_port_client.find_run_by_external_id.return_value = None
+
+        await processor.handle_event(make_payload("success"), resource_config)
+
+        mock_port_client.report_run_completed.assert_not_awaited()


### PR DESCRIPTION
# Description

**What** - Reports status labels through the workflow dispatch lifecycle.

**Why** - A dispatched GitHub workflow left the Port run sitting in progress with no indication of the stage it reached.

**How** -

- Labels the executor's pre-dispatch and post-dispatch logs.
- `GithubActionError` subclasses carry a default label, so a failed dispatch reports the reason rather than a bare failure.
- The `workflow_run` webhook processor maps the run conclusion to a label when completing the run.

## Release (integrations / ocean core)

Release intent in `integrations/github/.ocean-release/dispatch-workflow-status-labels.yaml`.

## Stack

Based on #3918, which adds the core `status_label` support this PR uses. The diff shown is against that branch; it needs #3918 merged and released before CI here can pass.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Integration testing checklist

- [ ] Verified on a testing org that the labels appear on the run and update as the action progresses

### Preflight checklist

- [x] Implemented the code in async

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only changes to Port run logs/labels and exception typing; no auth or data-model changes, though behavior depends on ocean core `status_label` support from the stacked PR.
> 
> **Overview**
> Port runs for **`dispatch_workflow`** now show **where the action is in the lifecycle** instead of sitting in progress with no phase hint.
> 
> The executor posts run logs and **`status_label`** values for **dispatching**, **running**, and generic **dispatch failed**, and passes **Workflow running** when marking the run started. On failure it re-raises **`ActionExecutionError`** with a label from the underlying error when present (e.g. invalid inputs, missing default branch, untracked dispatch).
> 
> Several GitHub action exceptions now extend **`ActionExecutionError`** with default labels so those cases surface on the run automatically. When **`reportWorkflowStatus`** is enabled, the **`workflow_run`** webhook completion path maps GitHub **conclusion** values to human-readable labels on **`report_run_completed`**.
> 
> Release notes are recorded under **`.ocean-release/dispatch-workflow-status-labels.yaml`** (minor improvement).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44c4e1d047b63083f8301d91ff56456eccec913f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->