### PR TITLE
[Integration][GitHub] Add pull request comment actions

### DIFF
--- a/integrations/github/.ocean-release/pr-comment-actions.yaml
+++ b/integrations/github/.ocean-release/pr-comment-actions.yaml
@@ -1,0 +1,3 @@
+bump: minor
+changelog-type: feature
+changelog: Added Pull Request comment actions (create, edit, delete), enabling Port Workflows to manage GitHub Pull Request comments directly

--- a/integrations/github/.port/spec.json
+++ b/integrations/github/.port/spec.json
@@ -330,6 +330,104 @@
           "required": true
         }
       ]
+    },
+    {
+      "name": "create_pr_comment",
+      "icon": "Github",
+      "description": "Create a GitHub Pull Request Comment",
+      "inputs": [
+        {
+          "name": "org",
+          "title": "Organization",
+          "type": "string",
+          "description": "The GitHub organization or user that owns the repository",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "title": "Repository",
+          "type": "string",
+          "description": "The name of the GitHub repository",
+          "required": true
+        },
+        {
+          "name": "prNumber",
+          "title": "Pull request number",
+          "type": "string",
+          "description": "The number of the pull request to comment on",
+          "required": true
+        },
+        {
+          "name": "body",
+          "title": "Comment body",
+          "type": "string",
+          "description": "The comment text",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "edit_pr_comment",
+      "icon": "Github",
+      "description": "Edit a GitHub Pull Request Comment",
+      "inputs": [
+        {
+          "name": "org",
+          "title": "Organization",
+          "type": "string",
+          "description": "The GitHub organization or user that owns the repository",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "title": "Repository",
+          "type": "string",
+          "description": "The name of the GitHub repository",
+          "required": true
+        },
+        {
+          "name": "commentId",
+          "title": "Comment ID",
+          "type": "string",
+          "description": "The ID of the comment to edit",
+          "required": true
+        },
+        {
+          "name": "body",
+          "title": "New body",
+          "type": "string",
+          "description": "The updated comment text",
+          "required": true
+        }
+      ]
+    },
+    {
+      "name": "delete_pr_comment",
+      "icon": "Github",
+      "description": "Delete a GitHub Pull Request Comment",
+      "inputs": [
+        {
+          "name": "org",
+          "title": "Organization",
+          "type": "string",
+          "description": "The GitHub organization or user that owns the repository",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "title": "Repository",
+          "type": "string",
+          "description": "The name of the GitHub repository",
+          "required": true
+        },
+        {
+          "name": "commentId",
+          "title": "Comment ID",
+          "type": "string",
+          "description": "The ID of the comment to delete",
+          "required": true
+        }
+      ]
     }
   ],
   "installationDocs": {

--- a/integrations/github/github/actions/abstract_github_executor.py
+++ b/integrations/github/github/actions/abstract_github_executor.py
@@ -1,6 +1,6 @@
-from abc import abstractmethod
-
+from github.clients.client_factory import create_github_client_for_org
 from github.clients.http.base_client import AbstractGithubClient
+from github.helpers.exceptions import InvalidActionParametersException
 from port_ocean.core.handlers.actions.abstract_executor import AbstractExecutor
 from port_ocean.core.models import IntegrationRun
 
@@ -8,11 +8,13 @@ MIN_REMAINING_RATE_LIMIT_FOR_EXECUTE_WORKFLOW = 20
 
 
 class AbstractGithubExecutor(AbstractExecutor):
-    @abstractmethod
     async def _get_execution_clients(
         self, run: IntegrationRun
     ) -> list[AbstractGithubClient]:
-        pass
+        organization = run.execution_properties.get("org")
+        if not isinstance(organization, str):
+            raise InvalidActionParametersException("org is required")
+        return [await create_github_client_for_org(organization)]
 
     def _is_client_close_to_rate_limit(self, client: AbstractGithubClient) -> bool:
         info = client.get_rate_limit_status()

--- a/integrations/github/github/actions/create_pr_comment_executor.py
+++ b/integrations/github/github/actions/create_pr_comment_executor.py
@@ -1,0 +1,78 @@
+import httpx
+from loguru import logger
+from port_ocean.context.ocean import ocean
+from port_ocean.core.models import IntegrationRun
+
+from github.actions.abstract_github_executor import AbstractGithubExecutor
+from github.actions.exceptions import PullRequestCommentError
+from github.clients.http.rest_client import GithubRestClient
+from github.helpers.exceptions import InvalidActionParametersException
+
+
+class CreatePrCommentExecutor(AbstractGithubExecutor):
+    ACTION_NAME = "create_pr_comment"
+    WEBHOOK_PROCESSOR_CLASS = None
+
+    async def _get_partition_key(self, run: IntegrationRun) -> str | None:
+        org = run.execution_properties.get("org")
+        repo = run.execution_properties.get("repo")
+        if not org or not repo:
+            return None
+        return f"{org}/{repo}"
+
+    async def execute(self, run: IntegrationRun) -> None:
+        org = run.execution_properties.get("org")
+        repo = run.execution_properties.get("repo")
+        pr_number = run.execution_properties.get("prNumber")
+        body = run.execution_properties.get("body")
+
+        if not (org and repo and pr_number and body):
+            raise InvalidActionParametersException(
+                "org, repo, prNumber, and body are required"
+            )
+
+        rest_client = (await self._get_execution_clients(run))[0]
+        if not isinstance(rest_client, GithubRestClient):
+            raise InvalidActionParametersException("GitHub REST client is required")
+
+        await ocean.port_client.post_run_log(
+            run,
+            f"Creating comment on pull request #{pr_number} in {org}/{repo}",
+            should_raise=False,
+        )
+
+        try:
+            comment = await rest_client.send_api_request(
+                f"{rest_client.base_url}/repos/{org}/{repo}/issues/{pr_number}/comments",
+                method="POST",
+                json_data={"body": body},
+                ignore_default_errors=False,
+            )
+        except httpx.HTTPStatusError as e:
+            raise PullRequestCommentError.from_response(
+                e.response,
+                f"Could not create comment on pull request #{pr_number} in {org}/{repo}",
+            )
+
+        if not comment or "id" not in comment or "html_url" not in comment:
+            logger.warning(
+                f"Received empty or incomplete response from GitHub for comment creation on pull request #{pr_number} in {org}/{repo}",
+                org=org,
+                repo=repo,
+                pr_number=pr_number,
+            )
+            raise PullRequestCommentError(
+                "Failed to create comment: upstream returned an empty or incomplete response"
+            )
+
+        logger.info(
+            f"Created comment {comment['id']} on pull request #{pr_number} in {org}/{repo}",
+            comment_id=comment["id"],
+            html_url=comment["html_url"],
+        )
+
+        await ocean.port_client.report_run_completed(
+            run,
+            success=True,
+            message=f"Comment created on pull request #{pr_number}: {comment['html_url']}",
+        )

--- a/integrations/github/github/actions/delete_pr_comment_executor.py
+++ b/integrations/github/github/actions/delete_pr_comment_executor.py
@@ -1,0 +1,72 @@
+import httpx
+from loguru import logger
+from port_ocean.context.ocean import ocean
+from port_ocean.core.models import IntegrationRun
+
+from github.actions.abstract_github_executor import AbstractGithubExecutor
+from github.actions.exceptions import PullRequestCommentError
+from github.clients.http.rest_client import GithubRestClient
+from github.helpers.exceptions import InvalidActionParametersException
+
+
+class DeletePrCommentExecutor(AbstractGithubExecutor):
+    ACTION_NAME = "delete_pr_comment"
+    WEBHOOK_PROCESSOR_CLASS = None
+
+    async def _get_partition_key(self, run: IntegrationRun) -> str | None:
+        return None
+
+    async def execute(self, run: IntegrationRun) -> None:
+        org = run.execution_properties.get("org")
+        repo = run.execution_properties.get("repo")
+        comment_id = run.execution_properties.get("commentId")
+
+        if not (org and repo and comment_id):
+            raise InvalidActionParametersException(
+                "org, repo, and commentId are required"
+            )
+
+        rest_client = (await self._get_execution_clients(run))[0]
+        if not isinstance(rest_client, GithubRestClient):
+            raise InvalidActionParametersException("GitHub REST client is required")
+
+        await ocean.port_client.post_run_log(
+            run,
+            f"Deleting comment {comment_id} in {org}/{repo}",
+            should_raise=False,
+        )
+
+        try:
+            response = await rest_client.make_request(
+                f"{rest_client.base_url}/repos/{org}/{repo}/issues/comments/{comment_id}",
+                method="DELETE",
+                ignore_default_errors=False,
+            )
+        except httpx.HTTPStatusError as e:
+            raise PullRequestCommentError.from_response(
+                e.response,
+                f"Could not delete comment {comment_id} in {org}/{repo}",
+            )
+
+        if response.status_code != 204:
+            logger.warning(
+                f"Unexpected status code {response.status_code} when deleting comment {comment_id} in {org}/{repo}",
+                org=org,
+                repo=repo,
+                comment_id=comment_id,
+                status_code=response.status_code,
+            )
+            raise PullRequestCommentError(
+                f"Failed to delete comment: unexpected status code {response.status_code}"
+            )
+
+        logger.info(
+            f"Deleted comment {comment_id} in {org}/{repo}",
+            comment_id=comment_id,
+        )
+
+        await ocean.port_client.report_run_completed(
+            run,
+            success=True,
+            message=f"Comment {comment_id} deleted from {org}/{repo}",
+        )

--- a/integrations/github/github/actions/dispatch_workflow_executor.py
+++ b/integrations/github/github/actions/dispatch_workflow_executor.py
@@ -23,10 +23,6 @@ from github.webhook.webhook_processors.workflow_run.dispatch_workflow_webhook_pr
     DispatchWorkflowWebhookProcessor,
 )
 from github.core.exporters.workflow_runs_exporter import RestWorkflowRunExporter
-from github.clients.client_factory import (
-    create_github_client_for_org,
-)
-from github.clients.http.base_client import AbstractGithubClient
 from github.clients.http.rest_client import GithubRestClient
 from port_ocean.context.ocean import ocean
 
@@ -129,14 +125,6 @@ class DispatchWorkflowExecutor(AbstractGithubExecutor):
             return None
 
         return f"{organization}/{repo}/{workflow}"
-
-    async def _get_execution_clients(
-        self, run: IntegrationRun
-    ) -> list[AbstractGithubClient]:
-        organization = run.execution_properties.get("org")
-        if not isinstance(organization, str):
-            raise InvalidActionParametersException("org is required")
-        return [await create_github_client_for_org(organization)]
 
     async def _get_default_ref(
         self, rest_client: GithubRestClient, organization: str, repo_name: str

--- a/integrations/github/github/actions/edit_pr_comment_executor.py
+++ b/integrations/github/github/actions/edit_pr_comment_executor.py
@@ -1,0 +1,74 @@
+import httpx
+from loguru import logger
+from port_ocean.context.ocean import ocean
+from port_ocean.core.models import IntegrationRun
+
+from github.actions.abstract_github_executor import AbstractGithubExecutor
+from github.actions.exceptions import PullRequestCommentError
+from github.clients.http.rest_client import GithubRestClient
+from github.helpers.exceptions import InvalidActionParametersException
+
+
+class EditPrCommentExecutor(AbstractGithubExecutor):
+    ACTION_NAME = "edit_pr_comment"
+    WEBHOOK_PROCESSOR_CLASS = None
+
+    async def _get_partition_key(self, run: IntegrationRun) -> str | None:
+        return None
+
+    async def execute(self, run: IntegrationRun) -> None:
+        org = run.execution_properties.get("org")
+        repo = run.execution_properties.get("repo")
+        comment_id = run.execution_properties.get("commentId")
+        body = run.execution_properties.get("body")
+
+        if not (org and repo and comment_id and body):
+            raise InvalidActionParametersException(
+                "org, repo, commentId, and body are required"
+            )
+
+        rest_client = (await self._get_execution_clients(run))[0]
+        if not isinstance(rest_client, GithubRestClient):
+            raise InvalidActionParametersException("GitHub REST client is required")
+
+        await ocean.port_client.post_run_log(
+            run,
+            f"Editing comment {comment_id} in {org}/{repo}",
+            should_raise=False,
+        )
+
+        try:
+            comment = await rest_client.send_api_request(
+                f"{rest_client.base_url}/repos/{org}/{repo}/issues/comments/{comment_id}",
+                method="PATCH",
+                json_data={"body": body},
+                ignore_default_errors=False,
+            )
+        except httpx.HTTPStatusError as e:
+            raise PullRequestCommentError.from_response(
+                e.response,
+                f"Could not edit comment {comment_id} in {org}/{repo}",
+            )
+
+        if not comment or "id" not in comment or "html_url" not in comment:
+            logger.warning(
+                f"Received empty or incomplete response from GitHub for comment edit in {org}/{repo}",
+                org=org,
+                repo=repo,
+                comment_id=comment_id,
+            )
+            raise PullRequestCommentError(
+                "Failed to edit comment: upstream returned an empty or incomplete response"
+            )
+
+        logger.info(
+            f"Edited comment {comment['id']} in {org}/{repo}",
+            comment_id=comment["id"],
+            html_url=comment["html_url"],
+        )
+
+        await ocean.port_client.report_run_completed(
+            run,
+            success=True,
+            message=f"Comment updated: {comment['html_url']}",
+        )

--- a/integrations/github/github/actions/exceptions.py
+++ b/integrations/github/github/actions/exceptions.py
@@ -1,0 +1,11 @@
+import httpx
+from github.actions.utils import extract_error_message
+from port_ocean.exceptions.execution_manager import ActionExecutionError
+
+
+class PullRequestCommentError(ActionExecutionError):
+    @classmethod
+    def from_response(
+        cls, response: httpx.Response, prefix: str
+    ) -> "PullRequestCommentError":
+        return cls(f"{prefix}: {extract_error_message(response)}")

--- a/integrations/github/github/actions/registry.py
+++ b/integrations/github/github/actions/registry.py
@@ -11,6 +11,9 @@ from github.actions.external_custom_properties.bulk_update_external_custom_prope
 from github.actions.external_custom_properties.update_repo_external_custom_properties_executor import (
     UpdateRepoExternalCustomPropertiesExecutor,
 )
+from github.actions.create_pr_comment_executor import CreatePrCommentExecutor
+from github.actions.edit_pr_comment_executor import EditPrCommentExecutor
+from github.actions.delete_pr_comment_executor import DeletePrCommentExecutor
 
 
 def register_actions_executors() -> None:
@@ -19,3 +22,6 @@ def register_actions_executors() -> None:
     ocean.register_action_executor(UpdateRepoExternalCustomPropertiesExecutor())
     ocean.register_action_executor(BulkUpdateExternalCustomPropertyValuesExecutor())
     ocean.register_action_executor(BulkDeleteExternalCustomPropertyValuesExecutor())
+    ocean.register_action_executor(CreatePrCommentExecutor())
+    ocean.register_action_executor(EditPrCommentExecutor())
+    ocean.register_action_executor(DeletePrCommentExecutor())

--- a/integrations/github/tests/github/actions/conftest.py
+++ b/integrations/github/tests/github/actions/conftest.py
@@ -1,0 +1,42 @@
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from github.clients.http.rest_client import GithubRestClient
+from port_ocean.core.models import (
+    ActionRun,
+    IntegrationActionInvocationPayload,
+    RunStatus,
+)
+
+
+def make_action_run(
+    action_name: str, execution_properties: dict[str, Any]
+) -> ActionRun:
+    return ActionRun(
+        id="run-123",
+        status=RunStatus.IN_PROGRESS,
+        action=ActionRun.Action(identifier=action_name),
+        payload=IntegrationActionInvocationPayload(
+            type="INTEGRATION_ACTION",
+            installationId="inst-1",
+            integrationActionType=action_name,
+            integrationActionExecutionProperties=execution_properties,
+        ),
+    )
+
+
+@pytest.fixture
+def mock_port_client(patched_ocean: MagicMock) -> MagicMock:
+    return patched_ocean.port_client
+
+
+@pytest.fixture
+def mock_rest_client() -> MagicMock:
+    client = MagicMock(spec=GithubRestClient)
+    client.base_url = "https://api.github.com"
+    client.send_api_request = AsyncMock()
+    client.make_request = AsyncMock()
+    client.get_rate_limit_status = MagicMock(return_value=None)
+    return client

--- a/integrations/github/tests/github/actions/test_create_pr_comment_executor.py
+++ b/integrations/github/tests/github/actions/test_create_pr_comment_executor.py
@@ -6,13 +6,9 @@ import pytest
 
 from github.actions.create_pr_comment_executor import CreatePrCommentExecutor
 from github.actions.exceptions import PullRequestCommentError
-from github.clients.http.rest_client import GithubRestClient
 from github.helpers.exceptions import InvalidActionParametersException
-from port_ocean.core.models import (
-    ActionRun,
-    IntegrationActionInvocationPayload,
-    RunStatus,
-)
+from port_ocean.core.models import ActionRun
+from tests.github.actions.conftest import make_action_run
 
 COMMENT_RESPONSE = {
     "id": 555,
@@ -22,17 +18,7 @@ COMMENT_RESPONSE = {
 
 
 def make_run(execution_properties: dict[str, Any]) -> ActionRun:
-    return ActionRun(
-        id="run-123",
-        status=RunStatus.IN_PROGRESS,
-        action=ActionRun.Action(identifier="create_pr_comment"),
-        payload=IntegrationActionInvocationPayload(
-            type="INTEGRATION_ACTION",
-            installationId="inst-1",
-            integrationActionType="create_pr_comment",
-            integrationActionExecutionProperties=execution_properties,
-        ),
-    )
+    return make_action_run("create_pr_comment", execution_properties)
 
 
 @pytest.fixture(autouse=True)
@@ -43,20 +29,6 @@ def patched_ocean() -> Generator[MagicMock, None, None]:
     with patch("github.actions.create_pr_comment_executor.ocean") as mock_ocean:
         mock_ocean.port_client = mock_client
         yield mock_ocean
-
-
-@pytest.fixture
-def mock_port_client(patched_ocean: MagicMock) -> MagicMock:
-    return patched_ocean.port_client
-
-
-@pytest.fixture
-def mock_rest_client() -> MagicMock:
-    client = MagicMock(spec=GithubRestClient)
-    client.base_url = "https://api.github.com"
-    client.send_api_request = AsyncMock()
-    client.get_rate_limit_status = MagicMock(return_value=None)
-    return client
 
 
 @pytest.fixture
@@ -82,7 +54,7 @@ class TestCreatePrCommentExecutor:
             {
                 "org": "port-labs",
                 "repo": "ocean",
-                "prNumber": 42,
+                "prNumber": "42",
                 "body": "Test comment",
             }
         )
@@ -110,7 +82,7 @@ class TestCreatePrCommentExecutor:
         executor: CreatePrCommentExecutor,
         mock_rest_client: MagicMock,
     ) -> None:
-        run = make_run({"org": "port-labs", "repo": "ocean", "prNumber": 42})
+        run = make_run({"org": "port-labs", "repo": "ocean", "prNumber": "42"})
 
         with pytest.raises(
             InvalidActionParametersException,
@@ -130,7 +102,7 @@ class TestCreatePrCommentExecutor:
             {
                 "org": "port-labs",
                 "repo": "ocean",
-                "prNumber": 42,
+                "prNumber": "42",
                 "body": "Test comment",
             }
         )
@@ -157,7 +129,7 @@ class TestCreatePrCommentExecutor:
             {
                 "org": "port-labs",
                 "repo": "ocean",
-                "prNumber": 42,
+                "prNumber": "42",
                 "body": "Test comment",
             }
         )
@@ -176,7 +148,7 @@ class TestCreatePrCommentExecutor:
             {
                 "org": "port-labs",
                 "repo": "ocean",
-                "prNumber": 42,
+                "prNumber": "42",
                 "body": "Test comment",
             }
         )

