### PR TITLE
[Integration][aws-v3] Document live events and Port CFN requirements in ADDING_NEW_KINDS

### DIFF
--- a/.ocean-release/core/redis-stream-processing-concurrency.yaml
+++ b/.ocean-release/core/redis-stream-processing-concurrency.yaml
@@ -1,0 +1,3 @@
+bump: minor
+changelog-type: feature
+changelog: Add configurable processing concurrency for the Redis live-events stream consumer.

--- a/.ocean-release/core/redis-stream-processing-concurrency.yaml
+++ b/.ocean-release/core/redis-stream-processing-concurrency.yaml
@@ -1,3 +1,3 @@
 bump: minor
 changelog-type: feature
-changelog: Add configurable processing concurrency for the Redis live-events stream consumer.
+changelog: Add configurable processing concurrency for the Redis live-events stream consumer. Concurrent mode reads one message per free slot to avoid PEL entries piling up ahead of handlers.

--- a/integrations/aws-v3/ADDING_NEW_KINDS.md
+++ b/integrations/aws-v3/ADDING_NEW_KINDS.md
@@ -5,14 +5,35 @@ This guide walks you through adding a new AWS resource kind (like SQS queues, RD
 ## Overview
 
 The AWS-v3 integration follows a consistent pattern for all resource types:
+
+**Resync (scheduled / manual):**
 ```
 Ocean Event → Resync Handler → Exporter → ResourceInspector → Actions → AWS API
 ```
 
+**Live events (CloudTrail via EventBridge):**
+```
+EventBridge → CloudTrailWebhookProcessor → live_events metadata → Exporter.get_resource → Port
+```
+
+Every new kind must implement **both** resync and live events. Live events are routed
+through a single `CloudTrailWebhookProcessor`; per-kind behavior lives in a `live_events.py`
+module and is registered on `ExporterMetadata` in `exporter_metadata.py`.
+
+**Live events need three things — missing any one means silent failure** (resync still
+works; live create/update/delete does not):
+
+1. **Ocean code** (this repo) — `live_events.py` + `exporter_metadata.py`
+2. **Port CFN** ([Port repo](https://github.com/port-labs/Port)) — EventBridge rules that
+   match each mapped `eventSource` + `eventName`
+3. **Customer deployment** — updated live-events CloudFormation stack in their AWS
+   account(s), plus `live_events_api_key` and the `AWS_V3_LIVE_EVENTS_ENABLED` org flag
+
 After implementing the steps below, run the
 [Self-Review Checklist](#self-review-checklist-before-opening-a-pr) against the real AWS API
 before opening a PR. Bootstrapped kinds often look correct while still using non-existent
-paginators, redundant actions, or invented model fields.
+paginators, redundant actions, invented model fields, or CloudTrail event names that never
+appear in real EventBridge payloads.
 
 ## Prerequisites
 
@@ -20,6 +41,8 @@ paginators, redundant actions, or invented model fields.
 - Basic knowledge of Pydantic models
 - Familiarity with AWS SDK (boto3/aiobotocore)
 - Understanding of the existing AWS-v3 codebase structure
+- Familiarity with AWS CloudTrail event shapes (what `requestParameters` / `responseElements`
+  contain for create, update, and delete API calls on your resource)
 
 ## Step-by-Step Guide
 
@@ -70,7 +93,7 @@ class AWSPortAppConfig(PortAppConfig):
 
 ```
 
-**Why:** This defines the resource type that Ocean will recognize and trigger resync events for.
+**Why:** This defines the resource type that Ocean will recognize for resync and live events.
 
 ### Step 2: Create the Resource Models
 
@@ -324,6 +347,12 @@ class YourResourceExporter(IResourceExporter):
 - `ResourceInspector` handles the orchestration of actions
 - Use appropriate paginator for your AWS service
 - Include account and region context for debugging
+- **`get_resource` must work for live events**: CloudTrail only gives you a minimal
+  identifier (name, ARN, URL, etc.). Live-event upserts call `get_resource`, not
+  `get_paginated_resources`. If your default actions swallow not-found errors and return
+  empty stubs, add an upfront existence check (e.g. `head_bucket`, `describe_table`) so
+  a deleted resource raises and the live-event handler can emit a delete instead. See
+  `s3/bucket/exporter.py`, `dynamodb/table/exporter.py`, or `ses/configuration_set/exporter.py`.
 
 ### Step 5: Create Package Init File
 
@@ -379,7 +408,206 @@ async def resync_your_resource(kind: str) -> ASYNC_GENERATOR_RESYNC_TYPE:
             yield batch
 ```
 
-### Step 7: Update Port Specification
+### Step 7: Implement Live Events
+
+Live events keep Port in sync when resources are created, updated, or deleted outside
+of a resync. This step has three parts — Ocean integration code, Port repo CFN, and a
+customer redeploy note for the release.
+
+> ⚠️ **Ocean code alone is not enough**
+>
+> `live_events.py` tells Ocean *how* to handle an event. It does not *deliver* the event.
+> Delivery requires EventBridge rules in the customer's AWS account, defined in the Port
+> repo CloudFormation template. Add or update rules for every `eventName` in
+> `cloudtrail_mappings`, ship the CFN change with (or before) the Ocean release, and note
+> in the changelog that customers must redeploy the stack — otherwise live events for this
+> kind will never fire.
+
+#### Step 7a: Ocean integration (`live_events.py`)
+
+Each kind contributes a `LiveEventFactories` object that tells the shared webhook
+processor how to parse CloudTrail events and fetch/delete the affected entity.
+
+**File:** `aws/core/exporters/{service}/{resource}/live_events.py`
+
+```python
+from aws.core.exporters.{service}.{resource}.models import SingleYourResourceRequest
+from aws.core.helpers.metadata.types import (
+    CloudTrailDetail,
+    CloudTrailEventAction,
+    CloudTrailEventMapping,
+    LiveEventContext,
+    LiveEventFactories,
+)
+from aws.utils import RegionHelper
+
+CLOUDTRAIL_EVENT_SOURCE = "your-service.amazonaws.com"  # detail["eventSource"] value
+
+
+def _extract_resource_identifier(detail: CloudTrailDetail) -> str | None:
+    """Pull the resource identifier from a real CloudTrail record.
+
+    Inspect actual EventBridge/CloudTrail payloads — field names differ per API call.
+    Create events often put the name in responseElements; updates/deletes use
+    requestParameters. Return None when the identifier cannot be determined.
+    """
+    request_parameters = detail.get("requestParameters", {})
+    if not isinstance(request_parameters, dict):
+        return None
+
+    name = request_parameters.get("yourResourceName")
+    return name if isinstance(name, str) else None
+
+
+def _request_factory(
+    context: LiveEventContext, include_actions: list[str]
+) -> SingleYourResourceRequest:
+    """Build the Single*Request used by Exporter.get_resource for upsert events."""
+    return SingleYourResourceRequest(
+        resource_id=context.identifier,
+        region=context.region,
+        account_id=context.account_id,
+        include=include_actions,
+    )
+
+
+def _deletion_identifier_properties(context: LiveEventContext) -> dict[str, str]:
+    """Properties Port uses to match and delete the entity.
+
+    Keys must align with fields referenced by the kind's port-app-config identifier
+    mapping (e.g. .Properties.Arn, .Properties.TableName).
+    """
+    partition = RegionHelper.get_partition()
+    return {
+        "Arn": (
+            f"arn:{partition}:your-service:{context.region}:{context.account_id}:"
+            f"resource/{context.identifier}"
+        ),
+        "YourResourceName": context.identifier,
+    }
+
+
+YOUR_RESOURCE_LIVE_EVENTS = LiveEventFactories(
+    request_factory=_request_factory,
+    deletion_identifier_properties_factory=_deletion_identifier_properties,
+    cloudtrail_mappings={
+        "CreateYourResource": CloudTrailEventMapping(
+            CloudTrailEventAction.UPSERT,
+            _extract_resource_identifier,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
+        ),
+        "UpdateYourResource": CloudTrailEventMapping(
+            CloudTrailEventAction.UPSERT,
+            _extract_resource_identifier,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
+        ),
+        "DeleteYourResource": CloudTrailEventMapping(
+            CloudTrailEventAction.DELETE,
+            _extract_resource_identifier,
+            event_source=CLOUDTRAIL_EVENT_SOURCE,
+        ),
+    },
+)
+```
+
+**File:** `aws/core/exporters/exporter_metadata.py`
+
+Import your `YOUR_RESOURCE_LIVE_EVENTS` constant and pass it when registering the kind:
+
+```python
+from aws.core.exporters.{service}.{resource}.live_events import YOUR_RESOURCE_LIVE_EVENTS
+
+kind_to_export_metadata: dict[ObjectKind, ExporterMetadata] = {
+    # ...
+    ObjectKind.YOUR_RESOURCE: ExporterMetadata(
+        YourResourceExporter,
+        PaginatedYourResourceRequest,
+        live_events=YOUR_RESOURCE_LIVE_EVENTS,
+    ),
+}
+```
+
+No changes to `main.py` or the webhook processor are needed — mappings are discovered
+automatically via `build_event_name_mappings()` in `cloudtrail_event_mappings.py`.
+
+**Key Points:**
+- **`cloudtrail_mappings`**: map CloudTrail `eventName` values to `UPSERT` or `DELETE`.
+  Include every API call that should trigger a Port update (creates, attribute changes,
+  tag changes, etc.). Reuse the same `CloudTrailEventMapping` instance when several
+  event names share one extractor (see `ses/configuration_set/live_events.py`).
+- **`event_source`**: set to the CloudTrail `detail.eventSource` for your service
+  (e.g. `sqs.amazonaws.com`). Required when the same `eventName` exists on multiple
+  services.
+- **`extract_identifier`**: must return the same identifier your `_request_factory`
+  expects in `context.identifier`. Validate against real CloudTrail JSON, not AWS doc
+  prose — create events may only expose the ID in `responseElements` (see
+  `ec2/instance/live_events.py` `RunInstances`).
+- **`deletion_identifier_properties_factory`**: return the property bag Port's jq
+  mapping uses to find the entity. On delete CloudTrail events the processor skips
+  AWS fetch and emits `deleted_raw_results` directly from these properties.
+- **Partition-aware ARNs**: use `RegionHelper.get_partition()` when building ARNs or
+  URLs (required for `aws-cn`, etc.) — see `sqs/queue/live_events.py`.
+- **Feature flag**: live events are gated by the org-level `AWS_V3_LIVE_EVENTS_ENABLED`
+  flag and require `live_events_api_key` in integration config. Resync works without
+  either; live events do not.
+
+**Tests:** add parser coverage in `tests/webhook/test_cloudtrail_parser.py` — assert
+`is_supported_cloudtrail_event` and `parse_cloudtrail_event` for each mapped
+`eventName`, including malformed/missing identifier cases. Use realistic
+`requestParameters` / `responseElements` shapes from real CloudTrail records.
+
+#### Step 7b: Port repo EventBridge rules (CloudFormation)
+
+CloudTrail events only reach Ocean when the customer's account has an EventBridge rule
+that matches them and forwards to Port's webhook. That rule is **not** in this Ocean
+repo — it lives in the Port repo:
+
+**File:** [`s3/port-cloudformation-templates/ocean/aws-v3/live-events-region-stack.yaml`](https://github.com/port-labs/Port/blob/main/s3/port-cloudformation-templates/ocean/aws-v3/live-events-region-stack.yaml)
+
+(`live-events-single-account.yaml` and `live-events-multi-account.yaml` are the
+customer-facing entry points; they deploy this regional stack per account/region.)
+
+For every new kind, update `LiveEventsRule` in that template:
+
+1. **`EventPattern.source`** — add the EventBridge source for your service if not
+   already listed (e.g. `aws.sqs` for SQS). This corresponds to the CloudTrail
+   `detail.eventSource` domain (`sqs.amazonaws.com` → `aws.sqs`).
+2. **`EventPattern.detail.eventName`** — add every key from your `cloudtrail_mappings`,
+   grouped under a comment naming the kind (follow the existing `# AWS::S3::Bucket`
+   style). The CFN `eventName` list and `cloudtrail_mappings` keys must stay in sync.
+
+Example snippet (add alongside existing entries):
+
+```yaml
+        detail:
+          errorCode:
+            - exists: false
+          eventName:
+            # ... existing kinds ...
+            # AWS::YourService::YourResource
+            - CreateYourResource
+            - UpdateYourResource
+            - DeleteYourResource
+```
+
+**PR requirement:** do not merge Ocean-only live-events PRs without a linked Port repo
+CFN PR (or an explicit follow-up ticket). Drift between Ocean `cloudtrail_mappings` and
+CFN `eventName` patterns is a production bug — the integration will parse events that
+never arrive, or receive events it cannot parse.
+
+#### Step 7c: Customer redeploy (release note)
+
+After this kind ships, customers already on live events must **update/redeploy** their
+Port live-events CloudFormation stack (single- or multi-account) in each linked AWS
+account. Until they do, the new kind resyncs on schedule but will not receive live
+updates.
+
+Add a changelog entry when releasing, for example:
+
+> Customers using live events must redeploy the Port AWS live-events CloudFormation stack
+> to receive live updates for `AWS::YourService::YourResource`.
+
+### Step 8: Update Port Specification
 
 **File:** `.port/spec.yaml`
 
@@ -397,7 +625,7 @@ features:
       - kind: AWS::YourService::YourResource  # Add your kind here
 ```
 
-### Step 8: Create Blueprint
+### Step 9: Create Blueprint
 
 **File:** `.port/resources/blueprints.json`
 
@@ -440,7 +668,7 @@ Add your blueprint to the blueprints array:
 }
 ```
 
-### Step 9: Add Default Mapping
+### Step 10: Add Default Mapping
 
 **File:** `.port/resources/port-app-config.yml`
 
@@ -538,8 +766,9 @@ async def get_paginated_resources(self, options) -> AsyncGenerator[list[dict], N
 New kinds (`aws/core/exporters/{service}/{resource}/`) are usually one-shot bootstrapped from
 this guide, with no real AWS calls made and no tests run against live data. Pattern-matching
 other kinds can hallucinate: paginators that don't exist, actions for data that's already
-available elsewhere, model fields that don't exist on the real API. Nothing catches this until
-it runs against a real account.
+available elsewhere, model fields that don't exist on the real API, or CloudTrail mappings
+with no matching EventBridge rule in the Port repo CFN. Nothing catches this until it runs
+against a real account.
 
 **Do not open a PR until every item below is verified against the actual AWS API** — not against
 what "looks right" or what other kinds do.
@@ -639,6 +868,11 @@ If the defaults are pass-through actions that expect full response items (e.g., 
 MemoryDB users), `get_resource` may perform the single "describe/get" call and pass its result to
 the inspector — but it must not call an API that a default action will call again.
 
+**Live events:** `get_resource` is also the code path for CloudTrail upserts. An extra upfront
+existence check (before `inspector.inspect`) is acceptable when it prevents returning a stub for
+a resource that was already deleted — see Step 4. Do not swallow not-found in actions used by
+live-event fetches unless `get_resource` raises first.
+
 ### 7. Actions run concurrently over the same raw input, not chained
 
 All actions in `defaults` + selected `options` run via `asyncio.gather` over the *same* raw
@@ -708,3 +942,32 @@ key at the construction site.
 This does **not** apply when the API's list call returns plain strings (e.g. SQS's
 `list_queues` → `QueueUrls`, a `list[str]`) — there's no dict shape to document, so keep
 `Action[list[str]]` as-is.
+
+### 15. Live events must be implemented for every new kind
+
+Every new kind needs a `live_events.py` and `live_events=` on its `ExporterMetadata`
+entry. Without it, resync works but CloudTrail changes are silently ignored.
+
+**Verify:**
+- Mapped CloudTrail `eventName` values exist and match `detail.eventSource` for your
+  service (check real EventBridge payloads or CloudTrail log samples, not just API docs).
+- `extract_identifier` returns a value for each mapped event — create APIs often put the
+  ID only in `responseElements`.
+- `deletion_identifier_properties_factory` returns property keys that match the kind's
+  `port-app-config.yml` identifier jq (run the same jq against the deletion property dict).
+- `request_factory` produces a `Single*Request` that `get_resource` accepts with only
+  the CloudTrail-derived identifier (no fields only available from a full list/describe).
+- Parser tests in `tests/webhook/test_cloudtrail_parser.py` cover each new mapping.
+
+### 16. Port repo CFN EventBridge rules match `cloudtrail_mappings`
+
+Every `eventName` in `cloudtrail_mappings` must appear under `LiveEventsRule` →
+`EventPattern.detail.eventName` in
+[`live-events-region-stack.yaml`](https://github.com/port-labs/Port/blob/main/s3/port-cloudformation-templates/ocean/aws-v3/live-events-region-stack.yaml),
+and the service's EventBridge `source` must be listed under `EventPattern.source`.
+A kind with Ocean live-event code but no CFN rule passes tests here and still never
+receives events in production.
+
+**Verify:** diff your `cloudtrail_mappings` keys against the CFN `eventName` list side
+by side; confirm the Port repo PR is linked before merging the Ocean PR; add a changelog
+note that customers must redeploy the live-events stack.

--- a/port_ocean/config/settings.py
+++ b/port_ocean/config/settings.py
@@ -222,6 +222,14 @@ class LiveEventsRedisSettings(BaseOceanModel):
         ge=1,
         description="Maximum number of stream entries to return per XREADGROUP call.",
     )
+    processing_concurrency: int = Field(
+        default=1,
+        ge=1,
+        description=(
+            "Maximum number of Redis stream messages processed concurrently "
+            "by a single consumer instance."
+        ),
+    )
     stream_ttl_seconds: int | None = Field(
         default=2_592_000,  # 30 days
         ge=1,

--- a/port_ocean/config/settings.py
+++ b/port_ocean/config/settings.py
@@ -227,7 +227,9 @@ class LiveEventsRedisSettings(BaseOceanModel):
         ge=1,
         description=(
             "Maximum number of Redis stream messages processed concurrently "
-            "by a single consumer instance."
+            "by a single consumer instance. When greater than 1, the consumer "
+            "reads one stream entry per free slot (read_count is ignored) to "
+            "avoid assigning more PEL entries than are actively being processed."
         ),
     )
     stream_ttl_seconds: int | None = Field(

--- a/port_ocean/consumers/redis_stream_consumer.py
+++ b/port_ocean/consumers/redis_stream_consumer.py
@@ -62,6 +62,10 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
         self._ssl_key_file: str | None = None
         self._is_running = False
         self._read_task: asyncio.Task[None] | None = None
+        self._pending_message_tasks: set[asyncio.Task[None]] = set()
+        self._processing_semaphore = asyncio.Semaphore(
+            self._settings.processing_concurrency
+        )
         self._consumer_name = (
             f"{ocean.config.integration.identifier}-{socket.gethostname()}"
         )
@@ -163,6 +167,12 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
             self._read_task.cancel()
             await asyncio.gather(self._read_task, return_exceptions=True)
             self._read_task = None
+        if self._pending_message_tasks:
+            await asyncio.gather(
+                *self._pending_message_tasks,
+                return_exceptions=True,
+            )
+            self._pending_message_tasks.clear()
         if self._stream_maintenance_worker is not None:
             await self._stream_maintenance_worker.stop()
             self._stream_maintenance_worker = None
@@ -225,7 +235,14 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
 
                 for _stream_name, messages in response:
                     for message_id, fields in messages:
-                        await self._handle_message(message_id, fields)
+                        if not self._is_running:
+                            break
+                        await self._processing_semaphore.acquire()
+                        task = asyncio.create_task(
+                            self._process_message(message_id, fields)
+                        )
+                        self._pending_message_tasks.add(task)
+                        task.add_done_callback(self._pending_message_tasks.discard)
             except asyncio.CancelledError:
                 break
             except ResponseError as error:
@@ -251,6 +268,12 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
                         stream_key=self._stream_key,
                         error=str(error),
                     )
+
+    async def _process_message(self, message_id: str, fields: dict[str, str]) -> None:
+        try:
+            await self._handle_message(message_id, fields)
+        finally:
+            self._processing_semaphore.release()
 
     async def _handle_message(self, message_id: str, fields: dict[str, str]) -> None:
         start_time = time.monotonic()

--- a/port_ocean/consumers/redis_stream_consumer.py
+++ b/port_ocean/consumers/redis_stream_consumer.py
@@ -63,8 +63,10 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
         self._is_running = False
         self._read_task: asyncio.Task[None] | None = None
         self._pending_message_tasks: set[asyncio.Task[None]] = set()
-        self._processing_semaphore = asyncio.Semaphore(
-            self._settings.processing_concurrency
+        self._processing_semaphore: asyncio.Semaphore | None = (
+            asyncio.Semaphore(self._settings.processing_concurrency)
+            if self._settings.processing_concurrency > 1
+            else None
         )
         self._consumer_name = (
             f"{ocean.config.integration.identifier}-{socket.gethostname()}"
@@ -167,15 +169,15 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
             self._read_task.cancel()
             await asyncio.gather(self._read_task, return_exceptions=True)
             self._read_task = None
+        if self._stream_maintenance_worker is not None:
+            await self._stream_maintenance_worker.stop()
+            self._stream_maintenance_worker = None
         if self._pending_message_tasks:
             await asyncio.gather(
                 *self._pending_message_tasks,
                 return_exceptions=True,
             )
             self._pending_message_tasks.clear()
-        if self._stream_maintenance_worker is not None:
-            await self._stream_maintenance_worker.stop()
-            self._stream_maintenance_worker = None
         if self._redis is not None:
             await self._redis.aclose()
             self._redis = None
@@ -219,6 +221,12 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
             )
 
     async def _read_loop(self) -> None:
+        if self._settings.processing_concurrency > 1:
+            await self._read_loop_concurrent()
+        else:
+            await self._read_loop_sequential()
+
+    async def _read_loop_sequential(self) -> None:
         redis = self._require_redis()
 
         while self._is_running:
@@ -237,12 +245,7 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
                     for message_id, fields in messages:
                         if not self._is_running:
                             break
-                        await self._processing_semaphore.acquire()
-                        task = asyncio.create_task(
-                            self._process_message(message_id, fields)
-                        )
-                        self._pending_message_tasks.add(task)
-                        task.add_done_callback(self._pending_message_tasks.discard)
+                        await self._handle_message(message_id, fields)
             except asyncio.CancelledError:
                 break
             except ResponseError as error:
@@ -269,11 +272,89 @@ class RedisStreamConsumer(AbstractLiveEventsConsumer):
                         error=str(error),
                     )
 
+    async def _read_loop_concurrent(self) -> None:
+        """Read one message per free processing slot to limit PEL exposure.
+
+        With batch XREADGROUP, every returned entry is assigned to this
+        consumer's PEL immediately, even before a handler starts. If messages
+        wait behind the concurrency limit longer than ``pel_stuck_timeout_seconds``,
+        the maintenance worker may XAUTOCLAIM and requeue them while handlers
+        are still running, causing duplicate delivery.
+        """
+        redis = self._require_redis()
+        processing_semaphore = self._require_processing_semaphore()
+
+        while self._is_running:
+            try:
+                await processing_semaphore.acquire()
+                if not self._is_running:
+                    processing_semaphore.release()
+                    break
+
+                try:
+                    response = await redis.xreadgroup(
+                        groupname=self._consumer_group,
+                        consumername=self._consumer_name,
+                        streams={self._stream_key: ">"},
+                        count=1,
+                        block=self._settings.block_ms,
+                    )
+                except Exception:
+                    processing_semaphore.release()
+                    raise
+
+                if not response:
+                    processing_semaphore.release()
+                    continue
+
+                for _stream_name, messages in response:
+                    for message_id, fields in messages:
+                        task = asyncio.create_task(
+                            self._process_message(message_id, fields)
+                        )
+                        self._pending_message_tasks.add(task)
+                        task.add_done_callback(self._pending_message_tasks.discard)
+                        break
+            except asyncio.CancelledError:
+                break
+            except ResponseError as error:
+                if is_missing_stream_or_group_error(error):
+                    await self._recover_missing_stream()
+                else:
+                    logger.exception(
+                        "Unexpected Redis error in stream read loop",
+                        stream_key=self._stream_key,
+                        error=str(error),
+                    )
+            except Exception as error:
+                if is_redis_connection_error(error):
+                    logger.exception(
+                        "Lost connection to Redis, retrying",
+                        stream_key=self._stream_key,
+                        error=str(error),
+                    )
+                    await asyncio.sleep(self._settings.connection_error_backoff_seconds)
+                else:
+                    logger.exception(
+                        "Unexpected error in Redis stream read loop",
+                        stream_key=self._stream_key,
+                        error=str(error),
+                    )
+
+    def _require_processing_semaphore(self) -> asyncio.Semaphore:
+        if self._processing_semaphore is None:
+            raise RuntimeError(
+                "Processing semaphore is only initialized when processing_concurrency > 1"
+            )
+        return self._processing_semaphore
+
     async def _process_message(self, message_id: str, fields: dict[str, str]) -> None:
+        processing_semaphore = self._processing_semaphore
         try:
             await self._handle_message(message_id, fields)
         finally:
-            self._processing_semaphore.release()
+            if processing_semaphore is not None:
+                processing_semaphore.release()
 
     async def _handle_message(self, message_id: str, fields: dict[str, str]) -> None:
         start_time = time.monotonic()

--- a/port_ocean/tests/config/test_live_events_redis_settings.py
+++ b/port_ocean/tests/config/test_live_events_redis_settings.py
@@ -59,6 +59,35 @@ class TestLiveEventsRedisSettingsValidation:
 
         assert config.live_events.redis.stream_ttl_seconds == 7200
 
+    def test_processing_concurrency_defaults_to_one(self) -> None:
+        settings = LiveEventsRedisSettings(url="redis://localhost:6379")
+
+        assert settings.processing_concurrency == 1
+
+    def test_processing_concurrency_from_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from port_ocean.config.settings import IntegrationConfiguration
+
+        monkeypatch.setenv(
+            "OCEAN__LIVE_EVENTS__REDIS__PROCESSING_CONCURRENCY", "5"
+        )
+        monkeypatch.setenv("OCEAN__PORT__CLIENT_ID", "test-client-id")
+        monkeypatch.setenv("OCEAN__PORT__CLIENT_SECRET", "test-client-secret")
+        monkeypatch.setenv("OCEAN__INTEGRATION__TYPE", "test")
+        monkeypatch.setenv("OCEAN__INTEGRATION__IDENTIFIER", "test-id")
+
+        config = IntegrationConfiguration()
+
+        assert config.live_events.redis.processing_concurrency == 5
+
+    def test_rejects_processing_concurrency_below_one(self) -> None:
+        with pytest.raises(ValidationError):
+            LiveEventsRedisSettings(
+                url="redis://localhost:6379",
+                processing_concurrency=0,
+            )
+
     def test_accepts_rediss_url_with_tls_enabled(self) -> None:
         settings = LiveEventsRedisSettings(
             url="rediss://localhost:6379",

--- a/port_ocean/tests/consumers/test_redis_stream_consumer.py
+++ b/port_ocean/tests/consumers/test_redis_stream_consumer.py
@@ -366,6 +366,163 @@ class TestRedisStreamConsumerConnection:
         mock_sleep.assert_awaited_once_with(2.5)
         assert mock_redis.xreadgroup.await_count == 2
 
+    @pytest.mark.asyncio
+    async def test_read_loop_respects_processing_concurrency(
+        self,
+        mock_ocean_config: MagicMock,
+    ) -> None:
+        settings = LiveEventsRedisSettings(
+            url="redis://localhost:6379",
+            block_ms=100,
+            processing_concurrency=2,
+        )
+        mock_redis = AsyncMock()
+        active_handlers = 0
+        max_active_handlers = 0
+        handler_lock = asyncio.Lock()
+        can_finish = asyncio.Event()
+        handlers_at_peak = asyncio.Event()
+        on_message = AsyncMock()
+
+        async def slow_handler(*_args: object, **_kwargs: object) -> None:
+            nonlocal active_handlers, max_active_handlers
+            async with handler_lock:
+                active_handlers += 1
+                max_active_handlers = max(max_active_handlers, active_handlers)
+                if active_handlers == 2:
+                    handlers_at_peak.set()
+            await can_finish.wait()
+            async with handler_lock:
+                active_handlers -= 1
+
+        on_message.side_effect = slow_handler
+
+        messages = [
+            (
+                "stream",
+                [
+                    ("1-0", {"eventId": "e1", "webhookPath": "webhook"}),
+                    ("2-0", {"eventId": "e2", "webhookPath": "webhook"}),
+                    ("3-0", {"eventId": "e3", "webhookPath": "webhook"}),
+                ],
+            )
+        ]
+
+        read_calls = 0
+
+        async def read_side_effect(**_kwargs: object) -> list[object]:
+            nonlocal read_calls
+            read_calls += 1
+            if read_calls == 1:
+                return messages
+            consumer._is_running = False
+            return []
+
+        mock_redis.xreadgroup = AsyncMock(side_effect=read_side_effect)
+
+        with (
+            patch(
+                "port_ocean.consumers.redis_stream_consumer.ocean", mock_ocean_config
+            ),
+            patch(
+                "port_ocean.consumers.redis_stream_consumer.ack_and_finalize_stream_entry",
+                new=AsyncMock(),
+            ),
+        ):
+            consumer = RedisStreamConsumer(
+                redis_settings=settings,
+                stream_key="stream",
+                on_message=on_message,
+                registered_paths={"/webhook"},
+            )
+            consumer._redis = mock_redis
+            consumer._is_running = True
+
+            read_task = asyncio.create_task(consumer._read_loop())
+            await asyncio.wait_for(handlers_at_peak.wait(), timeout=1)
+            can_finish.set()
+            await read_task
+
+        assert max_active_handlers == 2
+        assert on_message.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_stop_waits_for_pending_message_tasks(
+        self,
+        mock_ocean_config: MagicMock,
+    ) -> None:
+        settings = LiveEventsRedisSettings(
+            url="redis://localhost:6379",
+            processing_concurrency=2,
+        )
+        mock_redis = AsyncMock()
+        handler_started = asyncio.Event()
+        allow_handler_to_finish = asyncio.Event()
+        on_message = AsyncMock()
+
+        async def blocking_handler(*_args: object, **_kwargs: object) -> None:
+            handler_started.set()
+            await allow_handler_to_finish.wait()
+
+        on_message.side_effect = blocking_handler
+
+        read_calls = 0
+
+        async def read_side_effect(**_kwargs: object) -> list[object]:
+            nonlocal read_calls
+            read_calls += 1
+            if read_calls == 1:
+                return [
+                    (
+                        "stream",
+                        [
+                            (
+                                "1-0",
+                                {
+                                    "eventId": "e1",
+                                    "webhookPath": "webhook",
+                                    "payload": "{}",
+                                },
+                            ),
+                        ],
+                    )
+                ]
+            await asyncio.sleep(0)
+            return []
+
+        mock_redis.xreadgroup = AsyncMock(side_effect=read_side_effect)
+        mock_redis.xgroup_create = AsyncMock()
+
+        with (
+            patch(
+                "port_ocean.consumers.redis_stream_consumer.ocean", mock_ocean_config
+            ),
+            patch(
+                "port_ocean.consumers.redis_stream_consumer.create_redis_client_with_retry",
+                new=AsyncMock(return_value=mock_redis),
+            ),
+            patch(
+                "port_ocean.consumers.redis_stream_consumer.ack_and_finalize_stream_entry",
+                new=AsyncMock(),
+            ),
+        ):
+            consumer = RedisStreamConsumer(
+                redis_settings=settings,
+                stream_key="stream",
+                on_message=on_message,
+                registered_paths={"/webhook"},
+            )
+            await consumer.start()
+            await handler_started.wait()
+            stop_task = asyncio.create_task(consumer.stop())
+            await asyncio.sleep(0)
+            assert not stop_task.done()
+            allow_handler_to_finish.set()
+            await stop_task
+
+        on_message.assert_awaited_once()
+        mock_redis.aclose.assert_awaited_once()
+
 
 class TestRedisStreamConsumerGroupCreation:
     @pytest.mark.asyncio

--- a/port_ocean/tests/consumers/test_redis_stream_consumer.py
+++ b/port_ocean/tests/consumers/test_redis_stream_consumer.py
@@ -397,24 +397,32 @@ class TestRedisStreamConsumerConnection:
 
         on_message.side_effect = slow_handler
 
-        messages = [
-            (
-                "stream",
-                [
-                    ("1-0", {"eventId": "e1", "webhookPath": "webhook"}),
-                    ("2-0", {"eventId": "e2", "webhookPath": "webhook"}),
-                    ("3-0", {"eventId": "e3", "webhookPath": "webhook"}),
-                ],
-            )
-        ]
-
         read_calls = 0
 
         async def read_side_effect(**_kwargs: object) -> list[object]:
             nonlocal read_calls
             read_calls += 1
             if read_calls == 1:
-                return messages
+                return [
+                    (
+                        "stream",
+                        [("1-0", {"eventId": "e1", "webhookPath": "webhook"})],
+                    )
+                ]
+            if read_calls == 2:
+                return [
+                    (
+                        "stream",
+                        [("2-0", {"eventId": "e2", "webhookPath": "webhook"})],
+                    )
+                ]
+            if read_calls == 3:
+                return [
+                    (
+                        "stream",
+                        [("3-0", {"eventId": "e3", "webhookPath": "webhook"})],
+                    )
+                ]
             consumer._is_running = False
             return []
 
@@ -445,6 +453,156 @@ class TestRedisStreamConsumerConnection:
 
         assert max_active_handlers == 2
         assert on_message.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_concurrent_read_loop_reads_one_message_per_slot(
+        self,
+        mock_ocean_config: MagicMock,
+    ) -> None:
+        settings = LiveEventsRedisSettings(
+            url="redis://localhost:6379",
+            block_ms=100,
+            processing_concurrency=3,
+            read_count=25,
+        )
+        mock_redis = AsyncMock()
+        release_handler = asyncio.Event()
+
+        async def wait_for_release(*_args: object, **_kwargs: object) -> None:
+            await release_handler.wait()
+
+        on_message = AsyncMock(side_effect=wait_for_release)
+
+        async def stop_after_first_read(**_kwargs: object) -> list[object]:
+            consumer._is_running = False
+            return [
+                (
+                    "stream",
+                    [("1-0", {"eventId": "e1", "webhookPath": "webhook"})],
+                )
+            ]
+
+        mock_redis.xreadgroup = AsyncMock(side_effect=stop_after_first_read)
+
+        with (
+            patch(
+                "port_ocean.consumers.redis_stream_consumer.ocean", mock_ocean_config
+            ),
+            patch(
+                "port_ocean.consumers.redis_stream_consumer.ack_and_finalize_stream_entry",
+                new=AsyncMock(),
+            ),
+        ):
+            consumer = RedisStreamConsumer(
+                redis_settings=settings,
+                stream_key="stream",
+                on_message=on_message,
+                registered_paths={"/webhook"},
+            )
+            consumer._redis = mock_redis
+            consumer._is_running = True
+
+            read_task = asyncio.create_task(consumer._read_loop())
+            await asyncio.sleep(0)
+            release_handler.set()
+            await read_task
+
+        mock_redis.xreadgroup.assert_awaited_once()
+        assert mock_redis.xreadgroup.await_args is not None
+        assert mock_redis.xreadgroup.await_args.kwargs["count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_stop_stops_maintenance_worker_before_draining_handlers(
+        self,
+        mock_ocean_config: MagicMock,
+    ) -> None:
+        settings = LiveEventsRedisSettings(
+            url="redis://localhost:6379",
+            block_ms=100,
+            processing_concurrency=2,
+        )
+        mock_redis = AsyncMock()
+        handler_started = asyncio.Event()
+        allow_handler_to_finish = asyncio.Event()
+        maintenance_stopped = asyncio.Event()
+        on_message = AsyncMock()
+
+        async def blocking_handler(*_args: object, **_kwargs: object) -> None:
+            handler_started.set()
+            await allow_handler_to_finish.wait()
+
+        on_message.side_effect = blocking_handler
+
+        read_calls = 0
+
+        async def read_side_effect(**_kwargs: object) -> list[object]:
+            nonlocal read_calls
+            read_calls += 1
+            if read_calls == 1:
+                return [
+                    (
+                        "stream",
+                        [
+                            (
+                                "1-0",
+                                {
+                                    "eventId": "e1",
+                                    "webhookPath": "webhook",
+                                    "payload": "{}",
+                                },
+                            ),
+                        ],
+                    )
+                ]
+            await asyncio.sleep(0)
+            return []
+
+        mock_redis.xreadgroup = AsyncMock(side_effect=read_side_effect)
+        mock_redis.xgroup_create = AsyncMock()
+
+        mock_maintenance_worker = AsyncMock()
+
+        async def stop_maintenance() -> None:
+            maintenance_stopped.set()
+
+        mock_maintenance_worker.stop = AsyncMock(side_effect=stop_maintenance)
+
+        with (
+            patch(
+                "port_ocean.consumers.redis_stream_consumer.ocean", mock_ocean_config
+            ),
+            patch(
+                "port_ocean.consumers.redis_stream_consumer.create_redis_client_with_retry",
+                new=AsyncMock(return_value=mock_redis),
+            ),
+            patch(
+                "port_ocean.consumers.redis_stream_consumer.RedisStreamMaintenanceWorker",
+                return_value=mock_maintenance_worker,
+            ),
+            patch(
+                "port_ocean.consumers.redis_stream_consumer.ack_and_finalize_stream_entry",
+                new=AsyncMock(),
+            ),
+        ):
+            consumer = RedisStreamConsumer(
+                redis_settings=settings,
+                stream_key="stream",
+                on_message=on_message,
+                registered_paths={"/webhook"},
+            )
+            await consumer.start()
+            await handler_started.wait()
+
+            stop_task = asyncio.create_task(consumer.stop())
+            await asyncio.wait_for(maintenance_stopped.wait(), timeout=1)
+            assert not stop_task.done()
+
+            allow_handler_to_finish.set()
+            await stop_task
+
+        mock_maintenance_worker.stop.assert_awaited_once()
+        on_message.assert_awaited_once()
+        mock_redis.aclose.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_stop_waits_for_pending_message_tasks(


### PR DESCRIPTION
# Description

Updates `integrations/aws-v3/ADDING_NEW_KINDS.md` now that CloudTrail live events are supported. Every new kind must implement live events end-to-end - not just resync - including the Port repo EventBridge/CloudFormation wiring that actually delivers events to Ocean.

- Document the live-events architecture (resync vs. EventBridge → `CloudTrailWebhookProcessor` flow)
- Add **Step 7: Implement Live Events**, split into:
  - **7a** — Ocean integration (`live_events.py`, `exporter_metadata.py`, parser tests)
  - **7b** — Port repo CFN (`live-events-region-stack.yaml` EventBridge rule updates)
  - **7c** — Customer stack redeploy + changelog reminder
  
- Call out the three requirements for live events to work (Ocean code, Port CFN, customer deployment) and warn that missing any one fails silently while resync still works.

- Extend exporter guidance (`get_resource` existence checks for live-event upserts)


## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Concurrent live-events processing changes stream read/PEL behavior and shutdown order; default concurrency 1 preserves prior behavior, but values >1 affect duplicate-delivery and handler parallelism in production.
> 
> **Overview**
> This PR adds **two deliverables**: expanded AWS-v3 contributor docs and a **configurable concurrent Redis live-events consumer** in Ocean core (with a minor core release intent).
> 
> **AWS-v3 `ADDING_NEW_KINDS.md`** now treats **live events as mandatory** alongside resync. It documents the EventBridge → `CloudTrailWebhookProcessor` path, the three-part requirement (Ocean `live_events.py` + Port repo EventBridge CFN + customer stack redeploy), and a new **Step 7** with Ocean wiring, CFN sync rules, and release notes. Exporter guidance and self-review items **#15–#16** cover `get_resource` for CloudTrail upserts and CFN/`cloudtrail_mappings` parity.
> 
> **Ocean core** introduces `LiveEventsRedisSettings.processing_concurrency` (default **1**, env `OCEAN__LIVE_EVENTS__REDIS__PROCESSING_CONCURRENCY`). When **> 1**, `RedisStreamConsumer` uses a semaphore-backed loop that **XREADGROUPs with `count=1` per free slot** (ignoring `read_count`) so PEL entries do not pile up ahead of slow handlers and trigger premature XAUTOCLAIM duplicates. **`stop()`** stops the maintenance worker first, then **awaits in-flight handler tasks** before closing Redis. Tests cover defaults, env binding, concurrency limits, per-slot reads, and shutdown ordering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c84dda87be87f3947da67fa583b82331e58909cb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->