### PR TITLE
[Integration][Jira] Add change-issue-status action

### DIFF
--- a/integrations/jira/.ocean-release/change-issue-status-action.yaml
+++ b/integrations/jira/.ocean-release/change-issue-status-action.yaml
@@ -1,0 +1,3 @@
+bump: minor
+changelog-type: feature
+changelog: Added a change_issue_status action for updating Jira issue statuses from Port

--- a/integrations/jira/.port/spec.json
+++ b/integrations/jira/.port/spec.json
@@ -118,6 +118,27 @@
           "description": "The Atlassian account ID of the user to assign the issue to"
         }
       ]
+    },
+    {
+      "name": "change_issue_status",
+      "icon": "Jira",
+      "description": "Change the status of a Jira issue",
+      "inputs": [
+        {
+          "name": "issueKey",
+          "title": "Issue key",
+          "type": "string",
+          "description": "The Jira issue key to update, for example PORT-123",
+          "required": true
+        },
+        {
+          "name": "status",
+          "title": "Status",
+          "type": "string",
+          "description": "The target Jira status name, for example In Progress or Done",
+          "required": true
+        }
+      ]
     }
   ],
   "saas": {

--- a/integrations/jira/jira/actions/change_issue_status_executor.py
+++ b/integrations/jira/jira/actions/change_issue_status_executor.py
@@ -1,0 +1,199 @@
+import httpx
+from loguru import logger
+from pydantic import Field
+from port_ocean.context.ocean import ocean
+from port_ocean.core.models import IntegrationRun, WorkflowNodeRun
+from typing import Any
+
+from jira.actions.abstract_jira_action_input import AbstractJiraActionInput
+from jira.actions.abstract_jira_executor import AbstractJiraExecutor
+from jira.actions.exceptions import ChangeIssueStatusError
+from jira.actions.utils import get_issue_browse_url
+
+
+class ChangeIssueStatusInput(AbstractJiraActionInput):
+    issue_key: str = Field(..., alias="issueKey", min_length=1)
+    status: str = Field(..., min_length=1)
+
+
+class ChangeIssueStatusExecutor(AbstractJiraExecutor):
+    ACTION_NAME = "change_issue_status"
+    WEBHOOK_PROCESSOR_CLASS = None
+
+    async def _get_partition_key(self, run: IntegrationRun) -> str | None:
+        issue_key = run.execution_properties.get("issueKey")
+        return str(issue_key) if issue_key else None
+
+    async def execute(self, run: IntegrationRun) -> None:
+        action_input = ChangeIssueStatusInput.from_execution_properties(
+            run.execution_properties
+        )
+
+        await ocean.port_client.post_run_log(
+            run,
+            f"Changing status of {action_input.issue_key} to {action_input.status}",
+            status_label="Changing status",
+            should_raise=False,
+        )
+
+        try:
+            issue = await self.client.get_single_issue(
+                action_input.issue_key, fields="status"
+            )
+        except httpx.HTTPStatusError as error:
+            raise ChangeIssueStatusError.from_response(
+                error.response,
+                f"Could not load issue '{action_input.issue_key}'",
+            )
+
+        current_status = self._get_issue_status_name(issue)
+        if current_status and self._normalize_status_name(
+            current_status
+        ) == self._normalize_status_name(action_input.status):
+            message = (
+                f"Issue {action_input.issue_key} is already in status "
+                f"'{current_status}'"
+            )
+            await self._complete_run(run, action_input, current_status, message)
+            return
+
+        try:
+            transitions = await self.client.get_issue_transitions(
+                action_input.issue_key
+            )
+        except httpx.HTTPStatusError as error:
+            raise ChangeIssueStatusError.from_response(
+                error.response,
+                f"Could not load transitions for issue '{action_input.issue_key}'",
+            )
+
+        transition_id = self._find_transition_id_for_status(
+            transitions, action_input.status
+        )
+        if not transition_id:
+            available_statuses = self._get_available_transition_statuses(transitions)
+            available_statuses_text = (
+                ", ".join(available_statuses) if available_statuses else "none"
+            )
+            raise ChangeIssueStatusError(
+                f"No transition found to status '{action_input.status}' for issue "
+                f"'{action_input.issue_key}'. Available target statuses: "
+                f"{available_statuses_text}"
+            )
+
+        try:
+            await self.client.transition_issue(action_input.issue_key, transition_id)
+        except httpx.HTTPStatusError as error:
+            raise ChangeIssueStatusError.from_response(
+                error.response,
+                f"Could not change status of issue '{action_input.issue_key}'",
+            )
+
+        message = (
+            f"Changed issue {action_input.issue_key} to status "
+            f"'{action_input.status}'"
+        )
+        await self._complete_run(run, action_input, action_input.status, message)
+        logger.info(
+            "Changed Jira issue status",
+            issue_key=action_input.issue_key,
+            status=action_input.status,
+            transition_id=transition_id,
+        )
+
+    async def _complete_run(
+        self,
+        run: IntegrationRun,
+        action_input: ChangeIssueStatusInput,
+        status: str,
+        message: str,
+    ) -> None:
+        issue_link = get_issue_browse_url(
+            self.client.jira_url,
+            action_input.issue_key,
+            oauth_enabled=self.client.is_oauth_enabled(),
+        )
+        if issue_link:
+            message = f"{message}: {issue_link}"
+
+        await ocean.port_client.post_run_log(
+            run,
+            message,
+            should_raise=False,
+        )
+
+        if isinstance(run, WorkflowNodeRun):
+            run.output = {
+                "issueKey": action_input.issue_key,
+                "status": status,
+                "issueUrl": issue_link or "",
+            }
+
+        await ocean.port_client.report_run_completed(
+            run,
+            success=True,
+            message=message,
+            status_label="Status changed",
+        )
+
+    @staticmethod
+    def _normalize_status_name(status: str) -> str:
+        return status.casefold().strip()
+
+    @staticmethod
+    def _get_issue_status_name(issue: dict[str, Any]) -> str | None:
+        fields = issue.get("fields")
+        if not isinstance(fields, dict):
+            return None
+        status = fields.get("status")
+        if not isinstance(status, dict):
+            return None
+        status_name = status.get("name")
+        return status_name if isinstance(status_name, str) else None
+
+    @classmethod
+    def _find_transition_id_for_status(
+        cls, transitions_response: dict[str, Any], target_status: str
+    ) -> str | None:
+        normalized_target = cls._normalize_status_name(target_status)
+        transitions = transitions_response.get("transitions")
+        if not isinstance(transitions, list):
+            return None
+
+        for transition in transitions:
+            if not isinstance(transition, dict):
+                continue
+            to_status = transition.get("to")
+            if not isinstance(to_status, dict):
+                continue
+            to_status_name = to_status.get("name")
+            if (
+                isinstance(to_status_name, str)
+                and cls._normalize_status_name(to_status_name) == normalized_target
+            ):
+                transition_id = transition.get("id")
+                if transition_id is not None:
+                    return str(transition_id)
+        return None
+
+    @staticmethod
+    def _get_available_transition_statuses(
+        transitions_response: dict[str, Any],
+    ) -> list[str]:
+        statuses: list[str] = []
+        seen: set[str] = set()
+        transitions = transitions_response.get("transitions")
+        if not isinstance(transitions, list):
+            return statuses
+
+        for transition in transitions:
+            if not isinstance(transition, dict):
+                continue
+            to_status = transition.get("to")
+            if not isinstance(to_status, dict):
+                continue
+            to_status_name = to_status.get("name")
+            if isinstance(to_status_name, str) and to_status_name not in seen:
+                seen.add(to_status_name)
+                statuses.append(to_status_name)
+        return statuses

--- a/integrations/jira/jira/actions/exceptions.py
+++ b/integrations/jira/jira/actions/exceptions.py
@@ -10,6 +10,29 @@ class MissingExecutionPropertyError(ActionExecutionError):
     DEFAULT_STATUS_LABEL = "Invalid input"
 
 
+def _jira_response_detail(response: httpx.Response) -> str:
+    try:
+        body = response.json()
+    except json.JSONDecodeError:
+        body = None
+
+    if isinstance(body, dict):
+        error_messages = body.get("errorMessages")
+        if isinstance(error_messages, list) and error_messages:
+            return "; ".join(str(message) for message in error_messages)
+
+        errors = body.get("errors")
+        if isinstance(errors, dict) and errors:
+            return "; ".join(f"{key}: {value}" for key, value in errors.items())
+
+        for key in ("message", "error"):
+            if (value := body.get(key)) is not None:
+                return value if isinstance(value, str) else json.dumps(value)
+
+    text = response.text.strip()
+    return text or f"HTTP {response.status_code}"
+
+
 class CreateIssueError(ActionExecutionError):
     """Raised when the Jira API returns an error while creating an issue."""
 
@@ -17,27 +40,16 @@ class CreateIssueError(ActionExecutionError):
 
     @classmethod
     def from_response(cls, response: httpx.Response, prefix: str) -> "CreateIssueError":
-        return cls(f"{prefix}: {cls._response_detail(response)}")
+        return cls(f"{prefix}: {_jira_response_detail(response)}")
 
-    @staticmethod
-    def _response_detail(response: httpx.Response) -> str:
-        try:
-            body = response.json()
-        except Exception:
-            body = None
 
-        if isinstance(body, dict):
-            error_messages = body.get("errorMessages")
-            if isinstance(error_messages, list) and error_messages:
-                return "; ".join(str(message) for message in error_messages)
+class ChangeIssueStatusError(ActionExecutionError):
+    """Raised when the Jira API returns an error while changing issue status."""
 
-            errors = body.get("errors")
-            if isinstance(errors, dict) and errors:
-                return "; ".join(f"{key}: {value}" for key, value in errors.items())
+    DEFAULT_STATUS_LABEL = "Status change failed"
 
-            for key in ("message", "error"):
-                if (value := body.get(key)) is not None:
-                    return value if isinstance(value, str) else json.dumps(value)
-
-        text = response.text.strip()
-        return text or f"HTTP {response.status_code}"
+    @classmethod
+    def from_response(
+        cls, response: httpx.Response, prefix: str
+    ) -> "ChangeIssueStatusError":
+        return cls(f"{prefix}: {_jira_response_detail(response)}")

--- a/integrations/jira/jira/actions/exceptions.py
+++ b/integrations/jira/jira/actions/exceptions.py
@@ -1,4 +1,5 @@
 import json
+from typing import Self
 
 import httpx
 from port_ocean.exceptions.execution_manager import ActionExecutionError
@@ -10,46 +11,42 @@ class MissingExecutionPropertyError(ActionExecutionError):
     DEFAULT_STATUS_LABEL = "Invalid input"
 
 
-def _jira_response_detail(response: httpx.Response) -> str:
-    try:
-        body = response.json()
-    except json.JSONDecodeError:
-        body = None
+class JiraActionError(ActionExecutionError):
+    @staticmethod
+    def _response_detail(response: httpx.Response) -> str:
+        try:
+            body = response.json()
+        except json.JSONDecodeError:
+            body = None
 
-    if isinstance(body, dict):
-        error_messages = body.get("errorMessages")
-        if isinstance(error_messages, list) and error_messages:
-            return "; ".join(str(message) for message in error_messages)
+        if isinstance(body, dict):
+            error_messages = body.get("errorMessages")
+            if isinstance(error_messages, list) and error_messages:
+                return "; ".join(str(message) for message in error_messages)
 
-        errors = body.get("errors")
-        if isinstance(errors, dict) and errors:
-            return "; ".join(f"{key}: {value}" for key, value in errors.items())
+            errors = body.get("errors")
+            if isinstance(errors, dict) and errors:
+                return "; ".join(f"{key}: {value}" for key, value in errors.items())
 
-        for key in ("message", "error"):
-            if (value := body.get(key)) is not None:
-                return value if isinstance(value, str) else json.dumps(value)
+            for key in ("message", "error"):
+                if (value := body.get(key)) is not None:
+                    return value if isinstance(value, str) else json.dumps(value)
 
-    text = response.text.strip()
-    return text or f"HTTP {response.status_code}"
+        text = response.text.strip()
+        return text or f"HTTP {response.status_code}"
+
+    @classmethod
+    def from_response(cls, response: httpx.Response, prefix: str) -> Self:
+        return cls(f"{prefix}: {cls._response_detail(response)}")
 
 
-class CreateIssueError(ActionExecutionError):
+class CreateIssueError(JiraActionError):
     """Raised when the Jira API returns an error while creating an issue."""
 
     DEFAULT_STATUS_LABEL = "Create failed"
 
-    @classmethod
-    def from_response(cls, response: httpx.Response, prefix: str) -> "CreateIssueError":
-        return cls(f"{prefix}: {_jira_response_detail(response)}")
 
-
-class ChangeIssueStatusError(ActionExecutionError):
+class ChangeIssueStatusError(JiraActionError):
     """Raised when the Jira API returns an error while changing issue status."""
 
     DEFAULT_STATUS_LABEL = "Status change failed"
-
-    @classmethod
-    def from_response(
-        cls, response: httpx.Response, prefix: str
-    ) -> "ChangeIssueStatusError":
-        return cls(f"{prefix}: {_jira_response_detail(response)}")

--- a/integrations/jira/jira/actions/registry.py
+++ b/integrations/jira/jira/actions/registry.py
@@ -1,8 +1,10 @@
 from port_ocean.context.ocean import ocean
 
+from jira.actions.change_issue_status_executor import ChangeIssueStatusExecutor
 from jira.actions.create_issue_executor import CreateIssueExecutor
 
 
 def register_actions_executors() -> None:
     """Register all actions executors."""
     ocean.register_action_executor(CreateIssueExecutor())
+    ocean.register_action_executor(ChangeIssueStatusExecutor())

--- a/integrations/jira/jira/client.py
+++ b/integrations/jira/jira/client.py
@@ -614,8 +614,18 @@ class JiraClient(OAuthClient):
         ):
             yield projects
 
