### PR TITLE
[Integration][GitLab] Report status labels through the pipeline trigger lifecycle

### DIFF
--- a/integrations/gitlab-v2/.ocean-release/trigger-pipeline-status-labels.yaml
+++ b/integrations/gitlab-v2/.ocean-release/trigger-pipeline-status-labels.yaml
@@ -1,0 +1,3 @@
+bump: minor
+changelog-type: improvement
+changelog: Added status labels to the trigger_pipeline action, so Port shows when a pipeline is being triggered, running, or finished with its GitLab status

--- a/integrations/gitlab-v2/gitlab/actions/trigger_pipeline_executor.py
+++ b/integrations/gitlab-v2/gitlab/actions/trigger_pipeline_executor.py
@@ -16,6 +16,9 @@ from gitlab.webhook.webhook_processors.trigger_pipeline_webhook_processor import
     TriggerPipelineWebhookProcessor,
 )
 
+TRIGGERING_STATUS_LABEL = "Triggering pipeline"
+PIPELINE_RUNNING_STATUS_LABEL = "Pipeline running"
+
 
 class TriggerPipelineExecutor(AbstractGitlabExecutor):
     ACTION_NAME = "trigger_pipeline"
@@ -44,6 +47,7 @@ class TriggerPipelineExecutor(AbstractGitlabExecutor):
         await ocean.port_client.post_run_log(
             run,
             f"Triggering GitLab pipeline for {project} on ref {ref}",
+            status_label=TRIGGERING_STATUS_LABEL,
             should_raise=False,
         )
 
@@ -67,6 +71,7 @@ class TriggerPipelineExecutor(AbstractGitlabExecutor):
             run,
             pipeline["web_url"],
             external_id,
