### PR TITLE
[Core] Replace Redis live-events org feature flag with blocked-org check

### DIFF
--- a/.ocean-release/core/redis-live-events-org-blocked.yaml
+++ b/.ocean-release/core/redis-live-events-org-blocked.yaml
@@ -1,0 +1,3 @@
+bump: patch
+changelog-type: improvement
+changelog: Redis live-events stream consumption no longer requires the LIVE_EVENTS_REDIS_STREAM_ENABLED organization feature flag and is disabled for blocked organizations instead.

--- a/port_ocean/clients/port/mixins/organization.py
+++ b/port_ocean/clients/port/mixins/organization.py
@@ -1,5 +1,5 @@
 import time
-from typing import List
+from typing import Any, List
 
 import httpx
 from loguru import logger
@@ -16,12 +16,12 @@ class OrganizationClientMixin:
     ):
         self.auth = auth
         self.client = client
-        self._feature_flags_cache_ttl = feature_flags_cache_ttl_seconds
-        self._feature_flags_cache: list[str] | None = None
-        self._feature_flags_cached_at: float | None = None
+        self._organization_cache_ttl = feature_flags_cache_ttl_seconds
+        self._organization_cache: dict[str, Any] | None = None
+        self._organization_cached_at: float | None = None
 
-    async def _get_organization_feature_flags(self) -> httpx.Response:
-        logger.info("Fetching organization feature flags")
+    async def _fetch_organization(self) -> httpx.Response:
+        logger.info("Fetching organization details")
 
         response = await self.client.get(
             f"{self.auth.api_url}/organization",
@@ -29,22 +29,32 @@ class OrganizationClientMixin:
         )
         return response
 
+    async def _get_organization(
+        self, should_raise: bool = True, should_log: bool = True
+    ) -> dict[str, Any]:
+        now = time.monotonic()
+        if (
+            self._organization_cache is not None
+            and self._organization_cached_at is not None
+            and now - self._organization_cached_at < self._organization_cache_ttl
+        ):
+            return self._organization_cache
+
+        response = await self._fetch_organization()
+        handle_port_status_code(response, should_raise, should_log)
+        organization: dict[str, Any] = response.json().get("organization", {})
+        self._organization_cache = organization
+        self._organization_cached_at = now
+        return organization
+
     async def get_organization_feature_flags(
         self, should_raise: bool = True, should_log: bool = True
     ) -> List[str]:
-        now = time.monotonic()
-        if (
-            self._feature_flags_cache is not None
-            and self._feature_flags_cached_at is not None
-            and now - self._feature_flags_cached_at < self._feature_flags_cache_ttl
-        ):
-            return self._feature_flags_cache
+        organization = await self._get_organization(should_raise, should_log)
+        return organization.get("featureFlags", [])
 
-        response = await self._get_organization_feature_flags()
-        handle_port_status_code(response, should_raise, should_log)
-        flags: list[str] = (
-            response.json().get("organization", {}).get("featureFlags", [])
-        )
-        self._feature_flags_cache = flags
-        self._feature_flags_cached_at = now
-        return flags
+    async def is_organization_blocked(
+        self, should_raise: bool = True, should_log: bool = True
+    ) -> bool:
+        organization = await self._get_organization(should_raise, should_log)
+        return bool(organization.get("isBlocked", False))