--- a/integrations/github/tests/github/actions/test_create_pr_comment_executor.py
+++ b/integrations/github/tests/github/actions/test_create_pr_comment_executor.py
@@ -1,0 +1,191 @@
+from typing import Any, Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from github.actions.create_pr_comment_executor import CreatePrCommentExecutor
+from github.actions.exceptions import PullRequestCommentError
+from github.clients.http.rest_client import GithubRestClient
+from github.helpers.exceptions import InvalidActionParametersException
+from port_ocean.core.models import (
+    ActionRun,
+    IntegrationActionInvocationPayload,
+    RunStatus,
+)
+
+COMMENT_RESPONSE = {
+    "id": 555,
+    "body": "Test comment",
+    "html_url": "https://github.com/port-labs/ocean/pull/42#issuecomment-555",
+}
+
+
+def make_run(execution_properties: dict[str, Any]) -> ActionRun:
+    return ActionRun(
+        id="run-123",
+        status=RunStatus.IN_PROGRESS,
+        action=ActionRun.Action(identifier="create_pr_comment"),
+        payload=IntegrationActionInvocationPayload(
+            type="INTEGRATION_ACTION",
+            installationId="inst-1",
+            integrationActionType="create_pr_comment",
+            integrationActionExecutionProperties=execution_properties,
+        ),
+    )
+
+
+@pytest.fixture(autouse=True)
+def patched_ocean() -> Generator[MagicMock, None, None]:
+    mock_client = MagicMock()
+    mock_client.post_run_log = AsyncMock()
+    mock_client.report_run_completed = AsyncMock()
+    with patch("github.actions.create_pr_comment_executor.ocean") as mock_ocean:
+        mock_ocean.port_client = mock_client
+        yield mock_ocean
+
+
+@pytest.fixture
+def mock_port_client(patched_ocean: MagicMock) -> MagicMock:
+    return patched_ocean.port_client
+
+
+@pytest.fixture
+def mock_rest_client() -> MagicMock:
+    client = MagicMock(spec=GithubRestClient)
+    client.base_url = "https://api.github.com"
+    client.send_api_request = AsyncMock()
+    client.get_rate_limit_status = MagicMock(return_value=None)
+    return client
+
+
+@pytest.fixture
+def executor(
+    mock_rest_client: MagicMock,
+) -> Generator[CreatePrCommentExecutor, None, None]:
+    with patch(
+        "github.actions.abstract_github_executor.create_github_client_for_org",
+        new=AsyncMock(return_value=mock_rest_client),
+    ):
+        yield CreatePrCommentExecutor()
+
+
+class TestCreatePrCommentExecutor:
+    @pytest.mark.asyncio
+    async def test_happy_path(
+        self,
+        executor: CreatePrCommentExecutor,
+        mock_rest_client: MagicMock,
+        mock_port_client: MagicMock,
+    ) -> None:
+        run = make_run(
+            {
+                "org": "port-labs",
+                "repo": "ocean",
+                "prNumber": 42,
+                "body": "Test comment",
+            }
+        )
+
+        mock_rest_client.send_api_request.return_value = COMMENT_RESPONSE
+
+        await executor.execute(run)
+
+        mock_rest_client.send_api_request.assert_awaited_once_with(
+            "https://api.github.com/repos/port-labs/ocean/issues/42/comments",
+            method="POST",
+            json_data={"body": "Test comment"},
+            ignore_default_errors=False,
+        )
+
+        mock_port_client.report_run_completed.assert_awaited_once_with(
+            run,
+            success=True,
+            message="Comment created on pull request #42: https://github.com/port-labs/ocean/pull/42#issuecomment-555",
+        )
+
+    @pytest.mark.asyncio
+    async def test_missing_required_inputs(
+        self,
+        executor: CreatePrCommentExecutor,
+        mock_rest_client: MagicMock,
+    ) -> None:
+        run = make_run({"org": "port-labs", "repo": "ocean", "prNumber": 42})
+
+        with pytest.raises(
+            InvalidActionParametersException,
+            match="org, repo, prNumber, and body are required",
+        ):
+            await executor.execute(run)
+
+        mock_rest_client.send_api_request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_upstream_http_error(
+        self,
+        executor: CreatePrCommentExecutor,
+        mock_rest_client: MagicMock,
+    ) -> None:
+        run = make_run(
+            {
+                "org": "port-labs",
+                "repo": "ocean",
+                "prNumber": 42,
+                "body": "Test comment",
+            }
+        )
+
+        request = httpx.Request(
+            "POST",
+            "https://api.github.com/repos/port-labs/ocean/issues/42/comments",
+        )
+        response = httpx.Response(404, json={"message": "Not Found"}, request=request)
+        mock_rest_client.send_api_request.side_effect = httpx.HTTPStatusError(
+            "404", request=request, response=response
+        )
+
+        with pytest.raises(PullRequestCommentError, match="Could not create comment"):
+            await executor.execute(run)
+
+    @pytest.mark.asyncio
+    async def test_malformed_response(
+        self,
+        executor: CreatePrCommentExecutor,
+        mock_rest_client: MagicMock,
+    ) -> None:
+        run = make_run(
+            {
+                "org": "port-labs",
+                "repo": "ocean",
+                "prNumber": 42,
+                "body": "Test comment",
+            }
+        )
+
+        mock_rest_client.send_api_request.return_value = {}
+
+        with pytest.raises(PullRequestCommentError, match="empty or incomplete"):
+            await executor.execute(run)
+
+    @pytest.mark.asyncio
+    async def test_partition_key(
+        self,
+        executor: CreatePrCommentExecutor,
+    ) -> None:
+        run = make_run(
+            {
+                "org": "port-labs",
+                "repo": "ocean",
+                "prNumber": 42,
+                "body": "Test comment",
+            }
+        )
+        assert await executor._get_partition_key(run) == "port-labs/ocean"
+
+    @pytest.mark.asyncio
+    async def test_partition_key_missing_inputs_returns_none(
+        self,
+        executor: CreatePrCommentExecutor,
+    ) -> None:
+        run = make_run({"org": "port-labs"})
+        assert await executor._get_partition_key(run) is None

