### PR TITLE
[Integration][AWS-v3] Include __ExtraContext on CloudTrail live-event delete payloads

### DIFF
--- a/integrations/aws-v3/.ocean-release/fix-live-event-delete-extra-context.yaml
+++ b/integrations/aws-v3/.ocean-release/fix-live-event-delete-extra-context.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: bugfix
+changelog: Include ExtraContext on CloudTrail live-event delete payloads so custom port-app-config identifier mappings resolve on deletes, not just upserts.

--- a/integrations/aws-v3/aws/webhook/webhook_processors/cloudtrail_webhook_processor.py
+++ b/integrations/aws-v3/aws/webhook/webhook_processors/cloudtrail_webhook_processor.py
@@ -112,6 +112,22 @@ class CloudTrailWebhookProcessor(AbstractWebhookProcessor):
         return metadata, metadata.live_events
 
     @staticmethod
+    def _build_live_event_delete_raw_item(
+        kind: str,
+        properties: dict[str, str],
+        context: LiveEventContext,
+    ) -> dict[str, Any]:
+        """Build a delete stub shaped like upsert raw items for customer jq mappings."""
+        return {
+            "Type": kind,
+            "Properties": properties,
+            "__ExtraContext": {
+                "AccountId": context.account_id,
+                "Region": context.region,
+            },
+        }
+
+    @staticmethod
     def _build_deletion_result(
         kind: str,
         live_events: LiveEventFactories,
@@ -120,12 +136,11 @@ class CloudTrailWebhookProcessor(AbstractWebhookProcessor):
         return WebhookEventRawResults(
             updated_raw_results=[],
             deleted_raw_results=[
-                {
-                    "Type": kind,
-                    "Properties": live_events.deletion_identifier_properties_factory(
-                        context
-                    ),
-                }
+                CloudTrailWebhookProcessor._build_live_event_delete_raw_item(
+                    kind,
+                    live_events.deletion_identifier_properties_factory(context),
+                    context,
+                )
             ],
         )
 

--- a/integrations/aws-v3/tests/webhook/webhook_processors/test_cloudtrail_webhook_processor.py
+++ b/integrations/aws-v3/tests/webhook/webhook_processors/test_cloudtrail_webhook_processor.py
@@ -5,7 +5,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from port_ocean.core.handlers.webhook.webhook_event import WebhookEvent
 
-from aws.core.helpers.metadata.types import ExporterMetadata, LiveEventFactories
+from aws.core.helpers.metadata.types import (
+    ExporterMetadata,
+    LiveEventContext,
+    LiveEventFactories,
+)
 from aws.core.helpers.types import ObjectKind
 from aws.core.interfaces.exporter import IResourceExporter
 from aws.webhook.cloudtrail_parser import parse_cloudtrail_event
@@ -15,6 +19,26 @@ from aws.webhook.webhook_processors.cloudtrail_webhook_processor import (
 )
 
 MODULE = "aws.webhook.webhook_processors.cloudtrail_webhook_processor"
+
+_DEFAULT_ACCOUNT_ID = "111122223333"
+_DEFAULT_REGION = "us-east-1"
+
+
+def _expected_deleted_raw_result(
+    kind: str,
+    properties: dict[str, str],
+    *,
+    account_id: str = _DEFAULT_ACCOUNT_ID,
+    region: str = _DEFAULT_REGION,
+) -> dict[str, object]:
+    return {
+        "Type": kind,
+        "Properties": properties,
+        "__ExtraContext": {
+            "AccountId": account_id,
+            "Region": region,
+        },
+    }
 
 
 @dataclass
@@ -368,6 +392,35 @@ async def test_parse_cloudtrail_event_called_once_per_processor(
     assert mock_parse.call_count == 1
 
 
+def test_build_deletion_result_includes_extra_context() -> None:
+    live_events = LiveEventFactories(
+        request_factory=MagicMock(),
+        deletion_identifier_properties_factory=lambda context: {
+            "QueueName": context.identifier,
+        },
+    )
+    context = LiveEventContext(
+        identifier="my-queue",
+        account_id="999988887777",
+        region="eu-west-1",
+    )
+
+    result = CloudTrailWebhookProcessor._build_deletion_result(
+        ObjectKind.SQS_QUEUE,
+        live_events,
+        context,
+    )
+
+    assert result.deleted_raw_results == [
+        _expected_deleted_raw_result(
+            ObjectKind.SQS_QUEUE,
+            {"QueueName": "my-queue"},
+            account_id="999988887777",
+            region="eu-west-1",
+        )
+    ]
+
+
 @pytest.mark.asyncio
 async def test_handle_event_delete_returns_deleted_result(
     processor: CloudTrailWebhookProcessor,
@@ -376,13 +429,13 @@ async def test_handle_event_delete_returns_deleted_result(
 
     assert result.updated_raw_results == []
     assert result.deleted_raw_results == [
-        {
-            "Type": ObjectKind.S3_BUCKET,
-            "Properties": {
+        _expected_deleted_raw_result(
+            ObjectKind.S3_BUCKET,
+            {
                 "Arn": "arn:aws:s3:::bucket-to-delete",
                 "BucketName": "bucket-to-delete",
             },
-        }
+        )
     ]
 
 
@@ -444,15 +497,15 @@ async def test_handle_event_lambda_delete_returns_deleted_result(
 
     assert result.updated_raw_results == []
     assert result.deleted_raw_results == [
-        {
-            "Type": ObjectKind.LAMBDA_FUNCTION,
-            "Properties": {
+        _expected_deleted_raw_result(
+            ObjectKind.LAMBDA_FUNCTION,
+            {
                 "FunctionArn": (
                     "arn:aws:lambda:us-east-1:111122223333:function:function-to-delete"
                 ),
                 "FunctionName": "function-to-delete",
             },
-        }
+        )
     ]
 
 
@@ -503,15 +556,15 @@ async def test_handle_event_dynamodb_delete_returns_deleted_result(
 
     assert result.updated_raw_results == []
     assert result.deleted_raw_results == [
-        {
-            "Type": ObjectKind.DYNAMODB_TABLE,
-            "Properties": {
+        _expected_deleted_raw_result(
+            ObjectKind.DYNAMODB_TABLE,
+            {
                 "TableArn": (
                     "arn:aws:dynamodb:us-east-1:111122223333:table/table-to-delete"
                 ),
                 "TableName": "table-to-delete",
             },
-        }
+        )
     ]
 
 
@@ -562,15 +615,15 @@ async def test_handle_event_rds_db_instance_delete_returns_deleted_result(
 
     assert result.updated_raw_results == []
     assert result.deleted_raw_results == [
-        {
-            "Type": ObjectKind.RDS_DB_INSTANCE,
-            "Properties": {
+        _expected_deleted_raw_result(
+            ObjectKind.RDS_DB_INSTANCE,
+            {
                 "DBInstanceArn": (
                     "arn:aws:rds:us-east-1:111122223333:db:db-instance-to-delete"
                 ),
                 "DBInstanceIdentifier": "db-instance-to-delete",
             },
-        }
+        )
     ]
 
 
@@ -638,15 +691,15 @@ async def test_handle_event_rds_db_instance_create_treats_not_found_as_deleted(
 
     assert result.updated_raw_results == []
     assert result.deleted_raw_results == [
-        {
-            "Type": ObjectKind.RDS_DB_INSTANCE,
-            "Properties": {
+        _expected_deleted_raw_result(
+            ObjectKind.RDS_DB_INSTANCE,
+            {
                 "DBInstanceArn": (
                     "arn:aws:rds:us-east-1:111122223333:db:missing-db-instance"
                 ),
                 "DBInstanceIdentifier": "missing-db-instance",
             },
-        }
+        )
     ]
 
 
@@ -666,15 +719,15 @@ async def test_handle_event_ecr_repository_delete_returns_deleted_result(
 
     assert result.updated_raw_results == []
     assert result.deleted_raw_results == [
-        {
-            "Type": ObjectKind.ECR_REPOSITORY,
-            "Properties": {
+        _expected_deleted_raw_result(
+            ObjectKind.ECR_REPOSITORY,
+            {
                 "RepositoryArn": (
                     "arn:aws:ecr:us-east-1:111122223333:repository/repo-to-delete"
                 ),
                 "RepositoryName": "repo-to-delete",
             },
-        }
+        )
     ]
 
 
@@ -725,15 +778,15 @@ async def test_handle_event_ecs_cluster_delete_returns_deleted_result(
 
     assert result.updated_raw_results == []
     assert result.deleted_raw_results == [
-        {
-            "Type": ObjectKind.ECS_CLUSTER,
-            "Properties": {
+        _expected_deleted_raw_result(
+            ObjectKind.ECS_CLUSTER,
+            {
                 "ClusterArn": (
                     "arn:aws:ecs:us-east-1:111122223333:cluster/ecs-cluster-to-delete"
                 ),
                 "ClusterName": "ecs-cluster-to-delete",
             },
-        }
+        )
     ]
 
 
@@ -784,15 +837,15 @@ async def test_handle_event_eks_cluster_delete_returns_deleted_result(
 
     assert result.updated_raw_results == []
     assert result.deleted_raw_results == [
-        {
-            "Type": ObjectKind.EKS_CLUSTER,
-            "Properties": {
+        _expected_deleted_raw_result(
+            ObjectKind.EKS_CLUSTER,
+            {
                 "Arn": (
                     "arn:aws:eks:us-east-1:111122223333:cluster/eks-cluster-to-delete"
                 ),
                 "Name": "eks-cluster-to-delete",
             },
-        }
+        )
     ]
 
 
@@ -885,11 +938,11 @@ async def test_handle_event_create_treats_not_found_as_deleted(
 
     assert result.updated_raw_results == []
     assert result.deleted_raw_results == [
-        {
-            "Type": ObjectKind.S3_BUCKET,
-            "Properties": {
+        _expected_deleted_raw_result(
+            ObjectKind.S3_BUCKET,
+            {
                 "Arn": "arn:aws:s3:::missing-bucket",
                 "BucketName": "missing-bucket",
             },
-        }
+        )
     ]


### PR DESCRIPTION
# Description

CloudTrail live-event **delete** stubs were missing `__ExtraContext`, unlike upsert payloads returned by exporters. This caused port-app-config mappings that reference `.__ExtraContext` (e.g. `relations.account: .__ExtraContext.AccountId` in the default S3 bucket mapping) to fail on deletes, so entities were not removed from Port.


## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow live-events webhook payload fix with no auth or exporter changes; improves delete behavior for mappings that already rely on __ExtraContext on upserts.
> 
> **Overview**
> **CloudTrail live-event deletes** now emit the same raw-item shape as upserts by adding `__ExtraContext` (`AccountId`, `Region`) to deletion stubs in `CloudTrailWebhookProcessor`.
> 
> Previously, delete payloads only had `Type` and `Properties`, so port-app-config identifier or relation mappings that depend on `.__ExtraContext` (e.g. account relations) could not resolve and entities were not removed from Port on delete.
> 
> A dedicated `_build_live_event_delete_raw_item` helper builds these stubs; tests assert `__ExtraContext` across delete paths (including not-found-as-deleted). Patch release intent is recorded under `.ocean-release`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d2819237757f4a0802c52e4c1f7365cf18a6b13. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->