--- a/port_ocean/core/integrations/mixins/utils.py
+++ b/port_ocean/core/integrations/mixins/utils.py
@@ -170,8 +170,9 @@ async def is_dsp_mode_enabled() -> bool:
 async def is_redis_live_events_enabled() -> bool:
     """Check if live events should be consumed from a Redis stream.
 
-    Gated by the organization feature flag and the integration-level
-    ``OCEAN__LIVE_EVENTS__IS_REDIS_STREAM_CONSUMER_ENABLED`` setting (default false).
+    Gated by the integration-level
+    ``OCEAN__LIVE_EVENTS__IS_REDIS_STREAM_CONSUMER_ENABLED`` setting (default false)
+    and whether the organization is blocked.
     Errors are swallowed so this never blocks core flows.
 
     Returns:
@@ -180,11 +181,12 @@ async def is_redis_live_events_enabled() -> bool:
     try:
         if not ocean.config.live_events.is_redis_stream_consumer_enabled:
             return False
-        flags = await ocean.port_client.get_organization_feature_flags()
-        return IntegrationFeatureFlag.LIVE_EVENTS_REDIS_STREAM_ENABLED in flags
+        if await ocean.port_client.is_organization_blocked():
+            return False
+        return True
     except Exception as e:
         logger.bind(local_only=True).warning(
-            f"Failed to check Redis live events feature flags, assuming disabled: {e}"
+            f"Failed to check Redis live events settings, assuming disabled: {e}"
         )
         return False
 

--- a/port_ocean/tests/clients/port/mixins/test_organization_mixin.py
+++ b/port_ocean/tests/clients/port/mixins/test_organization_mixin.py
@@ -1,7 +1,16 @@
+from typing import Any, cast
+
 import pytest
 from unittest.mock import MagicMock, AsyncMock
 
 from port_ocean.clients.port.mixins.organization import OrganizationClientMixin
+
+
+def _set_organization_response(
+    mixin: OrganizationClientMixin, organization: dict[str, Any]
+) -> None:
+    mock_client = cast(MagicMock, mixin.client)
+    mock_client.get.return_value.json.return_value = {"organization": organization}
 
 
 @pytest.fixture
@@ -35,9 +44,10 @@ async def test_org_feature_flags_should_fetch_proper_json_path(
 async def test_is_organization_blocked_returns_true_when_org_is_blocked(
     mocked_org_mixin: OrganizationClientMixin,
 ) -> None:
-    mocked_org_mixin.client.get.return_value.json.return_value = {
-        "organization": {"id": "org-123", "featureFlags": [], "isBlocked": True}
-    }
+    _set_organization_response(
+        mocked_org_mixin,
+        {"id": "org-123", "featureFlags": [], "isBlocked": True},
+    )
 
     result = await mocked_org_mixin.is_organization_blocked()
 
@@ -47,9 +57,10 @@ async def test_is_organization_blocked_returns_true_when_org_is_blocked(
 async def test_is_organization_blocked_returns_false_when_field_missing(
     mocked_org_mixin: OrganizationClientMixin,
 ) -> None:
-    mocked_org_mixin.client.get.return_value.json.return_value = {
-        "organization": {"id": "org-123", "featureFlags": []}
-    }
+    _set_organization_response(
+        mocked_org_mixin,
+        {"id": "org-123", "featureFlags": []},
+    )
 
     result = await mocked_org_mixin.is_organization_blocked()
 

--- a/port_ocean/tests/clients/port/mixins/test_organization_mixin.py
+++ b/port_ocean/tests/clients/port/mixins/test_organization_mixin.py
@@ -14,7 +14,11 @@ async def mocked_org_mixin() -> OrganizationClientMixin:
     client.get.return_value = MagicMock()
     client.get.return_value.json = MagicMock()
     client.get.return_value.json.return_value = {
-        "organization": {"id": "org-123", "featureFlags": ["aa", "bb"]}
+        "organization": {
+            "id": "org-123",
+            "featureFlags": ["aa", "bb"],
+            "isBlocked": False,
+        }
     }
     client.get.return_value.status_code = 200
     return OrganizationClientMixin(auth=auth, client=client)
@@ -26,3 +30,27 @@ async def test_org_feature_flags_should_fetch_proper_json_path(
     result = await mocked_org_mixin.get_organization_feature_flags()
 
     assert result == ["aa", "bb"]
+
+
+async def test_is_organization_blocked_returns_true_when_org_is_blocked(
+    mocked_org_mixin: OrganizationClientMixin,
+) -> None:
+    mocked_org_mixin.client.get.return_value.json.return_value = {
+        "organization": {"id": "org-123", "featureFlags": [], "isBlocked": True}
+    }
+
+    result = await mocked_org_mixin.is_organization_blocked()
+
+    assert result is True
+
+
+async def test_is_organization_blocked_returns_false_when_field_missing(
+    mocked_org_mixin: OrganizationClientMixin,
+) -> None:
+    mocked_org_mixin.client.get.return_value.json.return_value = {
+        "organization": {"id": "org-123", "featureFlags": []}
+    }
+
+    result = await mocked_org_mixin.is_organization_blocked()
+
+    assert result is False

--- a/port_ocean/tests/core/integrations/mixins/test_integration_utils.py
+++ b/port_ocean/tests/core/integrations/mixins/test_integration_utils.py
@@ -1108,21 +1108,21 @@ class TestProcessingModes:
         )
 
     @pytest.mark.asyncio
-    async def test_is_redis_live_events_enabled_when_flag_on(self) -> None:
+    async def test_is_redis_live_events_enabled_when_org_not_blocked(self) -> None:
         with patch(
             "port_ocean.core.integrations.mixins.utils.ocean"
         ) as mock_ocean_context:
             mock_ocean_context.config.live_events.is_redis_stream_consumer_enabled = (
                 True
             )
-            mock_ocean_context.port_client.get_organization_feature_flags = AsyncMock(
-                return_value=[IntegrationFeatureFlag.LIVE_EVENTS_REDIS_STREAM_ENABLED]
+            mock_ocean_context.port_client.is_organization_blocked = AsyncMock(
+                return_value=False
             )
 
             result = await is_redis_live_events_enabled()
 
         assert result is True
-        mock_ocean_context.port_client.get_organization_feature_flags.assert_called_once()
+        mock_ocean_context.port_client.is_organization_blocked.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_is_redis_live_events_disabled_when_env_opt_in_off(self) -> None:
@@ -1132,31 +1132,31 @@ class TestProcessingModes:
             mock_ocean_context.config.live_events.is_redis_stream_consumer_enabled = (
                 False
             )
-            mock_ocean_context.port_client.get_organization_feature_flags = AsyncMock(
-                return_value=[IntegrationFeatureFlag.LIVE_EVENTS_REDIS_STREAM_ENABLED]
+            mock_ocean_context.port_client.is_organization_blocked = AsyncMock(
+                return_value=False
             )
 
             result = await is_redis_live_events_enabled()
 
         assert result is False
-        mock_ocean_context.port_client.get_organization_feature_flags.assert_not_called()
+        mock_ocean_context.port_client.is_organization_blocked.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_is_redis_live_events_disabled_when_flag_off(self) -> None:
+    async def test_is_redis_live_events_disabled_when_org_blocked(self) -> None:
         with patch(
             "port_ocean.core.integrations.mixins.utils.ocean"
         ) as mock_ocean_context:
             mock_ocean_context.config.live_events.is_redis_stream_consumer_enabled = (
                 True
             )
-            mock_ocean_context.port_client.get_organization_feature_flags = AsyncMock(
-                return_value=[]
+            mock_ocean_context.port_client.is_organization_blocked = AsyncMock(
+                return_value=True
             )
 
             result = await is_redis_live_events_enabled()
 
         assert result is False
-        mock_ocean_context.port_client.get_organization_feature_flags.assert_called_once()
+        mock_ocean_context.port_client.is_organization_blocked.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_is_redis_live_events_enabled_uses_local_only_warning_on_exception(
@@ -1165,7 +1165,10 @@ class TestProcessingModes:
         with patch(
             "port_ocean.core.integrations.mixins.utils.ocean"
         ) as mock_ocean_context:
-            mock_ocean_context.port_client.get_organization_feature_flags = AsyncMock(
+            mock_ocean_context.config.live_events.is_redis_stream_consumer_enabled = (
+                True
+            )
+            mock_ocean_context.port_client.is_organization_blocked = AsyncMock(
                 side_effect=Exception("timeout")
             )
 
@@ -1178,6 +1181,6 @@ class TestProcessingModes:
         assert result is False
         mock_logger.bind.assert_called_with(local_only=True)
         mock_bound.warning.assert_called_once()
-        assert "Failed to check Redis live events feature flags" in (
+        assert "Failed to check Redis live events settings" in (
             mock_bound.warning.call_args.args[0]
         )


### PR DESCRIPTION
# Description
- Remove the `LIVE_EVENTS_REDIS_STREAM_ENABLED` organization feature flag gate for Redis live-events stream consumption
- Gate Redis live-events on the integration-level `OCEAN__LIVE_EVENTS__IS_REDIS_STREAM_CONSUMER_ENABLED` setting (default `false`) and whether the organization is blocked (`isBlocked` from `/organization`)
- Refactor `OrganizationClientMixin` to cache the full organization response instead of only feature flags, so `get_organization_feature_flags()` and the new `is_organization_blocked()` share a single cached `/organization` fetch


## Release (integrations / ocean core)

If this PR changes an integration or `port_ocean/`, add a release intent file **or** manually bump `pyproject.toml` and `CHANGELOG.md` (manual takes priority):

- Integration: `integrations/<name>/.ocean-release/<unique-name>.yaml`
- Core: `.ocean-release/core/<unique-name>.yaml`

```yaml
bump: patch
changelog-type: bugfix
changelog: Describe the change
```

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] New Integration (non-breaking change which adds a new integration)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)

<h4> All tests should be run against the port production environment(using a testing org). </h4>

### Core testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Resync finishes successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Scheduled resync able to abort existing resync and start a new one
- [ ] Tested with at least 2 integrations from scratch
- [ ] Tested with Kafka and Polling event listeners
- [ ] Tested deletion of entities that don't pass the selector


### Integration testing checklist

- [ ] Integration able to create all default resources from scratch
- [ ] Completed a full resync from a freshly installed integration and it completed successfully
- [ ] Resync able to create entities
- [ ] Resync able to update entities
- [ ] Resync able to detect and delete entities
- [ ] Resync finishes successfully
- [ ] If new resource kind is added or updated in the integration, add example raw data, mapping and expected result to the `examples` folder in the integration directory.
- [ ] If resource kind is updated, run the integration with the example data and check if the expected result is achieved
- [ ] If new resource kind is added or updated, validate that live-events for that resource are working as expected
- [ ] Docs PR link [here](#)

### Preflight checklist

- [ ] Handled rate limiting
- [ ] Handled pagination
- [ ] Implemented the code in async
- [ ] Support Multi account

## Screenshots

Include screenshots from your environment showing how the resources of the integration will look.

## API Documentation

Provide links to the API documentation used for this integration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout criteria for Redis live-events (orgs with the integration opt-in but without the old org flag may now consume streams); blocked-org handling affects live event processing for those tenants.
> 
> **Overview**
> **Redis live-events stream consumption** no longer depends on the `LIVE_EVENTS_REDIS_STREAM_ENABLED` organization feature flag. It is enabled when the integration sets `OCEAN__LIVE_EVENTS__IS_REDIS_STREAM_CONSUMER_ENABLED` and the organization is **not** blocked (`isBlocked` from `/organization`).
> 
> `OrganizationClientMixin` now caches the full organization payload from `/organization` (same TTL as before) so `get_organization_feature_flags()` and the new `is_organization_blocked()` share one fetch. `is_redis_live_events_enabled()` calls the blocked check instead of reading feature flags.
> 
> Tests and a core `.ocean-release` patch changelog entry cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e8cf37f070028d616e3a271a3c9adf01d33d58d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->