--- a/integrations/github/tests/github/actions/test_delete_pr_comment_executor.py
+++ b/integrations/github/tests/github/actions/test_delete_pr_comment_executor.py
@@ -1,0 +1,185 @@
+from typing import Any, Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from github.actions.delete_pr_comment_executor import DeletePrCommentExecutor
+from github.actions.exceptions import PullRequestCommentError
+from github.clients.http.rest_client import GithubRestClient
+from github.helpers.exceptions import InvalidActionParametersException
+from port_ocean.core.models import (
+    ActionRun,
+    IntegrationActionInvocationPayload,
+    RunStatus,
+)
+
+
+def make_run(execution_properties: dict[str, Any]) -> ActionRun:
+    return ActionRun(
+        id="run-123",
+        status=RunStatus.IN_PROGRESS,
+        action=ActionRun.Action(identifier="delete_pr_comment"),
+        payload=IntegrationActionInvocationPayload(
+            type="INTEGRATION_ACTION",
+            installationId="inst-1",
+            integrationActionType="delete_pr_comment",
+            integrationActionExecutionProperties=execution_properties,
+        ),
+    )
+
+
+@pytest.fixture(autouse=True)
+def patched_ocean() -> Generator[MagicMock, None, None]:
+    mock_client = MagicMock()
+    mock_client.post_run_log = AsyncMock()
+    mock_client.report_run_completed = AsyncMock()
+    with patch("github.actions.delete_pr_comment_executor.ocean") as mock_ocean:
+        mock_ocean.port_client = mock_client
+        yield mock_ocean
+
+
+@pytest.fixture
+def mock_port_client(patched_ocean: MagicMock) -> MagicMock:
+    return patched_ocean.port_client
+
+
+@pytest.fixture
+def mock_rest_client() -> MagicMock:
+    client = MagicMock(spec=GithubRestClient)
+    client.base_url = "https://api.github.com"
+    client.send_api_request = AsyncMock()
+    client.make_request = AsyncMock()
+    client.get_rate_limit_status = MagicMock(return_value=None)
+    return client
+
+
+@pytest.fixture
+def executor(
+    mock_rest_client: MagicMock,
+) -> Generator[DeletePrCommentExecutor, None, None]:
+    with patch(
+        "github.actions.abstract_github_executor.create_github_client_for_org",
+        new=AsyncMock(return_value=mock_rest_client),
+    ):
+        yield DeletePrCommentExecutor()
+
+
+class TestDeletePrCommentExecutor:
+    @pytest.mark.asyncio
+    async def test_happy_path(
+        self,
+        executor: DeletePrCommentExecutor,
+        mock_rest_client: MagicMock,
+        mock_port_client: MagicMock,
+    ) -> None:
+        run = make_run(
+            {
+                "org": "port-labs",
+                "repo": "ocean",
+                "commentId": 555,
+            }
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 204
+        mock_rest_client.make_request.return_value = mock_response
+
+        await executor.execute(run)
+
+        mock_rest_client.make_request.assert_awaited_once_with(
+            "https://api.github.com/repos/port-labs/ocean/issues/comments/555",
+            method="DELETE",
+            ignore_default_errors=False,
+        )
+
+        mock_port_client.report_run_completed.assert_awaited_once_with(
+            run,
+            success=True,
+            message="Comment 555 deleted from port-labs/ocean",
+        )
+
+    @pytest.mark.asyncio
+    async def test_missing_required_inputs(
+        self,
+        executor: DeletePrCommentExecutor,
+        mock_rest_client: MagicMock,
+    ) -> None:
+        run = make_run({"org": "port-labs", "repo": "ocean"})
+
+        with pytest.raises(
+            InvalidActionParametersException,
+            match="org, repo, and commentId are required",
+        ):
+            await executor.execute(run)
+
+        mock_rest_client.make_request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_upstream_http_error(
+        self,
+        executor: DeletePrCommentExecutor,
+        mock_rest_client: MagicMock,
+    ) -> None:
+        run = make_run(
+            {
+                "org": "port-labs",
+                "repo": "ocean",
+                "commentId": 555,
+            }
+        )
+
+        request = httpx.Request(
+            "DELETE",
+            "https://api.github.com/repos/port-labs/ocean/issues/comments/555",
+        )
+        response = httpx.Response(404, json={"message": "Not Found"}, request=request)
+        mock_rest_client.make_request.side_effect = httpx.HTTPStatusError(
+            "404", request=request, response=response
+        )
+
+        with pytest.raises(PullRequestCommentError, match="Could not delete comment"):
+            await executor.execute(run)
+
+    @pytest.mark.asyncio
+    async def test_unexpected_status_code(
+        self,
+        executor: DeletePrCommentExecutor,
+        mock_rest_client: MagicMock,
+    ) -> None:
+        run = make_run(
+            {
+                "org": "port-labs",
+                "repo": "ocean",
+                "commentId": 555,
+            }
+        )
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_rest_client.make_request.return_value = mock_response
+
+        with pytest.raises(PullRequestCommentError, match="unexpected status code 200"):
+            await executor.execute(run)
+
+    @pytest.mark.asyncio
+    async def test_partition_key(
+        self,
+        executor: DeletePrCommentExecutor,
+    ) -> None:
+        run = make_run(
+            {
+                "org": "port-labs",
+                "repo": "ocean",
+                "commentId": 555,
+            }
+        )
+        assert await executor._get_partition_key(run) is None
+
+    @pytest.mark.asyncio
+    async def test_partition_key_missing_inputs_returns_none(
+        self,
+        executor: DeletePrCommentExecutor,
+    ) -> None:
+        run = make_run({"org": "port-labs"})
+        assert await executor._get_partition_key(run) is None

--- a/integrations/github/tests/github/actions/test_delete_pr_comment_executor.py
+++ b/integrations/github/tests/github/actions/test_delete_pr_comment_executor.py
@@ -6,27 +6,13 @@ import pytest
 
 from github.actions.delete_pr_comment_executor import DeletePrCommentExecutor
 from github.actions.exceptions import PullRequestCommentError
-from github.clients.http.rest_client import GithubRestClient
 from github.helpers.exceptions import InvalidActionParametersException
-from port_ocean.core.models import (
-    ActionRun,
-    IntegrationActionInvocationPayload,
-    RunStatus,
-)
+from port_ocean.core.models import ActionRun
+from tests.github.actions.conftest import make_action_run
 
 
 def make_run(execution_properties: dict[str, Any]) -> ActionRun:
-    return ActionRun(
-        id="run-123",
-        status=RunStatus.IN_PROGRESS,
-        action=ActionRun.Action(identifier="delete_pr_comment"),
-        payload=IntegrationActionInvocationPayload(
-            type="INTEGRATION_ACTION",
-            installationId="inst-1",
-            integrationActionType="delete_pr_comment",
-            integrationActionExecutionProperties=execution_properties,
-        ),
-    )
+    return make_action_run("delete_pr_comment", execution_properties)
 
 
 @pytest.fixture(autouse=True)
@@ -37,21 +23,6 @@ def patched_ocean() -> Generator[MagicMock, None, None]:
     with patch("github.actions.delete_pr_comment_executor.ocean") as mock_ocean:
         mock_ocean.port_client = mock_client
         yield mock_ocean
-
-
-@pytest.fixture
-def mock_port_client(patched_ocean: MagicMock) -> MagicMock:
-    return patched_ocean.port_client
-
-
-@pytest.fixture
-def mock_rest_client() -> MagicMock:
-    client = MagicMock(spec=GithubRestClient)
-    client.base_url = "https://api.github.com"
-    client.send_api_request = AsyncMock()
-    client.make_request = AsyncMock()
-    client.get_rate_limit_status = MagicMock(return_value=None)
-    return client
 
 
 @pytest.fixture
@@ -77,7 +48,7 @@ class TestDeletePrCommentExecutor:
             {
                 "org": "port-labs",
                 "repo": "ocean",
-                "commentId": 555,
+                "commentId": "555",
             }
         )
 
