### PR TITLE
[Integration][pagerduty] Bootstrap actions processing support

### DIFF
--- a/integrations/pagerduty/.ocean-release/actions-support.yaml
+++ b/integrations/pagerduty/.ocean-release/actions-support.yaml
@@ -1,0 +1,3 @@
+bump: minor
+changelog-type: feature
+changelog: Added actions processing support for PagerDuty integration

--- a/integrations/pagerduty/actions/abstract_pagerduty_executor.py
+++ b/integrations/pagerduty/actions/abstract_pagerduty_executor.py
@@ -1,3 +1,4 @@
+from clients.rate_limiter import RateLimitInfo
 from port_ocean.core.handlers.actions.abstract_executor import AbstractExecutor
 from port_ocean.core.handlers.webhook.abstract_webhook_processor import (
     AbstractWebhookProcessor,
@@ -17,18 +18,30 @@ class AbstractPagerDutyExecutor(AbstractExecutor):
     def __init__(self) -> None:
         self.client = PagerDutyClient.from_ocean_configuration()
 
-    async def is_close_to_rate_limit(self, run: IntegrationRun) -> bool:
-        info = self.client.get_rate_limit_status()
-        if not info:
+    @staticmethod
+    def _is_snapshot_close_to_rate_limit(info: RateLimitInfo | None) -> bool:
+        """Treat an expired snapshot as replenished.
+
+        The execution manager backs off without making PagerDuty requests, so
+        `remaining` never refreshes on its own. Once the reset window has
+        passed we must allow the run to proceed even if the cached remaining
+        count is still low.
+        """
+        if info is None or info.limit == 0 or info.seconds_until_reset <= 0:
             return False
 
         return info.remaining < MIN_REMAINING_RATE_LIMIT_FOR_EXECUTE
+
+    async def is_close_to_rate_limit(self, run: IntegrationRun) -> bool:
+        return self._is_snapshot_close_to_rate_limit(
+            self.client.get_rate_limit_status()
+        )
 
     async def get_remaining_seconds_until_rate_limit(
         self, run: IntegrationRun
     ) -> float:
         info = self.client.get_rate_limit_status()
-        if not info:
+        if info is None or not self._is_snapshot_close_to_rate_limit(info):
             return 0.0
 
         return float(info.seconds_until_reset)

--- a/integrations/pagerduty/actions/abstract_pagerduty_executor.py
+++ b/integrations/pagerduty/actions/abstract_pagerduty_executor.py
@@ -1,0 +1,34 @@
+from port_ocean.core.handlers.actions.abstract_executor import AbstractExecutor
+from port_ocean.core.handlers.webhook.abstract_webhook_processor import (
+    AbstractWebhookProcessor,
+)
+from port_ocean.core.models import IntegrationRun
+
+from clients.pagerduty import PagerDutyClient
+
+MIN_REMAINING_RATE_LIMIT_FOR_EXECUTE = 20
+
+
+class AbstractPagerDutyExecutor(AbstractExecutor):
+    """Base executor for PagerDuty actions."""
+
+    WEBHOOK_PROCESSOR_CLASS: type[AbstractWebhookProcessor] | None = None
+
+    def __init__(self) -> None:
+        self.client = PagerDutyClient.from_ocean_configuration()
+
+    async def is_close_to_rate_limit(self, run: IntegrationRun) -> bool:
+        info = self.client.get_rate_limit_status()
+        if not info:
+            return False
+
+        return info.remaining < MIN_REMAINING_RATE_LIMIT_FOR_EXECUTE
+
+    async def get_remaining_seconds_until_rate_limit(
+        self, run: IntegrationRun
+    ) -> float:
+        info = self.client.get_rate_limit_status()
+        if not info:
+            return 0.0
+
+        return float(info.seconds_until_reset)

--- a/integrations/pagerduty/actions/exceptions.py
+++ b/integrations/pagerduty/actions/exceptions.py
@@ -1,0 +1,5 @@
+from port_ocean.exceptions.execution_manager import ActionExecutionError
+
+
+class MissingExecutionPropertyError(ActionExecutionError):
+    """Raised when a required execution property is absent from the action run."""

--- a/integrations/pagerduty/actions/registry.py
+++ b/integrations/pagerduty/actions/registry.py
@@ -1,0 +1,2 @@
+def register_action_executors() -> None:
+    """Register all action executors."""

--- a/integrations/pagerduty/clients/pagerduty.py
+++ b/integrations/pagerduty/clients/pagerduty.py
@@ -15,6 +15,7 @@ from port_ocean.utils.relative_time import days_ago, to_rfc3339
 from clients.rate_limiter import (
     PagerDutyDailyRateLimitExceededError,
     PagerDutyRateLimiter,
+    RateLimitInfo,
     daily_quota_exhausted,
 )
 from clients.retry_transport import PagerDutyRetryTransport
@@ -428,3 +429,11 @@ class PagerDutyClient(OAuthClient):
             entity["__custom_fields"] = result
 
         return entities
+
+    def get_rate_limit_status(self) -> Optional[RateLimitInfo]:
+        """Return the most-recently observed per-minute rate-limit info, or None if unknown."""
+        return self._rate_limiter.rate_limit_info
+
+    def get_rate_limit_status(self) -> Optional[RateLimitInfo]:
+        """Return the most-recently observed per-minute rate-limit info, or None if unknown."""
+        return self._rate_limiter.rate_limit_info

--- a/integrations/pagerduty/clients/pagerduty.py
+++ b/integrations/pagerduty/clients/pagerduty.py
@@ -433,7 +433,3 @@ class PagerDutyClient(OAuthClient):
     def get_rate_limit_status(self) -> Optional[RateLimitInfo]:
         """Return the most-recently observed per-minute rate-limit info, or None if unknown."""
         return self._rate_limiter.rate_limit_info
-
-    def get_rate_limit_status(self) -> Optional[RateLimitInfo]:
-        """Return the most-recently observed per-minute rate-limit info, or None if unknown."""
-        return self._rate_limiter.rate_limit_info

--- a/integrations/pagerduty/clients/rate_limiter.py
+++ b/integrations/pagerduty/clients/rate_limiter.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Type
 
@@ -11,7 +12,11 @@ from pydantic.v1 import BaseModel, Field
 class RateLimitInfo:
     limit: int
     remaining: int
-    seconds_until_reset: int
+    reset_at: int
+
+    @property
+    def seconds_until_reset(self) -> int:
+        return max(0, self.reset_at - int(time.time()))
 
     @property
     def utilization_percentage(self) -> float:
@@ -19,6 +24,16 @@ class RateLimitInfo:
             return 0.0
         used = self.limit - self.remaining
         return max(0.0, min(100.0, (used / self.limit) * 100.0))
+
+    @classmethod
+    def with_seconds_until_reset(
+        cls, *, limit: int, remaining: int, seconds_until_reset: int
+    ) -> "RateLimitInfo":
+        return cls(
+            limit=limit,
+            remaining=remaining,
+            reset_at=int(time.time()) + seconds_until_reset,
+        )
 
 
 class PagerDutyDailyRateLimitExceededError(Exception):
@@ -100,7 +115,7 @@ class PagerDutyRateLimiter:
         return RateLimitInfo(
             limit=int(headers.ratelimit_limit),
             remaining=int(headers.ratelimit_remaining),
-            seconds_until_reset=int(headers.ratelimit_reset),
+            reset_at=int(time.time()) + int(headers.ratelimit_reset),
         )
 
     def _parse_daily_headers(
@@ -115,7 +130,7 @@ class PagerDutyRateLimiter:
         return RateLimitInfo(
             limit=int(headers.daily_ratelimit_limit),
             remaining=int(headers.daily_ratelimit_remaining),
-            seconds_until_reset=int(headers.daily_ratelimit_reset),
+            reset_at=int(time.time()) + int(headers.daily_ratelimit_reset),
         )
 
     def update_rate_limits(

--- a/integrations/pagerduty/main.py
+++ b/integrations/pagerduty/main.py
@@ -7,6 +7,7 @@ from port_ocean.context.event import event
 from port_ocean.context.ocean import ocean
 from port_ocean.core.ocean_types import ASYNC_GENERATOR_RESYNC_TYPE
 
+from actions.registry import register_action_executors
 from clients.pagerduty import PagerDutyClient
 from clients.rate_limiter import PagerDutyDailyRateLimitExceededError
 from integration import (
@@ -192,3 +193,5 @@ async def on_start() -> None:
 
 ocean.add_webhook_processor("/webhook", ServiceWebhookProcessor)
 ocean.add_webhook_processor("/webhook", IncidentWebhookProcessor)
+
+register_action_executors()

--- a/integrations/pagerduty/tests/test_actions.py
+++ b/integrations/pagerduty/tests/test_actions.py
@@ -1,0 +1,87 @@
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+from port_ocean.core.models import IntegrationRun
+
+from actions.abstract_pagerduty_executor import AbstractPagerDutyExecutor
+from clients.rate_limiter import RateLimitInfo
+
+
+class _TestExecutor(AbstractPagerDutyExecutor):
+    ACTION_NAME = "test_action"
+
+    async def execute(self, run: IntegrationRun) -> None:
+        pass
+
+
+def _build_executor(
+    rate_limit_info: RateLimitInfo | None,
+) -> _TestExecutor:
+    client_mock = MagicMock()
+    client_mock.get_rate_limit_status.return_value = rate_limit_info
+    with patch.object(AbstractPagerDutyExecutor, "__init__", lambda self: None):
+        executor = _TestExecutor()
+    executor.client = client_mock
+    return executor
+
+
+@pytest.mark.asyncio
+async def test_is_close_to_rate_limit_when_remaining_is_low() -> None:
+    executor = _build_executor(
+        RateLimitInfo.with_seconds_until_reset(
+            limit=960, remaining=10, seconds_until_reset=30
+        )
+    )
+
+    assert await executor.is_close_to_rate_limit(MagicMock()) is True
+
+
+@pytest.mark.asyncio
+async def test_is_close_to_rate_limit_false_when_remaining_is_high() -> None:
+    executor = _build_executor(
+        RateLimitInfo.with_seconds_until_reset(
+            limit=960, remaining=100, seconds_until_reset=30
+        )
+    )
+
+    assert await executor.is_close_to_rate_limit(MagicMock()) is False
+
+
+@pytest.mark.asyncio
+async def test_is_close_to_rate_limit_false_once_reset_window_has_passed() -> None:
+    executor = _build_executor(
+        RateLimitInfo(
+            limit=960,
+            remaining=10,
+            reset_at=int(time.time()) - 5,
+        )
+    )
+
+    assert await executor.is_close_to_rate_limit(MagicMock()) is False
+
+
+@pytest.mark.asyncio
+async def test_get_remaining_seconds_until_rate_limit_returns_zero_when_not_close() -> (
+    None
+):
+    executor = _build_executor(
+        RateLimitInfo.with_seconds_until_reset(
+            limit=960, remaining=100, seconds_until_reset=30
+        )
+    )
+
+    assert await executor.get_remaining_seconds_until_rate_limit(MagicMock()) == 0.0
+
+
+@pytest.mark.asyncio
+async def test_get_remaining_seconds_until_rate_limit_returns_reset_countdown() -> None:
+    executor = _build_executor(
+        RateLimitInfo.with_seconds_until_reset(
+            limit=960, remaining=10, seconds_until_reset=25
+        )
+    )
+
+    remaining = await executor.get_remaining_seconds_until_rate_limit(MagicMock())
+
+    assert 24 <= remaining <= 25

--- a/integrations/pagerduty/tests/test_client.py
+++ b/integrations/pagerduty/tests/test_client.py
@@ -303,8 +303,10 @@ class TestPagerDutyClient:
         not even reach the HTTP layer."""
         from clients.rate_limiter import RateLimitInfo
 
-        client._rate_limiter.daily_rate_limit_info = RateLimitInfo(
-            limit=10, remaining=-1, seconds_until_reset=49015
+        client._rate_limiter.daily_rate_limit_info = (
+            RateLimitInfo.with_seconds_until_reset(
+                limit=10, remaining=-1, seconds_until_reset=49015
+            )
         )
 
         request_mock = AsyncMock()
@@ -323,8 +325,10 @@ class TestPagerDutyClient:
         """Daily-quota state from a prior analytics 429 must not block REST calls."""
         from clients.rate_limiter import RateLimitInfo
 
-        client._rate_limiter.daily_rate_limit_info = RateLimitInfo(
-            limit=10, remaining=-1, seconds_until_reset=49015
+        client._rate_limiter.daily_rate_limit_info = (
+            RateLimitInfo.with_seconds_until_reset(
+                limit=10, remaining=-1, seconds_until_reset=49015
+            )
         )
 
         rest_response = MagicMock()

--- a/integrations/pagerduty/tests/test_rate_limiter.py
+++ b/integrations/pagerduty/tests/test_rate_limiter.py
@@ -54,7 +54,7 @@ class TestPagerDutyRateLimiter:
 
         # 90% usage: 900 used, 100 remaining out of 1000
         reset_in = 5
-        limiter.rate_limit_info = RateLimitInfo(
+        limiter.rate_limit_info = RateLimitInfo.with_seconds_until_reset(
             limit=1000, remaining=100, seconds_until_reset=reset_in
         )
 
@@ -72,7 +72,7 @@ class TestPagerDutyRateLimiter:
         limiter = PagerDutyRateLimiter(max_concurrent=3)
 
         # 50% usage: 500 used, 500 remaining out of 1000
-        limiter.rate_limit_info = RateLimitInfo(
+        limiter.rate_limit_info = RateLimitInfo.with_seconds_until_reset(
             limit=1000, remaining=500, seconds_until_reset=60
         )
 
@@ -103,7 +103,7 @@ class TestPagerDutyRateLimiter:
         assert limiter.daily_rate_limit_info is not None
         assert limiter.daily_rate_limit_info.limit == 10
         assert limiter.daily_rate_limit_info.remaining == 5
-        assert limiter.daily_rate_limit_info.seconds_until_reset == 49015
+        assert 49014 <= limiter.daily_rate_limit_info.seconds_until_reset <= 49016
         mock_sleep.assert_not_called()
 
     @pytest.mark.asyncio
@@ -111,7 +111,7 @@ class TestPagerDutyRateLimiter:
         self, mock_sleep: Mock
     ) -> None:
         limiter = PagerDutyRateLimiter(max_concurrent=5)
-        limiter.daily_rate_limit_info = RateLimitInfo(
+        limiter.daily_rate_limit_info = RateLimitInfo.with_seconds_until_reset(
             limit=10, remaining=2, seconds_until_reset=49000
         )
         headers = httpx.Headers(
@@ -126,7 +126,7 @@ class TestPagerDutyRateLimiter:
 
         assert limiter.daily_rate_limit_info.limit == 10
         assert limiter.daily_rate_limit_info.remaining == 2
-        assert limiter.daily_rate_limit_info.seconds_until_reset == 49000
+        assert 48999 <= limiter.daily_rate_limit_info.seconds_until_reset <= 49001
         assert limiter.rate_limit_info is not None
         assert limiter.rate_limit_info.remaining == 900
         mock_sleep.assert_not_called()
@@ -136,7 +136,7 @@ class TestPagerDutyRateLimiter:
         self, mock_sleep: Mock
     ) -> None:
         limiter = PagerDutyRateLimiter(max_concurrent=5)
-        limiter.daily_rate_limit_info = RateLimitInfo(
+        limiter.daily_rate_limit_info = RateLimitInfo.with_seconds_until_reset(
             limit=10, remaining=-1, seconds_until_reset=49015
         )
 
@@ -148,7 +148,7 @@ class TestPagerDutyRateLimiter:
         self, mock_sleep: Mock
     ) -> None:
         limiter = PagerDutyRateLimiter(max_concurrent=5)
-        limiter.daily_rate_limit_info = RateLimitInfo(
+        limiter.daily_rate_limit_info = RateLimitInfo.with_seconds_until_reset(
             limit=10, remaining=-1, seconds_until_reset=49015
         )
 


### PR DESCRIPTION
# Description

Adds the foundational infrastructure for PagerDuty integration actions, enabling future self-service actions to be implemented without additional wiring.

## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scaffolding only: empty registry, no new action behavior; duplicate client method is a merge hygiene issue, not runtime risk unless both definitions ship.
> 
> **Overview**
> Adds the **foundational wiring** for Port self-service actions on the PagerDuty integration, with a **minor** release entry documenting actions processing support.
> 
> Introduces an `actions` package with **`AbstractPagerDutyExecutor`** (shared `PagerDutyClient`, optional webhook processor hook) and **rate-limit backoff** via `is_close_to_rate_limit` / `get_remaining_seconds_until_rate_limit` when remaining quota drops below 20. **`MissingExecutionPropertyError`** extends `ActionExecutionError` for missing action run properties.
> 
> **`PagerDutyClient.get_rate_limit_status`** exposes the rate limiter’s last observed per-minute `RateLimitInfo`. **`main.py`** invokes **`register_action_executors()`** at startup; the registry is a **no-op stub** today (no executors registered yet), matching the “bootstrap for future actions” intent.
> 
> **Note:** the client diff currently defines **`get_rate_limit_status` twice** with identical bodies—likely an accidental duplicate to clean up before merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe46620d75c57548acb8355528f30ff573f66f5a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->