### PR TITLE
fix(linear): paginate nested label children past Linear's 50-node default

### DIFF
--- a/integrations/linear/linear/client.py
+++ b/integrations/linear/linear/client.py
@@ -140,7 +140,7 @@ class LinearClient:
             end_cursor = team_response_list["data"]["teams"]["pageInfo"]["endCursor"]
 
     async def _append_remaining_label_children(self, label: dict[str, Any]) -> None:
-        """Fetch children pages past the initial inline `children(first: 250)` window."""
+        """Fetch children pages past the initial inline children window."""
         children = label.get("children")
         if not children or not children.get("pageInfo", {}).get("hasNextPage"):
             return
@@ -275,5 +275,6 @@ class LinearClient:
         label_response.raise_for_status()
         # Response format is: { data: { issueLabel: {...} } }
         # Returning just the label object for mapping consistency
-        label_json = label_response.json()
-        return label_json["data"]["issueLabel"]
+        label = label_response.json()["data"]["issueLabel"]
+        await self._append_remaining_label_children(label)
+        return label

--- a/integrations/linear/linear/client.py
+++ b/integrations/linear/linear/client.py
@@ -19,6 +19,7 @@ class LinearObject(StrEnum):
 
 
 PAGE_SIZE = 50
+LINEAR_MAX_PAGE_SIZE = 250
 WEBHOOK_NAME = "Port-Ocean-Events-Webhook"
 
 WEBHOOK_EVENTS = [
@@ -138,6 +139,32 @@ class LinearClient:
             ]
             end_cursor = team_response_list["data"]["teams"]["pageInfo"]["endCursor"]
 
+    async def _append_remaining_label_children(self, label: dict[str, Any]) -> None:
+        """Fetch children pages past the initial inline `children(first: 250)` window."""
+        children = label.get("children")
+        if not children or not children.get("pageInfo", {}).get("hasNextPage"):
+            return
+
+        has_next_page = True
+        end_cursor = children["pageInfo"]["endCursor"]
+        while has_next_page:
+            template = jinja2.Template(
+                QUERIES["GET_LABEL_CHILDREN_PAGE"], enable_async=True
+            )
+            query = await template.render_async(
+                label_id=label["id"],
+                page_size=LINEAR_MAX_PAGE_SIZE,
+                after_cursor=f', after: "{end_cursor}"' if end_cursor else "",
+            )
+            response = await self.client.post(self.linear_url, json={"query": query})
+            response.raise_for_status()
+            children_connection = response.json()["data"]["issueLabel"]["children"]
+            children["edges"].extend(children_connection["edges"])
+            has_next_page = children_connection["pageInfo"]["hasNextPage"]
+            end_cursor = children_connection["pageInfo"]["endCursor"]
+
+        children["pageInfo"]["hasNextPage"] = False
+
     async def get_paginated_labels(
         self,
     ) -> AsyncGenerator[list[dict[str, Any]], None]:
@@ -149,12 +176,14 @@ class LinearClient:
             label_response_list = await self._get_paginated_objects(
                 LinearObject.LABELS, PAGE_SIZE, end_cursor
             )