@@ -125,7 +96,7 @@ class TestDeletePrCommentExecutor:
             {
                 "org": "port-labs",
                 "repo": "ocean",
-                "commentId": 555,
+                "commentId": "555",
             }
         )
 
@@ -151,7 +122,7 @@ class TestDeletePrCommentExecutor:
             {
                 "org": "port-labs",
                 "repo": "ocean",
-                "commentId": 555,
+                "commentId": "555",
             }
         )
 
@@ -171,7 +142,7 @@ class TestDeletePrCommentExecutor:
             {
                 "org": "port-labs",
                 "repo": "ocean",
-                "commentId": 555,
+                "commentId": "555",
             }
         )
         assert await executor._get_partition_key(run) is None

--- a/integrations/github/tests/github/actions/test_dispatch_workflow_executor.py
+++ b/integrations/github/tests/github/actions/test_dispatch_workflow_executor.py
@@ -84,7 +84,7 @@ def executor(
     mock_rest_client: MagicMock,
 ) -> Generator[DispatchWorkflowExecutor, None, None]:
     with patch(
-        "github.actions.dispatch_workflow_executor.create_github_client_for_org",
+        "github.actions.abstract_github_executor.create_github_client_for_org",
         new=AsyncMock(return_value=mock_rest_client),
     ):
         yield DispatchWorkflowExecutor()