+            status_label=PIPELINE_RUNNING_STATUS_LABEL,
         )
         await ocean.port_client.post_run_log(
             run,

--- a/integrations/gitlab-v2/gitlab/helpers/exceptions.py
+++ b/integrations/gitlab-v2/gitlab/helpers/exceptions.py
@@ -2,13 +2,19 @@ import json
 
 import httpx
 
+from port_ocean.exceptions.execution_manager import ActionExecutionError
 
-class MissingExecutionPropertyError(Exception):
+
+class MissingExecutionPropertyError(ActionExecutionError):
     """Raised when a required execution property is absent from the action run."""
 
+    DEFAULT_STATUS_LABEL = "Invalid inputs"
 
-class GitlabTriggerPipelineError(Exception):
+
+class GitlabTriggerPipelineError(ActionExecutionError):
     """Raised when the GitLab API returns an error while triggering a pipeline."""
+
+    DEFAULT_STATUS_LABEL = "Trigger failed"
 
     @classmethod
     def from_response(

--- a/integrations/gitlab-v2/gitlab/webhook/webhook_processors/trigger_pipeline_webhook_processor.py
+++ b/integrations/gitlab-v2/gitlab/webhook/webhook_processors/trigger_pipeline_webhook_processor.py
@@ -17,6 +17,14 @@ from gitlab.webhook.webhook_processors._gitlab_abstract_webhook_processor import
 
 TERMINAL_PIPELINE_STATUSES = frozenset({"success", "failed", "canceled", "skipped"})
 
+# Status labels for terminal GitLab pipeline statuses, shown on the Port run.
+PIPELINE_STATUS_LABELS = {
+    "success": "Pipeline succeeded",
+    "failed": "Pipeline failed",
+    "canceled": "Pipeline cancelled",
+    "skipped": "Pipeline skipped",
+}
+
 
 class TriggerPipelineWebhookProcessor(_GitlabAbstractWebhookProcessor):
     events = ["pipeline"]
@@ -85,7 +93,12 @@ class TriggerPipelineWebhookProcessor(_GitlabAbstractWebhookProcessor):
             should_raise=False,
         )
         await ocean.port_client.report_run_completed(
-            run, success, f"Pipeline completed: {status}"
+            run,
+            success,
+            f"Pipeline completed: {status}",
+            status_label=PIPELINE_STATUS_LABELS.get(
+                status, f"Pipeline completed: {status}"
+            ),
         )
 
         return WebhookEventRawResults(updated_raw_results=[], deleted_raw_results=[])

--- a/integrations/gitlab-v2/gitlab/webhook/webhook_processors/trigger_pipeline_webhook_processor.py
+++ b/integrations/gitlab-v2/gitlab/webhook/webhook_processors/trigger_pipeline_webhook_processor.py
@@ -18,6 +18,8 @@ from gitlab.webhook.webhook_processors._gitlab_abstract_webhook_processor import
 TERMINAL_PIPELINE_STATUSES = frozenset({"success", "failed", "canceled", "skipped"})
 
 # Status labels for terminal GitLab pipeline statuses, shown on the Port run.
+# Anything unmapped echoes the raw status. Keep every label to two words at most
+# so it stays readable in Port's UI.
 PIPELINE_STATUS_LABELS = {
     "success": "Pipeline succeeded",
     "failed": "Pipeline failed",
@@ -96,9 +98,7 @@ class TriggerPipelineWebhookProcessor(_GitlabAbstractWebhookProcessor):
             run,
             success,
             f"Pipeline completed: {status}",
-            status_label=PIPELINE_STATUS_LABELS.get(
-                status, f"Pipeline completed: {status}"
-            ),
+            status_label=PIPELINE_STATUS_LABELS.get(status, f"Pipeline {status}"),
         )
 
         return WebhookEventRawResults(updated_raw_results=[], deleted_raw_results=[])

--- a/integrations/gitlab-v2/tests/actions/test_trigger_pipeline_executor.py
+++ b/integrations/gitlab-v2/tests/actions/test_trigger_pipeline_executor.py
@@ -10,7 +10,10 @@ from port_ocean.core.models import (
     WorkflowNodeRunStatus,
 )
 
-from gitlab.actions.trigger_pipeline_executor import TriggerPipelineExecutor
+from gitlab.actions.trigger_pipeline_executor import (
+    PIPELINE_RUNNING_STATUS_LABEL,
+    TriggerPipelineExecutor,
+)
 from gitlab.helpers.exceptions import (
     GitlabTriggerPipelineError,
     MissingExecutionPropertyError,
@@ -73,6 +76,7 @@ class TestTriggerPipelineExecutor:
             run,
             PIPELINE_RESPONSE["web_url"],
             "gl_42_99",
+            status_label=PIPELINE_RUNNING_STATUS_LABEL,
         )
         assert mock_port_client.post_run_log.await_count == 2
         mock_port_client.report_run_completed.assert_not_called()

--- a/integrations/gitlab-v2/tests/webhook/webhook_processors/test_trigger_pipeline_webhook_processor.py
+++ b/integrations/gitlab-v2/tests/webhook/webhook_processors/test_trigger_pipeline_webhook_processor.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from port_ocean.core.handlers.webhook.webhook_event import WebhookEvent
 
 from gitlab.webhook.webhook_processors.trigger_pipeline_webhook_processor import (
+    PIPELINE_STATUS_LABELS,
     TriggerPipelineWebhookProcessor,
 )
 
@@ -85,7 +86,10 @@ class TestTriggerPipelineWebhookProcessor:
                 should_raise=False,
             )
             mock_ocean.port_client.report_run_completed.assert_called_once_with(
-                run, True, "Pipeline completed: success"
+                run,
+                True,
+                "Pipeline completed: success",
+                status_label=PIPELINE_STATUS_LABELS["success"],
             )
 
     @pytest.mark.parametrize("status", ["failed", "canceled", "skipped"])
@@ -111,7 +115,10 @@ class TestTriggerPipelineWebhookProcessor:
                 should_raise=False,
             )
             mock_ocean.port_client.report_run_completed.assert_called_once_with(
-                run, False, f"Pipeline completed: {status}"
+                run,
+                False,
+                f"Pipeline completed: {status}",
+                status_label=PIPELINE_STATUS_LABELS[status],
             )
 
     async def test_no_matching_run_skips_silently(

--- a/integrations/gitlab-v2/tests/webhook/webhook_processors/test_trigger_pipeline_webhook_processor.py
+++ b/integrations/gitlab-v2/tests/webhook/webhook_processors/test_trigger_pipeline_webhook_processor.py
@@ -163,11 +163,6 @@ class TestTriggerPipelineWebhookProcessor:
             ]
             assert label == "Pipeline brand_new"
 
