### PR TITLE
[Integration][Cursor Cloud Agents] Add IDLE to cursor_agent and map v0 statuses on webhook upserts

### DIFF
--- a/integrations/cursor-cloud-agents/.ocean-release/agent-idle-status.yaml
+++ b/integrations/cursor-cloud-agents/.ocean-release/agent-idle-status.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: bugfix
+changelog: Add IDLE to the cursor_agent blueprint and map v0 run lifecycle statuses to v1 agent lifecycle values on webhook and action upserts.

--- a/integrations/cursor-cloud-agents/.port/resources/blueprints.json
+++ b/integrations/cursor-cloud-agents/.port/resources/blueprints.json
@@ -10,10 +10,12 @@
                     "title": "Status",
                     "enum": [
                         "ACTIVE",
+                        "IDLE",
                         "ARCHIVED"
                     ],
                     "enumColors": {
                         "ACTIVE": "blue",
+                        "IDLE": "yellow",
                         "ARCHIVED": "lightGray"
                     }
                 },

--- a/integrations/cursor-cloud-agents/core/catalog.py
+++ b/integrations/cursor-cloud-agents/core/catalog.py
@@ -6,7 +6,17 @@ from typing import Any
 from actions.utils import build_agent_link
 from integration import ObjectKind
 
-_V1_AGENT_STATUSES = frozenset({"ACTIVE", "ARCHIVED"})
+# v0 launch / webhook payloads carry run lifecycle statuses. Map them to v1 agent
+# lifecycle values before upserting the cursor_agent blueprint.
+_V0_TO_AGENT_STATUS = {
+    "CREATING": "ACTIVE",
+    "RUNNING": "ACTIVE",
+    "STOPPED": "IDLE",
+    "FINISHED": "IDLE",
+    "ERROR": "IDLE",
+    "CANCELLED": "IDLE",
+    "EXPIRED": "ARCHIVED",
+}
 
 
 def format_datetime_for_catalog(value: datetime) -> str:
@@ -45,17 +55,15 @@ def normalize_agent_raw_for_catalog(
 ) -> dict[str, Any]:
     """Shape a Cursor agent API object for the `cursor_agent` blueprint.
 
-    v1 List/Get Agents use durable ``ACTIVE`` / ``ARCHIVED`` statuses. v0 launch
-    and webhook snapshots reuse run lifecycle values (``CREATING``, ``RUNNING``,
-    ``FINISHED``, …) which fail blueprint validation if passed through unchanged.
+    v0 launch and webhook snapshots use ``source``/``target`` instead of the
+    v1 ``repos``/``url`` fields expected by port mappings. v0 run lifecycle
+    ``status`` values are mapped to v1 agent lifecycle values.
     """
     normalized = enrich_v0_agent_raw_for_catalog(raw, console_host=console_host)
     status = normalized.get("status")
-    if status in _V1_AGENT_STATUSES:
-        pass
-    elif status is not None:
-        normalized["status"] = "ACTIVE"
-    else:
+    if status in _V0_TO_AGENT_STATUS:
+        normalized["status"] = _V0_TO_AGENT_STATUS[status]
+    elif status is None:
         normalized.pop("status", None)
 
     # Optional url/date-time fields reject explicit null after jq mapping.

--- a/integrations/cursor-cloud-agents/tests/test_actions.py
+++ b/integrations/cursor-cloud-agents/tests/test_actions.py
@@ -26,7 +26,6 @@ _V0_LAUNCH_AGENT: dict[str, object] = {
     "createdAt": "2026-07-16T11:11:03.025Z",
 }
 
-
 @asynccontextmanager
 async def _noop_event_context(*args: Any, **kwargs: Any) -> AsyncIterator[None]:
     yield

--- a/integrations/cursor-cloud-agents/tests/test_actions.py
+++ b/integrations/cursor-cloud-agents/tests/test_actions.py
@@ -26,6 +26,7 @@ _V0_LAUNCH_AGENT: dict[str, object] = {
     "createdAt": "2026-07-16T11:11:03.025Z",
 }
 
+
 @asynccontextmanager
 async def _noop_event_context(*args: Any, **kwargs: Any) -> AsyncIterator[None]:
     yield

--- a/integrations/cursor-cloud-agents/tests/test_catalog.py
+++ b/integrations/cursor-cloud-agents/tests/test_catalog.py
@@ -56,6 +56,27 @@ def test_normalize_agent_raw_maps_v0_creating_to_active() -> None:
     }
 
 
