### PR TITLE
[Integration][GitLab] Add create-merge-request action

### DIFF
--- a/integrations/gitlab-v2/.ocean-release/create-merge-request.yaml
+++ b/integrations/gitlab-v2/.ocean-release/create-merge-request.yaml
@@ -1,0 +1,3 @@
+bump: minor
+changelog-type: feature
+changelog: Added a create_merge_request action that creates a GitLab merge request

--- a/integrations/gitlab-v2/.port/spec.json
+++ b/integrations/gitlab-v2/.port/spec.json
@@ -115,6 +115,41 @@
           "description": "Key-value pairs passed as CI/CD variables to the pipeline"
         }
       ]
+    },
+    {
+      "name": "create_merge_request",
+      "icon": "GitLab",
+      "description": "Create a GitLab merge request",
+      "inputs": [
+        {
+          "name": "project",
+          "title": "Project",
+          "type": "string",
+          "description": "GitLab project path (e.g., \"my-group/my-project\") or numeric ID",
+          "required": true
+        },
+        {
+          "name": "sourceBranch",
+          "title": "Source branch",
+          "type": "string",
+          "description": "The branch containing the changes to merge",
+          "required": true
+        },
+        {
+          "name": "targetBranch",
+          "title": "Target branch",
+          "type": "string",
+          "description": "The branch to merge changes into",
+          "required": true
+        },
+        {
+          "name": "title",
+          "title": "Title",
+          "type": "string",
+          "description": "Title of the merge request",
+          "required": true
+        }
+      ]
     }
   ],
   "deploymentMethodOverride": [

--- a/integrations/gitlab-v2/gitlab/actions/create_merge_request_executor.py
+++ b/integrations/gitlab-v2/gitlab/actions/create_merge_request_executor.py
@@ -1,0 +1,69 @@
+import httpx
+from loguru import logger
+from port_ocean.context.ocean import ocean
+from port_ocean.core.models import IntegrationRun
+
+from gitlab.actions.abstract_gitlab_executor import AbstractGitlabExecutor
+from gitlab.helpers.exceptions import (
+    GitlabCreateMergeRequestError,
+    MissingExecutionPropertyError,
+)
+
+
+class CreateMergeRequestExecutor(AbstractGitlabExecutor):
+    ACTION_NAME = "create_merge_request"
+    WEBHOOK_PROCESSOR_CLASS = None
+
+    async def execute(self, run: IntegrationRun) -> None:
+        project = run.execution_properties.get("project")
+        source_branch = run.execution_properties.get("sourceBranch")
+        target_branch = run.execution_properties.get("targetBranch")
+        title = run.execution_properties.get("title")
+
+        if not project:
+            raise MissingExecutionPropertyError("project is required")
+        if not source_branch:
+            raise MissingExecutionPropertyError("sourceBranch is required")
+        if not target_branch:
+            raise MissingExecutionPropertyError("targetBranch is required")
+        if not title:
+            raise MissingExecutionPropertyError("title is required")
+
+        await ocean.port_client.post_run_log(
+            run,
+            f"Creating merge request in {project}: {source_branch} -> {target_branch}",
+            should_raise=False,
+        )
+
+        try:
+            merge_request = await self.client.create_merge_request(
+                project, source_branch, target_branch, title
+            )
+        except httpx.HTTPStatusError as e:
+            raise GitlabCreateMergeRequestError.from_response(
+                e.response,
+                f"Could not create merge request in project '{project}'",
+            )
+
+        if not merge_request or not all(k in merge_request for k in ("id", "web_url")):
+            raise GitlabCreateMergeRequestError(
+                "Failed to create merge request: GitLab returned an empty or incomplete response"
+            )
+
+        await ocean.port_client.report_run_completed(
+            run,
+            success=True,
+            message=f"Merge request created: {merge_request['web_url']}",
+        )
+        await ocean.port_client.post_run_log(
+            run,
+            f"Merge request created: {merge_request['web_url']}",
+            should_raise=False,
+        )
+        logger.info(
+            f"Merge request {merge_request['id']} created in project {project}",
+            merge_request_id=merge_request["id"],
+            project=project,
+            source_branch=source_branch,
+            target_branch=target_branch,
+        )

--- a/integrations/gitlab-v2/gitlab/actions/registry.py
+++ b/integrations/gitlab-v2/gitlab/actions/registry.py
@@ -1,7 +1,9 @@
 from port_ocean.context.ocean import ocean
 
+from gitlab.actions.create_merge_request_executor import CreateMergeRequestExecutor
 from gitlab.actions.trigger_pipeline_executor import TriggerPipelineExecutor
 
 
 def register_actions_executors() -> None:
     ocean.register_action_executor(TriggerPipelineExecutor())
+    ocean.register_action_executor(CreateMergeRequestExecutor())

--- a/integrations/gitlab-v2/gitlab/clients/gitlab_client.py
+++ b/integrations/gitlab-v2/gitlab/clients/gitlab_client.py
@@ -1536,6 +1536,24 @@ class GitLabClient:
             "POST", f"projects/{encoded_id}/pipeline", data=data
         )
 
