### PR TITLE
[Integration][GitHub] Add issue actions

### DIFF
--- a/integrations/github/.ocean-release/issue-actions.yaml
+++ b/integrations/github/.ocean-release/issue-actions.yaml
@@ -1,0 +1,3 @@
+bump: minor
+changelog-type: feature
+changelog: Added issue actions (create, edit, close), enabling Port Workflows to create, update, and close GitHub issues with labels and assignee support

--- a/integrations/github/.port/spec.json
+++ b/integrations/github/.port/spec.json
@@ -334,7 +334,7 @@
     {
       "name": "create_issue",
       "icon": "Github",
-      "description": "Create a GitHub issue",
+      "description": "Create a GitHub Issue",
       "inputs": [
         {
           "name": "org",
@@ -380,7 +380,7 @@
     {
       "name": "edit_issue",
       "icon": "Github",
-      "description": "Edit a GitHub issue",
+      "description": "Edit a GitHub Issue",
       "inputs": [
         {
           "name": "org",
@@ -438,7 +438,7 @@
     {
       "name": "close_issue",
       "icon": "Github",
-      "description": "Close a GitHub issue",
+      "description": "Close a GitHub Issue",
       "inputs": [
         {
           "name": "org",

--- a/integrations/github/.port/spec.json
+++ b/integrations/github/.port/spec.json
@@ -330,6 +330,145 @@
           "required": true
         }
       ]
+    },
+    {
+      "name": "create_issue",
+      "icon": "Github",
+      "description": "Create a GitHub issue",
+      "inputs": [
+        {
+          "name": "org",
+          "title": "Organization",
+          "type": "string",
+          "description": "The GitHub organization or user that owns the repository",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "title": "Repository",
+          "type": "string",
+          "description": "The name of the GitHub repository",
+          "required": true
+        },
+        {
+          "name": "title",
+          "title": "Title",
+          "type": "string",
+          "description": "The title of the issue",
+          "required": true
+        },
+        {
+          "name": "body",
+          "title": "Body",
+          "type": "string",
+          "description": "The description of the issue"
+        },
+        {
+          "name": "labels",
+          "title": "Labels",
+          "type": "array",
+          "description": "Labels to apply to the issue"
+        },
+        {
+          "name": "assignees",
+          "title": "Assignees",
+          "type": "array",
+          "description": "GitHub usernames to assign to the issue"
+        }
+      ]
+    },
+    {
+      "name": "edit_issue",
+      "icon": "Github",
+      "description": "Edit a GitHub issue",
+      "inputs": [
+        {
+          "name": "org",
+          "title": "Organization",
+          "type": "string",
+          "description": "The GitHub organization or user that owns the repository",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "title": "Repository",
+          "type": "string",
+          "description": "The name of the GitHub repository",
+          "required": true
+        },
+        {
+          "name": "issueNumber",
+          "title": "Issue number",
+          "type": "string",
+          "description": "The number of the issue to edit",
+          "required": true
+        },
+        {
+          "name": "title",
+          "title": "Title",
+          "type": "string",
+          "description": "The new title of the issue"
+        },
+        {
+          "name": "body",
+          "title": "Body",
+          "type": "string",
+          "description": "The new description of the issue"
+        },
+        {
+          "name": "state",
+          "title": "State",
+          "type": "string",
+          "description": "The state of the issue (open or closed)"
+        },
+        {
+          "name": "labels",
+          "title": "Labels",
+          "type": "array",
+          "description": "Labels to set on the issue"
+        },
+        {
+          "name": "assignees",
+          "title": "Assignees",
+          "type": "array",
+          "description": "GitHub usernames to assign to the issue"
+        }
+      ]
+    },
+    {
+      "name": "close_issue",
+      "icon": "Github",
+      "description": "Close a GitHub issue",
+      "inputs": [
+        {
+          "name": "org",
+          "title": "Organization",
+          "type": "string",
+          "description": "The GitHub organization or user that owns the repository",
+          "required": true
+        },
+        {
+          "name": "repo",
+          "title": "Repository",
+          "type": "string",
+          "description": "The name of the GitHub repository",
+          "required": true
+        },
+        {
+          "name": "issueNumber",
+          "title": "Issue number",
+          "type": "string",
+          "description": "The number of the issue to close",
+          "required": true
+        },
+        {
+          "name": "stateReason",
+          "title": "Close reason",
+          "type": "string",
+          "description": "The reason for closing: completed or not_planned",
+          "default": "completed"
+        }
+      ]
     }
   ],
   "installationDocs": {

--- a/integrations/github/github/actions/abstract_github_executor.py
+++ b/integrations/github/github/actions/abstract_github_executor.py
@@ -1,5 +1,3 @@
-from abc import abstractmethod
-
 from github.clients.client_factory import create_github_client_for_org
 from github.clients.http.base_client import AbstractGithubClient
 from github.helpers.exceptions import InvalidActionParametersException

--- a/integrations/github/github/actions/abstract_github_executor.py
+++ b/integrations/github/github/actions/abstract_github_executor.py
@@ -1,6 +1,8 @@
 from abc import abstractmethod
 
+from github.clients.client_factory import create_github_client_for_org
 from github.clients.http.base_client import AbstractGithubClient
+from github.helpers.exceptions import InvalidActionParametersException
 from port_ocean.core.handlers.actions.abstract_executor import AbstractExecutor
 from port_ocean.core.models import IntegrationRun
 
@@ -8,11 +10,13 @@ MIN_REMAINING_RATE_LIMIT_FOR_EXECUTE_WORKFLOW = 20
 
 
 class AbstractGithubExecutor(AbstractExecutor):
-    @abstractmethod
     async def _get_execution_clients(
         self, run: IntegrationRun
     ) -> list[AbstractGithubClient]:
-        pass
+        organization = run.execution_properties.get("org")
+        if not isinstance(organization, str):
+            raise InvalidActionParametersException("org is required")
+        return [await create_github_client_for_org(organization)]
 
     def _is_client_close_to_rate_limit(self, client: AbstractGithubClient) -> bool:
         info = client.get_rate_limit_status()

--- a/integrations/github/github/actions/close_issue_executor.py
+++ b/integrations/github/github/actions/close_issue_executor.py
@@ -34,6 +34,7 @@ class CloseIssueExecutor(AbstractGithubExecutor):
         if not isinstance(rest_client, GithubRestClient):
             raise InvalidActionParametersException("GitHub REST client is required")
 
+        # https://docs.github.com/en/rest/issues/issues#update-an-issue
         state_reason = run.execution_properties.get("stateReason", "completed")
 
         await ocean.port_client.post_run_log(
@@ -42,7 +43,6 @@ class CloseIssueExecutor(AbstractGithubExecutor):
             should_raise=False,
         )
 
-        # https://docs.github.com/en/rest/issues/issues#update-an-issue
         try:
             issue = await rest_client.send_api_request(
                 f"{rest_client.base_url}/repos/{org}/{repo}/issues/{issue_number}",

--- a/integrations/github/github/actions/close_issue_executor.py
+++ b/integrations/github/github/actions/close_issue_executor.py
@@ -1,0 +1,80 @@
+import httpx
+from loguru import logger
+from port_ocean.context.ocean import ocean
+from port_ocean.core.models import IntegrationRun
+
+from github.actions.abstract_github_executor import AbstractGithubExecutor
+from github.actions.exceptions import IssueActionError
+from github.clients.http.rest_client import GithubRestClient
+from github.helpers.exceptions import InvalidActionParametersException
+
+
+class CloseIssueExecutor(AbstractGithubExecutor):
+    ACTION_NAME = "close_issue"
+    WEBHOOK_PROCESSOR_CLASS = None
+
+    async def _get_partition_key(self, run: IntegrationRun) -> str | None:
+        org = run.execution_properties.get("org")
+        repo = run.execution_properties.get("repo")
+        if not org or not repo:
+            return None
+        return f"{org}/{repo}"
+
+    async def execute(self, run: IntegrationRun) -> None:
+        org = run.execution_properties.get("org")
+        repo = run.execution_properties.get("repo")
+        issue_number = run.execution_properties.get("issueNumber")
+
+        if not (org and repo and issue_number):
+            raise InvalidActionParametersException(
+                "org, repo, and issueNumber are required"
+            )
+
+        rest_client = (await self._get_execution_clients(run))[0]
+        if not isinstance(rest_client, GithubRestClient):
+            raise InvalidActionParametersException("GitHub REST client is required")
+
+        state_reason = run.execution_properties.get("stateReason", "completed")
+
+        await ocean.port_client.post_run_log(
+            run,
+            f"Closing issue #{issue_number} in {org}/{repo} as {state_reason}",
+            should_raise=False,
+        )
+
+        # https://docs.github.com/en/rest/issues/issues#update-an-issue
+        try:
+            issue = await rest_client.send_api_request(
+                f"{rest_client.base_url}/repos/{org}/{repo}/issues/{issue_number}",
+                method="PATCH",
+                json_data={"state": "closed", "state_reason": state_reason},
+                ignore_default_errors=False,
+            )
+        except httpx.HTTPStatusError as e:
+            raise IssueActionError.from_response(
+                e.response,
+                f"Could not close issue #{issue_number} in {org}/{repo}",
+            )
+
+        if not issue or "number" not in issue or "html_url" not in issue:
+            logger.warning(
+                f"Received empty or incomplete response from GitHub for issue close in {org}/{repo}",
+                org=org,
+                repo=repo,
+                issue_number=issue_number,
+            )
+            raise IssueActionError(
+                "Failed to close issue: upstream returned an empty or incomplete response"
+            )
+
+        logger.info(
+            f"Closed issue #{issue['number']} in {org}/{repo}",
+            issue_number=issue["number"],
+            html_url=issue["html_url"],
+        )
+
+        await ocean.port_client.report_run_completed(
+            run,
+            success=True,
+            message=f"Issue #{issue['number']} closed: {issue['html_url']}",
+        )

--- a/integrations/github/github/actions/create_issue_executor.py
+++ b/integrations/github/github/actions/create_issue_executor.py
@@ -1,0 +1,85 @@
+import httpx
+from loguru import logger
+from port_ocean.context.ocean import ocean
+from port_ocean.core.models import IntegrationRun
+
+from github.actions.abstract_github_executor import AbstractGithubExecutor
+from github.actions.exceptions import IssueActionError
+from github.clients.http.rest_client import GithubRestClient
+from github.helpers.exceptions import InvalidActionParametersException
+
+
+class CreateIssueExecutor(AbstractGithubExecutor):
+    ACTION_NAME = "create_issue"
+    WEBHOOK_PROCESSOR_CLASS = None
+
+    async def _get_partition_key(self, run: IntegrationRun) -> str | None:
+        org = run.execution_properties.get("org")
+        repo = run.execution_properties.get("repo")
+        if not org or not repo:
+            return None
+        return f"{org}/{repo}"
+
+    async def execute(self, run: IntegrationRun) -> None:
+        org = run.execution_properties.get("org")
+        repo = run.execution_properties.get("repo")
+        title = run.execution_properties.get("title")
+
+        if not (org and repo and title):
+            raise InvalidActionParametersException("org, repo, and title are required")
+
+        rest_client = (await self._get_execution_clients(run))[0]
+        if not isinstance(rest_client, GithubRestClient):
+            raise InvalidActionParametersException("GitHub REST client is required")
+
+        await ocean.port_client.post_run_log(
+            run,
+            f"Creating issue '{title}' in {org}/{repo}",
+            should_raise=False,
+        )
+
+        # https://docs.github.com/en/rest/issues/issues#create-an-issue
+        issue_body: dict[str, str | list[str]] = {"title": title}
+        body = run.execution_properties.get("body")
+        if body:
+            issue_body["body"] = body
+        labels = run.execution_properties.get("labels")
+        if labels:
+            issue_body["labels"] = labels
+        assignees = run.execution_properties.get("assignees")
+        if assignees:
+            issue_body["assignees"] = assignees
+
+        try:
+            issue = await rest_client.send_api_request(
+                f"{rest_client.base_url}/repos/{org}/{repo}/issues",
+                method="POST",
+                json_data=issue_body,
+                ignore_default_errors=False,
+            )
+        except httpx.HTTPStatusError as e:
+            raise IssueActionError.from_response(
+                e.response, f"Could not create issue in {org}/{repo}"
+            )
+
+        if not issue or "number" not in issue or "html_url" not in issue:
+            logger.warning(
+                f"Received empty or incomplete response from GitHub for issue creation in {org}/{repo}",
+                org=org,
+                repo=repo,
+            )
+            raise IssueActionError(
+                "Failed to create issue: upstream returned an empty or incomplete response"
+            )
+
+        logger.info(
+            f"Created issue #{issue['number']} in {org}/{repo}",
+            issue_number=issue["number"],
+            html_url=issue["html_url"],
+        )
+
+        await ocean.port_client.report_run_completed(
+            run,
+            success=True,
+            message=f"Issue #{issue['number']} created: {issue['html_url']}",
+        )

--- a/integrations/github/github/actions/edit_issue_executor.py
+++ b/integrations/github/github/actions/edit_issue_executor.py
@@ -1,0 +1,95 @@
+import httpx
+from loguru import logger
+from port_ocean.context.ocean import ocean
+from port_ocean.core.models import IntegrationRun
+
+from github.actions.abstract_github_executor import AbstractGithubExecutor
+from github.actions.exceptions import IssueActionError
+from github.clients.http.rest_client import GithubRestClient
+from github.helpers.exceptions import InvalidActionParametersException
+
+
+class EditIssueExecutor(AbstractGithubExecutor):
+    ACTION_NAME = "edit_issue"
+    WEBHOOK_PROCESSOR_CLASS = None
+
+    async def _get_partition_key(self, run: IntegrationRun) -> str | None:
+        org = run.execution_properties.get("org")
+        repo = run.execution_properties.get("repo")
+        if not org or not repo:
+            return None
+        return f"{org}/{repo}"
+
+    async def execute(self, run: IntegrationRun) -> None:
+        org = run.execution_properties.get("org")
+        repo = run.execution_properties.get("repo")
+        issue_number = run.execution_properties.get("issueNumber")
+
+        if not (org and repo and issue_number):
+            raise InvalidActionParametersException(
+                "org, repo, and issueNumber are required"
+            )
+
+        # https://docs.github.com/en/rest/issues/issues#update-an-issue
+        patch_body: dict[str, str | list[str]] = {}
+        for key in ("title", "body", "state"):
+            value = run.execution_properties.get(key)
+            if value is not None:
+                patch_body[key] = value
+        labels = run.execution_properties.get("labels")
+        if labels is not None:
+            patch_body["labels"] = labels
+        assignees = run.execution_properties.get("assignees")
+        if assignees is not None:
+            patch_body["assignees"] = assignees
+
+        if not patch_body:
+            raise InvalidActionParametersException(
+                "At least one field to update is required (title, body, state, labels, or assignees)"
+            )
+
+        rest_client = (await self._get_execution_clients(run))[0]
+        if not isinstance(rest_client, GithubRestClient):
+            raise InvalidActionParametersException("GitHub REST client is required")
+
+        await ocean.port_client.post_run_log(
+            run,
+            f"Editing issue #{issue_number} in {org}/{repo}",
+            should_raise=False,
+        )
+
+        try:
+            issue = await rest_client.send_api_request(
+                f"{rest_client.base_url}/repos/{org}/{repo}/issues/{issue_number}",
+                method="PATCH",
+                json_data=patch_body,
+                ignore_default_errors=False,
+            )
+        except httpx.HTTPStatusError as e:
+            raise IssueActionError.from_response(
+                e.response,
+                f"Could not edit issue #{issue_number} in {org}/{repo}",
+            )
+
+        if not issue or "number" not in issue or "html_url" not in issue:
+            logger.warning(
+                f"Received empty or incomplete response from GitHub for issue edit in {org}/{repo}",
+                org=org,
+                repo=repo,
+                issue_number=issue_number,
+            )
+            raise IssueActionError(
+                "Failed to edit issue: upstream returned an empty or incomplete response"
+            )
+
+        logger.info(
+            f"Edited issue #{issue['number']} in {org}/{repo}",
+            issue_number=issue["number"],
+            html_url=issue["html_url"],
+        )
+
+        await ocean.port_client.report_run_completed(
+            run,
+            success=True,
+            message=f"Issue #{issue['number']} updated: {issue['html_url']}",
+        )

--- a/integrations/github/github/actions/exceptions.py
+++ b/integrations/github/github/actions/exceptions.py
@@ -1,0 +1,9 @@
+import httpx
+from github.actions.utils import extract_error_message
+from port_ocean.exceptions.execution_manager import ActionExecutionError
+
+
+class IssueActionError(ActionExecutionError):
+    @classmethod
+    def from_response(cls, response: httpx.Response, prefix: str) -> "IssueActionError":
+        return cls(f"{prefix}: {extract_error_message(response)}")

--- a/integrations/github/github/actions/registry.py
+++ b/integrations/github/github/actions/registry.py
@@ -1,7 +1,10 @@
 from port_ocean.context.ocean import ocean
+from github.actions.close_issue_executor import CloseIssueExecutor
+from github.actions.create_issue_executor import CreateIssueExecutor
 from github.actions.dispatch_workflow_executor import (
     DispatchWorkflowExecutor,
 )
+from github.actions.edit_issue_executor import EditIssueExecutor
 from github.actions.external_custom_properties.bulk_delete_external_custom_property_values_executor import (
     BulkDeleteExternalCustomPropertyValuesExecutor,
 )
@@ -19,3 +22,6 @@ def register_actions_executors() -> None:
     ocean.register_action_executor(UpdateRepoExternalCustomPropertiesExecutor())
     ocean.register_action_executor(BulkUpdateExternalCustomPropertyValuesExecutor())
     ocean.register_action_executor(BulkDeleteExternalCustomPropertyValuesExecutor())
+    ocean.register_action_executor(CreateIssueExecutor())
+    ocean.register_action_executor(EditIssueExecutor())
+    ocean.register_action_executor(CloseIssueExecutor())

--- a/integrations/github/tests/github/actions/test_close_issue_executor.py
+++ b/integrations/github/tests/github/actions/test_close_issue_executor.py
@@ -1,0 +1,229 @@
+"""Tests for CloseIssueExecutor."""
+
+from typing import Any, Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from github.actions.close_issue_executor import CloseIssueExecutor
+from github.actions.exceptions import IssueActionError
+from github.clients.http.rest_client import GithubRestClient
+from github.helpers.exceptions import InvalidActionParametersException
+from port_ocean.core.models import (
+    ActionRun,
+    IntegrationActionInvocationPayload,
+    RunStatus,
+)
+
+ACTION = "close_issue"
+
+ISSUE_RESPONSE = {
+    "number": 7,
+    "id": 123456,
+    "title": "Test issue",
+    "html_url": "https://github.com/port-labs/ocean/issues/7",
+    "state": "closed",
+}
+
+
+def make_run(execution_properties: dict[str, Any]) -> ActionRun:
+    return ActionRun(
+        id="run-123",
+        status=RunStatus.IN_PROGRESS,
+        action=ActionRun.Action(identifier=ACTION),
+        payload=IntegrationActionInvocationPayload(
+            type="INTEGRATION_ACTION",
+            installationId="inst-1",
+            integrationActionType=ACTION,
+            integrationActionExecutionProperties=execution_properties,
+        ),
+    )
+
+
+@pytest.fixture
+def mock_rest_client() -> MagicMock:
+    client = MagicMock(spec=GithubRestClient)
+    client.base_url = "https://api.github.com"
+    client.send_api_request = AsyncMock(return_value=ISSUE_RESPONSE)
+    client.get_rate_limit_status = MagicMock(return_value=None)
+    return client
+
+
+@pytest.fixture
+def mock_port_client() -> MagicMock:
+    pc = MagicMock()
+    pc.post_run_log = AsyncMock()
+    pc.report_run_completed = AsyncMock()
+    return pc
+
+
+@pytest.fixture
+def executor(
+    mock_rest_client: MagicMock,
+) -> Generator[CloseIssueExecutor, None, None]:
+    with patch(
+        "github.actions.abstract_github_executor.create_github_client_for_org",
+        new=AsyncMock(return_value=mock_rest_client),
+    ):
+        yield CloseIssueExecutor()
+
+
+class TestCloseIssueExecutor:
+    @pytest.mark.asyncio
+    async def test_happy_path(
+        self,
+        executor: CloseIssueExecutor,
+        mock_rest_client: MagicMock,
+        mock_port_client: MagicMock,
+    ) -> None:
+        run = make_run({"org": "port-labs", "repo": "ocean", "issueNumber": 7})
+
+        with patch("github.actions.close_issue_executor.ocean") as mock_ocean:
+            mock_ocean.port_client = mock_port_client
+            await executor.execute(run)
+
+        mock_rest_client.send_api_request.assert_awaited_once()
+        call_kwargs = mock_rest_client.send_api_request.call_args
+        assert "repos/port-labs/ocean/issues/7" in call_kwargs.args[0]
+        assert call_kwargs.kwargs["method"] == "PATCH"
+        assert call_kwargs.kwargs["json_data"] == {
+            "state": "closed",
+            "state_reason": "completed",
+        }
+
+        mock_port_client.report_run_completed.assert_awaited_once_with(
+            run,
+            success=True,
+            message="Issue #7 closed: https://github.com/port-labs/ocean/issues/7",
+        )
+
+    @pytest.mark.asyncio
+    async def test_with_not_planned(
+        self,
+        executor: CloseIssueExecutor,
+        mock_rest_client: MagicMock,
+        mock_port_client: MagicMock,
+    ) -> None:
+        run = make_run(
+            {
+                "org": "port-labs",
+                "repo": "ocean",
+                "issueNumber": 7,
+                "stateReason": "not_planned",
+            }
+        )
+
+        with patch("github.actions.close_issue_executor.ocean") as mock_ocean:
+            mock_ocean.port_client = mock_port_client
+            await executor.execute(run)
+
+        call_kwargs = mock_rest_client.send_api_request.call_args
+        assert call_kwargs.kwargs["json_data"] == {
+            "state": "closed",
+            "state_reason": "not_planned",
+        }
+
+    @pytest.mark.asyncio
+    async def test_missing_org_raises(
+        self,
+        executor: CloseIssueExecutor,
+        mock_rest_client: MagicMock,
+        mock_port_client: MagicMock,
+    ) -> None:
+        run = make_run({"repo": "ocean", "issueNumber": 7})
+
+        with pytest.raises(
+            InvalidActionParametersException, match="org.*repo.*issueNumber"
+        ):
+            with patch("github.actions.close_issue_executor.ocean") as mock_ocean:
+                mock_ocean.port_client = mock_port_client
+                await executor.execute(run)
+
+        mock_rest_client.send_api_request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_repo_raises(
+        self,
+        executor: CloseIssueExecutor,
+        mock_rest_client: MagicMock,
+        mock_port_client: MagicMock,
+    ) -> None:
+        run = make_run({"org": "port-labs", "issueNumber": 7})
+
+        with pytest.raises(
+            InvalidActionParametersException, match="org.*repo.*issueNumber"
+        ):
+            with patch("github.actions.close_issue_executor.ocean") as mock_ocean:
+                mock_ocean.port_client = mock_port_client
+                await executor.execute(run)
+
+        mock_rest_client.send_api_request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_issue_number_raises(
+        self,
+        executor: CloseIssueExecutor,
+        mock_rest_client: MagicMock,
+        mock_port_client: MagicMock,
+    ) -> None:
+        run = make_run({"org": "port-labs", "repo": "ocean"})
+
+        with pytest.raises(
+            InvalidActionParametersException, match="org.*repo.*issueNumber"
+        ):
+            with patch("github.actions.close_issue_executor.ocean") as mock_ocean:
+                mock_ocean.port_client = mock_port_client
+                await executor.execute(run)
+
+        mock_rest_client.send_api_request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_http_error_raises(
+        self,
+        executor: CloseIssueExecutor,
+        mock_rest_client: MagicMock,
+        mock_port_client: MagicMock,
+    ) -> None:
+        run = make_run({"org": "port-labs", "repo": "ocean", "issueNumber": 7})
+
+        request = httpx.Request(
+            "PATCH", "https://api.github.com/repos/port-labs/ocean/issues/7"
+        )
+        response = httpx.Response(404, json={"message": "Not Found"}, request=request)
+        mock_rest_client.send_api_request.side_effect = httpx.HTTPStatusError(
+            "404", request=request, response=response
+        )
+
+        with pytest.raises(IssueActionError, match="Not Found"):
+            with patch("github.actions.close_issue_executor.ocean") as mock_ocean:
+                mock_ocean.port_client = mock_port_client
+                await executor.execute(run)
+
+    @pytest.mark.asyncio
+    async def test_malformed_response_raises(
+        self,
+        executor: CloseIssueExecutor,
+        mock_rest_client: MagicMock,
+        mock_port_client: MagicMock,
+    ) -> None:
+        run = make_run({"org": "port-labs", "repo": "ocean", "issueNumber": 7})
+        mock_rest_client.send_api_request.return_value = {}
+
+        with pytest.raises(IssueActionError, match="empty or incomplete"):
+            with patch("github.actions.close_issue_executor.ocean") as mock_ocean:
+                mock_ocean.port_client = mock_port_client
+                await executor.execute(run)
+
+    @pytest.mark.asyncio
+    async def test_partition_key(self, executor: CloseIssueExecutor) -> None:
+        run = make_run({"org": "port-labs", "repo": "ocean", "issueNumber": 7})
+        assert await executor._get_partition_key(run) == "port-labs/ocean"
+
+    @pytest.mark.asyncio
+    async def test_partition_key_missing(self, executor: CloseIssueExecutor) -> None:
+        run = make_run({"issueNumber": 7})
+        assert await executor._get_partition_key(run) is None
+
+    def test_action_name(self, executor: CloseIssueExecutor) -> None:
+        assert executor.ACTION_NAME == ACTION

--- a/integrations/github/tests/github/actions/test_create_issue_executor.py
+++ b/integrations/github/tests/github/actions/test_create_issue_executor.py
@@ -1,0 +1,226 @@
+"""Tests for CreateIssueExecutor."""
+
+from typing import Any, Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from github.actions.create_issue_executor import CreateIssueExecutor
+from github.actions.exceptions import IssueActionError
+from github.clients.http.rest_client import GithubRestClient
+from github.helpers.exceptions import InvalidActionParametersException
+from port_ocean.core.models import (
+    ActionRun,
+    IntegrationActionInvocationPayload,
+    RunStatus,
+)
+
+ACTION = "create_issue"
+
+ISSUE_RESPONSE = {
+    "number": 7,
+    "id": 123456,
+    "title": "Test issue",
+    "html_url": "https://github.com/port-labs/ocean/issues/7",
+    "state": "open",
+}
+
+
+def make_run(execution_properties: dict[str, Any]) -> ActionRun:
+    return ActionRun(
+        id="run-123",
+        status=RunStatus.IN_PROGRESS,
+        action=ActionRun.Action(identifier=ACTION),
+        payload=IntegrationActionInvocationPayload(
+            type="INTEGRATION_ACTION",
+            installationId="inst-1",
+            integrationActionType=ACTION,
+            integrationActionExecutionProperties=execution_properties,
+        ),
+    )
+
+
+@pytest.fixture
+def mock_rest_client() -> MagicMock:
+    client = MagicMock(spec=GithubRestClient)
+    client.base_url = "https://api.github.com"
+    client.send_api_request = AsyncMock(return_value=ISSUE_RESPONSE)
+    client.get_rate_limit_status = MagicMock(return_value=None)
+    return client
+
+
+@pytest.fixture
+def mock_port_client() -> MagicMock:
+    pc = MagicMock()
+    pc.post_run_log = AsyncMock()
+    pc.report_run_completed = AsyncMock()
+    return pc
+
+
+@pytest.fixture
+def executor(
+    mock_rest_client: MagicMock,
+) -> Generator[CreateIssueExecutor, None, None]:
+    with patch(
+        "github.actions.abstract_github_executor.create_github_client_for_org",
+        new=AsyncMock(return_value=mock_rest_client),
+    ):
+        yield CreateIssueExecutor()
+
+
+class TestCreateIssueExecutor:
+    @pytest.mark.asyncio
+    async def test_happy_path(
+        self,
+        executor: CreateIssueExecutor,
+        mock_rest_client: MagicMock,
+        mock_port_client: MagicMock,
+    ) -> None:
+        run = make_run({"org": "port-labs", "repo": "ocean", "title": "Test issue"})
+
+        with patch("github.actions.create_issue_executor.ocean") as mock_ocean:
+            mock_ocean.port_client = mock_port_client
+            await executor.execute(run)
+
+        mock_rest_client.send_api_request.assert_awaited_once()
+        call_kwargs = mock_rest_client.send_api_request.call_args
+        assert "repos/port-labs/ocean/issues" in call_kwargs.args[0]
+        assert call_kwargs.kwargs["method"] == "POST"
+        assert call_kwargs.kwargs["json_data"] == {"title": "Test issue"}
+
+        mock_port_client.report_run_completed.assert_awaited_once_with(
+            run,
+            success=True,
+            message="Issue #7 created: https://github.com/port-labs/ocean/issues/7",
+        )
+
+    @pytest.mark.asyncio
+    async def test_with_optional_fields(
+        self,
+        executor: CreateIssueExecutor,
+        mock_rest_client: MagicMock,
+        mock_port_client: MagicMock,
+    ) -> None:
+        run = make_run(
+            {
+                "org": "port-labs",
+                "repo": "ocean",
+                "title": "Test issue",
+                "body": "Description",
+                "labels": ["bug"],
+                "assignees": ["user1"],
+            }
+        )
+
+        with patch("github.actions.create_issue_executor.ocean") as mock_ocean:
+            mock_ocean.port_client = mock_port_client
+            await executor.execute(run)
+
+        call_kwargs = mock_rest_client.send_api_request.call_args
+        assert call_kwargs.kwargs["json_data"] == {
+            "title": "Test issue",
+            "body": "Description",
+            "labels": ["bug"],
+            "assignees": ["user1"],
+        }
+
+    @pytest.mark.asyncio
+    async def test_missing_org_raises(
+        self,
+        executor: CreateIssueExecutor,
+        mock_rest_client: MagicMock,
+        mock_port_client: MagicMock,
+    ) -> None:
+        run = make_run({"repo": "ocean", "title": "Test issue"})
+
+        with pytest.raises(InvalidActionParametersException, match="org.*repo.*title"):
+            with patch("github.actions.create_issue_executor.ocean") as mock_ocean:
+                mock_ocean.port_client = mock_port_client
+                await executor.execute(run)
+
+        mock_rest_client.send_api_request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_repo_raises(
+        self,
+        executor: CreateIssueExecutor,
+        mock_rest_client: MagicMock,
+        mock_port_client: MagicMock,
+    ) -> None:
+        run = make_run({"org": "port-labs", "title": "Test issue"})
+
+        with pytest.raises(InvalidActionParametersException, match="org.*repo.*title"):
+            with patch("github.actions.create_issue_executor.ocean") as mock_ocean:
+                mock_ocean.port_client = mock_port_client
+                await executor.execute(run)
+
+        mock_rest_client.send_api_request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_title_raises(
+        self,
+        executor: CreateIssueExecutor,
+        mock_rest_client: MagicMock,
+        mock_port_client: MagicMock,
+    ) -> None:
+        run = make_run({"org": "port-labs", "repo": "ocean"})
+
+        with pytest.raises(InvalidActionParametersException, match="org.*repo.*title"):
+            with patch("github.actions.create_issue_executor.ocean") as mock_ocean:
+                mock_ocean.port_client = mock_port_client
+                await executor.execute(run)
+
+        mock_rest_client.send_api_request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_http_error_raises(
+        self,
+        executor: CreateIssueExecutor,
+        mock_rest_client: MagicMock,
+        mock_port_client: MagicMock,
+    ) -> None:
+        run = make_run({"org": "port-labs", "repo": "ocean", "title": "Test issue"})
+
+        request = httpx.Request(
+            "POST", "https://api.github.com/repos/port-labs/ocean/issues"
+        )
+        response = httpx.Response(
+            422, json={"message": "Validation Failed"}, request=request
+        )
+        mock_rest_client.send_api_request.side_effect = httpx.HTTPStatusError(
+            "422", request=request, response=response
+        )
+
+        with pytest.raises(IssueActionError, match="Validation Failed"):
+            with patch("github.actions.create_issue_executor.ocean") as mock_ocean:
+                mock_ocean.port_client = mock_port_client
+                await executor.execute(run)
+
+    @pytest.mark.asyncio
+    async def test_malformed_response_raises(
+        self,
+        executor: CreateIssueExecutor,
+        mock_rest_client: MagicMock,
+        mock_port_client: MagicMock,
+    ) -> None:
+        run = make_run({"org": "port-labs", "repo": "ocean", "title": "Test issue"})
+        mock_rest_client.send_api_request.return_value = {}
+
+        with pytest.raises(IssueActionError, match="empty or incomplete"):
+            with patch("github.actions.create_issue_executor.ocean") as mock_ocean:
+                mock_ocean.port_client = mock_port_client
+                await executor.execute(run)
+
+    @pytest.mark.asyncio
+    async def test_partition_key(self, executor: CreateIssueExecutor) -> None:
+        run = make_run({"org": "port-labs", "repo": "ocean", "title": "Test issue"})
+        assert await executor._get_partition_key(run) == "port-labs/ocean"
+
+    @pytest.mark.asyncio
+    async def test_partition_key_missing(self, executor: CreateIssueExecutor) -> None:
+        run = make_run({"title": "Test issue"})
+        assert await executor._get_partition_key(run) is None
+
+    def test_action_name(self, executor: CreateIssueExecutor) -> None:
+        assert executor.ACTION_NAME == ACTION

--- a/integrations/github/tests/github/actions/test_edit_issue_executor.py
+++ b/integrations/github/tests/github/actions/test_edit_issue_executor.py
@@ -1,0 +1,239 @@
+"""Tests for EditIssueExecutor."""
+
+from typing import Any, Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from github.actions.edit_issue_executor import EditIssueExecutor
+from github.actions.exceptions import IssueActionError
+from github.clients.http.rest_client import GithubRestClient
+from github.helpers.exceptions import InvalidActionParametersException
+from port_ocean.core.models import (
+    ActionRun,
+    IntegrationActionInvocationPayload,
+    RunStatus,
+)
+
+ACTION = "edit_issue"
+
+ISSUE_RESPONSE = {
+    "number": 7,
+    "id": 123456,
+    "title": "Updated issue",
+    "html_url": "https://github.com/port-labs/ocean/issues/7",
+    "state": "open",
+}
+
+
+def make_run(execution_properties: dict[str, Any]) -> ActionRun:
+    return ActionRun(
+        id="run-123",
+        status=RunStatus.IN_PROGRESS,
+        action=ActionRun.Action(identifier=ACTION),
+        payload=IntegrationActionInvocationPayload(
+            type="INTEGRATION_ACTION",
+            installationId="inst-1",
+            integrationActionType=ACTION,
+            integrationActionExecutionProperties=execution_properties,
+        ),
+    )
+
+
+@pytest.fixture
+def mock_rest_client() -> MagicMock:
+    client = MagicMock(spec=GithubRestClient)
+    client.base_url = "https://api.github.com"
+    client.send_api_request = AsyncMock(return_value=ISSUE_RESPONSE)
+    client.get_rate_limit_status = MagicMock(return_value=None)
+    return client
+
+
+@pytest.fixture
+def mock_port_client() -> MagicMock:
+    pc = MagicMock()
+    pc.post_run_log = AsyncMock()
+    pc.report_run_completed = AsyncMock()
+    return pc
+
+
+@pytest.fixture
+def executor(
+    mock_rest_client: MagicMock,
+) -> Generator[EditIssueExecutor, None, None]:
+    with patch(
+        "github.actions.abstract_github_executor.create_github_client_for_org",
+        new=AsyncMock(return_value=mock_rest_client),
+    ):
+        yield EditIssueExecutor()
+
+
+class TestEditIssueExecutor:
+    @pytest.mark.asyncio
+    async def test_happy_path(
+        self,
+        executor: EditIssueExecutor,
+        mock_rest_client: MagicMock,
+        mock_port_client: MagicMock,
+    ) -> None:
+        run = make_run(
+            {
+                "org": "port-labs",
+                "repo": "ocean",
+                "issueNumber": 7,
+                "title": "Updated issue",
+            }
+        )
+
+        with patch("github.actions.edit_issue_executor.ocean") as mock_ocean:
+            mock_ocean.port_client = mock_port_client
+            await executor.execute(run)
+
+        mock_rest_client.send_api_request.assert_awaited_once()
+        call_kwargs = mock_rest_client.send_api_request.call_args
+        assert "repos/port-labs/ocean/issues/7" in call_kwargs.args[0]
+        assert call_kwargs.kwargs["method"] == "PATCH"
+        assert call_kwargs.kwargs["json_data"] == {"title": "Updated issue"}
+
+        mock_port_client.report_run_completed.assert_awaited_once_with(
+            run,
+            success=True,
+            message="Issue #7 updated: https://github.com/port-labs/ocean/issues/7",
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_update_fields_raises(
+        self,
+        executor: EditIssueExecutor,
+        mock_rest_client: MagicMock,
+        mock_port_client: MagicMock,
+    ) -> None:
+        run = make_run({"org": "port-labs", "repo": "ocean", "issueNumber": 7})
+
+        with pytest.raises(
+            InvalidActionParametersException, match="At least one field"
+        ):
+            with patch("github.actions.edit_issue_executor.ocean") as mock_ocean:
+                mock_ocean.port_client = mock_port_client
+                await executor.execute(run)
+
+        mock_rest_client.send_api_request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_org_raises(
+        self,
+        executor: EditIssueExecutor,
+        mock_rest_client: MagicMock,
+        mock_port_client: MagicMock,
+    ) -> None:
+        run = make_run({"repo": "ocean", "issueNumber": 7, "title": "Updated issue"})
+
+        with pytest.raises(
+            InvalidActionParametersException, match="org.*repo.*issueNumber"
+        ):
+            with patch("github.actions.edit_issue_executor.ocean") as mock_ocean:
+                mock_ocean.port_client = mock_port_client
+                await executor.execute(run)
+
+        mock_rest_client.send_api_request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_repo_raises(
+        self,
+        executor: EditIssueExecutor,
+        mock_rest_client: MagicMock,
+        mock_port_client: MagicMock,
+    ) -> None:
+        run = make_run({"org": "port-labs", "issueNumber": 7, "title": "Updated issue"})
+
+        with pytest.raises(
+            InvalidActionParametersException, match="org.*repo.*issueNumber"
+        ):
+            with patch("github.actions.edit_issue_executor.ocean") as mock_ocean:
+                mock_ocean.port_client = mock_port_client
+                await executor.execute(run)
+
+        mock_rest_client.send_api_request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_issue_number_raises(
+        self,
+        executor: EditIssueExecutor,
+        mock_rest_client: MagicMock,
+        mock_port_client: MagicMock,
+    ) -> None:
+        run = make_run({"org": "port-labs", "repo": "ocean", "title": "Updated issue"})
+
+        with pytest.raises(
+            InvalidActionParametersException, match="org.*repo.*issueNumber"
+        ):
+            with patch("github.actions.edit_issue_executor.ocean") as mock_ocean:
+                mock_ocean.port_client = mock_port_client
+                await executor.execute(run)
+
+        mock_rest_client.send_api_request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_http_error_raises(
+        self,
+        executor: EditIssueExecutor,
+        mock_rest_client: MagicMock,
+        mock_port_client: MagicMock,
+    ) -> None:
+        run = make_run(
+            {
+                "org": "port-labs",
+                "repo": "ocean",
+                "issueNumber": 7,
+                "title": "Updated issue",
+            }
+        )
+
+        request = httpx.Request(
+            "PATCH", "https://api.github.com/repos/port-labs/ocean/issues/7"
+        )
+        response = httpx.Response(404, json={"message": "Not Found"}, request=request)
+        mock_rest_client.send_api_request.side_effect = httpx.HTTPStatusError(
+            "404", request=request, response=response
+        )
+
+        with pytest.raises(IssueActionError, match="Not Found"):
+            with patch("github.actions.edit_issue_executor.ocean") as mock_ocean:
+                mock_ocean.port_client = mock_port_client
+                await executor.execute(run)
+
+    @pytest.mark.asyncio
+    async def test_malformed_response_raises(
+        self,
+        executor: EditIssueExecutor,
+        mock_rest_client: MagicMock,
+        mock_port_client: MagicMock,
+    ) -> None:
+        run = make_run(
+            {
+                "org": "port-labs",
+                "repo": "ocean",
+                "issueNumber": 7,
+                "title": "Updated issue",
+            }
+        )
+        mock_rest_client.send_api_request.return_value = {}
+
+        with pytest.raises(IssueActionError, match="empty or incomplete"):
+            with patch("github.actions.edit_issue_executor.ocean") as mock_ocean:
+                mock_ocean.port_client = mock_port_client
+                await executor.execute(run)
+
+    @pytest.mark.asyncio
+    async def test_partition_key(self, executor: EditIssueExecutor) -> None:
+        run = make_run({"org": "port-labs", "repo": "ocean", "issueNumber": 7})
+        assert await executor._get_partition_key(run) == "port-labs/ocean"
+
+    @pytest.mark.asyncio
+    async def test_partition_key_missing(self, executor: EditIssueExecutor) -> None:
+        run = make_run({"issueNumber": 7})
+        assert await executor._get_partition_key(run) is None
+
+    def test_action_name(self, executor: EditIssueExecutor) -> None:
+        assert executor.ACTION_NAME == ACTION


### PR DESCRIPTION
# Description

What - Added 3 new self-service actions for the GitHub integration: create, edit, and close issues.

Why -

How -
  - 3 executors extending `AbstractGithubExecutor`: `CreateIssueExecutor` (POST), `EditIssueExecutor` (PATCH), `CloseIssueExecutor` (PATCH state=closed with state_reason)
  - Moved `_get_execution_clients` from abstract to concrete in `AbstractGithubExecutor` so all executors inherit org-based client creation without overriding                                                       
  - Create supports optional body, labels, and assignees; edit supports title, body, state, labels, and assignees (at least one required); close supports state_reason (completed or not_planned, defaults to        
  completed)                                                                                                                                                                                                         
  - Shared `IssueActionError` exception with `from_response()` for structured GitHub error reporting 
  -
## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [X] New feature (non-breaking change which adds functionality)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [X] Integration able to create all default resources from scratch
- [X] Resync finishes successfully
- [X] Resync able to create entities
- [X] Resync able to update entities
- [X] Resync able to detect and delete entities
- [X] Scheduled resync able to abort existing resync and start a new one
- [X] Tested with at least 2 integrations from scratch
- [X] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots
<img width="1472" height="762" alt="Screenshot 2026-09-08 at 09 36 28" src="https://github.com/user-attachments/assets/314c7e8c-c593-45c1-a275-b063f3728343" />
<img width="1467" height="666" alt="Screenshot 2026-09-08 at 09 36 06" src="https://github.com/user-attachments/assets/c851e776-6d90-4b1d-8ced-f35e788b2830" />
<img width="1452" height="667" alt="Screenshot 2026-09-08 at 09 23 20" src="https://github.com/user-attachments/assets/3420822d-3f8a-46b3-8cba-643efde11e40" />
<img width="1304" height="656" alt="Screenshot 2026-09-08 at 09 44 54" src="https://github.com/user-attachments/assets/6af3188f-0af1-4639-9fbc-e396e244dc66" />






## API Documentation

Provide links to the API documentation used for this integration.

## Related PRs

- Ocean: https://github.com/port-labs/ocean/pull/3973
- Port UI: https://github.com/port-labs/Port/pull/18433
- Docs: https://github.com/port-labs/port-docs/pull/5840
- Port task: https://app.getport.io/taskEntity?identifier=task_tl3gsx
- Deliverable: https://app.getport.io/deliverableEntity?identifier=deliverable_tkzk1r