@@ -101,7 +101,7 @@ class TestDispatchWorkflowExecutor:
         )
 
         with patch(
-            "github.actions.dispatch_workflow_executor.create_github_client_for_org",
+            "github.actions.abstract_github_executor.create_github_client_for_org",
             new=AsyncMock(return_value=mock_rest_client),
         ) as create_client:
             executor = DispatchWorkflowExecutor()
@@ -407,7 +407,7 @@ class TestLegacyDispatchWorkflowExecutor:
 
         with (
             patch(
-                "github.actions.dispatch_workflow_executor.create_github_client_for_org",
+                "github.actions.abstract_github_executor.create_github_client_for_org",
                 new=AsyncMock(return_value=mock_rest_client),
             ),
             patch(
@@ -461,7 +461,7 @@ class TestLegacyDispatchWorkflowExecutor:
 
         with (
             patch(
-                "github.actions.dispatch_workflow_executor.create_github_client_for_org",
+                "github.actions.abstract_github_executor.create_github_client_for_org",
                 new=AsyncMock(return_value=mock_rest_client),
             ),
             patch(

--- a/integrations/github/tests/github/actions/test_edit_pr_comment_executor.py
+++ b/integrations/github/tests/github/actions/test_edit_pr_comment_executor.py
@@ -6,13 +6,9 @@ import pytest
 
 from github.actions.edit_pr_comment_executor import EditPrCommentExecutor
 from github.actions.exceptions import PullRequestCommentError
-from github.clients.http.rest_client import GithubRestClient
 from github.helpers.exceptions import InvalidActionParametersException
-from port_ocean.core.models import (
-    ActionRun,
-    IntegrationActionInvocationPayload,
-    RunStatus,
-)
+from port_ocean.core.models import ActionRun
+from tests.github.actions.conftest import make_action_run
 
 COMMENT_RESPONSE = {
     "id": 555,
@@ -22,17 +18,7 @@ COMMENT_RESPONSE = {
 
 
 def make_run(execution_properties: dict[str, Any]) -> ActionRun:
-    return ActionRun(
-        id="run-123",
-        status=RunStatus.IN_PROGRESS,
-        action=ActionRun.Action(identifier="edit_pr_comment"),
-        payload=IntegrationActionInvocationPayload(
-            type="INTEGRATION_ACTION",
-            installationId="inst-1",
-            integrationActionType="edit_pr_comment",
-            integrationActionExecutionProperties=execution_properties,
-        ),
-    )
+    return make_action_run("edit_pr_comment", execution_properties)
 
 
 @pytest.fixture(autouse=True)
@@ -43,20 +29,6 @@ def patched_ocean() -> Generator[MagicMock, None, None]:
     with patch("github.actions.edit_pr_comment_executor.ocean") as mock_ocean:
         mock_ocean.port_client = mock_client
         yield mock_ocean
-
-
-@pytest.fixture
-def mock_port_client(patched_ocean: MagicMock) -> MagicMock:
-    return patched_ocean.port_client
-
-
-@pytest.fixture
-def mock_rest_client() -> MagicMock:
-    client = MagicMock(spec=GithubRestClient)
-    client.base_url = "https://api.github.com"
-    client.send_api_request = AsyncMock()
-    client.get_rate_limit_status = MagicMock(return_value=None)
-    return client
 
 
 @pytest.fixture
@@ -82,7 +54,7 @@ class TestEditPrCommentExecutor:
             {
                 "org": "port-labs",
                 "repo": "ocean",
-                "commentId": 555,
+                "commentId": "555",
                 "body": "Updated comment",
             }
         )
@@ -130,7 +102,7 @@ class TestEditPrCommentExecutor:
             {
                 "org": "port-labs",
                 "repo": "ocean",
-                "commentId": 555,
+                "commentId": "555",
                 "body": "Updated comment",
             }
         )
@@ -157,7 +129,7 @@ class TestEditPrCommentExecutor:
             {
                 "org": "port-labs",
                 "repo": "ocean",
-                "commentId": 555,
+                "commentId": "555",
                 "body": "Updated comment",
             }
         )
@@ -176,7 +148,7 @@ class TestEditPrCommentExecutor:
             {
                 "org": "port-labs",
                 "repo": "ocean",
-                "commentId": 555,
+                "commentId": "555",
                 "body": "Updated comment",
             }
         )

--- a/integrations/github/tests/github/actions/test_edit_pr_comment_executor.py
+++ b/integrations/github/tests/github/actions/test_edit_pr_comment_executor.py
@@ -1,0 +1,191 @@
+from typing import Any, Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from github.actions.edit_pr_comment_executor import EditPrCommentExecutor
+from github.actions.exceptions import PullRequestCommentError
+from github.clients.http.rest_client import GithubRestClient
+from github.helpers.exceptions import InvalidActionParametersException
+from port_ocean.core.models import (
+    ActionRun,
+    IntegrationActionInvocationPayload,
+    RunStatus,
+)
+
+COMMENT_RESPONSE = {
+    "id": 555,
+    "body": "Updated comment",
+    "html_url": "https://github.com/port-labs/ocean/pull/42#issuecomment-555",
+}
+
+
+def make_run(execution_properties: dict[str, Any]) -> ActionRun:
+    return ActionRun(
+        id="run-123",
+        status=RunStatus.IN_PROGRESS,
+        action=ActionRun.Action(identifier="edit_pr_comment"),
+        payload=IntegrationActionInvocationPayload(
+            type="INTEGRATION_ACTION",
+            installationId="inst-1",
+            integrationActionType="edit_pr_comment",
+            integrationActionExecutionProperties=execution_properties,
+        ),
+    )
+
+
+@pytest.fixture(autouse=True)
+def patched_ocean() -> Generator[MagicMock, None, None]:
+    mock_client = MagicMock()
+    mock_client.post_run_log = AsyncMock()
+    mock_client.report_run_completed = AsyncMock()
+    with patch("github.actions.edit_pr_comment_executor.ocean") as mock_ocean:
+        mock_ocean.port_client = mock_client
+        yield mock_ocean
+
+
+@pytest.fixture
+def mock_port_client(patched_ocean: MagicMock) -> MagicMock:
+    return patched_ocean.port_client
+
+
+@pytest.fixture
+def mock_rest_client() -> MagicMock:
+    client = MagicMock(spec=GithubRestClient)
+    client.base_url = "https://api.github.com"
+    client.send_api_request = AsyncMock()
+    client.get_rate_limit_status = MagicMock(return_value=None)
+    return client
+
+
+@pytest.fixture
+def executor(
+    mock_rest_client: MagicMock,
+) -> Generator[EditPrCommentExecutor, None, None]:
+    with patch(
+        "github.actions.abstract_github_executor.create_github_client_for_org",
+        new=AsyncMock(return_value=mock_rest_client),
+    ):
+        yield EditPrCommentExecutor()
+
+
+class TestEditPrCommentExecutor:
+    @pytest.mark.asyncio
+    async def test_happy_path(
+        self,
+        executor: EditPrCommentExecutor,
+        mock_rest_client: MagicMock,
+        mock_port_client: MagicMock,
+    ) -> None:
+        run = make_run(
+            {
+                "org": "port-labs",
+                "repo": "ocean",
+                "commentId": 555,
+                "body": "Updated comment",
+            }
+        )
+
+        mock_rest_client.send_api_request.return_value = COMMENT_RESPONSE
+
+        await executor.execute(run)
+
+        mock_rest_client.send_api_request.assert_awaited_once_with(
+            "https://api.github.com/repos/port-labs/ocean/issues/comments/555",
+            method="PATCH",
+            json_data={"body": "Updated comment"},
+            ignore_default_errors=False,
+        )
+
+        mock_port_client.report_run_completed.assert_awaited_once_with(
+            run,
+            success=True,
+            message="Comment updated: https://github.com/port-labs/ocean/pull/42#issuecomment-555",
+        )
+
+    @pytest.mark.asyncio
+    async def test_missing_required_inputs(
+        self,
+        executor: EditPrCommentExecutor,
+        mock_rest_client: MagicMock,
+    ) -> None:
+        run = make_run({"org": "port-labs", "repo": "ocean"})
+
+        with pytest.raises(
+            InvalidActionParametersException,
+            match="org, repo, commentId, and body are required",
+        ):
+            await executor.execute(run)
+
+        mock_rest_client.send_api_request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_upstream_http_error(
+        self,
+        executor: EditPrCommentExecutor,
+        mock_rest_client: MagicMock,
+    ) -> None:
+        run = make_run(
+            {
+                "org": "port-labs",
+                "repo": "ocean",
+                "commentId": 555,
+                "body": "Updated comment",
+            }
+        )
+
+        request = httpx.Request(
+            "PATCH",
+            "https://api.github.com/repos/port-labs/ocean/issues/comments/555",
+        )
+        response = httpx.Response(404, json={"message": "Not Found"}, request=request)
+        mock_rest_client.send_api_request.side_effect = httpx.HTTPStatusError(
+            "404", request=request, response=response
+        )
+
+        with pytest.raises(PullRequestCommentError, match="Could not edit comment"):
+            await executor.execute(run)
+
+    @pytest.mark.asyncio
+    async def test_malformed_response(
+        self,
+        executor: EditPrCommentExecutor,
+        mock_rest_client: MagicMock,
+    ) -> None:
+        run = make_run(
+            {
+                "org": "port-labs",
+                "repo": "ocean",
+                "commentId": 555,
+                "body": "Updated comment",
+            }
+        )
+
+        mock_rest_client.send_api_request.return_value = {}
+
+        with pytest.raises(PullRequestCommentError, match="empty or incomplete"):
+            await executor.execute(run)
+
+    @pytest.mark.asyncio
+    async def test_partition_key(
+        self,
+        executor: EditPrCommentExecutor,
+    ) -> None:
+        run = make_run(
+            {
+                "org": "port-labs",
+                "repo": "ocean",
+                "commentId": 555,
+                "body": "Updated comment",
+            }
+        )
+        assert await executor._get_partition_key(run) is None
+
+    @pytest.mark.asyncio
+    async def test_partition_key_missing_inputs_returns_none(
+        self,
+        executor: EditPrCommentExecutor,
+    ) -> None:
+        run = make_run({"org": "port-labs"})
+        assert await executor._get_partition_key(run) is None


### PR DESCRIPTION
# Description

What - Added new self-service actions for the GitHub integration: create/edit/delete PR comments

Why -

How -
  - Extracted `_get_execution_clients` to `AbstractGithubExecutor` — single source of truth for org-based client creation across all executors (including existing `dispatch_workflow`)                            
  - Added `AbstractPullRequestExecutor` intermediate base with shared `_get_partition_key` for the 5 PR actions (create, update, close, merge, review)                                                               
  - 3 comment executors extend `AbstractGithubExecutor` directly — they use GitHub's issue comments API (`/repos/{owner}/{repo}/issues/{number}/comments`) since GitHub treats PRs as issues for commenting          
  - Delete comment uses `make_request` (not `send_api_request`) to handle the 204 No Content response

## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [X] New feature (non-breaking change which adds functionality)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [X] Integration able to create all default resources from scratch
- [X] Resync finishes successfully
- [X] Resync able to create entities
- [X] Resync able to update entities
- [X] Resync able to detect and delete entities
- [X] Scheduled resync able to abort existing resync and start a new one
- [X] Tested with at least 2 integrations from scratch
- [X] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots
<img width="1509" height="810" alt="Screenshot 2026-09-08 at 05 41 53" src="https://github.com/user-attachments/assets/428a9fdb-9e90-45e6-8391-b25df2a1c486" />
<img width="1482" height="701" alt="Screenshot 2026-09-08 at 05 41 44" src="https://github.com/user-attachments/assets/50a48f24-1407-42d6-a837-966e6e7dd94e" />
<img width="1443" height="674" alt="Screenshot 2026-09-08 at 05 40 16" src="https://github.com/user-attachments/assets/58ef7e7f-cb46-4b92-a54d-eb9e0b45c094" />
<img width="1462" height="603" alt="Screenshot 2026-09-08 at 05 34 57" src="https://github.com/user-attachments/assets/156e88e3-55d6-4d5a-bda0-b2413a603722" />



## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New write actions can merge, close, review, and mutate PR comments on real repos when workflows invoke them; impact depends on GitHub token permissions and how customers wire automations.
> 
> **Overview**
> **Adds eight GitHub integration Port actions** so workflows can drive pull requests and PR-thread comments via the REST API, with matching entries in `.port/spec.json` and a **minor** release note in `.ocean-release/pr-crud-actions.yaml`.
> 
> **PR lifecycle:** `create_pull_request`, `update_pull_request`, `close_pull_request`, `merge_pull_request` (merge/squash/rebase + optional commit metadata), and `review_pull_request` (APPROVE / REQUEST_CHANGES / COMMENT, with body required for REQUEST_CHANGES). Executors share `AbstractPullRequestExecutor` for `org/repo` partition keys.
> 
> **Comments:** `create_pr_comment` posts via the issues comments endpoint; `edit_pr_comment` and `delete_pr_comment` patch/delete by `commentId` (delete uses `make_request` and expects **204**).
> 
> **Refactor:** `_get_execution_clients` is implemented on `AbstractGithubExecutor` (org-scoped client); `DispatchWorkflowExecutor` drops its duplicate implementation. New typed errors in `exceptions.py` and registration in `registry.py`, with unit tests per executor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 518a9aa00a625003ade408420320af5728323940. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->