+    async def create_merge_request(
+        self,
+        project_id: str | int,
+        source_branch: str,
+        target_branch: str,
+        title: str,
+    ) -> dict[str, Any]:
+        """Create a merge request in the given project."""
+        encoded_id = quote(str(project_id), safe="")
+        data = {
+            "source_branch": source_branch,
+            "target_branch": target_branch,
+            "title": title,
+        }
+        return await self.rest.send_api_request(
+            "POST", f"projects/{encoded_id}/merge_requests", data=data
+        )
+
     def get_rate_limit_status(self) -> Optional[RateLimitInfo]:
         """Return the most-recently observed rate-limit info, or None if unknown."""
         return self.rest._rate_limiter.rate_limit_info

--- a/integrations/gitlab-v2/gitlab/helpers/exceptions.py
+++ b/integrations/gitlab-v2/gitlab/helpers/exceptions.py
@@ -7,6 +7,21 @@ class MissingExecutionPropertyError(Exception):
     """Raised when a required execution property is absent from the action run."""
 
 
+def _response_detail(response: httpx.Response) -> str:
+    try:
+        body = response.json()
+    except Exception:
+        body = None
+
+    if isinstance(body, dict):
+        for key in ("error_description", "message", "error"):
+            if (value := body.get(key)) is not None:
+                return value if isinstance(value, str) else json.dumps(value)
+
+    text = response.text.strip()
+    return text or f"HTTP {response.status_code}"
+
+
 class GitlabTriggerPipelineError(Exception):
     """Raised when the GitLab API returns an error while triggering a pipeline."""
 
@@ -14,19 +29,14 @@ class GitlabTriggerPipelineError(Exception):
     def from_response(
         cls, response: httpx.Response, prefix: str
     ) -> "GitlabTriggerPipelineError":
-        return cls(f"{prefix}: {cls._response_detail(response)}")
+        return cls(f"{prefix}: {_response_detail(response)}")
 
-    @staticmethod
-    def _response_detail(response: httpx.Response) -> str:
-        try:
-            body = response.json()
-        except Exception:
-            body = None
 
-        if isinstance(body, dict):
-            for key in ("error_description", "message", "error"):
-                if (value := body.get(key)) is not None:
-                    return value if isinstance(value, str) else json.dumps(value)
+class GitlabCreateMergeRequestError(Exception):
+    """Raised when the GitLab API returns an error while creating a merge request."""
 
-        text = response.text.strip()
-        return text or f"HTTP {response.status_code}"
+    @classmethod
+    def from_response(
+        cls, response: httpx.Response, prefix: str
+    ) -> "GitlabCreateMergeRequestError":
+        return cls(f"{prefix}: {_response_detail(response)}")