-
-def test_status_labels_are_two_words_max() -> None:
-    for label in PIPELINE_STATUS_LABELS.values():
-        assert len(label.split()) <= 2, label
-
     async def test_duplicate_webhook_ignored(
         self, processor: TriggerPipelineWebhookProcessor
     ) -> None:
@@ -198,3 +193,8 @@ def test_status_labels_are_two_words_max() -> None:
             await processor.handle_event(make_event("success").payload, resource_config)
 
             mock_ocean.port_client.report_run_completed.assert_not_called()
+
+
+def test_status_labels_are_two_words_max() -> None:
+    for label in PIPELINE_STATUS_LABELS.values():
+        assert len(label.split()) <= 2, label

--- a/integrations/gitlab-v2/tests/webhook/webhook_processors/test_trigger_pipeline_webhook_processor.py
+++ b/integrations/gitlab-v2/tests/webhook/webhook_processors/test_trigger_pipeline_webhook_processor.py
@@ -140,6 +140,34 @@ class TestTriggerPipelineWebhookProcessor:
             mock_ocean.port_client.report_run_completed.assert_not_called()
             assert result.updated_raw_results == []
 
+    async def test_unmapped_status_falls_back_to_raw_status(
+        self, processor: TriggerPipelineWebhookProcessor
+    ) -> None:
+        """A status GitLab adds later should still yield a short label."""
+        run = make_mock_run()
+        resource_config = MagicMock()
+        with patch(
+            "gitlab.webhook.webhook_processors.trigger_pipeline_webhook_processor.ocean"
+        ) as mock_ocean:
+            mock_ocean.port_client.find_run_by_external_id = AsyncMock(return_value=run)
+            mock_ocean.port_client.is_run_in_progress = MagicMock(return_value=True)
+            mock_ocean.port_client.post_run_log = AsyncMock()
+            mock_ocean.port_client.report_run_completed = AsyncMock()
+
+            await processor.handle_event(
+                make_event("brand_new").payload, resource_config
+            )
+
+            label = mock_ocean.port_client.report_run_completed.call_args.kwargs[
+                "status_label"
+            ]
+            assert label == "Pipeline brand_new"
+
+
+def test_status_labels_are_two_words_max() -> None:
+    for label in PIPELINE_STATUS_LABELS.values():
+        assert len(label.split()) <= 2, label
+
     async def test_duplicate_webhook_ignored(
         self, processor: TriggerPipelineWebhookProcessor
     ) -> None:


### PR DESCRIPTION
# Description

**What** - Reports status labels through the pipeline trigger lifecycle.

**Why** - A triggered GitLab pipeline left the Port run sitting in progress with no indication of the stage it reached.

**How** -

- Labels the executor's log when the pipeline is handed off to GitLab.
- `GitlabActionError` subclasses carry a default label, so a failed trigger reports the reason rather than a bare failure.
- The pipeline webhook processor maps the pipeline status to a label when completing the run.

## Release (integrations / ocean core)

Release intent in `integrations/gitlab-v2/.ocean-release/trigger-pipeline-status-labels.yaml`.

## Stack

Based on #3918, which adds the core `status_label` support this PR uses. The diff shown is against that branch; it needs #3918 merged and released before CI here can pass.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Integration testing checklist

- [ ] Verified on a testing org that the labels appear on the run and update as the action progresses

### Preflight checklist

- [x] Implemented the code in async

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Non-breaking UX improvement on run reporting; exception base-class change only affects how failures are labeled, not pipeline or auth behavior.
> 
> **Overview**
> The GitLab `trigger_pipeline` action now surfaces **status labels** on Port runs so users can see progress instead of a generic in-progress state.
> 
> During execution, logs and `update_run_started` set labels like **"Triggering pipeline"** and **"Pipeline running"**. When the pipeline webhook reports a terminal status, `report_run_completed` sends mapped labels (e.g. **"Pipeline succeeded"** / **"Pipeline failed"**). `MissingExecutionPropertyError` and `GitlabTriggerPipelineError` now extend `ActionExecutionError` with default labels (**"Invalid action inputs"**, **"Pipeline trigger failed"**) so failed triggers show a clear reason. Tests and a minor integration release changelog were updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a6630608ef4b61beefafba69444573a5fa5b959. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->