+def test_normalize_agent_raw_maps_v0_finished_to_idle() -> None:
+    assert (
+        normalize_agent_raw_for_catalog({"id": "bc-1", "status": "FINISHED"})["status"]
+        == "IDLE"
+    )
+
+
+def test_normalize_agent_raw_maps_v0_stopped_to_idle() -> None:
+    assert (
+        normalize_agent_raw_for_catalog({"id": "bc-1", "status": "STOPPED"})["status"]
+        == "IDLE"
+    )
+
+
+def test_normalize_agent_raw_maps_v0_expired_to_archived() -> None:
+    assert (
+        normalize_agent_raw_for_catalog({"id": "bc-1", "status": "EXPIRED"})["status"]
+        == "ARCHIVED"
+    )
+
+
 def test_normalize_agent_raw_preserves_v1_statuses() -> None:
     assert (
         normalize_agent_raw_for_catalog({"id": "bc-1", "status": "ARCHIVED"})["status"]
@@ -64,4 +85,8 @@ def test_normalize_agent_raw_preserves_v1_statuses() -> None:
     assert (
         normalize_agent_raw_for_catalog({"id": "bc-1", "status": "ACTIVE"})["status"]
         == "ACTIVE"
+    )
+    assert (
+        normalize_agent_raw_for_catalog({"id": "bc-1", "status": "IDLE"})["status"]
+        == "IDLE"
     )

--- a/integrations/cursor-cloud-agents/tests/test_webhook_processors.py
+++ b/integrations/cursor-cloud-agents/tests/test_webhook_processors.py
@@ -180,7 +180,7 @@ async def test_handle_event_completes_create_run_via_agent_id_fallback() -> None
         [
             {
                 "id": "bc-1",
-                "status": "ACTIVE",
+                "status": "IDLE",
                 "summary": "Added README",
                 "target": {"branchName": "cursor/add-readme"},
                 "timestamp": "2025-06-01T12:00:00Z",
@@ -317,7 +317,7 @@ async def test_handle_event_upserts_catalog_when_no_run_tracked() -> None:
         [
             {
                 "id": "bc-1",
-                "status": "ACTIVE",
+                "status": "IDLE",
                 "summary": "Done",
                 "timestamp": "2025-06-01T12:00:00Z",
             }


### PR DESCRIPTION
# Description

**What** - Fix `cursor_agent` entity validation when Cursor returns `IDLE`, and normalize v0 run-lifecycle statuses to v1 agent-lifecycle values on webhook/action upserts.

**Why** - Resync failed with `"status" must be equal to one of the allowed values: "ACTIVE", "ARCHIVED"` after Cursor added `IDLE`. v0 create/webhook payloads also carry run statuses (`CREATING`, `FINISHED`, etc.) that do not belong on the agent blueprint.

**How** - Add `IDLE` to the `cursor_agent` blueprint enum. Map v0 statuses to v1 agent statuses in `normalize_agent_raw_for_catalog` (used by `register_raw` on webhooks and v0 create only; resync stays pass-through). Keep v0 field enrich (`source`/`target` → `repos`/`url`) and null-stripping as-is.

v0 → agent status mapping:
- `CREATING`, `RUNNING` → `ACTIVE`
- `STOPPED`, `FINISHED`, `ERROR`, `CANCELLED` → `IDLE`
- `EXPIRED` → `ARCHIVED`

## Release (integrations / ocean core)

Release intent: `integrations/cursor-cloud-agents/.ocean-release/agent-idle-status.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Add IDLE to the cursor_agent blueprint and map v0 run lifecycle statuses to v1 agent lifecycle values on webhook and action upserts.
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Integration testing checklist

- [x] Completed a full resync from a freshly installed integration and it completed successfully
- [x] Resync able to create entities (including agents with `IDLE` status)
- [x] v0 create + webhook upsert agent entities with mapped status (`CREATING` → `ACTIVE`, `FINISHED` → `IDLE`)
- [x] Docs PR link [here](https://github.com/port-labs/port-docs/pull/5860)

## API Documentation

- [Cursor Cloud Agents v1 endpoints](https://cursor.com/docs/cloud-agent/api/endpoints)
- [Cursor Cloud Agents v0 API](https://cursor.com/docs/cloud-agent/api/v0)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive blueprint enum and catalog normalization for integration entities; no auth, payment, or core API behavior changes.
> 
> **Overview**
> Fixes **cursor_agent** resync/upsert validation after Cursor added **`IDLE`**, and stops v0 **run** lifecycle values from being written onto the agent blueprint.
> 
> **`IDLE`** is added to the **`cursor_agent`** blueprint enum (yellow). In **`normalize_agent_raw_for_catalog`**, v0/webhook statuses are mapped via **`_V0_TO_AGENT_STATUS`** (e.g. **`CREATING`/`RUNNING` → `ACTIVE`**, **`FINISHED`/`STOPPED`/errors → `IDLE`**, **`EXPIRED` → `ARCHIVED`**) instead of defaulting unknown values to **`ACTIVE`**. v1 **`ACTIVE`**, **`IDLE`**, and **`ARCHIVED`** pass through unchanged. Webhook and v0 create **`register_raw`** paths pick up the new mapping; tests and a patch **`.ocean-release`** changelog entry are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa44e84508362386a752809371ac15e05171d6df. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->