--- a/integrations/gitlab-v2/tests/actions/test_create_merge_request_executor.py
+++ b/integrations/gitlab-v2/tests/actions/test_create_merge_request_executor.py
@@ -1,0 +1,193 @@
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from port_ocean.core.models import (
+    WorkflowIntegrationActionConfig,
+    WorkflowNodeRun,
+    WorkflowNodeRunStatus,
+)
+
+from gitlab.actions.create_merge_request_executor import CreateMergeRequestExecutor
+from gitlab.helpers.exceptions import (
+    GitlabCreateMergeRequestError,
+    MissingExecutionPropertyError,
+)
+
+MERGE_REQUEST_RESPONSE = {
+    "id": 7,
+    "iid": 3,
+    "web_url": "https://gitlab.com/my-group/my-project/-/merge_requests/3",
+    "source_branch": "feature-branch",
+    "target_branch": "main",
+    "title": "Add new feature",
+}
+
+
+def make_run(execution_properties: dict[str, Any]) -> WorkflowNodeRun:
+    return WorkflowNodeRun(
+        id="run-1",
+        status=WorkflowNodeRunStatus.IN_PROGRESS,
+        config=WorkflowIntegrationActionConfig(
+            type="INTEGRATION_ACTION",
+            installationId="test-installation-id",
+            integrationProvider="gitlab",
+            integrationInvocationType="create_merge_request",
+            integrationActionExecutionProperties=execution_properties,
+        ),
+    )
+
+
+@pytest.fixture
+def executor() -> CreateMergeRequestExecutor:
+    with patch("gitlab.actions.abstract_gitlab_executor.create_gitlab_client"):
+        ex = CreateMergeRequestExecutor()
+        ex.client = MagicMock()
+        ex.client.create_merge_request = AsyncMock(return_value=MERGE_REQUEST_RESPONSE)
+        return ex
+
+
+@pytest.fixture
+def mock_port_client() -> MagicMock:
+    client = MagicMock()
+    client.report_run_completed = AsyncMock()
+    client.post_run_log = AsyncMock()
+    return client
+
+
+@pytest.mark.asyncio
+class TestCreateMergeRequestExecutor:
+    async def test_happy_path(
+        self, executor: CreateMergeRequestExecutor, mock_port_client: MagicMock
+    ) -> None:
+        run = make_run(
+            {
+                "project": "my-group/my-project",
+                "sourceBranch": "feature-branch",
+                "targetBranch": "main",
+                "title": "Add new feature",
+            }
+        )
+        with patch("gitlab.actions.create_merge_request_executor.ocean") as mock_ocean:
+            mock_ocean.port_client = mock_port_client
+            await executor.execute(run)
+
+        executor.client.create_merge_request.assert_called_once_with(  # type: ignore[attr-defined]
+            "my-group/my-project",
+            "feature-branch",
+            "main",
+            "Add new feature",
+        )
+        mock_port_client.report_run_completed.assert_called_once_with(
+            run,
+            success=True,
+            message=f"Merge request created: {MERGE_REQUEST_RESPONSE['web_url']}",
+        )
+        assert mock_port_client.post_run_log.await_count == 2
+
+    async def test_missing_project_raises(
+        self, executor: CreateMergeRequestExecutor
+    ) -> None:
+        run = make_run(
+            {
+                "sourceBranch": "feature-branch",
+                "targetBranch": "main",
+                "title": "Add new feature",
+            }
+        )
+        with pytest.raises(MissingExecutionPropertyError, match="project is required"):
+            await executor.execute(run)
+
+    async def test_missing_source_branch_raises(
+        self, executor: CreateMergeRequestExecutor
+    ) -> None:
+        run = make_run(
+            {
+                "project": "my-group/my-project",
+                "targetBranch": "main",
+                "title": "Add new feature",
+            }
+        )
+        with pytest.raises(
+            MissingExecutionPropertyError, match="sourceBranch is required"
+        ):
+            await executor.execute(run)
+
+    async def test_missing_target_branch_raises(
+        self, executor: CreateMergeRequestExecutor
+    ) -> None:
+        run = make_run(
+            {
+                "project": "my-group/my-project",
+                "sourceBranch": "feature-branch",
+                "title": "Add new feature",
+            }
+        )
+        with pytest.raises(
+            MissingExecutionPropertyError, match="targetBranch is required"
+        ):
+            await executor.execute(run)
+
+    async def test_missing_title_raises(
+        self, executor: CreateMergeRequestExecutor
+    ) -> None:
+        run = make_run(
+            {
+                "project": "my-group/my-project",
+                "sourceBranch": "feature-branch",
+                "targetBranch": "main",
+            }
+        )
+        with pytest.raises(MissingExecutionPropertyError, match="title is required"):
+            await executor.execute(run)
+
+    async def test_api_error_raises_create_error(
+        self, executor: CreateMergeRequestExecutor
+    ) -> None:
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"message": "403 Forbidden"}
+        executor.client.create_merge_request = AsyncMock(  # type: ignore[method-assign]
+            side_effect=httpx.HTTPStatusError(
+                "403",
+                request=MagicMock(),
+                response=mock_response,
+            ),
+        )
+        run = make_run(
+            {
+                "project": "my-group/my-project",
+                "sourceBranch": "feature-branch",
+                "targetBranch": "main",
+                "title": "Add new feature",
+            }
+        )
+        with (
+            patch("gitlab.actions.create_merge_request_executor.ocean") as mock_ocean,
+            pytest.raises(GitlabCreateMergeRequestError, match="403 Forbidden"),
+        ):
+            mock_ocean.port_client = MagicMock()
+            mock_ocean.port_client.post_run_log = AsyncMock()
+            await executor.execute(run)
+
+    async def test_incomplete_response_raises(
+        self, executor: CreateMergeRequestExecutor
+    ) -> None:
+        executor.client.create_merge_request = AsyncMock(  # type: ignore[method-assign]
+            return_value={"id": 7},
+        )
+        run = make_run(
+            {
+                "project": "my-group/my-project",
+                "sourceBranch": "feature-branch",
+                "targetBranch": "main",
+                "title": "Add new feature",
+            }
+        )
+        with (
+            patch("gitlab.actions.create_merge_request_executor.ocean") as mock_ocean,
+            pytest.raises(GitlabCreateMergeRequestError, match="empty or incomplete"),
+        ):
+            mock_ocean.port_client = MagicMock()
+            mock_ocean.port_client.post_run_log = AsyncMock()
+            await executor.execute(run)


