### PR TITLE
[Core] Task tkzwzo/fix workflow status label ocean api

### DIFF
--- a/.ocean-release/core/workflow-node-status-label-object.yaml
+++ b/.ocean-release/core/workflow-node-status-label-object.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: bugfix
+changelog: Fix workflow node run status labels to use the object shape Port expects

--- a/port_ocean/clients/port/mixins/actions_and_workflow_runs.py
+++ b/port_ocean/clients/port/mixins/actions_and_workflow_runs.py
@@ -34,7 +34,7 @@ class ActionsAndWorkflowRunsClientMixin(ActionsClientMixin, WorkflowNodesClientM
         if output:
             patch["output"] = output
         if status_label:
-            patch["statusLabel"] = status_label
+            patch["statusLabel"] = {"text": status_label}
         return patch
 
     async def claim_pending_runs(
@@ -104,7 +104,7 @@ class ActionsAndWorkflowRunsClientMixin(ActionsClientMixin, WorkflowNodesClientM
             if status_label:
                 await self.patch_wf_node_run(
                     run.id,
-                    {"statusLabel": status_label},
+                    {"statusLabel": {"text": status_label}},
                     should_raise=should_raise,
                 )
         else:
@@ -168,7 +168,7 @@ class ActionsAndWorkflowRunsClientMixin(ActionsClientMixin, WorkflowNodesClientM
                 "links": [link],
             }
             if status_label:
-                patch["statusLabel"] = status_label
+                patch["statusLabel"] = {"text": status_label}
             await self.patch_wf_node_run(run.id, patch)
             run.output = output
         else:

--- a/port_ocean/tests/clients/port/mixins/test_actions_and_workflow_runs.py
+++ b/port_ocean/tests/clients/port/mixins/test_actions_and_workflow_runs.py
@@ -373,7 +373,9 @@ class TestWorkflowNodeRunStatusLabel:
             ("INFO", "Triggering pipeline")
         ]
         mock_patch.assert_awaited_once_with(
-            run.id, {"statusLabel": "Triggering pipeline"}, should_raise=False
+            run.id,
+            {"statusLabel": {"text": "Triggering pipeline"}},
+            should_raise=False,
         )
 
     async def test_post_run_log_skips_patch_without_status_label(
@@ -411,7 +413,7 @@ class TestWorkflowNodeRunStatusLabel:
                 "externalRunId": EXTERNAL_ID,
                 "output": {"workflowRunUrl": "https://gitlab.example/pipelines/99"},
                 "links": ["https://gitlab.example/pipelines/99"],
-                "statusLabel": "Pipeline running",
+                "statusLabel": {"text": "Pipeline running"},
             },
         )
 
@@ -436,7 +438,7 @@ class TestWorkflowNodeRunStatusLabel:
                 "status": WorkflowNodeRunStatus.COMPLETED,
                 "result": WorkflowNodeRunResult.SUCCESS,
                 "output": {"workflowRunUrl": "https://gitlab.example/pipelines/99"},
-                "statusLabel": "Pipeline succeeded",
+                "statusLabel": {"text": "Pipeline succeeded"},
             },
             should_raise=False,
         )


### PR DESCRIPTION
# Description

What -

Why -

How -

## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow API payload fix for workflow node runs only; action-run behavior is unchanged and tests cover the new shape.
> 
> **Overview**
> Fixes **workflow node run** patches so `statusLabel` is sent as `{"text": "<label>"}` instead of a plain string, matching the shape Port’s API expects for workflow nodes.
> 
> The change applies wherever Ocean patches workflow node runs with a status label: completion (`_wf_node_completion_patch`), `post_run_log`, and `update_run_started`. **Action runs** are unchanged and still use a string `statusLabel`.
> 
> Adds a core **patch** release note (`.ocean-release/core/workflow-node-status-label-object.yaml`) and updates mixin tests to assert the new payload shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 829d0a2b19550b1dbf5448c8c40a9778bba85653. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->