### PR TITLE
[Integration][Github] Add conclusion to the output of the workflow node run

### DIFF
--- a/integrations/github/.ocean-release/expose-workflow-node-conclusion-output.yaml
+++ b/integrations/github/.ocean-release/expose-workflow-node-conclusion-output.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: improvement
+changelog: Expose GitHub workflow conclusion on workflow node run output when dispatch_workflow completes, so downstream workflow JQ can reference it

--- a/integrations/github/github/webhook/webhook_processors/workflow_run/dispatch_workflow_webhook_processor.py
+++ b/integrations/github/github/webhook/webhook_processors/workflow_run/dispatch_workflow_webhook_processor.py
@@ -15,6 +15,8 @@ from port_ocean.core.handlers.webhook.abstract_webhook_processor import (
 )
 from loguru import logger
 
+from port_ocean.core.models import WorkflowNodeRun
+
 # Status labels for the GitHub `workflow_run.conclusion` values, shown on the
 # Port run. Anything unmapped echoes the raw conclusion. Keep every label to
 # two words at most so it stays readable in Port's UI.
@@ -105,6 +107,10 @@ class DispatchWorkflowWebhookProcessor(BaseWorkflowRunWebhookProcessor):
                 run_id=run.id,
                 conclusion=conclusion,
             )
+
+            if isinstance(run, WorkflowNodeRun):
+                run.output["conclusion"] = conclusion
+
             await ocean.port_client.report_run_completed(
                 run,
                 success,


### PR DESCRIPTION
# Description

Expose the GitHub workflow conclusion on workflow node run output when dispatch_workflow completes, so downstream workflow JQ can reference it.

## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive change in the GitHub webhook path when completing workflow node runs; no auth or core API behavior changes.
> 
> **Overview**
> When a GitHub `workflow_run` completion webhook updates an in-progress Port run with `reportWorkflowStatus`, **workflow node runs** now get the GitHub `conclusion` written to `run.output["conclusion"]` before completion is reported, so downstream workflows can read the raw conclusion (not only success/failure and status labels).
> 
> Action runs are unchanged; only `WorkflowNodeRun` instances are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2228ed41b278d9e9da02e10ae14b59ef906c262f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->