### PR DESCRIPTION
## Summary
- Add a sync `create_merge_request` action to gitlab-v2 for `POST /projects/:id/merge_requests`.
- Required inputs: `project`, `sourceBranch`, `targetBranch`, `title`.
- Include executor tests and a minor release-intent file.

Companion Port PR adds the workflow-builder node for this action.

## Test plan
- [ ] `cd integrations/gitlab-v2 && make test`
- [ ] `cd integrations/gitlab-v2 && make lint`
- [ ] Confirm `.port/spec.json` `actions[].name` is `create_merge_request` and input names match executor `execution_properties` keys

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The action mutates GitLab state (creates MRs) using the integration token; mistakes in workflows could open unwanted merge requests, though scope is limited to the new action path and mirrors existing trigger_pipeline patterns.
> 
> **Overview**
> Adds a **sync Port action** `create_merge_request` so workflows can open GitLab merge requests via `POST /projects/:id/merge_requests`.
> 
> Port **`.port/spec.json`** declares required inputs `project`, `sourceBranch`, `targetBranch`, and `title`. **`CreateMergeRequestExecutor`** validates those properties, logs progress, calls the client, and on success reports completion with the MR `web_url`; API failures map to **`GitlabCreateMergeRequestError`**, with a shared **`_response_detail`** helper extracted from the pipeline error path.
> 
> **`GitLabClient.create_merge_request`** wraps the REST call. The executor is registered in **`registry.py`**, covered by unit tests, and tagged for a **minor** release in `.ocean-release/create-merge-request.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1afeed3f2a58d352b675714a5f152cd80ded4640. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->