-    async def get_single_issue(self, issue_key: str) -> dict[str, Any]:
-        return await self._send_api_request("GET", f"{self.api_url}/issue/{issue_key}")
+    async def get_single_issue(
+        self, issue_key: str, *, fields: str | None = None
+    ) -> dict[str, Any]:
+        if fields is None:
+            return await self._send_api_request(
+                "GET", f"{self.api_url}/issue/{issue_key}"
+            )
+        return await self._send_api_request(
+            "GET",
+            f"{self.api_url}/issue/{issue_key}",
+            params={"fields": fields},
+        )
 
     async def create_issue(self, payload: dict[str, Any]) -> dict[str, Any]:
         return await self._send_api_request(

--- a/integrations/jira/jira/client.py
+++ b/integrations/jira/jira/client.py
@@ -252,6 +252,8 @@ class JiraClient(OAuthClient):
                 )
                 response.raise_for_status()
                 await self._rate_limiter.on_response(response)
+                if not response.content:
+                    return None
                 return response.json()
         except httpx.HTTPStatusError as e:
             response = e.response

--- a/integrations/jira/jira/client.py
+++ b/integrations/jira/jira/client.py
@@ -634,6 +634,19 @@ class JiraClient(OAuthClient):
             json=payload,
         )
 
+    async def get_issue_transitions(self, issue_key: str) -> dict[str, Any]:
+        return await self._send_api_request(
+            "GET",
+            f"{self.api_url}/issue/{issue_key}/transitions",
+        )
+
+    async def transition_issue(self, issue_key: str, transition_id: str) -> None:
+        await self._send_api_request(
+            "POST",
+            f"{self.api_url}/issue/{issue_key}/transitions",
+            json={"transition": {"id": transition_id}},
+        )
+
     @staticmethod
     def _build_issue_search_body(
         jql: str,

--- a/integrations/jira/tests/actions/test_change_issue_status_executor.py
+++ b/integrations/jira/tests/actions/test_change_issue_status_executor.py
@@ -1,0 +1,305 @@
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from pydantic import ValidationError
+from port_ocean.core.models import (
+    WorkflowIntegrationActionConfig,
+    WorkflowNodeRun,
+    WorkflowNodeRunStatus,
+)
+
+from jira.actions.change_issue_status_executor import (
+    ChangeIssueStatusExecutor,
+    ChangeIssueStatusInput,
+)
+from jira.actions.exceptions import (
+    ChangeIssueStatusError,
+    MissingExecutionPropertyError,
+)
+
+TRANSITIONS_RESPONSE = {
+    "transitions": [
+        {
+            "id": "21",
+            "name": "In Progress",
+            "to": {"name": "In Progress"},
+        },
+        {
+            "id": "31",
+            "name": "Done",
+            "to": {"name": "Done"},
+        },
+    ]
+}
+
+
+def make_run(execution_properties: dict[str, Any]) -> WorkflowNodeRun:
+    return WorkflowNodeRun(
+        id="run-1",
+        status=WorkflowNodeRunStatus.IN_PROGRESS,
+        config=WorkflowIntegrationActionConfig(
+            type="INTEGRATION_ACTION",
+            installationId="test-installation-id",
+            integrationProvider="jira",
+            integrationInvocationType="change_issue_status",
+            integrationActionExecutionProperties=execution_properties,
+        ),
+    )
+
+
+@pytest.fixture
+def executor() -> ChangeIssueStatusExecutor:
+    with patch("jira.actions.abstract_jira_executor.get_or_create_jira_client"):
+        action_executor = ChangeIssueStatusExecutor()
+        action_executor.client = MagicMock()
+        action_executor.client.jira_url = "https://example.atlassian.net"
+        action_executor.client.is_oauth_enabled = MagicMock(return_value=False)
+        action_executor.client.get_single_issue = AsyncMock(
+            return_value={"fields": {"status": {"name": "To Do"}}}
+        )
+        action_executor.client.get_issue_transitions = AsyncMock(
+            return_value=TRANSITIONS_RESPONSE
+        )
+        action_executor.client.transition_issue = AsyncMock(return_value=None)
+        return action_executor
+
+
+@pytest.fixture
+def mock_port_client() -> MagicMock:
+    client = MagicMock()
+    client.post_run_log = AsyncMock()
+    client.report_run_completed = AsyncMock()
+    return client
+
+
+def test_from_execution_properties_parses_camel_case_fields() -> None:
+    # Arrange
+    execution_properties = {
+        "issueKey": "PORT-42",
+        "status": "In Progress",
+    }
+
+    # Act
+    action_input = ChangeIssueStatusInput.from_execution_properties(
+        execution_properties
+    )
+
+    # Assert
+    assert action_input.issue_key == "PORT-42"
+    assert action_input.status == "In Progress"
+
+
+def test_from_execution_properties_raises_for_missing_required_field() -> None:
+    # Arrange
+    execution_properties = {"status": "Done"}
+
+    # Act + Assert
+    with pytest.raises(MissingExecutionPropertyError, match="issueKey"):
+        ChangeIssueStatusInput.from_execution_properties(execution_properties)
+
+
+def test_model_validate_raises_for_empty_required_field() -> None:
+    # Act + Assert
+    with pytest.raises(ValidationError):
+        ChangeIssueStatusInput.model_validate({"issueKey": "", "status": "Done"})
+
+
+@pytest.mark.asyncio
+async def test_happy_path(
+    executor: ChangeIssueStatusExecutor, mock_port_client: MagicMock
+) -> None:
+    # Arrange
+    run = make_run({"issueKey": "PORT-42", "status": "In Progress"})
+
+    # Act
+    with patch("jira.actions.change_issue_status_executor.ocean") as mock_ocean:
+        mock_ocean.port_client = mock_port_client
+        await executor.execute(run)
+
+    # Assert
+    executor.client.get_single_issue.assert_awaited_once_with(  # type: ignore[attr-defined]
+        "PORT-42", fields="status"
+    )
+    executor.client.get_issue_transitions.assert_awaited_once_with("PORT-42")  # type: ignore[attr-defined]
+    executor.client.transition_issue.assert_awaited_once_with("PORT-42", "21")  # type: ignore[attr-defined]
+    assert run.output == {
+        "issueKey": "PORT-42",
+        "status": "In Progress",
+        "issueUrl": "https://example.atlassian.net/browse/PORT-42",
+    }
+    mock_port_client.report_run_completed.assert_called_once_with(
+        run,
+        success=True,
+        message=(
+            "Changed issue PORT-42 to status 'In Progress': "
+            "https://example.atlassian.net/browse/PORT-42"
+        ),
+        status_label="Status changed",
+    )
+
+
+@pytest.mark.asyncio
+async def test_already_in_target_status(
+    executor: ChangeIssueStatusExecutor, mock_port_client: MagicMock
+) -> None:
+    # Arrange
+    executor.client.get_single_issue = AsyncMock(  # type: ignore[method-assign]
+        return_value={"fields": {"status": {"name": "Done"}}}
+    )
+    run = make_run({"issueKey": "PORT-42", "status": "done"})
+
+    # Act
+    with patch("jira.actions.change_issue_status_executor.ocean") as mock_ocean:
+        mock_ocean.port_client = mock_port_client
+        await executor.execute(run)
+
+    # Assert
+    executor.client.get_issue_transitions.assert_not_awaited()  # type: ignore[attr-defined]
+    executor.client.transition_issue.assert_not_awaited()  # type: ignore[attr-defined]
+    mock_port_client.report_run_completed.assert_called_once_with(
+        run,
+        success=True,
+        message=(
+            "Issue PORT-42 is already in status 'Done': "
+            "https://example.atlassian.net/browse/PORT-42"
+        ),
+        status_label="Status changed",
+    )
+
+
+@pytest.mark.asyncio
+async def test_missing_required_input(
+    executor: ChangeIssueStatusExecutor, mock_port_client: MagicMock
+) -> None:
+    # Arrange
+    run = make_run({"issueKey": "PORT-42"})
+
+    # Act + Assert
+    with patch("jira.actions.change_issue_status_executor.ocean") as mock_ocean:
+        mock_ocean.port_client = mock_port_client
+        with pytest.raises(MissingExecutionPropertyError) as exc_info:
+            await executor.execute(run)
+
+    assert exc_info.value.status_label == "Invalid input"
+
+
+@pytest.mark.asyncio
+async def test_upstream_http_error(
+    executor: ChangeIssueStatusExecutor, mock_port_client: MagicMock
+) -> None:
+    # Arrange
+    response = httpx.Response(
+        404,
+        json={"errorMessages": ["Issue does not exist"]},
+        request=httpx.Request("GET", "http://x"),
+    )
+    executor.client.get_single_issue = AsyncMock(  # type: ignore[method-assign]
+        side_effect=httpx.HTTPStatusError(
+            "404", request=response.request, response=response
+        )
+    )
+    run = make_run({"issueKey": "PORT-42", "status": "Done"})
+
+    # Act + Assert
+    with patch("jira.actions.change_issue_status_executor.ocean") as mock_ocean:
+        mock_ocean.port_client = mock_port_client
+        with pytest.raises(
+            ChangeIssueStatusError, match="Issue does not exist"
+        ) as exc_info:
+            await executor.execute(run)
+
+    assert exc_info.value.status_label == "Status change failed"
+
+
+@pytest.mark.asyncio
+async def test_no_matching_transition(
+    executor: ChangeIssueStatusExecutor, mock_port_client: MagicMock
+) -> None:
+    # Arrange
+    run = make_run({"issueKey": "PORT-42", "status": "Blocked"})
+
+    # Act + Assert
+    with patch("jira.actions.change_issue_status_executor.ocean") as mock_ocean:
+        mock_ocean.port_client = mock_port_client
+        with pytest.raises(
+            ChangeIssueStatusError,
+            match="Available target statuses: In Progress, Done",
+        ):
+            await executor.execute(run)
+
+
+@pytest.mark.asyncio
+async def test_get_partition_key_returns_issue_key(
+    executor: ChangeIssueStatusExecutor,
+) -> None:
+    # Arrange
+    run = make_run({"issueKey": "PORT-42", "status": "Done"})
+
+    # Act
+    partition_key = await executor._get_partition_key(run)
+
+    # Assert
+    assert partition_key == "PORT-42"
+
+
+@pytest.mark.asyncio
+async def test_get_partition_key_returns_none_when_issue_key_missing(
+    executor: ChangeIssueStatusExecutor,
+) -> None:
+    # Arrange
+    run = make_run({"status": "Done"})
+
+    # Act
+    partition_key = await executor._get_partition_key(run)
+
+    # Assert
+    assert partition_key is None
+
+
+def test_get_issue_status_name() -> None:
+    # Act + Assert
+    assert (
+        ChangeIssueStatusExecutor._get_issue_status_name(
+            {"fields": {"status": {"name": "Done"}}}
+        )
+        == "Done"
+    )
+    assert ChangeIssueStatusExecutor._get_issue_status_name({"fields": {}}) is None
+
+
+def test_find_transition_id_for_status_matches_case_insensitively() -> None:
+    # Arrange
+    transitions = {
+        "transitions": [
+            {"id": "21", "to": {"name": "In Progress"}},
+            {"id": "31", "to": {"name": "Done"}},
+        ]
+    }
+
+    # Act + Assert
+    assert (
+        ChangeIssueStatusExecutor._find_transition_id_for_status(transitions, "done")
+        == "31"
+    )
+    assert (
+        ChangeIssueStatusExecutor._find_transition_id_for_status(transitions, "Unknown")
+        is None
+    )
+
+
+def test_get_available_transition_statuses() -> None:
+    # Arrange
+    transitions = {
+        "transitions": [
+            {"to": {"name": "In Progress"}},
+            {"to": {"name": "Done"}},
+            {"to": {"name": "Done"}},
+        ]
+    }
+
+    # Act + Assert
+    assert ChangeIssueStatusExecutor._get_available_transition_statuses(
+        transitions
+    ) == ["In Progress", "Done"]

--- a/integrations/jira/tests/actions/test_exceptions.py
+++ b/integrations/jira/tests/actions/test_exceptions.py
@@ -1,0 +1,129 @@
+import httpx
+import pytest
+
+from jira.actions.exceptions import JiraActionError
+
+
+def _make_response(
+    *,
+    status_code: int = 400,
+    json_body: object | None = None,
+    text: str | None = None,
+) -> httpx.Response:
+    kwargs: dict[str, object] = {
+        "status_code": status_code,
+        "request": httpx.Request("GET", "https://example.atlassian.net"),
+    }
+    if json_body is not None:
+        kwargs["json"] = json_body
+    elif text is not None:
+        kwargs["text"] = text
+    return httpx.Response(**kwargs)  # type: ignore[arg-type]
+
+
+def test_from_response_uses_error_messages() -> None:
+    # Arrange
+    response = _make_response(
+        json_body={"errorMessages": ["First error", "Second error"]}
+    )
+
+    # Act
+    error = JiraActionError.from_response(response, "Could not create issue")
+
+    # Assert
+    assert str(error) == ("Could not create issue: First error; Second error")
+
+
+def test_from_response_uses_errors_dict() -> None:
+    # Arrange
+    response = _make_response(
+        json_body={"errors": {"summary": "Field is required", "project": "Invalid key"}}
+    )
+
+    # Act
+    error = JiraActionError.from_response(response, "Validation failed")
+
+    # Assert
+    assert str(error) == (
+        "Validation failed: summary: Field is required; project: Invalid key"
+    )
+
+
+@pytest.mark.parametrize(
+    ("field_name", "field_value", "expected_detail"),
+    [
+        ("message", "Transition is unavailable", "Transition is unavailable"),
+        ("error", "Unauthorized", "Unauthorized"),
+    ],
+)
+def test_from_response_uses_message_or_error_field(
+    field_name: str, field_value: str, expected_detail: str
+) -> None:
+    # Arrange
+    response = _make_response(json_body={field_name: field_value})
+
+    # Act
+    error = JiraActionError.from_response(response, "Request failed")
+
+    # Assert
+    assert str(error) == f"Request failed: {expected_detail}"
+
+
+def test_from_response_serializes_non_string_message_field() -> None:
+    # Arrange
+    response = _make_response(json_body={"message": {"code": "INVALID"}})
+
+    # Act
+    error = JiraActionError.from_response(response, "Request failed")
+
+    # Assert
+    assert str(error) == 'Request failed: {"code": "INVALID"}'
+
+
+def test_from_response_prefers_error_messages_over_errors_dict() -> None:
+    # Arrange
+    response = _make_response(
+        json_body={
+            "errorMessages": ["Primary message"],
+            "errors": {"summary": "Should not be used"},
+        }
+    )
+
+    # Act
+    error = JiraActionError.from_response(response, "Request failed")
+
+    # Assert
+    assert str(error) == "Request failed: Primary message"
+
+
+def test_from_response_falls_back_to_response_text_for_invalid_json() -> None:
+    # Arrange
+    response = _make_response(text="Plain text error body")
+
+    # Act
+    error = JiraActionError.from_response(response, "Request failed")
+
+    # Assert
+    assert str(error) == "Request failed: Plain text error body"
+
+
+def test_from_response_falls_back_to_status_code_for_empty_body() -> None:
+    # Arrange
+    response = _make_response(status_code=503)
+
+    # Act
+    error = JiraActionError.from_response(response, "Request failed")
+
+    # Assert
+    assert str(error) == "Request failed: HTTP 503"
+
+
+def test_from_response_falls_back_to_response_text_for_non_object_json() -> None:
+    # Arrange
+    response = _make_response(json_body=["not", "a", "dict"])
+
+    # Act
+    error = JiraActionError.from_response(response, "Request failed")
+
+    # Assert
+    assert str(error) == 'Request failed: ["not","a","dict"]'

--- a/integrations/jira/tests/test_client.py
+++ b/integrations/jira/tests/test_client.py
@@ -615,6 +615,56 @@ async def test_create_issue(mock_jira_client: JiraClient) -> None:
 
 
 @pytest.mark.asyncio
+async def test_get_single_issue_with_fields(mock_jira_client: JiraClient) -> None:
+    issue_data = {"key": "TEST-1", "fields": {"status": {"name": "Done"}}}
+
+    with patch.object(
+        mock_jira_client, "_send_api_request", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.return_value = issue_data
+        result = await mock_jira_client.get_single_issue("TEST-1", fields="status")
+
+        mock_request.assert_called_once_with(
+            "GET",
+            f"{mock_jira_client.api_url}/issue/TEST-1",
+            params={"fields": "status"},
+        )
+        assert result == issue_data
+
+
+@pytest.mark.asyncio
+async def test_get_issue_transitions(mock_jira_client: JiraClient) -> None:
+    transitions = {"transitions": [{"id": "21", "to": {"name": "In Progress"}}]}
+
+    with patch.object(
+        mock_jira_client, "_send_api_request", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.return_value = transitions
+        result = await mock_jira_client.get_issue_transitions("TEST-1")
+
+        mock_request.assert_called_once_with(
+            "GET",
+            f"{mock_jira_client.api_url}/issue/TEST-1/transitions",
+        )
+        assert result == transitions
+
+
+@pytest.mark.asyncio
+async def test_transition_issue(mock_jira_client: JiraClient) -> None:
+    with patch.object(
+        mock_jira_client, "_send_api_request", new_callable=AsyncMock
+    ) as mock_request:
+        mock_request.return_value = None
+        await mock_jira_client.transition_issue("TEST-1", "21")
+
+        mock_request.assert_called_once_with(
+            "POST",
+            f"{mock_jira_client.api_url}/issue/TEST-1/transitions",
+            json={"transition": {"id": "21"}},
+        )
+
+
+@pytest.mark.asyncio
 async def test_get_paginated_issues(mock_jira_client: JiraClient) -> None:
     """Test get_paginated_issues with params including JQL filtering"""
 


### PR DESCRIPTION
## Summary
- Add **`change_issue_status`** integration action (`issueKey`, `status`) with workflow node outputs `issueKey`, `status`, `issueUrl`.

## Companion PRs
- Ocean: https://github.com/port-labs/ocean/pull/3972
- Port: https://github.com/port-labs/Port/pull/18680
- port-docs: https://github.com/port-labs/port-docs/pull/6122

## Test plan
- [x] `cd integrations/jira && make test`
- [x] `cd integrations/jira && make lint`
- [x] Confirm `.port/spec.json` `actions[].name` is `change_issue_status` and input names match executor `execution_properties` keys