-            # Response format is: { data: { issueLabels: { edges: [ { cursor: "...", node: {...} } ] } } }
-            # yielding array of nodes as top-level objects for mapping consistency
-            yield [
+            nodes = [
                 edge["node"]
                 for edge in label_response_list["data"]["issueLabels"]["edges"]
             ]
+            for label in nodes:
+                await self._append_remaining_label_children(label)
+            # yielding array of nodes as top-level objects for mapping consistency
+            yield nodes
 
             has_next_page = label_response_list["data"]["issueLabels"]["pageInfo"][
                 "hasNextPage"

--- a/integrations/linear/linear/queries.py
+++ b/integrations/linear/linear/queries.py
@@ -126,11 +126,15 @@ QUERIES = {
     parent {
     id
     }
-    children{
+    children(first: 250) {
         edges {
             node {
                 id
             }
+        }
+        pageInfo {
+            hasNextPage
+            endCursor
         }
     }
     """,
@@ -227,6 +231,23 @@ QUERIES = {
                 hasNextPage
                 startCursor
                 endCursor
+            }
+        }
+    }
+    """,
+    "GET_LABEL_CHILDREN_PAGE": """
+    query IssueLabelChildren {
+        issueLabel(id: "{{ label_id }}") {
+            children(first: {{ page_size }}{{ after_cursor }}) {
+                edges {
+                    node {
+                        id
+                    }
+                }
+                pageInfo {
+                    hasNextPage
+                    endCursor
+                }
             }
         }
     }

--- a/integrations/linear/linear/queries.py
+++ b/integrations/linear/linear/queries.py
@@ -114,6 +114,10 @@ QUERIES = {
         number
     }
     """,
+    # The nested `children` connection must stay at Linear's default page size:
+    # Linear multiplies nested `first` values into its 10,000-point per-query
+    # complexity cap, and this template is expanded inside the 50-label page
+    # query. _append_remaining_label_children pages past the inline window.
     "BASE_LABELS_QUERY_FIELDS": """
     id
     createdAt
@@ -126,7 +130,7 @@ QUERIES = {
     parent {
     id
     }
-    children(first: 250) {
+    children {
         edges {
             node {
                 id

--- a/integrations/linear/tests/test_client.py
+++ b/integrations/linear/tests/test_client.py
@@ -100,3 +100,108 @@ class TestLinearDocumentClient:
         payload = mock_post.await_args.kwargs["json"]["query"]
         assert "document(id:" in payload.replace(" ", "")
         assert "50e3e770-03ef-4c12-9f5a-e3122a768bc4" in payload
+
+
+@pytest.mark.asyncio
+class TestLinearLabelChildrenPagination:
+    async def test_paginates_children_past_inline_window(
+        self, linear_client: LinearClient
+    ) -> None:
+        label_page = {
+            "data": {
+                "issueLabels": {
+                    "edges": [
+                        {
+                            "node": {
+                                "id": "label-1",
+                                "name": "group",
+                                "children": {
+                                    "edges": [
+                                        {"node": {"id": f"child-{i}"}}
+                                        for i in range(250)
+                                    ],
+                                    "pageInfo": {
+                                        "hasNextPage": True,
+                                        "endCursor": "child-cursor-1",
+                                    },
+                                },
+                            }
+                        }
+                    ],
+                    "pageInfo": {"hasNextPage": False, "endCursor": "label-cursor-1"},
+                }
+            }
+        }
+        children_page = {
+            "data": {
+                "issueLabel": {
+                    "children": {
+                        "edges": [{"node": {"id": "child-250"}}],
+                        "pageInfo": {
+                            "hasNextPage": False,
+                            "endCursor": "child-cursor-2",
+                        },
+                    }
+                }
+            }
+        }
+
+        mock_post = AsyncMock(
+            return_value=MagicMock(json=MagicMock(return_value=children_page))
+        )
+        with (
+            patch.object(
+                linear_client, "_get_paginated_objects", new_callable=AsyncMock
+            ) as mock_get,
+            patch.object(linear_client.client, "post", mock_post),
+        ):
+            mock_get.return_value = label_page
+            results = [batch async for batch in linear_client.get_paginated_labels()]
+
+        assert len(results) == 1
+        children = results[0][0]["children"]["edges"]
+        assert [edge["node"]["id"] for edge in children][-1] == "child-250"
+        assert len(children) == 251
+        assert mock_post.await_count == 1
+        query = mock_post.await_args.kwargs["json"]["query"]
+        assert "issueLabel(id:" in query.replace(" ", "")
+        assert 'after: "child-cursor-1"' in query
+
+    async def test_no_extra_calls_when_children_fit_inline_window(
+        self, linear_client: LinearClient
+    ) -> None:
+        label_page = {
+            "data": {
+                "issueLabels": {
+                    "edges": [
+                        {
+                            "node": {
+                                "id": "label-1",
+                                "name": "group",
+                                "children": {
+                                    "edges": [{"node": {"id": "child-0"}}],
+                                    "pageInfo": {
+                                        "hasNextPage": False,
+                                        "endCursor": "child-cursor-1",
+                                    },
+                                },
+                            }
+                        }
+                    ],
+                    "pageInfo": {"hasNextPage": False, "endCursor": "label-cursor-1"},
+                }
+            }
+        }
+
+        mock_post = AsyncMock()
+        with (
+            patch.object(
+                linear_client, "_get_paginated_objects", new_callable=AsyncMock
+            ) as mock_get,
+            patch.object(linear_client.client, "post", mock_post),
+        ):
+            mock_get.return_value = label_page
+            results = [batch async for batch in linear_client.get_paginated_labels()]
+
+        assert results[0][0]["children"]["edges"] == [{"node": {"id": "child-0"}}]
+        mock_post.assert_not_awaited()

--- a/integrations/linear/tests/test_client.py
+++ b/integrations/linear/tests/test_client.py
@@ -205,3 +205,45 @@ class TestLinearLabelChildrenPagination:
 
         assert results[0][0]["children"]["edges"] == [{"node": {"id": "child-0"}}]
         mock_post.assert_not_awaited()
+
+    async def test_get_single_label_follows_child_pagination(
+        self, linear_client: LinearClient
+    ) -> None:
+        single_label = {
+            "data": {
+                "issueLabel": {
+                    "id": "label-1",
+                    "name": "group",
+                    "children": {
+                        "edges": [{"node": {"id": f"child-{i}"}} for i in range(50)],
+                        "pageInfo": {"hasNextPage": True, "endCursor": "child-cursor-1"},
+                    },
+                }
+            }
+        }
+        children_page = {
+            "data": {
+                "issueLabel": {
+                    "children": {
+                        "edges": [{"node": {"id": "child-50"}}],
+                        "pageInfo": {"hasNextPage": False, "endCursor": "child-cursor-2"},
+                    }
+                }
+            }
+        }
+
+        mock_post = AsyncMock(
+            side_effect=[
+                MagicMock(json=MagicMock(return_value=single_label)),
+                MagicMock(json=MagicMock(return_value=children_page)),
+            ]
+        )
+        with patch.object(linear_client.client, "post", mock_post):
+            label = await linear_client.get_single_label("label-1")
+
+        assert label["id"] == "label-1"
+        children = label["children"]["edges"]
+        assert len(children) == 51
+        assert [edge["node"]["id"] for edge in children][-1] == "child-50"
+        query = mock_post.await_args.kwargs["json"]["query"]
+        assert 'after: "child-cursor-1"' in query


### PR DESCRIPTION
Fixes #3908

## Problem

`GET_LABELS_PAGE` paginates the top-level `issueLabels` connection, but the nested `children` connection inside each label is requested with no `first` argument:

```graphql
children { edges { node { id } } }
```

Linear returns only the first 50 nodes for a connection queried without `first`, so any label group with more than 50 child labels silently loses the overflow — the resync succeeds, `transform.failed` stays 0, and the default `childLabels: '[.children.edges[].node.id]'` mapping populates an incomplete relation with no signal.

## Fix

- The inline `children` window stays at Linear's default page size (50) and now requests `pageInfo { hasNextPage endCursor }`. It must stay at 50: Linear multiplies nested `first` values into its 10,000-point per-query complexity cap, and this template is expanded inside the 50-label page query, so a larger inline window (e.g. `first: 250`) gets every labels page rejected.
- `get_paginated_labels` and `get_single_label` call a new `_append_remaining_label_children` helper that follows up with paginated `issueLabel(id) { children(...) }` queries for any label whose children report `hasNextPage`, appending the remaining edges before returning — so every child label is captured regardless of group size.

## Validation

- `python -m pytest tests/test_client.py` in `integrations/linear`: 26 passed (23 pre-existing + 3 new):
  - `test_paginates_children_past_inline_window` — a label with a full inline window of children + `hasNextPage` gets a follow-up query (with the returned `endCursor`) and ends with all children; fails before the fix (children truncated, no follow-up call)
  - `test_no_extra_calls_when_children_fit_inline_window` — no follow-up request when `hasNextPage` is false
  - `test_get_single_label_follows_child_pagination` — the webhook path (`get_single_label`) also follows child pagination instead of overwriting the complete relation with a truncated window
- `ruff check` + `ruff format` clean on touched files
